### PR TITLE
refactor: simplify trait bounds and re-export secondary maps

### DIFF
--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -47,7 +47,7 @@ use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
 use crate::geometry::predicates::Orientation;
 use crate::geometry::robust_predicates::robust_orientation;
-use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarSummable};
+use crate::geometry::traits::coordinate::CoordinateScalar;
 use slotmap::Key;
 use std::collections::VecDeque;
 use std::fmt;
@@ -89,7 +89,6 @@ fn repair_delaunay_with_flips_k2_k3_attempt<K, U, V, const D: usize>(
 ) -> Result<DelaunayRepairStats, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -536,7 +535,6 @@ fn is_delaunay_violation_k3<K, U, V, const D: usize>(
 ) -> Result<bool, FlipError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -1724,7 +1722,6 @@ fn delaunay_violation_k2_for_facet<K, U, V, const D: usize>(
 ) -> Result<bool, FlipError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -1906,7 +1903,6 @@ fn is_delaunay_violation_k2<K, U, V, const D: usize>(
 ) -> Result<bool, FlipError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2158,7 +2154,6 @@ fn delaunay_violation_k3_for_ridge<K, U, V, const D: usize>(
 ) -> Result<bool, FlipError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2339,7 +2334,6 @@ fn repair_delaunay_with_flips_k2_attempt<K, U, V, const D: usize>(
 ) -> Result<DelaunayRepairStats, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2534,7 +2528,6 @@ pub(crate) fn repair_delaunay_with_flips_k2_k3<K, U, V, const D: usize>(
 ) -> Result<DelaunayRepairStats, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2654,7 +2647,6 @@ pub(crate) fn repair_delaunay_local_single_pass<K, U, V, const D: usize>(
 ) -> Result<DelaunayRepairStats, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2767,7 +2759,6 @@ pub fn verify_delaunay_via_flip_predicates<K, U, V, const D: usize>(
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2781,7 +2772,6 @@ fn verify_repair_postcondition<K, U, V, const D: usize>(
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2795,7 +2785,6 @@ fn verify_repair_postcondition_locally<K, U, V, const D: usize>(
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2881,7 +2870,6 @@ fn verify_postcondition_k2_facets<K, U, V, const D: usize>(
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -2976,7 +2964,6 @@ fn verify_postcondition_k3_ridges<K, U, V, const D: usize>(
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -3053,7 +3040,6 @@ fn verify_postcondition_inverse_k2_edges<K, U, V, const D: usize>(
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -3134,7 +3120,6 @@ fn verify_postcondition_inverse_k3_triangles<K, U, V, const D: usize>(
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -3761,7 +3746,6 @@ fn process_ridge_queue_step<K, U, V, const D: usize>(
 ) -> Result<bool, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -3936,7 +3920,6 @@ fn process_edge_queue_step<K, U, V, const D: usize>(
 ) -> Result<bool, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -4108,7 +4091,6 @@ fn process_triangle_queue_step<K, U, V, const D: usize>(
 ) -> Result<bool, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -4274,7 +4256,6 @@ fn process_facet_queue_step<K, U, V, const D: usize>(
 ) -> Result<bool, DelaunayRepairError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -27,9 +27,7 @@ use crate::core::triangulation_data_structure::{CellKey, Tds, VertexKey};
 use crate::core::util::canonical_points::{sorted_cell_points, sorted_facet_points_with_extra};
 use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{
-    CoordinateConversionError, CoordinateScalar, ScalarSummable,
-};
+use crate::geometry::traits::coordinate::{CoordinateConversionError, CoordinateScalar};
 use std::hash::{Hash, Hasher};
 #[cfg(debug_assertions)]
 #[derive(Debug, Clone, Copy)]
@@ -407,7 +405,6 @@ pub fn locate<K, U, V, const D: usize>(
 ) -> Result<LocateResult, LocateError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -453,11 +450,10 @@ pub fn locate_with_stats<K, U, V, const D: usize>(
 ) -> Result<(LocateResult, LocateStats), LocateError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
-    const MAX_STEPS: usize = 10000; // Safety limit; cycles/step limits fall back to a scan
+    const MAX_STEPS: usize = 10000;
 
     if tds.number_of_cells() == 0 {
         return Err(LocateError::EmptyTriangulation);
@@ -537,7 +533,6 @@ pub(crate) fn locate_by_scan<K, U, V, const D: usize>(
 ) -> Result<LocateResult, LocateError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -595,7 +590,6 @@ fn is_point_outside_facet<K, U, V, const D: usize>(
 ) -> Result<Option<bool>, LocateError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {
@@ -724,7 +718,6 @@ pub fn find_conflict_region<K, U, V, const D: usize>(
 ) -> Result<CellKeyBuffer, ConflictError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarSummable,
     U: DataType,
     V: DataType,
 {

--- a/src/core/collections/secondary_maps.rs
+++ b/src/core/collections/secondary_maps.rs
@@ -37,7 +37,7 @@ use slotmap::SparseSecondaryMap;
 /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
 /// let tds = dt.tds();
 ///
-/// use delaunay::core::collections::CellSecondaryMap;
+/// use delaunay::prelude::collections::CellSecondaryMap;
 /// let mut in_conflict: CellSecondaryMap<bool> = CellSecondaryMap::new();
 /// for (cell_key, _) in tds.cells() {
 ///     in_conflict.insert(cell_key, true);
@@ -77,7 +77,7 @@ pub type CellSecondaryMap<V> = SparseSecondaryMap<CellKey, V>;
 /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
 /// let tds = dt.tds();
 ///
-/// use delaunay::core::collections::VertexSecondaryMap;
+/// use delaunay::prelude::collections::VertexSecondaryMap;
 /// let mut processing_order: VertexSecondaryMap<usize> = VertexSecondaryMap::new();
 /// for (idx, (vertex_key, _)) in tds.vertices().enumerate() {
 ///     processing_order.insert(vertex_key, idx);

--- a/src/core/delaunay_triangulation.rs
+++ b/src/core/delaunay_triangulation.rs
@@ -4560,10 +4560,7 @@ where
     /// assert_eq!(cell_vertices.len(), 3); // D+1 for a 2D simplex
     /// ```
     #[must_use]
-    pub fn cell_vertices(&self, c: CellKey) -> Option<&[VertexKey]>
-    where
-        K::Scalar: CoordinateScalar,
-    {
+    pub fn cell_vertices(&self, c: CellKey) -> Option<&[VertexKey]> {
         self.as_triangulation().cell_vertices(c)
     }
 
@@ -4595,10 +4592,7 @@ where
     /// assert_eq!(dt.vertex_coords(v_key).unwrap(), [1.0, 0.0]);
     /// ```
     #[must_use]
-    pub fn vertex_coords(&self, v: VertexKey) -> Option<&[K::Scalar]>
-    where
-        K::Scalar: CoordinateScalar,
-    {
+    pub fn vertex_coords(&self, v: VertexKey) -> Option<&[K::Scalar]> {
         self.as_triangulation().vertex_coords(v)
     }
 
@@ -5245,10 +5239,7 @@ where
     /// // Levels 1–4: elements + structure + topology + Delaunay property
     /// assert!(dt.validate().is_ok());
     /// ```
-    pub fn validate(&self) -> Result<(), DelaunayTriangulationValidationError>
-    where
-        K::Scalar: CoordinateScalar,
-    {
+    pub fn validate(&self) -> Result<(), DelaunayTriangulationValidationError> {
         self.tri.validate().map_err(|e| match e {
             InvariantError::Tds(tds_err) => DelaunayTriangulationValidationError::Tds(tds_err),
             InvariantError::Triangulation(tri_err) => {
@@ -5379,10 +5370,7 @@ where
     /// let report = dt.validation_report();
     /// assert!(report.is_ok());
     /// ```
-    pub fn validation_report(&self) -> Result<(), TriangulationValidationReport>
-    where
-        K::Scalar: CoordinateScalar,
-    {
+    pub fn validation_report(&self) -> Result<(), TriangulationValidationReport> {
         // Levels 1–3: reuse the Triangulation layer report.
         match self.tri.validation_report() {
             Ok(()) => {

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -804,7 +804,6 @@ where
 impl<K, U, V, const D: usize> Triangulation<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -673,7 +673,6 @@ where
     K::Scalar: ScalarAccumulative + Sub<Output = K::Scalar> + DivAssign + Copy,
     U: DataType,
     V: DataType,
-    [K::Scalar; D]: Copy + Sized,
 {
     /// Creates a new convex hull from a d-dimensional triangulation
     ///
@@ -1577,10 +1576,8 @@ where
 impl<K, U, V, const D: usize> Default for ConvexHull<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
-    [K::Scalar; D]: Copy + Sized,
 {
     fn default() -> Self {
         Self {
@@ -1613,8 +1610,6 @@ mod tests {
     use crate::core::util::{checked_facet_key_from_vertex_keys, facet_view_to_vertices};
     use crate::geometry::kernel::AdaptiveKernel;
     use crate::vertex;
-    use serde::Serialize;
-    use serde::de::DeserializeOwned;
     use std::error::Error;
     use std::sync::atomic::Ordering;
     use std::thread;
@@ -1644,10 +1639,8 @@ mod tests {
     ) -> Result<Vec<Vertex<K::Scalar, U, D>>, ConvexHullConstructionError>
     where
         K: Kernel<D>,
-        K::Scalar: CoordinateScalar,
         U: DataType,
         V: DataType,
-        [K::Scalar; D]: Copy + Sized + Serialize + DeserializeOwned,
     {
         let tds = &tri.tds;
         let facet_view =

--- a/src/geometry/kernel.rs
+++ b/src/geometry/kernel.rs
@@ -28,7 +28,7 @@ use crate::geometry::predicates::{InSphere, Orientation, insphere_lifted, simple
 use crate::geometry::robust_predicates::{robust_insphere, robust_orientation};
 use crate::geometry::sos::exact_det_sign;
 use crate::geometry::traits::coordinate::{
-    Coordinate, CoordinateConversionError, CoordinateScalar, ScalarSummable,
+    Coordinate, CoordinateConversionError, CoordinateScalar,
 };
 use crate::geometry::util::{safe_coords_to_f64, safe_scalar_to_f64, squared_norm};
 use core::marker::PhantomData;
@@ -300,7 +300,7 @@ impl<T: CoordinateScalar> FastKernel<T> {
 
 impl<T, const D: usize> Kernel<D> for FastKernel<T>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     type Scalar = T;
 
@@ -408,7 +408,7 @@ impl<T: CoordinateScalar> RobustKernel<T> {
 
 impl<T, const D: usize> Kernel<D> for RobustKernel<T>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     type Scalar = T;
 
@@ -514,7 +514,7 @@ impl<T: CoordinateScalar> AdaptiveKernel<T> {
 
 impl<T, const D: usize> Kernel<D> for AdaptiveKernel<T>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     type Scalar = T;
 

--- a/src/geometry/predicates.rs
+++ b/src/geometry/predicates.rs
@@ -9,7 +9,7 @@
 use crate::core::cell::CellValidationError;
 use crate::geometry::matrix::{matrix_get, matrix_set, matrix_zero_like};
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{CoordinateConversionError, ScalarSummable};
+use crate::geometry::traits::coordinate::{CoordinateConversionError, CoordinateScalar};
 use crate::geometry::util::{
     circumcenter, circumradius_with_center, hypot, safe_coords_to_f64, safe_scalar_to_f64,
     squared_norm,
@@ -261,7 +261,7 @@ pub fn simplex_orientation<T, const D: usize>(
     simplex_points: &[Point<T, D>],
 ) -> Result<Orientation, CoordinateConversionError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     if simplex_points.len() != D + 1 {
         return Err(CoordinateConversionError::ConversionFailed {
@@ -362,7 +362,7 @@ pub fn insphere_distance<T, const D: usize>(
     test_point: Point<T, D>,
 ) -> Result<InSphere, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     let circumcenter = circumcenter(simplex_points)?;
     let circumradius = circumradius_with_center(simplex_points, &circumcenter)?;
@@ -519,7 +519,7 @@ pub fn insphere<T, const D: usize>(
     test_point: Point<T, D>,
 ) -> Result<InSphere, CoordinateConversionError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     if simplex_points.len() != D + 1 {
         return Err(CoordinateConversionError::ConversionFailed {
@@ -723,7 +723,7 @@ pub fn insphere_lifted<T, const D: usize>(
     test_point: Point<T, D>,
 ) -> Result<InSphere, CellValidationError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     if simplex_points.len() != D + 1 {
         return Err(CellValidationError::InsufficientVertices {
@@ -1759,7 +1759,7 @@ mod tests {
         dimension: usize,
         orientation_label: &str,
     ) where
-        T: ScalarSummable,
+        T: CoordinateScalar,
     {
         let orientation = simplex_orientation(simplex).unwrap();
         assert_eq!(

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -42,7 +42,7 @@ use crate::core::{
 use crate::geometry::{
     kernel::Kernel,
     point::Point,
-    traits::coordinate::{ScalarAccumulative, ScalarSummable},
+    traits::coordinate::{CoordinateScalar, ScalarAccumulative},
     util::{circumradius, hypot, inradius as simplex_inradius, simplex_volume},
 };
 use num_traits::{NumCast, One};
@@ -141,7 +141,7 @@ fn compute_scale_aware_epsilon<T, const D: usize>(
     points: &SmallBuffer<Point<T, D>, MAX_PRACTICAL_DIMENSION_SIZE>,
 ) -> Result<(T, T), QualityError>
 where
-    T: ScalarSummable + AddAssign<T>,
+    T: CoordinateScalar + AddAssign<T>,
 {
     let mut total_edge_length = T::zero();
     let mut edge_count = 0;

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -13,7 +13,7 @@ use super::util::{safe_coords_to_f64, safe_scalar_to_f64, squared_norm};
 use crate::geometry::matrix::matrix_set;
 use crate::geometry::point::Point;
 use crate::geometry::traits::coordinate::{
-    Coordinate, CoordinateConversionError, CoordinateScalar, ScalarSummable,
+    Coordinate, CoordinateConversionError, CoordinateScalar,
 };
 use std::sync::LazyLock;
 
@@ -155,8 +155,7 @@ pub fn robust_insphere<T, const D: usize>(
     test_point: &Point<T, D>,
 ) -> Result<InSphere, CoordinateConversionError>
 where
-    T: ScalarSummable,
-    [T; D]: Copy + Sized,
+    T: CoordinateScalar,
 {
     if simplex_points.len() != D + 1 {
         return Err(CoordinateConversionError::ConversionFailed {
@@ -249,7 +248,6 @@ fn fill_insphere_predicate_matrix<T, const D: usize, const K: usize>(
 ) -> Result<(), CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Sized,
 {
     debug_assert_eq!(K, D + 2);
 
@@ -303,7 +301,6 @@ fn adaptive_tolerance_insphere<T, const D: usize>(
 ) -> Result<InSphere, CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Sized,
 {
     // Get simplex orientation for correct interpretation.
     let orientation = robust_orientation(simplex_points)?;
@@ -358,7 +355,6 @@ pub fn robust_orientation<T, const D: usize>(
 ) -> Result<Orientation, CoordinateConversionError>
 where
     T: CoordinateScalar,
-    [T; D]: Copy + Sized,
 {
     if simplex_points.len() != D + 1 {
         return Err(CoordinateConversionError::ConversionFailed {
@@ -429,8 +425,7 @@ fn verify_insphere_consistency<T, const D: usize>(
     determinant_result: InSphere,
 ) -> ConsistencyResult
 where
-    T: ScalarSummable,
-    [T; D]: Copy + Sized,
+    T: CoordinateScalar,
 {
     // Use the existing distance-based insphere test for verification
     super::predicates::insphere_distance(simplex_points, *test_point).map_or(

--- a/src/geometry/util/circumsphere.rs
+++ b/src/geometry/util/circumsphere.rs
@@ -9,7 +9,7 @@ use super::conversions::{safe_coords_to_f64, safe_scalar_from_f64, safe_scalar_t
 use super::norms::{hypot, squared_norm};
 use crate::geometry::matrix::matrix_set;
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{Coordinate, ScalarSummable};
+use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
 use la_stack::{DEFAULT_PIVOT_TOL, LaError, Vector as LaVector};
 
 // Re-export error type
@@ -84,7 +84,7 @@ pub fn circumcenter<T, const D: usize>(
     points: &[Point<T, D>],
 ) -> Result<Point<T, D>, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     #[cfg(debug_assertions)]
     if std::env::var_os("DELAUNAY_DEBUG_UNUSED_IMPORTS").is_some() {
@@ -218,7 +218,7 @@ where
 /// ```
 pub fn circumradius<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     let circumcenter = circumcenter(points)?;
     circumradius_with_center(points, &circumcenter)
@@ -267,7 +267,7 @@ pub fn circumradius_with_center<T, const D: usize>(
     circumcenter: &Point<T, D>,
 ) -> Result<T, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     if points.is_empty() {
         return Err(CircumcenterError::EmptyPointSet);

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -11,7 +11,7 @@ use crate::core::facet::FacetView;
 use crate::core::traits::data_type::DataType;
 use crate::geometry::matrix::{Matrix, matrix_get, matrix_set};
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{Coordinate, ScalarAccumulative, ScalarSummable};
+use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar, ScalarAccumulative};
 use la_stack::{DEFAULT_SINGULAR_TOL, LaError};
 use num_traits::Float;
 use std::ops::AddAssign;
@@ -77,7 +77,7 @@ pub use super::{CircumcenterError, SurfaceMeasureError, ValueConversionError};
 /// ```
 pub fn simplex_volume<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     #[cfg(debug_assertions)]
     if std::env::var_os("DELAUNAY_DEBUG_UNUSED_IMPORTS").is_some() {
@@ -274,7 +274,7 @@ fn simplex_volume_gram_matrix<T, const D: usize>(
     points: &[Point<T, D>],
 ) -> Result<T, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     // Convert points to f64 and create edge vectors from first point to all others
     let p0_coords = points[0].coords();
@@ -369,7 +369,7 @@ where
 /// ```
 pub fn inradius<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where
-    T: ScalarSummable + AddAssign<T>,
+    T: CoordinateScalar + AddAssign<T>,
 {
     if points.len() != D + 1 {
         return Err(CircumcenterError::InvalidSimplex {
@@ -496,7 +496,7 @@ where
 /// ```
 pub fn facet_measure<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     if points.len() != D {
         return Err(CircumcenterError::InvalidSimplex {
@@ -625,7 +625,7 @@ fn facet_measure_gram_matrix<T, const D: usize>(
     points: &[Point<T, D>],
 ) -> Result<T, CircumcenterError>
 where
-    T: ScalarSummable,
+    T: CoordinateScalar,
 {
     // Convert points to f64.
     let mut coords_f64 = [[0.0f64; D]; D];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -850,8 +850,9 @@ pub mod prelude {
     // Re-export commonly used collection types from core::collections
     // These are frequently used in advanced examples and downstream code
     pub use crate::core::collections::{
-        CellNeighborsMap, FacetToCellsMap, FastHashMap, FastHashSet, SmallBuffer, VertexToCellsMap,
-        fast_hash_map_with_capacity, fast_hash_set_with_capacity,
+        CellNeighborsMap, CellSecondaryMap, FacetToCellsMap, FastHashMap, FastHashSet, SmallBuffer,
+        VertexSecondaryMap, VertexToCellsMap, fast_hash_map_with_capacity,
+        fast_hash_set_with_capacity,
     };
 
     // Re-export from geometry
@@ -896,8 +897,9 @@ pub mod prelude {
     /// Focused exports for collection types used throughout the crate.
     pub mod collections {
         pub use crate::core::collections::{
-            CellNeighborsMap, FacetToCellsMap, FastHashMap, FastHashSet, SmallBuffer,
-            VertexToCellsMap, fast_hash_map_with_capacity, fast_hash_set_with_capacity,
+            CellNeighborsMap, CellSecondaryMap, FacetToCellsMap, FastHashMap, FastHashSet,
+            SmallBuffer, VertexSecondaryMap, VertexToCellsMap, fast_hash_map_with_capacity,
+            fast_hash_set_with_capacity,
         };
     }
 

--- a/src/triangulation/flips.rs
+++ b/src/triangulation/flips.rs
@@ -25,8 +25,6 @@ use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
-use crate::geometry::traits::coordinate::CoordinateScalar;
-
 /// High-level triangulation editing operations via bistellar flips.
 ///
 /// # Example
@@ -56,7 +54,6 @@ use crate::geometry::traits::coordinate::CoordinateScalar;
 pub trait BistellarFlips<K, U, V, const D: usize>
 where
     K: Kernel<D>,
-    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -221,7 +218,6 @@ where
 impl<K, U, V, const D: usize> BistellarFlips<K, U, V, D> for Triangulation<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -275,7 +271,6 @@ where
 impl<K, U, V, const D: usize> BistellarFlips<K, U, V, D> for DelaunayTriangulation<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {


### PR DESCRIPTION
- Re-export VertexSecondaryMap and CellSecondaryMap in prelude and prelude::collections; update doc examples to use prelude path
- Replace ~50 vestigial ScalarSummable bounds with CoordinateScalar across geometry and core modules (Sum is never called on T)
- Remove ~34 redundant K::Scalar: CoordinateScalar where clauses already implied by K: Kernel<D> (associated type bound)
- Remove 8 redundant [T; D]: Copy + Sized bounds already implied by T: CoordinateScalar (Float → Copy; arrays are always Sized)
- Keep ScalarSummable trait definition and blanket impl for future use

Closes #275
Closes #281