### PR TITLE
Refactor/tds

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,7 @@
         "circumcircle",
         "circumradius",
         "circumsphere",
+        "circumspheres",
         "clippy",
         "Codacy",
         "codecov",

--- a/cspell.json
+++ b/cspell.json
@@ -18,7 +18,6 @@
         "circumcircle",
         "circumradius",
         "circumsphere",
-        "circumspheres",
         "clippy",
         "Codacy",
         "codecov",

--- a/src/delaunay_core/triangulation_data_structure.rs
+++ b/src/delaunay_core/triangulation_data_structure.rs
@@ -195,11 +195,11 @@ where
     ordered_float::OrderedFloat<f64>: From<T>,
 {
     /// The function creates a new instance of a triangulation data structure
-    /// with given points, initializing the vertices and cells.
+    /// with given vertices, initializing the vertices and cells.
     ///
     /// # Arguments
     ///
-    /// * `points`: A container of [Point]s with which to initialize the
+    /// * `vertices`: A container of [Vertex]s with which to initialize the
     ///   triangulation.
     ///
     /// # Returns
@@ -209,20 +209,21 @@ where
     ///
     /// # Examples
     ///
-    /// Create a new triangulation data structure with 3D points:
+    /// Create a new triangulation data structure with 3D vertices:
     ///
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
+    /// use d_delaunay::delaunay_core::vertex::{Vertex, VertexBuilder};
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let points = vec![
-    ///     Point::new([0.0, 0.0, 0.0]),
-    ///     Point::new([1.0, 0.0, 0.0]),
-    ///     Point::new([0.0, 1.0, 0.0]),
-    ///     Point::new([0.0, 0.0, 1.0]),
+    /// let vertices = vec![
+    ///     VertexBuilder::default().point(Point::new([0.0, 0.0, 0.0])).build().unwrap(),
+    ///     VertexBuilder::default().point(Point::new([1.0, 0.0, 0.0])).build().unwrap(),
+    ///     VertexBuilder::default().point(Point::new([0.0, 1.0, 0.0])).build().unwrap(),
+    ///     VertexBuilder::default().point(Point::new([0.0, 0.0, 1.0])).build().unwrap(),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 4);
     /// assert_eq!(tds.number_of_cells(), 0); // Cells are created later with bowyer_watson()
     /// assert_eq!(tds.dim(), 3);
@@ -232,10 +233,10 @@ where
     ///
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
-    /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
-    /// let points: Vec<Point<f64, 3>> = Vec::new();
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices: Vec<Vertex<f64, usize, 3>> = Vec::new();
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 0);
     /// assert_eq!(tds.dim(), -1);
     /// ```
@@ -244,28 +245,25 @@ where
     ///
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
+    /// use d_delaunay::delaunay_core::vertex::{Vertex, VertexBuilder};
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let points = vec![
-    ///     Point::new([0.0, 0.0]),
-    ///     Point::new([1.0, 0.0]),
-    ///     Point::new([0.5, 1.0]),
+    /// let vertices = vec![
+    ///     VertexBuilder::default().point(Point::new([0.0, 0.0])).build().unwrap(),
+    ///     VertexBuilder::default().point(Point::new([1.0, 0.0])).build().unwrap(),
+    ///     VertexBuilder::default().point(Point::new([0.5, 1.0])).build().unwrap(),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(points);
+    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 3);
     /// assert_eq!(tds.dim(), 2);
     /// ```
     #[must_use]
-    pub fn new(points: Vec<Point<T, D>>) -> Self {
-        // handle case where vertices are constructed with data
-        let vertices = Vertex::into_hashmap(Vertex::from_points(points));
-        // let cells_vec = bowyer_watson(vertices);
-        let cells = HashMap::new();
-        // assign_neighbors(cells_vec);
-        // assign_incident_cells(vertices);
-
-        Self { vertices, cells }
+    pub fn new(vertices: Vec<Vertex<T, U, D>>) -> Self {
+        Self {
+            vertices: Vertex::into_hashmap(vertices),
+            cells: HashMap::new(),
+        }
     }
 
     /// The `add` function checks if a [Vertex] with the same coordinates already
@@ -407,6 +405,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -415,7 +414,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 4);
     /// ```
     #[must_use]
@@ -480,6 +480,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// // 2D triangulation
     /// let points_2d = vec![
@@ -487,7 +488,8 @@ where
     ///     Point::new([1.0, 0.0]),
     ///     Point::new([0.5, 1.0]),
     /// ];
-    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(points_2d);
+    /// let vertices_2d = Vertex::from_points(points_2d);
+    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(vertices_2d);
     /// assert_eq!(tds_2d.dim(), 2);
     ///
     /// // 4D triangulation with 6 vertices (capped at D=4)
@@ -499,7 +501,8 @@ where
     ///     Point::new([0.0, 0.0, 0.0, 1.0]),
     ///     Point::new([1.0, 1.0, 1.0, 1.0]),
     /// ];
-    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(points_4d);
+    /// let vertices_4d = Vertex::from_points(points_4d);
+    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(vertices_4d);
     /// assert_eq!(tds_4d.dim(), 4);
     /// ```
     #[must_use]
@@ -525,6 +528,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -533,7 +537,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_cells(), 0); // No cells until triangulation is performed
     /// ```
     ///
@@ -542,6 +547,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -550,7 +556,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let triangulated = tds.bowyer_watson().unwrap();
     /// assert_eq!(triangulated.number_of_cells(), 1); // One tetrahedron for 4 points in 3D
     /// ```
@@ -729,6 +736,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -737,7 +745,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 4);
@@ -750,9 +759,11 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points: Vec<Point<f64, 3>> = Vec::new();
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 0);
@@ -764,6 +775,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0]),
@@ -771,7 +783,8 @@ where
     ///     Point::new([0.5, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 3);
@@ -783,6 +796,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -792,7 +806,8 @@ where
     ///     Point::new([1.0, 1.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 5);
@@ -1135,6 +1150,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -1143,7 +1159,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let triangulated = tds.bowyer_watson().unwrap();
     ///
     /// // Validation should pass for a properly triangulated structure
@@ -1167,6 +1184,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// // 2D triangulation
     /// let points_2d = vec![
@@ -1174,7 +1192,8 @@ where
     ///     Point::new([1.0, 0.0]),
     ///     Point::new([0.5, 1.0]),
     /// ];
-    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(points_2d);
+    /// let vertices_2d = Vertex::from_points(points_2d);
+    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(vertices_2d);
     /// let triangulated_2d = tds_2d.bowyer_watson().unwrap();
     /// assert!(triangulated_2d.is_valid().is_ok());
     ///
@@ -1186,7 +1205,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0, 0.0]),
     ///     Point::new([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(points_4d);
+    /// let vertices_4d = Vertex::from_points(points_4d);
+    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(vertices_4d);
     /// let triangulated_4d = tds_4d.bowyer_watson().unwrap();
     /// assert!(triangulated_4d.is_valid().is_ok());
     /// ```
@@ -1458,7 +1478,8 @@ mod tests {
             Point::new([-100.0, -100.0, -100.0]),
             Point::new([100.0, 100.0, 100.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell().unwrap();
 
         // Assert that supercell has proper dimensions
@@ -1480,7 +1501,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson();
         assert!(result.is_ok());
         let result_tds = result.unwrap();
@@ -1523,7 +1545,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result_tds = tds.bowyer_watson().expect("Triangulation failed");
 
         // Add duplicate cell manually
@@ -1543,7 +1566,8 @@ mod tests {
     #[test]
     fn test_bowyer_watson_empty() {
         let points: Vec<Point<f64, 3>> = Vec::new();
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         let result = tds.bowyer_watson();
         assert!(result.is_ok());
@@ -1585,8 +1609,9 @@ mod tests {
             Point::new([7.0, 8.0, 9.0]),
             Point::new([10.0, 11.0, 12.0]),
         ];
+        let vertices = Vertex::from_points(points);
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         assert_eq!(tds.number_of_vertices(), 4);
         assert_eq!(tds.number_of_cells(), 0);
@@ -1600,7 +1625,8 @@ mod tests {
     fn tds_add_dim() {
         let points: Vec<Point<f64, 3>> = Vec::new();
 
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         assert_eq!(tds.number_of_vertices(), 0);
         assert_eq!(tds.number_of_cells(), 0);
@@ -1660,7 +1686,8 @@ mod tests {
             Point::new([7.0, 8.0, 9.0]),
             Point::new([10.0, 11.0, 12.0]),
         ];
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         assert_eq!(tds.number_of_vertices(), 4);
         assert_eq!(tds.cells.len(), 0);
@@ -1685,7 +1712,8 @@ mod tests {
             Point::new([7.0, 8.0, 9.0]),
             Point::new([10.0, 11.0, 12.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell();
         let unwrapped_supercell =
             supercell.unwrap_or_else(|err| panic!("Error creating supercell: {err:?}!"));
@@ -1714,7 +1742,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         println!(
             "Initial TDS: {} vertices, {} cells",
             tds.number_of_vertices(),
@@ -1752,7 +1781,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0, 1.0]), // diagonal point
         ];
 
-        let tds: Tds<f64, usize, usize, 4> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 4> = Tds::new(vertices);
         println!("\n=== 4D BOWYER-WATSON TRIANGULATION TEST ===");
         println!(
             "Initial 4D TDS: {} vertices, {} cells",
@@ -1793,7 +1823,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0, 1.0, 1.0]), // diagonal point
         ];
 
-        let tds: Tds<f64, usize, usize, 5> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 5> = Tds::new(vertices);
         println!("\n=== 5D BOWYER-WATSON TRIANGULATION TEST ===");
         println!(
             "Initial 5D TDS: {} vertices, {} cells",
@@ -1889,7 +1920,8 @@ mod tests {
             })
             .collect();
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap_or_else(|err| {
             panic!("Error creating large triangulation: {err:?}");
         });
@@ -1913,7 +1945,8 @@ mod tests {
     fn test_supercell_with_different_dimensions() {
         // Test 2D supercell creation
         let points_2d = vec![Point::new([0.0, 0.0]), Point::new([10.0, 10.0])];
-        let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(points_2d);
+        let vertices_2d = Vertex::from_points(points_2d);
+        let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(vertices_2d);
         let supercell_2d = tds_2d.supercell().unwrap();
         assert_eq!(supercell_2d.vertices().len(), 3); // Triangle for 2D
 
@@ -1922,7 +1955,8 @@ mod tests {
             Point::new([0.0, 0.0, 0.0, 0.0]),
             Point::new([5.0, 5.0, 5.0, 5.0]),
         ];
-        let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(points_4d);
+        let vertices_4d = Vertex::from_points(points_4d);
+        let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(vertices_4d);
         let supercell_4d = tds_4d.supercell().unwrap();
         assert_eq!(supercell_4d.vertices().len(), 5); // 4-simplex for 4D
     }
@@ -1936,7 +1970,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
             Point::new([1.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Manually assign neighbors to test the logic
@@ -1965,7 +2000,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Test incident cell assignment
@@ -1994,7 +2030,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
             Point::new([1.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         if result.number_of_cells() >= 2 {
@@ -2205,7 +2242,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0]), // center point
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 8);
@@ -2235,7 +2273,8 @@ mod tests {
             Point::new([1000.0, 1000.0, 1000.0]),
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell().unwrap();
 
         // Verify supercell is even larger
@@ -2260,7 +2299,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         if result.number_of_cells() > 0 {
@@ -2292,7 +2332,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         let initial_cell_count = result.number_of_cells();
@@ -2324,7 +2365,8 @@ mod tests {
             Point::new([25.0, 30.0, 35.0]),
             Point::new([45.0, 50.0, 55.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell().unwrap();
 
         // Verify that all supercell vertices are outside the input range
@@ -2352,7 +2394,8 @@ mod tests {
     fn test_create_supercell_simplex_non_3d() {
         // Test supercell creation for dimensions other than 3D
         let points_1d = vec![Point::new([5.0]), Point::new([15.0])];
-        let tds_1d: Tds<f64, usize, usize, 1> = Tds::new(points_1d);
+        let vertices_1d = Vertex::from_points(points_1d);
+        let tds_1d: Tds<f64, usize, usize, 1> = Tds::new(vertices_1d);
         let supercell_1d = tds_1d.supercell().unwrap();
         assert_eq!(supercell_1d.vertices().len(), 2); // 1D simplex has 2 vertices
 
@@ -2360,7 +2403,8 @@ mod tests {
             Point::new([0.0, 0.0, 0.0, 0.0, 0.0]),
             Point::new([10.0, 10.0, 10.0, 10.0, 10.0]),
         ];
-        let tds_5d: Tds<f64, usize, usize, 5> = Tds::new(points_5d);
+        let vertices_5d = Vertex::from_points(points_5d);
+        let tds_5d: Tds<f64, usize, usize, 5> = Tds::new(vertices_5d);
         let supercell_5d = tds_5d.supercell().unwrap();
         assert_eq!(supercell_5d.vertices().len(), 6); // 5D simplex has 6 vertices
     }
@@ -2376,7 +2420,8 @@ mod tests {
             Point::new([1.0, 1.0, 0.0]),
             Point::new([1.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 6);
@@ -2405,7 +2450,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0]),
             Point::new([3.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 10);
@@ -2427,7 +2473,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
             Point::new([1.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Clear existing neighbors to test assignment logic
@@ -2465,7 +2512,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Clear existing incident cells to test assignment logic
@@ -2502,7 +2550,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Add multiple duplicate cells manually
@@ -2534,7 +2583,8 @@ mod tests {
             Point::new([0.0, 2.0, 0.0]),
             Point::new([0.0, 0.0, 2.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         if result.number_of_cells() > 0 {

--- a/src/delaunay_core/triangulation_data_structure.rs
+++ b/src/delaunay_core/triangulation_data_structure.rs
@@ -1090,16 +1090,18 @@ where
                             if facets_are_adjacent(facet1, facet2) {
                                 neighbor_map
                                     .get_mut(&cell1_id)
-                                    .ok_or(TriangulationValidationError::NotNeighbors {
-                                        cell1: cell1_id,
-                                        cell2: cell2_id,
+                                    .ok_or(TriangulationValidationError::FailedToCreateCell {
+                                        message: format!(
+                                            "Failed to access neighbor map for cell {cell1_id:?}"
+                                        ),
                                     })?
                                     .push(cell2_id);
                                 neighbor_map
                                     .get_mut(&cell2_id)
-                                    .ok_or(TriangulationValidationError::NotNeighbors {
-                                        cell1: cell2_id,
-                                        cell2: cell1_id,
+                                    .ok_or(TriangulationValidationError::FailedToCreateCell {
+                                        message: format!(
+                                            "Failed to access neighbor map for cell {cell2_id:?}"
+                                        ),
                                     })?
                                     .push(cell1_id);
                             }
@@ -1464,10 +1466,9 @@ where
 
                 // Early termination: check shared vertex count
                 if shared_count != D {
-                    return Err(TriangulationValidationError::InvalidNeighbors {
-                        message: format!(
-                            "Neighbor {neighbor_id:?} does not share a facet with {cell_id:?} (shared {shared_count} vertices)"
-                        ),
+                    return Err(TriangulationValidationError::NotNeighbors {
+                        cell1: *cell_id,
+                        cell2: *neighbor_id,
                     });
                 }
             }
@@ -2833,7 +2834,7 @@ mod tests {
         let result = tds.is_valid();
         assert!(matches!(
             result,
-            Err(TriangulationValidationError::InvalidNeighbors { .. })
+            Err(TriangulationValidationError::NotNeighbors { .. })
         ));
     }
 

--- a/src/delaunay_core/triangulation_data_structure.rs
+++ b/src/delaunay_core/triangulation_data_structure.rs
@@ -10,6 +10,7 @@ use super::{
     utilities::find_extreme_coordinates,
     vertex::Vertex,
 };
+use derive_builder::Builder;
 use na::{ComplexField, Const, OPoint};
 use nalgebra as na;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -125,7 +126,8 @@ where
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Builder, Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[builder(build_fn(validate = "Self::validate"))]
 /// The `Tds` struct represents a triangulation data structure with vertices
 /// and cells, where the vertices and cells are identified by UUIDs.
 ///
@@ -163,6 +165,7 @@ where
     /// A [`HashMap`] that stores [Vertex] objects with their corresponding [Uuid]s as
     /// keys. Each [Vertex] has a [Point] of type T, vertex data of type U,
     /// and a constant D representing the dimension.
+    #[builder(setter(into))]
     pub vertices: HashMap<Uuid, Vertex<T, U, D>>,
 
     /// A [`HashMap`] that stores [Cell] objects with their corresponding [Uuid]s as
@@ -171,7 +174,27 @@ where
     /// Note the dimensionality of the cell may differ from D, though the [Tds]
     /// only stores cells of maximal dimensionality D and infers other lower
     /// dimensional cells from the maximal cells and their vertices.
+    #[builder(setter(skip), default = "HashMap::new()")]
     pub cells: HashMap<Uuid, Cell<T, U, V, D>>,
+}
+
+impl<T, U, V, const D: usize> TdsBuilder<T, U, V, D>
+where
+    T: Clone + Copy + Default + PartialEq + PartialOrd + OrderedEq,
+    U: Clone + Copy + Eq + Hash + Ord + PartialEq + PartialOrd,
+    V: Clone + Copy + Eq + Hash + Ord + PartialEq + PartialOrd,
+    [T; D]: Copy + Default + DeserializeOwned + Serialize + Sized,
+{
+    fn validate(&self) -> Result<(), TdsBuilderError> {
+        // Basic validation - ensure vertices HashMap is set
+        if self.vertices.is_none() {
+            let err = TdsBuilderError::ValidationError(
+                "Must create a Tds with a vertices HashMap!".to_string(),
+            );
+            return Err(err);
+        }
+        Ok(())
+    }
 }
 
 impl<T, U, V, const D: usize> Tds<T, U, V, D>
@@ -195,11 +218,11 @@ where
     ordered_float::OrderedFloat<f64>: From<T>,
 {
     /// The function creates a new instance of a triangulation data structure
-    /// with given points, initializing the vertices and cells.
+    /// with given vertices, initializing the cells.
     ///
     /// # Arguments
     ///
-    /// * `points`: A container of [Point]s with which to initialize the
+    /// * `vertices`: A container of [Vertex]s with which to initialize the
     ///   triangulation.
     ///
     /// # Returns
@@ -207,12 +230,18 @@ where
     /// A Delaunay triangulation with cells and neighbors aligned, and vertices
     /// associated with cells.
     ///
+    /// # Panics
+    ///
+    /// This function should not panic under normal circumstances as the builder
+    /// validation is designed to always succeed with a valid vertices `HashMap`.
+    ///
     /// # Examples
     ///
-    /// Create a new triangulation data structure with 3D points:
+    /// Create a new triangulation data structure with 3D vertices:
     ///
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     /// use d_delaunay::delaunay_core::point::Point;
     ///
     /// let points = vec![
@@ -221,10 +250,36 @@ where
     ///     Point::new([0.0, 1.0, 0.0]),
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
+    /// let vertices = Vertex::from_points(points);
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 4);
     /// assert_eq!(tds.number_of_cells(), 0); // Cells are created later with bowyer_watson()
+    /// assert_eq!(tds.dim(), 3);
+    /// ```
+    ///
+    /// Create a triangulation using the builder pattern with vertices:
+    ///
+    /// ```
+    /// use d_delaunay::delaunay_core::triangulation_data_structure::{Tds, TdsBuilder};
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
+    /// use d_delaunay::delaunay_core::point::Point;
+    ///
+    /// let points = vec![
+    ///     Point::new([0.0, 0.0, 0.0]),
+    ///     Point::new([1.0, 0.0, 0.0]),
+    ///     Point::new([0.0, 1.0, 0.0]),
+    ///     Point::new([0.0, 0.0, 1.0]),
+    /// ];
+    /// let vertices = Vertex::from_points(points);
+    /// let vertices_map = Vertex::into_hashmap(vertices);
+    ///
+    /// let tds: Tds<f64, usize, usize, 3> = TdsBuilder::default()
+    ///     .vertices(vertices_map)
+    ///     .build()
+    ///     .unwrap();
+    /// assert_eq!(tds.number_of_vertices(), 4);
+    /// assert_eq!(tds.number_of_cells(), 0);
     /// assert_eq!(tds.dim(), 3);
     /// ```
     ///
@@ -232,10 +287,10 @@ where
     ///
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
-    /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
-    /// let points: Vec<Point<f64, 3>> = Vec::new();
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices: Vec<Vertex<f64, usize, 3>> = Vec::new();
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 0);
     /// assert_eq!(tds.dim(), -1);
     /// ```
@@ -244,6 +299,7 @@ where
     ///
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     /// use d_delaunay::delaunay_core::point::Point;
     ///
     /// let points = vec![
@@ -251,23 +307,21 @@ where
     ///     Point::new([1.0, 0.0]),
     ///     Point::new([0.5, 1.0]),
     /// ];
+    /// let vertices = Vertex::from_points(points);
     ///
-    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(points);
+    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 3);
     /// assert_eq!(tds.dim(), 2);
     /// ```
     #[must_use]
-    pub fn new(points: Vec<Point<T, D>>) -> Self {
-        // handle case where vertices are constructed with data
-        let vertices = Vertex::into_hashmap(Vertex::from_points(points));
-        // let cells_vec = bowyer_watson(vertices);
-        let cells = HashMap::new();
-        // assign_neighbors(cells_vec);
-        // assign_incident_cells(vertices);
-
-        Self { vertices, cells }
+    pub fn new(vertices: Vec<Vertex<T, U, D>>) -> Self {
+        // Convert vertices vector to HashMap and use the builder
+        let vertices_map = Vertex::into_hashmap(vertices);
+        TdsBuilder::default()
+            .vertices(vertices_map)
+            .build()
+            .expect("Building Tds with vertices should not fail")
     }
-
     /// The `add` function checks if a [Vertex] with the same coordinates already
     /// exists in the [`HashMap`], and if not, inserts the [Vertex].
     ///
@@ -407,6 +461,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -414,9 +469,10 @@ where
     ///     Point::new([0.0, 1.0, 0.0]),
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
-    ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_vertices(), 4);
+    /// assert_eq!(tds.dim(), 3);
     /// ```
     #[must_use]
     pub fn number_of_vertices(&self) -> usize {
@@ -480,6 +536,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// // 2D triangulation
     /// let points_2d = vec![
@@ -487,7 +544,8 @@ where
     ///     Point::new([1.0, 0.0]),
     ///     Point::new([0.5, 1.0]),
     /// ];
-    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(points_2d);
+    /// let vertices_2d = Vertex::from_points(points_2d);
+    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(vertices_2d);
     /// assert_eq!(tds_2d.dim(), 2);
     ///
     /// // 4D triangulation with 6 vertices (capped at D=4)
@@ -499,7 +557,8 @@ where
     ///     Point::new([0.0, 0.0, 0.0, 1.0]),
     ///     Point::new([1.0, 1.0, 1.0, 1.0]),
     /// ];
-    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(points_4d);
+    /// let vertices_4d = Vertex::from_points(points_4d);
+    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(vertices_4d);
     /// assert_eq!(tds_4d.dim(), 4);
     /// ```
     #[must_use]
@@ -525,6 +584,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -533,7 +593,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// assert_eq!(tds.number_of_cells(), 0); // No cells until triangulation is performed
     /// ```
     ///
@@ -542,6 +603,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -550,7 +612,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let triangulated = tds.bowyer_watson().unwrap();
     /// assert_eq!(triangulated.number_of_cells(), 1); // One tetrahedron for 4 points in 3D
     /// ```
@@ -729,6 +792,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -737,7 +801,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 4);
@@ -750,9 +815,11 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points: Vec<Point<f64, 3>> = Vec::new();
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 0);
@@ -764,6 +831,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0]),
@@ -771,7 +839,8 @@ where
     ///     Point::new([0.5, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 3);
@@ -783,6 +852,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -792,7 +862,8 @@ where
     ///     Point::new([1.0, 1.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let result = tds.bowyer_watson().unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 5);
@@ -1135,6 +1206,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let points = vec![
     ///     Point::new([0.0, 0.0, 0.0]),
@@ -1143,7 +1215,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+    /// let vertices = Vertex::from_points(points);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
     /// let triangulated = tds.bowyer_watson().unwrap();
     ///
     /// // Validation should pass for a properly triangulated structure
@@ -1167,6 +1240,7 @@ where
     /// ```
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
+    /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// // 2D triangulation
     /// let points_2d = vec![
@@ -1174,7 +1248,8 @@ where
     ///     Point::new([1.0, 0.0]),
     ///     Point::new([0.5, 1.0]),
     /// ];
-    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(points_2d);
+    /// let vertices_2d = Vertex::from_points(points_2d);
+    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(vertices_2d);
     /// let triangulated_2d = tds_2d.bowyer_watson().unwrap();
     /// assert!(triangulated_2d.is_valid().is_ok());
     ///
@@ -1186,7 +1261,8 @@ where
     ///     Point::new([0.0, 0.0, 1.0, 0.0]),
     ///     Point::new([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(points_4d);
+    /// let vertices_4d = Vertex::from_points(points_4d);
+    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(vertices_4d);
     /// let triangulated_4d = tds_4d.bowyer_watson().unwrap();
     /// assert!(triangulated_4d.is_valid().is_ok());
     /// ```
@@ -1458,7 +1534,8 @@ mod tests {
             Point::new([-100.0, -100.0, -100.0]),
             Point::new([100.0, 100.0, 100.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell().unwrap();
 
         // Assert that supercell has proper dimensions
@@ -1480,7 +1557,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson();
         assert!(result.is_ok());
         let result_tds = result.unwrap();
@@ -1523,7 +1601,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result_tds = tds.bowyer_watson().expect("Triangulation failed");
 
         // Add duplicate cell manually
@@ -1543,7 +1622,8 @@ mod tests {
     #[test]
     fn test_bowyer_watson_empty() {
         let points: Vec<Point<f64, 3>> = Vec::new();
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         let result = tds.bowyer_watson();
         assert!(result.is_ok());
@@ -1586,7 +1666,8 @@ mod tests {
             Point::new([10.0, 11.0, 12.0]),
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         assert_eq!(tds.number_of_vertices(), 4);
         assert_eq!(tds.number_of_cells(), 0);
@@ -1600,7 +1681,8 @@ mod tests {
     fn tds_add_dim() {
         let points: Vec<Point<f64, 3>> = Vec::new();
 
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         assert_eq!(tds.number_of_vertices(), 0);
         assert_eq!(tds.number_of_cells(), 0);
@@ -1660,7 +1742,8 @@ mod tests {
             Point::new([7.0, 8.0, 9.0]),
             Point::new([10.0, 11.0, 12.0]),
         ];
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
 
         assert_eq!(tds.number_of_vertices(), 4);
         assert_eq!(tds.cells.len(), 0);
@@ -1685,7 +1768,8 @@ mod tests {
             Point::new([7.0, 8.0, 9.0]),
             Point::new([10.0, 11.0, 12.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell();
         let unwrapped_supercell =
             supercell.unwrap_or_else(|err| panic!("Error creating supercell: {err:?}!"));
@@ -1714,7 +1798,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         println!(
             "Initial TDS: {} vertices, {} cells",
             tds.number_of_vertices(),
@@ -1752,7 +1837,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0, 1.0]), // diagonal point
         ];
 
-        let tds: Tds<f64, usize, usize, 4> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 4> = Tds::new(vertices);
         println!("\n=== 4D BOWYER-WATSON TRIANGULATION TEST ===");
         println!(
             "Initial 4D TDS: {} vertices, {} cells",
@@ -1793,7 +1879,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0, 1.0, 1.0]), // diagonal point
         ];
 
-        let tds: Tds<f64, usize, usize, 5> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 5> = Tds::new(vertices);
         println!("\n=== 5D BOWYER-WATSON TRIANGULATION TEST ===");
         println!(
             "Initial 5D TDS: {} vertices, {} cells",
@@ -1889,7 +1976,8 @@ mod tests {
             })
             .collect();
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap_or_else(|err| {
             panic!("Error creating large triangulation: {err:?}");
         });
@@ -1913,7 +2001,8 @@ mod tests {
     fn test_supercell_with_different_dimensions() {
         // Test 2D supercell creation
         let points_2d = vec![Point::new([0.0, 0.0]), Point::new([10.0, 10.0])];
-        let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(points_2d);
+        let vertices_2d = Vertex::from_points(points_2d);
+        let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(vertices_2d);
         let supercell_2d = tds_2d.supercell().unwrap();
         assert_eq!(supercell_2d.vertices().len(), 3); // Triangle for 2D
 
@@ -1922,7 +2011,8 @@ mod tests {
             Point::new([0.0, 0.0, 0.0, 0.0]),
             Point::new([5.0, 5.0, 5.0, 5.0]),
         ];
-        let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(points_4d);
+        let vertices_4d = Vertex::from_points(points_4d);
+        let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(vertices_4d);
         let supercell_4d = tds_4d.supercell().unwrap();
         assert_eq!(supercell_4d.vertices().len(), 5); // 4-simplex for 4D
     }
@@ -1936,7 +2026,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
             Point::new([1.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Manually assign neighbors to test the logic
@@ -1965,7 +2056,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Test incident cell assignment
@@ -1994,7 +2086,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
             Point::new([1.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         if result.number_of_cells() >= 2 {
@@ -2205,7 +2298,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0]), // center point
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 8);
@@ -2235,7 +2329,8 @@ mod tests {
             Point::new([1000.0, 1000.0, 1000.0]),
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell().unwrap();
 
         // Verify supercell is even larger
@@ -2260,7 +2355,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         if result.number_of_cells() > 0 {
@@ -2292,7 +2388,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         let initial_cell_count = result.number_of_cells();
@@ -2324,7 +2421,8 @@ mod tests {
             Point::new([25.0, 30.0, 35.0]),
             Point::new([45.0, 50.0, 55.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let supercell = tds.supercell().unwrap();
 
         // Verify that all supercell vertices are outside the input range
@@ -2352,7 +2450,8 @@ mod tests {
     fn test_create_supercell_simplex_non_3d() {
         // Test supercell creation for dimensions other than 3D
         let points_1d = vec![Point::new([5.0]), Point::new([15.0])];
-        let tds_1d: Tds<f64, usize, usize, 1> = Tds::new(points_1d);
+        let vertices_1d = Vertex::from_points(points_1d);
+        let tds_1d: Tds<f64, usize, usize, 1> = Tds::new(vertices_1d);
         let supercell_1d = tds_1d.supercell().unwrap();
         assert_eq!(supercell_1d.vertices().len(), 2); // 1D simplex has 2 vertices
 
@@ -2360,7 +2459,8 @@ mod tests {
             Point::new([0.0, 0.0, 0.0, 0.0, 0.0]),
             Point::new([10.0, 10.0, 10.0, 10.0, 10.0]),
         ];
-        let tds_5d: Tds<f64, usize, usize, 5> = Tds::new(points_5d);
+        let vertices_5d = Vertex::from_points(points_5d);
+        let tds_5d: Tds<f64, usize, usize, 5> = Tds::new(vertices_5d);
         let supercell_5d = tds_5d.supercell().unwrap();
         assert_eq!(supercell_5d.vertices().len(), 6); // 5D simplex has 6 vertices
     }
@@ -2376,7 +2476,8 @@ mod tests {
             Point::new([1.0, 1.0, 0.0]),
             Point::new([1.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 6);
@@ -2405,7 +2506,8 @@ mod tests {
             Point::new([1.0, 1.0, 1.0]),
             Point::new([3.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 10);
@@ -2427,7 +2529,8 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
             Point::new([1.0, 1.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Clear existing neighbors to test assignment logic
@@ -2465,7 +2568,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Clear existing incident cells to test assignment logic
@@ -2502,7 +2606,8 @@ mod tests {
             Point::new([0.0, 1.0, 0.0]),
             Point::new([0.0, 0.0, 1.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         // Add multiple duplicate cells manually
@@ -2534,7 +2639,8 @@ mod tests {
             Point::new([0.0, 2.0, 0.0]),
             Point::new([0.0, 0.0, 2.0]),
         ];
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(points);
+        let vertices = Vertex::from_points(points);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(vertices);
         let mut result = tds.bowyer_watson().unwrap();
 
         if result.number_of_cells() > 0 {

--- a/src/delaunay_core/triangulation_data_structure.rs
+++ b/src/delaunay_core/triangulation_data_structure.rs
@@ -245,9 +245,27 @@ where
     /// ];
     ///
     /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
+    ///
+    /// // Check basic structure
     /// assert_eq!(tds.number_of_vertices(), 4);
     /// assert_eq!(tds.number_of_cells(), 1); // Cells are automatically created via triangulation
     /// assert_eq!(tds.dim(), 3);
+    ///
+    /// // Verify cell creation and structure
+    /// let cells: Vec<_> = tds.cells.values().collect();
+    /// assert!(!cells.is_empty(), "Should have created at least one cell");
+    ///
+    /// // Check that the cell has the correct number of vertices (D+1 for a simplex)
+    /// let cell = &cells[0];
+    /// assert_eq!(cell.vertices().len(), 4, "3D cell should have 4 vertices");
+    ///
+    /// // Verify triangulation validity
+    /// assert!(tds.is_valid().is_ok(), "Triangulation should be valid after creation");
+    ///
+    /// // Check that all vertices are associated with the cell
+    /// for vertex in cell.vertices() {
+    ///     assert!(tds.vertices.contains_key(&vertex.uuid()), "Cell vertex should exist in triangulation");
+    /// }
     /// ```
     ///
     /// Create an empty triangulation:
@@ -290,12 +308,11 @@ where
         };
 
         // Initialize cells using Bowyer-Watson triangulation
-        if let Ok(cells_vector) = tds.bowyer_watson_logic(vertices) {
-            tds.cells = cells_vector
-                .into_iter()
-                .map(|cell| (cell.uuid(), cell))
-                .collect();
-        }
+        let cells_vector = tds.bowyer_watson_logic(vertices)?;
+        tds.cells = cells_vector
+            .into_iter()
+            .map(|cell| (cell.uuid(), cell))
+            .collect();
 
         Ok(tds)
     }

--- a/src/delaunay_core/triangulation_data_structure.rs
+++ b/src/delaunay_core/triangulation_data_structure.rs
@@ -221,6 +221,13 @@ where
     /// A Delaunay triangulation with cells and neighbors aligned, and vertices
     /// associated with cells.
     ///
+    /// # Errors
+    ///
+    /// Returns a `TriangulationValidationError` if:
+    /// - Triangulation computation fails during the Bowyer-Watson algorithm
+    /// - Cell creation or validation fails
+    /// - Neighbor assignment or duplicate cell removal fails
+    ///
     /// # Examples
     ///
     /// Create a new triangulation data structure with 3D vertices:
@@ -237,7 +244,7 @@ where
     ///     VertexBuilder::default().point(Point::new([0.0, 0.0, 1.0])).build().unwrap(),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     /// assert_eq!(tds.number_of_vertices(), 4);
     /// assert_eq!(tds.number_of_cells(), 1); // Cells are automatically created via triangulation
     /// assert_eq!(tds.dim(), 3);
@@ -250,7 +257,7 @@ where
     /// use d_delaunay::delaunay_core::vertex::Vertex;
     ///
     /// let vertices: Vec<Vertex<f64, usize, 3>> = Vec::new();
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     /// assert_eq!(tds.number_of_vertices(), 0);
     /// assert_eq!(tds.dim(), -1);
     /// ```
@@ -268,12 +275,11 @@ where
     ///     VertexBuilder::default().point(Point::new([0.5, 1.0])).build().unwrap(),
     /// ];
     ///
-    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(&vertices);
+    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(&vertices).unwrap();
     /// assert_eq!(tds.number_of_vertices(), 3);
     /// assert_eq!(tds.dim(), 2);
     /// ```
-    #[must_use]
-    pub fn new(vertices: &[Vertex<T, U, D>]) -> Self
+    pub fn new(vertices: &[Vertex<T, U, D>]) -> Result<Self, TriangulationValidationError>
     where
         OPoint<T, Const<D>>: From<[f64; D]>,
         [f64; D]: Default + DeserializeOwned + Serialize + Sized,
@@ -291,7 +297,7 @@ where
                 .collect();
         }
 
-        tds
+        Ok(tds)
     }
 
     /// The `add` function checks if a [Vertex] with the same coordinates already
@@ -322,7 +328,7 @@ where
     /// use d_delaunay::delaunay_core::vertex::{Vertex, VertexBuilder};
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     /// let point = Point::new([1.0, 2.0, 3.0]);
     /// let vertex = VertexBuilder::default().point(point).build().unwrap();
     ///
@@ -338,7 +344,7 @@ where
     /// use d_delaunay::delaunay_core::vertex::{Vertex, VertexBuilder};
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     /// let point = Point::new([1.0, 2.0, 3.0]);
     /// let vertex1 = VertexBuilder::default().point(point).build().unwrap();
     /// let vertex2 = VertexBuilder::default().point(point).build().unwrap(); // Same coordinates
@@ -355,7 +361,7 @@ where
     /// use d_delaunay::delaunay_core::vertex::{Vertex, VertexBuilder};
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     ///
     /// let vertices = vec![
     ///     VertexBuilder::default().point(Point::new([0.0, 0.0, 0.0])).build().unwrap(),
@@ -406,7 +412,7 @@ where
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     /// assert_eq!(tds.number_of_vertices(), 0);
     /// ```
     ///
@@ -417,7 +423,7 @@ where
     /// use d_delaunay::delaunay_core::vertex::{Vertex, VertexBuilder};
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     /// let vertex1 = VertexBuilder::default().point(Point::new([1.0, 2.0, 3.0])).build().unwrap();
     /// let vertex2 = VertexBuilder::default().point(Point::new([4.0, 5.0, 6.0])).build().unwrap();
     ///
@@ -443,7 +449,7 @@ where
     /// ];
     ///
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     /// assert_eq!(tds.number_of_vertices(), 4);
     /// ```
     #[must_use]
@@ -466,7 +472,7 @@ where
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     /// assert_eq!(tds.dim(), -1); // Empty triangulation
     /// ```
     ///
@@ -477,7 +483,7 @@ where
     /// use d_delaunay::delaunay_core::vertex::VertexBuilder;
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     ///
     /// // Start empty
     /// assert_eq!(tds.dim(), -1);
@@ -517,7 +523,7 @@ where
     ///     Point::new([0.5, 1.0]),
     /// ];
     /// let vertices_2d = Vertex::from_points(points_2d);
-    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(&vertices_2d);
+    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(&vertices_2d).unwrap();
     /// assert_eq!(tds_2d.dim(), 2);
     ///
     /// // 4D triangulation with 6 vertices (capped at D=4)
@@ -530,7 +536,7 @@ where
     ///     Point::new([1.0, 1.0, 1.0, 1.0]),
     /// ];
     /// let vertices_4d = Vertex::from_points(points_4d);
-    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(&vertices_4d);
+    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(&vertices_4d).unwrap();
     /// assert_eq!(tds_4d.dim(), 4);
     /// ```
     #[must_use]
@@ -566,7 +572,7 @@ where
     /// ];
     ///
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     /// assert_eq!(tds.number_of_cells(), 1); // Cells are automatically created via triangulation
     /// ```
     ///
@@ -585,8 +591,7 @@ where
     /// ];
     ///
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
-    /// let triangulated = tds.bowyer_watson().unwrap();
+    /// let triangulated: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     /// assert_eq!(triangulated.number_of_cells(), 1); // One tetrahedron for 4 points in 3D
     /// ```
     ///
@@ -596,11 +601,8 @@ where
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
-    /// assert_eq!(tds.number_of_cells(), 0);
-    ///
-    /// let triangulated = tds.bowyer_watson().unwrap();
-    /// assert_eq!(triangulated.number_of_cells(), 0); // Still no cells for empty input
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
+    /// assert_eq!(tds.number_of_cells(), 0); // No cells for empty input
     /// ```
     #[must_use]
     pub fn number_of_cells(&self) -> usize {
@@ -774,8 +776,7 @@ where
     /// ];
     ///
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
-    /// let result = tds.bowyer_watson().unwrap();
+    /// let result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 4);
     /// assert_eq!(result.number_of_cells(), 1); // One tetrahedron
@@ -791,8 +792,7 @@ where
     ///
     /// let points: Vec<Point<f64, 3>> = Vec::new();
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
-    /// let result = tds.bowyer_watson().unwrap();
+    /// let result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 0);
     /// assert_eq!(result.number_of_cells(), 0);
@@ -812,8 +812,7 @@ where
     /// ];
     ///
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 2> = Tds::new(&vertices);
-    /// let result = tds.bowyer_watson().unwrap();
+    /// let result: Tds<f64, usize, usize, 2> = Tds::new(&vertices).unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 3);
     /// assert_eq!(result.number_of_cells(), 1); // One triangle
@@ -835,8 +834,7 @@ where
     /// ];
     ///
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
-    /// let result = tds.bowyer_watson().unwrap();
+    /// let result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
     ///
     /// assert_eq!(result.number_of_vertices(), 5);
     /// assert!(result.number_of_cells() >= 1);
@@ -1292,11 +1290,10 @@ where
     /// ];
     ///
     /// let vertices = Vertex::from_points(points);
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
-    /// let triangulated = tds.bowyer_watson().unwrap();
-    ///
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
+    /// // Note: triangulation is automatically performed in Tds::new
     /// // Validation should pass for a properly triangulated structure
-    /// assert!(triangulated.is_valid().is_ok());
+    /// assert!(tds.is_valid().is_ok());
     /// ```
     ///
     /// Validate an empty triangulation:
@@ -1305,7 +1302,7 @@ where
     /// use d_delaunay::delaunay_core::triangulation_data_structure::Tds;
     /// use d_delaunay::delaunay_core::point::Point;
     ///
-    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     ///
     /// // Empty triangulation should be valid
     /// assert!(tds.is_valid().is_ok());
@@ -1325,9 +1322,9 @@ where
     ///     Point::new([0.5, 1.0]),
     /// ];
     /// let vertices_2d = Vertex::from_points(points_2d);
-    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(&vertices_2d);
-    /// let triangulated_2d = tds_2d.bowyer_watson().unwrap();
-    /// assert!(triangulated_2d.is_valid().is_ok());
+    /// let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(&vertices_2d).unwrap();
+    /// // Note: triangulation is automatically performed in Tds::new
+    /// assert!(tds_2d.is_valid().is_ok());
     ///
     /// // 4D triangulation
     /// let points_4d = vec![
@@ -1338,9 +1335,9 @@ where
     ///     Point::new([0.0, 0.0, 0.0, 1.0]),
     /// ];
     /// let vertices_4d = Vertex::from_points(points_4d);
-    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(&vertices_4d);
-    /// let triangulated_4d = tds_4d.bowyer_watson().unwrap();
-    /// assert!(triangulated_4d.is_valid().is_ok());
+    /// let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(&vertices_4d).unwrap();
+    /// // Note: triangulation is automatically performed in Tds::new
+    /// assert!(tds_4d.is_valid().is_ok());
     /// ```
     ///
     /// Example of validation error handling:
@@ -1351,7 +1348,7 @@ where
     /// use d_delaunay::delaunay_core::vertex::VertexBuilder;
     /// use d_delaunay::delaunay_core::cell::CellBuilder;
     ///
-    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+    /// let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
     ///
     /// // Create a cell with an invalid vertex (infinite coordinate)
     /// let vertices = vec![
@@ -1488,7 +1485,7 @@ mod tests {
 
     #[test]
     fn test_add_vertex_already_exists() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         let point = Point::new([1.0, 2.0, 3.0]);
         let vertex = VertexBuilder::default().point(point).build().unwrap();
@@ -1500,7 +1497,7 @@ mod tests {
 
     #[test]
     fn test_add_vertex_uuid_collision() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         let point1 = Point::new([1.0, 2.0, 3.0]);
         let vertex1 = VertexBuilder::default().point(point1).build().unwrap();
@@ -1530,7 +1527,7 @@ mod tests {
 
     #[test]
     fn test_dim_multiple_vertices() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         // Test empty triangulation
         assert_eq!(tds.dim(), -1);
@@ -1568,7 +1565,7 @@ mod tests {
 
     #[test]
     fn test_supercell_empty_vertices() {
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         let supercell = tds.supercell().unwrap();
         assert_eq!(supercell.vertices().len(), 4); // Should create a 3D simplex with 4 vertices
@@ -1577,7 +1574,7 @@ mod tests {
 
     #[test]
     fn test_bowyer_watson_empty_vertices() {
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
         assert_eq!(tds.is_valid(), Ok(())); // Initially valid with no vertices
     }
 
@@ -1588,7 +1585,7 @@ mod tests {
             Point::new([100.0, 100.0, 100.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         let supercell = tds.supercell().unwrap();
 
         // Assert that supercell has proper dimensions
@@ -1611,14 +1608,14 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let result_tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let result_tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         assert_eq!(result_tds.number_of_vertices(), 4);
         assert_eq!(result_tds.number_of_cells(), 1);
     }
 
     #[test]
     fn test_is_valid_with_invalid_neighbors() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         let point1 = Point::new([0.0, 0.0, 0.0]);
         let point2 = Point::new([1.0, 0.0, 0.0]);
@@ -1652,7 +1649,7 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let mut result_tds = tds;
 
@@ -1676,7 +1673,7 @@ mod tests {
     fn test_bowyer_watson_empty() {
         let points: Vec<Point<f64, 3>> = Vec::new();
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
 
         // Triangulation is automatically done in Tds::new
         assert_eq!(tds.number_of_vertices(), 0);
@@ -1685,7 +1682,7 @@ mod tests {
 
     #[test]
     fn test_number_of_cells() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
         assert_eq!(tds.number_of_cells(), 0);
 
         // Add a cell manually to test the count
@@ -1717,7 +1714,7 @@ mod tests {
         ];
         let vertices = Vertex::from_points(points);
 
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
 
         assert_eq!(tds.number_of_vertices(), 4);
         // After refactoring, Tds::new automatically triangulates, so we expect 1 cell
@@ -1733,7 +1730,7 @@ mod tests {
         let points: Vec<Point<f64, 3>> = Vec::new();
 
         let vertices = Vertex::from_points(points);
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
 
         assert_eq!(tds.number_of_vertices(), 0);
         assert_eq!(tds.number_of_cells(), 0);
@@ -1794,7 +1791,7 @@ mod tests {
             Point::new([10.0, 11.0, 12.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
 
         assert_eq!(tds.number_of_vertices(), 4);
         // After refactoring, Tds::new automatically triangulates, so we expect 1 cell
@@ -1821,7 +1818,7 @@ mod tests {
             Point::new([10.0, 11.0, 12.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         let supercell = tds.supercell();
         let unwrapped_supercell =
             supercell.unwrap_or_else(|err| panic!("Error creating supercell: {err:?}!"));
@@ -1851,7 +1848,7 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         println!(
             "Initial TDS: {} vertices, {} cells",
             tds.number_of_vertices(),
@@ -1889,7 +1886,7 @@ mod tests {
         ];
 
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 4> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 4> = Tds::new(&vertices).unwrap();
         println!("\n=== 4D BOWYER-WATSON TRIANGULATION TEST ===");
         println!(
             "Initial 4D TDS: {} vertices, {} cells",
@@ -1930,7 +1927,7 @@ mod tests {
         ];
 
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 5> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 5> = Tds::new(&vertices).unwrap();
         println!("\n=== 5D BOWYER-WATSON TRIANGULATION TEST ===");
         println!(
             "Initial 5D TDS: {} vertices, {} cells",
@@ -1960,7 +1957,7 @@ mod tests {
         use crate::delaunay_core::vertex::VertexBuilder;
 
         // Test validation with an invalid cell
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         // Create a valid vertex
         let vertex1 = VertexBuilder::default()
@@ -2026,7 +2023,7 @@ mod tests {
             .collect();
 
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let result = tds;
 
@@ -2050,7 +2047,7 @@ mod tests {
         // Test 2D supercell creation
         let points_2d = vec![Point::new([0.0, 0.0]), Point::new([10.0, 10.0])];
         let vertices_2d = Vertex::from_points(points_2d);
-        let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(&vertices_2d);
+        let tds_2d: Tds<f64, usize, usize, 2> = Tds::new(&vertices_2d).unwrap();
         let supercell_2d = tds_2d.supercell().unwrap();
         assert_eq!(supercell_2d.vertices().len(), 3); // Triangle for 2D
 
@@ -2060,7 +2057,7 @@ mod tests {
             Point::new([5.0, 5.0, 5.0, 5.0]),
         ];
         let vertices_4d = Vertex::from_points(points_4d);
-        let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(&vertices_4d);
+        let tds_4d: Tds<f64, usize, usize, 4> = Tds::new(&vertices_4d).unwrap();
         let supercell_4d = tds_4d.supercell().unwrap();
         assert_eq!(supercell_4d.vertices().len(), 5); // 4-simplex for 4D
     }
@@ -2075,7 +2072,7 @@ mod tests {
             Point::new([1.0, 1.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let mut result = tds;
 
@@ -2106,7 +2103,7 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let mut result = tds;
 
@@ -2137,7 +2134,7 @@ mod tests {
             Point::new([1.0, 1.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let result = tds;
 
@@ -2203,7 +2200,7 @@ mod tests {
 
     #[test]
     fn test_validation_with_too_many_neighbors() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         // Create a cell with too many neighbors (more than D+1=4)
         let vertices = vec![
@@ -2247,7 +2244,7 @@ mod tests {
 
     #[test]
     fn test_validation_with_wrong_vertex_count() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         // Create a cell with wrong number of vertices (3 instead of 4 for 3D)
         let vertices = vec![
@@ -2278,7 +2275,7 @@ mod tests {
 
     #[test]
     fn test_validation_with_non_mutual_neighbors() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         // Create two cells
         let vertices1 = vec![
@@ -2350,7 +2347,7 @@ mod tests {
         ];
 
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let result = tds;
 
@@ -2382,7 +2379,7 @@ mod tests {
         ];
 
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         let supercell = tds.supercell().unwrap();
 
         // Verify supercell is even larger
@@ -2408,7 +2405,7 @@ mod tests {
         ];
 
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let mut result = tds;
 
@@ -2442,7 +2439,7 @@ mod tests {
         ];
 
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // Triangulation is automatically done in Tds::new
         let mut result = tds;
 
@@ -2476,7 +2473,7 @@ mod tests {
             Point::new([45.0, 50.0, 55.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let tds: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         let supercell = tds.supercell().unwrap();
 
         // Verify that all supercell vertices are outside the input range
@@ -2505,7 +2502,7 @@ mod tests {
         // Test supercell creation for dimensions other than 3D
         let points_1d = vec![Point::new([5.0]), Point::new([15.0])];
         let vertices_1d = Vertex::from_points(points_1d);
-        let tds_1d: Tds<f64, usize, usize, 1> = Tds::new(&vertices_1d);
+        let tds_1d: Tds<f64, usize, usize, 1> = Tds::new(&vertices_1d).unwrap();
         let supercell_1d = tds_1d.supercell().unwrap();
         assert_eq!(supercell_1d.vertices().len(), 2); // 1D simplex has 2 vertices
 
@@ -2514,7 +2511,7 @@ mod tests {
             Point::new([10.0, 10.0, 10.0, 10.0, 10.0]),
         ];
         let vertices_5d = Vertex::from_points(points_5d);
-        let tds_5d: Tds<f64, usize, usize, 5> = Tds::new(&vertices_5d);
+        let tds_5d: Tds<f64, usize, usize, 5> = Tds::new(&vertices_5d).unwrap();
         let supercell_5d = tds_5d.supercell().unwrap();
         assert_eq!(supercell_5d.vertices().len(), 6); // 5D simplex has 6 vertices
     }
@@ -2531,7 +2528,7 @@ mod tests {
             Point::new([1.0, 0.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let result: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 6);
@@ -2561,7 +2558,7 @@ mod tests {
             Point::new([3.0, 1.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let result: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // let result = tds.bowyer_watson().unwrap();
 
         assert_eq!(result.number_of_vertices(), 10);
@@ -2584,7 +2581,7 @@ mod tests {
             Point::new([1.0, 1.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // let mut result = tds.bowyer_watson().unwrap();
 
         // Clear existing neighbors to test assignment logic
@@ -2623,7 +2620,7 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // let mut result = tds.bowyer_watson().unwrap();
 
         // Clear existing incident cells to test assignment logic
@@ -2661,7 +2658,7 @@ mod tests {
             Point::new([0.0, 0.0, 1.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // let mut result = tds.bowyer_watson().unwrap();
 
         // Add multiple duplicate cells manually
@@ -2705,7 +2702,7 @@ mod tests {
             Point::new([0.0, 0.0, 2.0]),
         ];
         let vertices = Vertex::from_points(points);
-        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices);
+        let mut result: Tds<f64, usize, usize, 3> = Tds::new(&vertices).unwrap();
         // let mut result = tds.bowyer_watson().unwrap();
 
         if result.number_of_cells() > 0 {
@@ -2746,7 +2743,7 @@ mod tests {
     #[test]
     fn test_validation_edge_cases() {
         // Test validation with cells that have exactly D neighbors
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         let vertices = vec![
             VertexBuilder::default()
@@ -2785,7 +2782,7 @@ mod tests {
 
     #[test]
     fn test_validation_shared_facet_count() {
-        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]);
+        let mut tds: Tds<f64, usize, usize, 3> = Tds::new(&[]).unwrap();
 
         // Create two cells that share some but not enough vertices
         let shared_vertices = vec![


### PR DESCRIPTION
This pull request includes a small change to the `cspell.json` file. The change adds the word "circumspheres" to the list of recognized terms.This pull request introduces significant updates to the `src/delaunay_core/triangulation_data_structure.rs` file, transitioning the triangulation data structure from using `Point` objects to `Vertex` objects. This change improves the clarity and consistency of the codebase by aligning the terminology and functionality with the underlying data structure. Additionally, the `cspell.json` file is updated to include a new term.

### Terminology and Functionality Update in `src/delaunay_core/triangulation_data_structure.rs`:

* **Refactor `new` method**: The `new` method now initializes the triangulation data structure using a `Vec<Vertex<T, U, D>>` instead of `Vec<Point<T, D>>`. This aligns with the updated design where vertices are constructed from points and encapsulate additional metadata.

* **Examples and Tests Updated**: All examples and tests in the file have been updated to reflect the use of `Vertex` objects instead of `Point` objects. This includes changes to example code snippets, function calls, and assertions in both documentation and test cases. [[1]](diffhunk://#diff-114f989e8c22ce3abd71417f8770647c4b8032593b657212d11d91c31ec557b1L212-R226) [[2]](diffhunk://#diff-114f989e8c22ce3abd71417f8770647c4b8032593b657212d11d91c31ec557b1L1461-R1482) [[3]](diffhunk://#diff-114f989e8c22ce3abd71417f8770647c4b8032593b657212d11d91c31ec557b1R1612-R1614)

* **Integration of `VertexBuilder`**: In examples, `VertexBuilder` is used to construct vertices from points, ensuring consistency and proper initialization of vertex objects. [[1]](diffhunk://#diff-114f989e8c22ce3abd71417f8770647c4b8032593b657212d11d91c31ec557b1R248-R266) [[2]](diffhunk://#diff-114f989e8c22ce3abd71417f8770647c4b8032593b657212d11d91c31ec557b1R778-R787)

### Miscellaneous Updates:

* **Addition to `cspell.json`**: The term "circumspheres" is added to the spell-check configuration file to support terminology used in the codebase.