### PR TITLE
feat: add explicit construction from vertices and cells (#293)

### DIFF
--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -469,20 +469,12 @@ where
         }
     }
 
-    /// Creates a builder for explicit combinatorial construction from `f64` vertices
-    /// and cell specifications.
+    /// `f64` convenience wrapper for
+    /// [`from_vertices_and_cells`](Self::from_vertices_and_cells).
     ///
-    /// This constructs a triangulation directly from the given connectivity,
-    /// **without** Delaunay point insertion. The result is a valid triangulation
-    /// (Levels 1–3: elements, structure, topology) but the Delaunay property
-    /// (Level 4) is **not** guaranteed.
-    ///
-    /// Each cell specification must contain exactly `D+1` vertex indices into
-    /// the `vertices` slice.
-    ///
-    /// To optionally repair to Delaunay after construction, call
-    /// [`repair_delaunay_with_flips`](DelaunayTriangulation::repair_delaunay_with_flips)
-    /// on the result.
+    /// Pins `T = f64` so that callers using the default `AdaptiveKernel` never
+    /// need explicit type annotations. For non-`f64` scalars, use the generic
+    /// version on the `T: CoordinateScalar` impl block.
     ///
     /// # Examples
     ///
@@ -496,10 +488,7 @@ where
     ///     vertex!([1.0, 1.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let cells = vec![
-    ///     vec![0, 1, 2],
-    ///     vec![0, 2, 3],
-    /// ];
+    /// let cells = vec![vec![0, 1, 2], vec![0, 2, 3]];
     ///
     /// let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
     ///     .build::<()>()
@@ -1147,8 +1136,6 @@ where
 
         // --- Normalize orientation ---
         if let Err(_err) = tds.normalize_coherent_orientation() {
-            // Best-effort: some configurations may not normalize cleanly.
-            // Defer hard failure to the subsequent is_valid() check.
             #[cfg(debug_assertions)]
             tracing::debug!(
                 ?_err,
@@ -1156,19 +1143,50 @@ where
             );
         }
 
-        // --- Validate Levels 1–3 ---
-        if let Err(e) = tds.is_valid() {
+        // --- Validate Levels 1–3 (structural + topology) ---
+        //
+        // We construct the DT first so that the Triangulation-layer topology
+        // checks (connectedness, isolated vertices, Euler characteristic,
+        // manifold facets, vertex/ridge links) run against the assembled
+        // complex.  Geometric orientation is NOT checked: the user-provided
+        // vertex orderings may produce negative determinants that are valid
+        // for non-Delaunay meshes.
+        let dt = DelaunayTriangulation::from_tds_with_topology_guarantee(
+            tds,
+            kernel.clone(),
+            topology_guarantee,
+        );
+
+        // Level 1–2: TDS structural validation (mappings, neighbors, facet
+        // sharing, coherent orientation, etc.).
+        if let Err(e) = dt.tri.tds.validate() {
             return Err(ExplicitConstructionError::ValidationFailed {
-                message: format!("TDS validation failed: {e}"),
+                message: format!("structural validation failed: {e}"),
             }
             .into());
         }
 
-        Ok(DelaunayTriangulation::from_tds_with_topology_guarantee(
-            tds,
-            kernel.clone(),
-            topology_guarantee,
-        ))
+        // Level 3 (topology, excluding geometric orientation): connectedness,
+        // manifold facets, isolated vertices, Euler characteristic, and
+        // PL-manifold vertex/ridge links when the topology guarantee requires
+        // them.  We call `is_valid()` which covers all these; the only check
+        // we intentionally omit is `validate_geometric_cell_orientation`.
+        if let Err(e) = dt.tri.is_valid_topology_only() {
+            return Err(ExplicitConstructionError::ValidationFailed {
+                message: format!("topology validation failed: {e}"),
+            }
+            .into());
+        }
+
+        // Completion-time PL-manifold check (vertex links) if required.
+        if let Err(e) = dt.tri.validate_at_completion() {
+            return Err(ExplicitConstructionError::ValidationFailed {
+                message: format!("PL-manifold completion validation failed: {e}"),
+            }
+            .into());
+        }
+
+        Ok(dt)
     }
 
     /// Builds a true periodic (toroidal) Delaunay triangulation using the 3^D image-point method.

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -360,6 +360,18 @@ pub enum ExplicitConstructionError {
     /// Toroidal topology is incompatible with explicit cell construction.
     #[error("Toroidal topology cannot be combined with explicit cell construction")]
     IncompatibleTopology,
+    /// Non-default [`ConstructionOptions`] were set on an explicit-cell builder.
+    ///
+    /// [`ConstructionOptions`] (insertion order, deduplication, retry policy) apply
+    /// only to the Delaunay point-insertion path and are not meaningful for
+    /// explicit cell construction.
+    ///
+    /// [`ConstructionOptions`]: crate::core::delaunay_triangulation::ConstructionOptions
+    #[error(
+        "ConstructionOptions are not applicable to explicit cell construction \
+         and must be left at their default values"
+    )]
+    UnsupportedConstructionOptions,
     /// The assembled TDS failed post-assembly validation.
     ///
     /// The caller-provided cells passed input validation but the resulting
@@ -493,11 +505,12 @@ where
     }
 
     /// `f64` convenience wrapper for
-    /// [`from_vertices_and_cells`](Self::from_vertices_and_cells).
+    /// [`from_vertices_and_cells_generic`](Self::from_vertices_and_cells_generic).
     ///
     /// Pins `T = f64` so that callers using the default `AdaptiveKernel` never
     /// need explicit type annotations. For non-`f64` scalars, use the generic
-    /// version on the `T: CoordinateScalar` impl block.
+    /// [`from_vertices_and_cells_generic`](Self::from_vertices_and_cells_generic)
+    /// on the `T: CoordinateScalar` impl block.
     ///
     /// # Examples
     ///
@@ -1020,12 +1033,7 @@ where
                 return Err(ExplicitConstructionError::IncompatibleTopology.into());
             }
             if self.construction_options != ConstructionOptions::default() {
-                return Err(ExplicitConstructionError::ValidationFailed {
-                    message: "ConstructionOptions are not applicable to explicit cell \
-                              construction and must be left at their default values"
-                        .to_string(),
-                }
-                .into());
+                return Err(ExplicitConstructionError::UnsupportedConstructionOptions.into());
             }
             return Self::build_explicit(kernel, self.vertices, cells, self.topology_guarantee);
         }
@@ -1115,9 +1123,13 @@ where
     /// 1. Validate input: each cell has D+1 in-bounds, unique vertex indices.
     /// 2. Build a `Tds`: insert all vertices, then insert cells from the specifications.
     /// 3. Compute adjacency via `assign_neighbors()`.
-    /// 4. Assign incident cells and normalize orientation.
-    /// 5. Validate structural integrity (`tds.is_valid()`).
+    /// 4. Assign incident cells via `assign_incident_cells()`.
+    /// 5. Normalize coherent orientation via `normalize_coherent_orientation()`.
     /// 6. Wrap in `DelaunayTriangulation` via `from_tds_with_topology_guarantee`.
+    /// 7. Validate Levels 1–2 (TDS structural: `tds.validate()`).
+    /// 8. Validate Level 3 topology (excluding geometric orientation).
+    /// 9. Validate PL-manifold completion (vertex links, if required).
+    /// 10. Validate geometric nondegeneracy (reject zero-volume cells).
     fn build_explicit<K, V>(
         kernel: &K,
         vertices: &[Vertex<T, U, D>],

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -295,12 +295,19 @@ fn search_closed_2d_selection(
 // ERROR TYPES
 // =============================================================================
 
-/// Input validation errors for explicit triangulation construction.
+/// Errors from explicit triangulation construction.
 ///
-/// These errors represent invalid inputs to
-/// [`from_vertices_and_cells`](DelaunayTriangulationBuilder::from_vertices_and_cells).
-/// TDS assembly errors (vertex/cell insertion, neighbor wiring, validation) flow
-/// through the existing [`TriangulationConstructionError`] hierarchy.
+/// Input validation errors (wrong arity, out-of-bounds indices, duplicate vertices,
+/// empty cells) and post-assembly failures (neighbor wiring, orientation
+/// normalization, structural/topology/nondegeneracy validation) are returned as
+/// variants of this enum — callers should match on
+/// [`ExplicitConstructionError`] (wrapped in
+/// [`DelaunayTriangulationConstructionError::ExplicitConstruction`]).
+///
+/// Only low-level TDS insertion failures (vertex/cell creation) flow through
+/// [`TriangulationConstructionError`].
+///
+/// [`DelaunayTriangulationConstructionError::ExplicitConstruction`]: crate::core::delaunay_triangulation::DelaunayTriangulationConstructionError::ExplicitConstruction
 ///
 /// # Examples
 ///
@@ -1124,8 +1131,9 @@ where
     /// 2. Build a `Tds`: insert all vertices, then insert cells from the specifications.
     /// 3. Compute adjacency via `assign_neighbors()`.
     /// 4. Assign incident cells via `assign_incident_cells()`.
-    /// 5. Normalize coherent orientation via `normalize_coherent_orientation()`.
-    /// 6. Wrap in `DelaunayTriangulation` via `from_tds_with_topology_guarantee`.
+    /// 5. Wrap in `DelaunayTriangulation` via `from_tds_with_topology_guarantee`.
+    /// 6. Normalize coherent orientation and promote to positive canonical sign
+    ///    via `normalize_and_promote_positive_orientation()`.
     /// 7. Validate Levels 1–2 (TDS structural: `tds.validate()`).
     /// 8. Validate Level 3 topology (excluding geometric orientation).
     /// 9. Validate PL-manifold completion (vertex links, if required).
@@ -1216,26 +1224,30 @@ where
             }
         })?;
 
-        // --- Normalize orientation ---
-        tds.normalize_coherent_orientation().map_err(|e| {
-            ExplicitConstructionError::ValidationFailed {
-                message: format!("coherent orientation normalization failed: {e}"),
-            }
-        })?;
-
-        // --- Validate Levels 1–3 (structural + topology) ---
+        // --- Wrap in DelaunayTriangulation ---
         //
-        // We construct the DT first so that the Triangulation-layer topology
-        // checks (connectedness, isolated vertices, Euler characteristic,
-        // manifold facets, vertex/ridge links) run against the assembled
-        // complex.  Geometric orientation is NOT checked: the user-provided
-        // vertex orderings may produce negative determinants that are valid
-        // for non-Delaunay meshes.
-        let dt = DelaunayTriangulation::from_tds_with_topology_guarantee(
+        // Construct the DT first so the Triangulation-layer helpers
+        // (orientation promotion, topology checks) operate on the assembled
+        // complex.
+        let mut dt = DelaunayTriangulation::from_tds_with_topology_guarantee(
             tds,
             kernel.clone(),
             topology_guarantee,
         );
+
+        // --- Normalize orientation and promote to positive ---
+        //
+        // normalize_and_promote_positive_orientation() combines:
+        //   1. BFS coherent-orientation normalization (adjacent cells agree)
+        //   2. Global sign canonicalization (flip all if representative is negative)
+        //   3. Bounded per-cell promotion passes for FP-precision edge cases
+        // This ensures the returned DT has positive geometric orientation,
+        // matching the invariant expected by validate_geometric_cell_orientation.
+        dt.tri
+            .normalize_and_promote_positive_orientation()
+            .map_err(|e| ExplicitConstructionError::ValidationFailed {
+                message: format!("orientation normalization/promotion failed: {e}"),
+            })?;
 
         // Level 1–2: TDS structural validation (mappings, neighbors, facet
         // sharing, coherent orientation, etc.).

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -317,9 +317,7 @@ pub enum ExplicitConstructionError {
         bound: usize,
     },
     /// A cell does not have exactly D+1 vertex indices.
-    #[error(
-        "Cell {cell_index}: has {actual} vertex indices, expected {expected} for a {expected}D simplex"
-    )]
+    #[error("Cell {cell_index}: has {actual} vertex indices, expected {expected} for a simplex")]
     InvalidCellArity {
         /// The index of the cell in the input slice.
         cell_index: usize,
@@ -340,6 +338,16 @@ pub enum ExplicitConstructionError {
     /// Toroidal topology is incompatible with explicit cell construction.
     #[error("Toroidal topology cannot be combined with explicit cell construction")]
     IncompatibleTopology,
+    /// The assembled TDS failed structural validation (Levels 1–3).
+    ///
+    /// The caller-provided cells passed input validation but the resulting
+    /// triangulation violates structural invariants (e.g., non-manifold facet
+    /// sharing, disconnected components, orientation contradictions).
+    #[error("Structural validation failed: {message}")]
+    ValidationFailed {
+        /// Description of the validation failure.
+        message: String,
+    },
 }
 
 // =============================================================================
@@ -1101,12 +1109,10 @@ where
 
         // Insert all vertices and build index → VertexKey map.
         let mut index_to_key = Vec::with_capacity(vertex_count);
-        for (idx, v) in vertices.iter().enumerate() {
-            let vk = tds.insert_vertex_with_mapping(*v).map_err(|e| {
-                TriangulationConstructionError::InternalInconsistency {
-                    message: format!("explicit: vertex {idx} insertion failed: {e}"),
-                }
-            })?;
+        for v in vertices {
+            let vk = tds
+                .insert_vertex_with_mapping(*v)
+                .map_err(TriangulationConstructionError::from)?;
             index_to_key.push(vk);
         }
 
@@ -1119,22 +1125,18 @@ where
                     message: format!("explicit: cell {cell_idx}: {e}"),
                 }
             })?;
-            tds.insert_cell_with_mapping(cell).map_err(|e| {
-                TriangulationConstructionError::InternalInconsistency {
-                    message: format!("explicit: cell {cell_idx} insertion failed: {e}"),
-                }
-            })?;
+            tds.insert_cell_with_mapping(cell)
+                .map_err(TriangulationConstructionError::from)?;
         }
 
         // Mark as constructed so validation doesn't reject incomplete state.
         tds.construction_state = TriangulationConstructionState::Constructed;
 
         // --- Compute adjacency ---
-        tds.assign_neighbors().map_err(|e| {
-            TriangulationConstructionError::InternalInconsistency {
-                message: format!("explicit: neighbor assignment failed: {e}"),
-            }
-        })?;
+        tds.assign_neighbors()
+            .map_err(|e| ExplicitConstructionError::ValidationFailed {
+                message: format!("neighbor assignment failed: {e}"),
+            })?;
 
         // --- Assign incident cells ---
         tds.assign_incident_cells().map_err(|e| {
@@ -1156,8 +1158,8 @@ where
 
         // --- Validate Levels 1–3 ---
         if let Err(e) = tds.is_valid() {
-            return Err(TriangulationConstructionError::InternalInconsistency {
-                message: format!("explicit: TDS validation failed: {e}"),
+            return Err(ExplicitConstructionError::ValidationFailed {
+                message: format!("TDS validation failed: {e}"),
             }
             .into());
         }

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -104,7 +104,7 @@
 #![forbid(unsafe_code)]
 
 use crate::core::cell::Cell;
-use crate::core::collections::{FastHashMap, FastHashSet, Uuid, VertexKeySet};
+use crate::core::collections::{FastHashMap, Uuid, VertexKeySet};
 use crate::core::delaunay_triangulation::{
     ConstructionOptions, DelaunayRepairPolicy, DelaunayTriangulation,
     DelaunayTriangulationConstructionError, InitialSimplexStrategy, RetryPolicy,
@@ -525,14 +525,7 @@ where
         vertices: &'v [Vertex<f64, U, D>],
         cells: &'v [Vec<usize>],
     ) -> Self {
-        Self {
-            vertices,
-            topology: None,
-            topology_guarantee: TopologyGuarantee::DEFAULT,
-            construction_options: ConstructionOptions::default(),
-            use_image_point_method: false,
-            explicit_cells: Some(cells),
-        }
+        Self::from_vertices_and_cells_generic(vertices, cells)
     }
 }
 
@@ -545,6 +538,51 @@ where
     T: CoordinateScalar,
     U: DataType,
 {
+    /// Creates a builder from explicit vertex and cell specifications.
+    ///
+    /// This constructs a triangulation from the given connectivity without
+    /// Delaunay point insertion. Works with any scalar type `T`.
+    ///
+    /// For `f64` coordinates, prefer the convenience wrapper on the
+    /// `f64`-specialised impl which avoids explicit type annotations.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::core::vertex::{Vertex, VertexBuilder};
+    /// use delaunay::geometry::point::Point;
+    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    ///
+    /// let vertices: Vec<Vertex<f32, (), 2>> = vec![
+    ///     VertexBuilder::default().point(Point::new([0.0_f32, 0.0])).build().unwrap(),
+    ///     VertexBuilder::default().point(Point::new([1.0_f32, 0.0])).build().unwrap(),
+    ///     VertexBuilder::default().point(Point::new([0.0_f32, 1.0])).build().unwrap(),
+    /// ];
+    /// let cells = vec![vec![0, 1, 2]];
+    ///
+    /// let dt = DelaunayTriangulationBuilder::from_vertices_and_cells_generic(&vertices, &cells)
+    ///     .build::<()>()
+    ///     .unwrap();
+    ///
+    /// assert_eq!(dt.number_of_vertices(), 3);
+    /// assert_eq!(dt.number_of_cells(), 1);
+    /// ```
+    #[must_use]
+    pub fn from_vertices_and_cells_generic(
+        vertices: &'v [Vertex<T, U, D>],
+        cells: &'v [Vec<usize>],
+    ) -> Self {
+        Self {
+            vertices,
+            topology: None,
+            topology_guarantee: TopologyGuarantee::DEFAULT,
+            construction_options: ConstructionOptions::default(),
+            use_image_point_method: false,
+            explicit_cells: Some(cells),
+        }
+    }
+
     /// Creates a builder from a vertex slice of any scalar type `T` and user data type `U`.
     ///
     /// For `f64` coordinates, prefer [`new`](DelaunayTriangulationBuilder::new) which
@@ -981,6 +1019,14 @@ where
             if self.topology.is_some() {
                 return Err(ExplicitConstructionError::IncompatibleTopology.into());
             }
+            if self.construction_options != ConstructionOptions::default() {
+                return Err(ExplicitConstructionError::ValidationFailed {
+                    message: "ConstructionOptions are not applicable to explicit cell \
+                              construction and must be left at their default values"
+                        .to_string(),
+                }
+                .into());
+            }
             return Self::build_explicit(kernel, self.vertices, cells, self.topology_guarantee);
         }
 
@@ -1097,8 +1143,7 @@ where
                 }
                 .into());
             }
-            let mut seen = FastHashSet::default();
-            for &vi in cell_spec {
+            for (i, &vi) in cell_spec.iter().enumerate() {
                 if vi >= vertex_count {
                     return Err(ExplicitConstructionError::IndexOutOfBounds {
                         cell_index: cell_idx,
@@ -1107,11 +1152,13 @@ where
                     }
                     .into());
                 }
-                if !seen.insert(vi) {
-                    return Err(ExplicitConstructionError::DuplicateVertexInCell {
-                        cell_index: cell_idx,
+                for &vj in &cell_spec[i + 1..] {
+                    if vi == vj {
+                        return Err(ExplicitConstructionError::DuplicateVertexInCell {
+                            cell_index: cell_idx,
+                        }
+                        .into());
                     }
-                    .into());
                 }
             }
         }
@@ -1204,6 +1251,20 @@ where
         if let Err(e) = dt.tri.validate_at_completion() {
             return Err(ExplicitConstructionError::ValidationFailed {
                 message: format!("PL-manifold completion validation failed: {e}"),
+            }
+            .into());
+        }
+
+        // --- Geometric nondegeneracy ---
+        //
+        // Reject degenerate simplices (zero-volume cells from collinear /
+        // coplanar vertices).  Unlike the Delaunay construction paths, which
+        // may tolerate near-degenerate cells from flip-based repair,
+        // explicit construction should not silently accept geometrically
+        // collapsed cells supplied by the user.
+        if let Err(e) = dt.tri.validate_geometric_nondegeneracy() {
+            return Err(ExplicitConstructionError::ValidationFailed {
+                message: format!("geometric nondegeneracy check failed: {e}"),
             }
             .into());
         }

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -301,6 +301,28 @@ fn search_closed_2d_selection(
 /// [`from_vertices_and_cells`](DelaunayTriangulationBuilder::from_vertices_and_cells).
 /// TDS assembly errors (vertex/cell insertion, neighbor wiring, validation) flow
 /// through the existing [`TriangulationConstructionError`] hierarchy.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::core::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
+/// use delaunay::core::delaunay_triangulation::DelaunayTriangulationConstructionError;
+/// use delaunay::vertex;
+///
+/// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
+/// let cells = vec![vec![0, 1]]; // Wrong arity for 2D (needs 3 vertices)
+///
+/// let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+///     .build::<()>()
+///     .unwrap_err();
+///
+/// assert!(matches!(
+///     err,
+///     DelaunayTriangulationConstructionError::ExplicitConstruction(
+///         ExplicitConstructionError::InvalidCellArity { cell_index: 0, actual: 2, expected: 3 }
+///     )
+/// ));
+/// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ExplicitConstructionError {
@@ -338,14 +360,15 @@ pub enum ExplicitConstructionError {
     /// Toroidal topology is incompatible with explicit cell construction.
     #[error("Toroidal topology cannot be combined with explicit cell construction")]
     IncompatibleTopology,
-    /// The assembled TDS failed structural validation (Levels 1–3).
+    /// The assembled TDS failed post-assembly validation.
     ///
     /// The caller-provided cells passed input validation but the resulting
-    /// triangulation violates structural invariants (e.g., non-manifold facet
-    /// sharing, disconnected components, orientation contradictions).
-    #[error("Structural validation failed: {message}")]
+    /// triangulation violates structural or topological invariants (e.g.,
+    /// non-manifold facet sharing, disconnected components, orientation
+    /// contradictions, isolated vertices, Euler characteristic mismatch).
+    #[error("Validation failed: {message}")]
     ValidationFailed {
-        /// Description of the validation failure.
+        /// Human-readable description of the validation failure.
         message: String,
     },
 }
@@ -1135,13 +1158,11 @@ where
         })?;
 
         // --- Normalize orientation ---
-        if let Err(_err) = tds.normalize_coherent_orientation() {
-            #[cfg(debug_assertions)]
-            tracing::debug!(
-                ?_err,
-                "explicit construction: skipping coherent-orientation normalization failure"
-            );
-        }
+        tds.normalize_coherent_orientation().map_err(|e| {
+            ExplicitConstructionError::ValidationFailed {
+                message: format!("coherent orientation normalization failed: {e}"),
+            }
+        })?;
 
         // --- Validate Levels 1–3 (structural + topology) ---
         //
@@ -1169,8 +1190,9 @@ where
         // Level 3 (topology, excluding geometric orientation): connectedness,
         // manifold facets, isolated vertices, Euler characteristic, and
         // PL-manifold vertex/ridge links when the topology guarantee requires
-        // them.  We call `is_valid()` which covers all these; the only check
-        // we intentionally omit is `validate_geometric_cell_orientation`.
+        // them.  We call `is_valid_topology_only()` which covers all these;
+        // the only check we intentionally omit is
+        // `validate_geometric_cell_orientation`.
         if let Err(e) = dt.tri.is_valid_topology_only() {
             return Err(ExplicitConstructionError::ValidationFailed {
                 message: format!("topology validation failed: {e}"),

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -104,7 +104,7 @@
 #![forbid(unsafe_code)]
 
 use crate::core::cell::Cell;
-use crate::core::collections::{FastHashMap, Uuid, VertexKeySet};
+use crate::core::collections::{FastHashMap, FastHashSet, Uuid, VertexKeySet};
 use crate::core::delaunay_triangulation::{
     ConstructionOptions, DelaunayRepairPolicy, DelaunayTriangulation,
     DelaunayTriangulationConstructionError, InitialSimplexStrategy, RetryPolicy,
@@ -112,7 +112,9 @@ use crate::core::delaunay_triangulation::{
 use crate::core::operations::InsertionOutcome;
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::{TopologyGuarantee, TriangulationConstructionError};
-use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+use crate::core::triangulation_data_structure::{
+    CellKey, Tds, TriangulationConstructionState, VertexKey,
+};
 use crate::core::util::periodic_facet_key_from_lifted_vertices;
 use crate::core::vertex::{Vertex, VertexBuilder};
 use crate::geometry::kernel::{AdaptiveKernel, Kernel};
@@ -128,16 +130,14 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use std::num::NonZeroUsize;
+use thiserror::Error;
 const TWO_POW_52_I64: i64 = 4_503_599_627_370_496; // 2^52
 const TWO_POW_52_F64: f64 = 4_503_599_627_370_496.0; // 2^52
 const MAX_OFFSET_UNITS: i64 = 1_048_576;
 const IMAGE_JITTER_UNITS: i64 = 64;
 const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
 const FNV_PRIME: u64 = 0x0100_0000_01b3;
-type LiftedVertex<const D: usize> = (
-    crate::core::triangulation_data_structure::VertexKey,
-    [i8; D],
-);
+type LiftedVertex<const D: usize> = (VertexKey, [i8; D]);
 type SymbolicSignature<const D: usize> = Vec<LiftedVertex<D>>;
 type PeriodicFacetKey = u64;
 type PeriodicCandidate<const D: usize> = (
@@ -292,6 +292,57 @@ fn search_closed_2d_selection(
 }
 
 // =============================================================================
+// ERROR TYPES
+// =============================================================================
+
+/// Input validation errors for explicit triangulation construction.
+///
+/// These errors represent invalid inputs to
+/// [`from_vertices_and_cells`](DelaunayTriangulationBuilder::from_vertices_and_cells).
+/// TDS assembly errors (vertex/cell insertion, neighbor wiring, validation) flow
+/// through the existing [`TriangulationConstructionError`] hierarchy.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ExplicitConstructionError {
+    /// A cell references a vertex index that is out of bounds.
+    #[error(
+        "Cell {cell_index}: vertex index {vertex_index} is out of bounds (vertex count: {bound})"
+    )]
+    IndexOutOfBounds {
+        /// The index of the cell in the input slice.
+        cell_index: usize,
+        /// The out-of-bounds vertex index.
+        vertex_index: usize,
+        /// The number of vertices provided.
+        bound: usize,
+    },
+    /// A cell does not have exactly D+1 vertex indices.
+    #[error(
+        "Cell {cell_index}: has {actual} vertex indices, expected {expected} for a {expected}D simplex"
+    )]
+    InvalidCellArity {
+        /// The index of the cell in the input slice.
+        cell_index: usize,
+        /// The actual number of vertex indices.
+        actual: usize,
+        /// The expected number (D+1).
+        expected: usize,
+    },
+    /// A cell contains duplicate vertex indices.
+    #[error("Cell {cell_index}: contains duplicate vertex indices")]
+    DuplicateVertexInCell {
+        /// The index of the cell in the input slice.
+        cell_index: usize,
+    },
+    /// No cells were provided.
+    #[error("No cells provided for explicit construction")]
+    EmptyCells,
+    /// Toroidal topology is incompatible with explicit cell construction.
+    #[error("Toroidal topology cannot be combined with explicit cell construction")]
+    IncompatibleTopology,
+}
+
+// =============================================================================
 // BUILDER STRUCT
 // =============================================================================
 
@@ -347,6 +398,12 @@ where
     /// When `true` (set by [`.toroidal_periodic()`](Self::toroidal_periodic)), the
     /// Phase 2 image-point algorithm is used instead of the Phase 1 canonicalization path.
     use_image_point_method: bool,
+    /// Optional explicit cell specifications for direct combinatorial construction.
+    ///
+    /// When set, the builder constructs a triangulation from the given vertices and
+    /// cells directly, bypassing point-insertion-based Delaunay construction.
+    /// Each inner slice must contain exactly D+1 vertex indices.
+    explicit_cells: Option<&'v [Vec<usize>]>,
 }
 
 // =============================================================================
@@ -400,6 +457,61 @@ where
             topology_guarantee: TopologyGuarantee::DEFAULT,
             construction_options: ConstructionOptions::default(),
             use_image_point_method: false,
+            explicit_cells: None,
+        }
+    }
+
+    /// Creates a builder for explicit combinatorial construction from `f64` vertices
+    /// and cell specifications.
+    ///
+    /// This constructs a triangulation directly from the given connectivity,
+    /// **without** Delaunay point insertion. The result is a valid triangulation
+    /// (Levels 1–3: elements, structure, topology) but the Delaunay property
+    /// (Level 4) is **not** guaranteed.
+    ///
+    /// Each cell specification must contain exactly `D+1` vertex indices into
+    /// the `vertices` slice.
+    ///
+    /// To optionally repair to Delaunay after construction, call
+    /// [`repair_delaunay_with_flips`](DelaunayTriangulation::repair_delaunay_with_flips)
+    /// on the result.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::vertex;
+    ///
+    /// let vertices = vec![
+    ///     vertex!([0.0, 0.0]),
+    ///     vertex!([1.0, 0.0]),
+    ///     vertex!([1.0, 1.0]),
+    ///     vertex!([0.0, 1.0]),
+    /// ];
+    /// let cells = vec![
+    ///     vec![0, 1, 2],
+    ///     vec![0, 2, 3],
+    /// ];
+    ///
+    /// let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+    ///     .build::<()>()
+    ///     .unwrap();
+    ///
+    /// assert_eq!(dt.number_of_vertices(), 4);
+    /// assert_eq!(dt.number_of_cells(), 2);
+    /// ```
+    #[must_use]
+    pub fn from_vertices_and_cells(
+        vertices: &'v [Vertex<f64, U, D>],
+        cells: &'v [Vec<usize>],
+    ) -> Self {
+        Self {
+            vertices,
+            topology: None,
+            topology_guarantee: TopologyGuarantee::DEFAULT,
+            construction_options: ConstructionOptions::default(),
+            use_image_point_method: false,
+            explicit_cells: Some(cells),
         }
     }
 }
@@ -448,6 +560,7 @@ where
             topology_guarantee: TopologyGuarantee::DEFAULT,
             construction_options: ConstructionOptions::default(),
             use_image_point_method: false,
+            explicit_cells: None,
         }
     }
 
@@ -843,6 +956,14 @@ where
         K::Scalar: ScalarAccumulative,
         V: DataType,
     {
+        // Explicit-cells path: bypass Delaunay insertion entirely.
+        if let Some(cells) = self.explicit_cells {
+            if self.topology.is_some() {
+                return Err(ExplicitConstructionError::IncompatibleTopology.into());
+            }
+            return Self::build_explicit(kernel, self.vertices, cells, self.topology_guarantee);
+        }
+
         match (self.topology, self.use_image_point_method) {
             (None, _) => {
                 // Euclidean path: delegate directly.
@@ -914,6 +1035,138 @@ where
                 Ok(dt)
             }
         }
+    }
+
+    /// Builds a triangulation from explicit vertex and cell specifications.
+    ///
+    /// This is a purely combinatorial construction that assembles a valid TDS from
+    /// the given connectivity without Delaunay point insertion. The result is validated
+    /// at Levels 1–3 (elements, structure, topology) but the Delaunay property
+    /// (Level 4) is **not** checked or guaranteed.
+    ///
+    /// # Algorithm
+    ///
+    /// 1. Validate input: each cell has D+1 in-bounds, unique vertex indices.
+    /// 2. Build a `Tds`: insert all vertices, then insert cells from the specifications.
+    /// 3. Compute adjacency via `assign_neighbors()`.
+    /// 4. Assign incident cells and normalize orientation.
+    /// 5. Validate structural integrity (`tds.is_valid()`).
+    /// 6. Wrap in `DelaunayTriangulation` via `from_tds_with_topology_guarantee`.
+    fn build_explicit<K, V>(
+        kernel: &K,
+        vertices: &[Vertex<T, U, D>],
+        cells: &[Vec<usize>],
+        topology_guarantee: TopologyGuarantee,
+    ) -> Result<DelaunayTriangulation<K, U, V, D>, DelaunayTriangulationConstructionError>
+    where
+        K: Kernel<D, Scalar = T>,
+        V: DataType,
+    {
+        // --- Input validation ---
+        if cells.is_empty() {
+            return Err(ExplicitConstructionError::EmptyCells.into());
+        }
+
+        let vertex_count = vertices.len();
+        for (cell_idx, cell_spec) in cells.iter().enumerate() {
+            if cell_spec.len() != D + 1 {
+                return Err(ExplicitConstructionError::InvalidCellArity {
+                    cell_index: cell_idx,
+                    actual: cell_spec.len(),
+                    expected: D + 1,
+                }
+                .into());
+            }
+            let mut seen = FastHashSet::default();
+            for &vi in cell_spec {
+                if vi >= vertex_count {
+                    return Err(ExplicitConstructionError::IndexOutOfBounds {
+                        cell_index: cell_idx,
+                        vertex_index: vi,
+                        bound: vertex_count,
+                    }
+                    .into());
+                }
+                if !seen.insert(vi) {
+                    return Err(ExplicitConstructionError::DuplicateVertexInCell {
+                        cell_index: cell_idx,
+                    }
+                    .into());
+                }
+            }
+        }
+
+        // --- Build TDS ---
+        let mut tds: Tds<T, U, V, D> = Tds::empty();
+
+        // Insert all vertices and build index → VertexKey map.
+        let mut index_to_key = Vec::with_capacity(vertex_count);
+        for (idx, v) in vertices.iter().enumerate() {
+            let vk = tds.insert_vertex_with_mapping(*v).map_err(|e| {
+                TriangulationConstructionError::InternalInconsistency {
+                    message: format!("explicit: vertex {idx} insertion failed: {e}"),
+                }
+            })?;
+            index_to_key.push(vk);
+        }
+
+        // Insert cells.
+        for (cell_idx, cell_spec) in cells.iter().enumerate() {
+            let vertex_keys: Vec<VertexKey> =
+                cell_spec.iter().map(|&vi| index_to_key[vi]).collect();
+            let cell = Cell::new(vertex_keys, None).map_err(|e| {
+                TriangulationConstructionError::FailedToCreateCell {
+                    message: format!("explicit: cell {cell_idx}: {e}"),
+                }
+            })?;
+            tds.insert_cell_with_mapping(cell).map_err(|e| {
+                TriangulationConstructionError::InternalInconsistency {
+                    message: format!("explicit: cell {cell_idx} insertion failed: {e}"),
+                }
+            })?;
+        }
+
+        // Mark as constructed so validation doesn't reject incomplete state.
+        tds.construction_state = TriangulationConstructionState::Constructed;
+
+        // --- Compute adjacency ---
+        tds.assign_neighbors().map_err(|e| {
+            TriangulationConstructionError::InternalInconsistency {
+                message: format!("explicit: neighbor assignment failed: {e}"),
+            }
+        })?;
+
+        // --- Assign incident cells ---
+        tds.assign_incident_cells().map_err(|e| {
+            TriangulationConstructionError::InternalInconsistency {
+                message: format!("explicit: incident cell assignment failed: {e}"),
+            }
+        })?;
+
+        // --- Normalize orientation ---
+        if let Err(_err) = tds.normalize_coherent_orientation() {
+            // Best-effort: some configurations may not normalize cleanly.
+            // Defer hard failure to the subsequent is_valid() check.
+            #[cfg(debug_assertions)]
+            tracing::debug!(
+                ?_err,
+                "explicit construction: skipping coherent-orientation normalization failure"
+            );
+        }
+
+        // --- Validate Levels 1–3 ---
+        if let Err(e) = tds.is_valid() {
+            return Err(TriangulationConstructionError::InternalInconsistency {
+                message: format!("explicit: TDS validation failed: {e}"),
+            }
+            .into());
+        }
+
+        Ok(DelaunayTriangulation::from_tds_with_topology_guarantee(
+            tds,
+            kernel.clone(),
+            topology_guarantee,
+        ))
     }
 
     /// Builds a true periodic (toroidal) Delaunay triangulation using the 3^D image-point method.

--- a/src/core/delaunay_triangulation.rs
+++ b/src/core/delaunay_triangulation.rs
@@ -2651,7 +2651,7 @@ where
                 kernel,
                 tds,
                 global_topology: GlobalTopology::DEFAULT,
-                validation_policy: ValidationPolicy::default(),
+                validation_policy: topology_guarantee.default_validation_policy(),
                 topology_guarantee,
             },
             insertion_state: DelaunayInsertionState::new(),
@@ -2761,7 +2761,7 @@ where
                 kernel,
                 tds,
                 global_topology: GlobalTopology::DEFAULT,
-                validation_policy: ValidationPolicy::default(),
+                validation_policy: topology_guarantee.default_validation_policy(),
                 topology_guarantee,
             },
             insertion_state: DelaunayInsertionState::new(),
@@ -5511,10 +5511,7 @@ where
         kernel: K,
         topology_guarantee: TopologyGuarantee,
     ) -> Self {
-        let validation_policy = match topology_guarantee {
-            TopologyGuarantee::PLManifoldStrict => ValidationPolicy::Always,
-            _ => ValidationPolicy::OnSuspicion,
-        };
+        let validation_policy = topology_guarantee.default_validation_policy();
         Self {
             tri: Triangulation {
                 kernel,

--- a/src/core/delaunay_triangulation.rs
+++ b/src/core/delaunay_triangulation.rs
@@ -5395,10 +5395,14 @@ where
                 }
 
                 // Level 4 (Delaunay property)
-                if let Err(e) = self.is_valid() {
+                if let Err(e) = self.is_delaunay_via_flips() {
                     report.violations.push(InvariantViolation {
                         kind: InvariantKind::DelaunayProperty,
-                        error: e.into(),
+                        error: InvariantError::Delaunay(
+                            DelaunayTriangulationValidationError::VerificationFailed {
+                                message: e.to_string(),
+                            },
+                        ),
                     });
                 }
 

--- a/src/core/delaunay_triangulation.rs
+++ b/src/core/delaunay_triangulation.rs
@@ -5484,17 +5484,7 @@ where
     /// ```
     #[must_use]
     pub const fn from_tds(tds: Tds<K::Scalar, U, V, D>, kernel: K) -> Self {
-        Self {
-            tri: Triangulation {
-                kernel,
-                tds,
-                global_topology: GlobalTopology::DEFAULT,
-                validation_policy: ValidationPolicy::OnSuspicion,
-                topology_guarantee: TopologyGuarantee::DEFAULT,
-            },
-            insertion_state: DelaunayInsertionState::new(),
-            spatial_index: None,
-        }
+        Self::from_tds_with_topology_guarantee(tds, kernel, TopologyGuarantee::DEFAULT)
     }
 
     /// Create a `DelaunayTriangulation` from a `Tds` with an explicit topology guarantee.

--- a/src/core/delaunay_triangulation.rs
+++ b/src/core/delaunay_triangulation.rs
@@ -116,6 +116,15 @@ pub enum DelaunayTriangulationConstructionError {
     /// Lower-layer construction error (Triangulation / TDS).
     #[error(transparent)]
     Triangulation(#[from] TriangulationConstructionError),
+
+    /// Input validation error from explicit combinatorial construction.
+    ///
+    /// Returned by [`DelaunayTriangulationBuilder::from_vertices_and_cells`](crate::core::builder::DelaunayTriangulationBuilder::from_vertices_and_cells)
+    /// when the caller-provided vertices/cells fail validation (wrong arity,
+    /// out-of-bounds indices, etc.). TDS assembly errors flow through the
+    /// [`Triangulation`](Self::Triangulation) variant instead.
+    #[error(transparent)]
+    ExplicitConstruction(#[from] crate::core::builder::ExplicitConstructionError),
 }
 
 /// Errors that can occur during Delaunay triangulation validation and repair.
@@ -5328,95 +5337,6 @@ where
         self.is_valid()
     }
 
-    /// Create a `DelaunayTriangulation` from a deserialized `Tds` with a default kernel.
-    ///
-    /// This is useful when you've serialized just the `Tds` and want to reconstruct
-    /// the `DelaunayTriangulation` with default kernel settings.
-    ///
-    /// # Notes
-    ///
-    /// - The internal `insertion_state.last_inserted_cell` "locate hint" is intentionally **not** persisted
-    ///   across serialization boundaries. Constructing via `from_tds` (including the serde
-    ///   `Deserialize` impl below) always resets it to `None`. This can make the first few
-    ///   insertions after loading slightly slower, but is otherwise behaviorally irrelevant.
-    /// - The internal spatial hash-grid index used to accelerate incremental insertion is also a
-    ///   performance-only cache and is not serialized. Constructing via `from_tds` leaves it unset
-    ///   so it can be rebuilt lazily on demand.
-    /// - The topology guarantee ([`TopologyGuarantee`]) is also not serialized (this type serializes
-    ///   only the `Tds`). Constructing via `from_tds` resets it to `TopologyGuarantee::DEFAULT`
-    ///   (currently `PLManifold`). Call [`set_topology_guarantee`](Self::set_topology_guarantee)
-    ///   after loading if you want to relax to `Pseudomanifold` for performance, or use
-    ///   [`from_tds_with_topology_guarantee`](Self::from_tds_with_topology_guarantee) to set it
-    ///   at construction time.
-    /// - Runtime global topology metadata ([`GlobalTopology`]) is also not serialized. Constructing
-    ///   via `from_tds` resets it to [`GlobalTopology::Euclidean`]. Use
-    ///   [`set_global_topology`](Self::set_global_topology) after loading if you need to restore
-    ///   toroidal metadata.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
-    /// use delaunay::core::triangulation_data_structure::Tds;
-    /// use delaunay::geometry::kernel::FastKernel;
-    /// use delaunay::vertex;
-    ///
-    /// let vertices = vec![
-    ///     vertex!([0.0, 0.0, 0.0, 0.0]),
-    ///     vertex!([1.0, 0.0, 0.0, 0.0]),
-    ///     vertex!([0.0, 1.0, 0.0, 0.0]),
-    ///     vertex!([0.0, 0.0, 1.0, 0.0]),
-    ///     vertex!([0.0, 0.0, 0.0, 1.0]),
-    /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
-    ///
-    /// // Serialize just the Tds
-    /// let json = serde_json::to_string(dt.tds()).unwrap();
-    ///
-    /// // Deserialize Tds and reconstruct DelaunayTriangulation
-    /// let tds: Tds<f64, (), (), 4> = serde_json::from_str(&json).unwrap();
-    /// let reconstructed = DelaunayTriangulation::from_tds(tds, FastKernel::new());
-    /// assert_eq!(reconstructed.number_of_vertices(), 5);
-    /// ```
-    #[must_use]
-    pub const fn from_tds(tds: Tds<K::Scalar, U, V, D>, kernel: K) -> Self {
-        Self {
-            tri: Triangulation {
-                kernel,
-                tds,
-                global_topology: GlobalTopology::DEFAULT,
-                validation_policy: ValidationPolicy::OnSuspicion,
-                topology_guarantee: TopologyGuarantee::DEFAULT,
-            },
-            insertion_state: DelaunayInsertionState::new(),
-            spatial_index: None,
-        }
-    }
-
-    /// Create a `DelaunayTriangulation` from a deserialized `Tds` with an explicit topology guarantee.
-    ///
-    /// This is identical to [`from_tds`](Self::from_tds), but allows callers to set the desired
-    /// [`TopologyGuarantee`] at construction time.
-    #[must_use]
-    pub const fn from_tds_with_topology_guarantee(
-        tds: Tds<K::Scalar, U, V, D>,
-        kernel: K,
-        topology_guarantee: TopologyGuarantee,
-    ) -> Self {
-        Self {
-            tri: Triangulation {
-                kernel,
-                tds,
-                global_topology: GlobalTopology::DEFAULT,
-                validation_policy: ValidationPolicy::OnSuspicion,
-                topology_guarantee,
-            },
-            insertion_state: DelaunayInsertionState::new(),
-            spatial_index: None,
-        }
-    }
-
     /// Generate a comprehensive validation report for the full validation hierarchy.
     ///
     /// This is intended for debugging/telemetry (e.g. `insert_with_statistics`) where
@@ -5488,6 +5408,111 @@ where
                     Err(report)
                 }
             }
+        }
+    }
+}
+
+// =============================================================================
+// PURE STRUCT ASSEMBLY (Minimal Bounds)
+// =============================================================================
+//
+// These methods only assemble the `DelaunayTriangulation` struct from its parts
+// and do not perform any geometric operations. They live in a minimally-bounded
+// impl block so callers (e.g. explicit combinatorial construction) are not
+// forced to satisfy `ScalarAccumulative + NumCast`.
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    /// Create a `DelaunayTriangulation` from a `Tds` with a default kernel.
+    ///
+    /// This is useful when you've serialized just the `Tds` and want to reconstruct
+    /// the `DelaunayTriangulation` with default kernel settings.
+    ///
+    /// # Notes
+    ///
+    /// - The internal `insertion_state.last_inserted_cell` "locate hint" is intentionally **not** persisted
+    ///   across serialization boundaries. Constructing via `from_tds` (including the serde
+    ///   `Deserialize` impl below) always resets it to `None`. This can make the first few
+    ///   insertions after loading slightly slower, but is otherwise behaviorally irrelevant.
+    /// - The internal spatial hash-grid index used to accelerate incremental insertion is also a
+    ///   performance-only cache and is not serialized. Constructing via `from_tds` leaves it unset
+    ///   so it can be rebuilt lazily on demand.
+    /// - The topology guarantee ([`TopologyGuarantee`]) is also not serialized (this type serializes
+    ///   only the `Tds`). Constructing via `from_tds` resets it to `TopologyGuarantee::DEFAULT`
+    ///   (currently `PLManifold`). Call [`set_topology_guarantee`](Self::set_topology_guarantee)
+    ///   after loading if you want to relax to `Pseudomanifold` for performance, or use
+    ///   [`from_tds_with_topology_guarantee`](Self::from_tds_with_topology_guarantee) to set it
+    ///   at construction time.
+    /// - Runtime global topology metadata ([`GlobalTopology`]) is also not serialized. Constructing
+    ///   via `from_tds` resets it to [`GlobalTopology::Euclidean`]. Use
+    ///   [`set_global_topology`](Self::set_global_topology) after loading if you need to restore
+    ///   toroidal metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::geometry::kernel::FastKernel;
+    /// use delaunay::vertex;
+    ///
+    /// let vertices = vec![
+    ///     vertex!([0.0, 0.0, 0.0, 0.0]),
+    ///     vertex!([1.0, 0.0, 0.0, 0.0]),
+    ///     vertex!([0.0, 1.0, 0.0, 0.0]),
+    ///     vertex!([0.0, 0.0, 1.0, 0.0]),
+    ///     vertex!([0.0, 0.0, 0.0, 1.0]),
+    /// ];
+    /// let dt: DelaunayTriangulation<_, (), (), 4> =
+    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    ///
+    /// // Serialize just the Tds
+    /// let json = serde_json::to_string(dt.tds()).unwrap();
+    ///
+    /// // Deserialize Tds and reconstruct DelaunayTriangulation
+    /// let tds: Tds<f64, (), (), 4> = serde_json::from_str(&json).unwrap();
+    /// let reconstructed = DelaunayTriangulation::from_tds(tds, FastKernel::new());
+    /// assert_eq!(reconstructed.number_of_vertices(), 5);
+    /// ```
+    #[must_use]
+    pub const fn from_tds(tds: Tds<K::Scalar, U, V, D>, kernel: K) -> Self {
+        Self {
+            tri: Triangulation {
+                kernel,
+                tds,
+                global_topology: GlobalTopology::DEFAULT,
+                validation_policy: ValidationPolicy::OnSuspicion,
+                topology_guarantee: TopologyGuarantee::DEFAULT,
+            },
+            insertion_state: DelaunayInsertionState::new(),
+            spatial_index: None,
+        }
+    }
+
+    /// Create a `DelaunayTriangulation` from a `Tds` with an explicit topology guarantee.
+    ///
+    /// This is identical to [`from_tds`](Self::from_tds), but allows callers to set the desired
+    /// [`TopologyGuarantee`] at construction time.
+    #[must_use]
+    pub const fn from_tds_with_topology_guarantee(
+        tds: Tds<K::Scalar, U, V, D>,
+        kernel: K,
+        topology_guarantee: TopologyGuarantee,
+    ) -> Self {
+        Self {
+            tri: Triangulation {
+                kernel,
+                tds,
+                global_topology: GlobalTopology::DEFAULT,
+                validation_policy: ValidationPolicy::OnSuspicion,
+                topology_guarantee,
+            },
+            insertion_state: DelaunayInsertionState::new(),
+            spatial_index: None,
         }
     }
 }

--- a/src/core/delaunay_triangulation.rs
+++ b/src/core/delaunay_triangulation.rs
@@ -5500,19 +5500,27 @@ where
     /// Create a `DelaunayTriangulation` from a `Tds` with an explicit topology guarantee.
     ///
     /// This is identical to [`from_tds`](Self::from_tds), but allows callers to set the desired
-    /// [`TopologyGuarantee`] at construction time.
+    /// [`TopologyGuarantee`] at construction time. The initial
+    /// [`ValidationPolicy`] is derived from the guarantee:
+    /// [`PLManifoldStrict`](TopologyGuarantee::PLManifoldStrict) uses
+    /// [`Always`](ValidationPolicy::Always); all others default to
+    /// [`OnSuspicion`](ValidationPolicy::OnSuspicion).
     #[must_use]
     pub const fn from_tds_with_topology_guarantee(
         tds: Tds<K::Scalar, U, V, D>,
         kernel: K,
         topology_guarantee: TopologyGuarantee,
     ) -> Self {
+        let validation_policy = match topology_guarantee {
+            TopologyGuarantee::PLManifoldStrict => ValidationPolicy::Always,
+            _ => ValidationPolicy::OnSuspicion,
+        };
         Self {
             tri: Triangulation {
                 kernel,
                 tds,
                 global_topology: GlobalTopology::DEFAULT,
-                validation_policy: ValidationPolicy::OnSuspicion,
+                validation_policy,
                 topology_guarantee,
             },
             insertion_state: DelaunayInsertionState::new(),

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -2536,6 +2536,48 @@ where
         Ok(())
     }
 
+    /// Validates topological invariants **without** geometric orientation checks.
+    ///
+    /// This is identical to [`is_valid`](Self::is_valid) but omits the
+    /// `validate_geometric_cell_orientation()` step. It is intended for
+    /// explicit combinatorial construction where the user-provided vertex
+    /// orderings may produce negative determinants that are nonetheless
+    /// topologically valid.
+    pub(crate) fn is_valid_topology_only(&self) -> Result<(), InvariantError> {
+        self.validate_global_connectedness()?;
+
+        let facet_to_cells: FacetToCellsMap = self.tds.build_facet_to_cells_map()?;
+        validate_facet_degree(&facet_to_cells)?;
+        validate_closed_boundary(&self.tds, &facet_to_cells)?;
+
+        if self.topology_guarantee.requires_ridge_links() {
+            validate_ridge_links(&self.tds)?;
+        }
+        if self
+            .topology_guarantee
+            .requires_vertex_links_during_insertion()
+        {
+            validate_vertex_links(&self.tds, &facet_to_cells)?;
+        }
+
+        self.validate_no_isolated_vertices()?;
+
+        let topology_result =
+            validate_triangulation_euler_with_facet_to_cells_map(&self.tds, &facet_to_cells);
+        if let Some(expected) = topology_result.expected
+            && topology_result.chi != expected
+        {
+            return Err(TriangulationValidationError::EulerCharacteristicMismatch {
+                computed: topology_result.chi,
+                expected,
+                classification: topology_result.classification,
+            }
+            .into());
+        }
+
+        Ok(())
+    }
+
     /// Validates vertex-link condition at construction completion.
     ///
     /// This should be called once after batch construction is complete to certify

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -680,6 +680,35 @@ impl TopologyGuarantee {
         matches!(self, Self::PLManifold | Self::PLManifoldStrict)
     }
 
+    /// Returns the [`ValidationPolicy`] that should be used by default for this guarantee.
+    ///
+    /// [`PLManifoldStrict`](Self::PLManifoldStrict) uses [`Always`](ValidationPolicy::Always)
+    /// so that vertex-link validation runs after every insertion; all others default to
+    /// [`OnSuspicion`](ValidationPolicy::OnSuspicion).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::core::triangulation::{TopologyGuarantee, ValidationPolicy};
+    ///
+    /// assert_eq!(
+    ///     TopologyGuarantee::PLManifoldStrict.default_validation_policy(),
+    ///     ValidationPolicy::Always,
+    /// );
+    /// assert_eq!(
+    ///     TopologyGuarantee::PLManifold.default_validation_policy(),
+    ///     ValidationPolicy::OnSuspicion,
+    /// );
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn default_validation_policy(self) -> ValidationPolicy {
+        match self {
+            Self::PLManifoldStrict => ValidationPolicy::Always,
+            _ => ValidationPolicy::OnSuspicion,
+        }
+    }
+
     /// Returns `true` if this guarantee is compatible with the given validation policy.
     ///
     /// `PLManifold` requires at least end-of-construction validation, so it's incompatible
@@ -2483,6 +2512,31 @@ where
     /// assert!(dt.as_triangulation().is_valid().is_ok());
     /// ```
     pub fn is_valid(&self) -> Result<(), InvariantError> {
+        self.validate_topology_core()?;
+        // Check geometric orientation after manifold/link checks so topology-specific
+        // diagnostics surface first when multiple invariants are violated.
+        self.validate_geometric_cell_orientation()?;
+        Ok(())
+    }
+
+    /// Validates topological invariants **without** geometric orientation checks.
+    ///
+    /// This is identical to [`is_valid`](Self::is_valid) but omits the
+    /// `validate_geometric_cell_orientation()` step. It is intended for
+    /// explicit combinatorial construction where the user-provided vertex
+    /// orderings may produce negative determinants that are nonetheless
+    /// topologically valid.
+    pub(crate) fn is_valid_topology_only(&self) -> Result<(), InvariantError> {
+        self.validate_topology_core()
+    }
+
+    /// Shared Level-3 topology validation sequence used by both [`is_valid`](Self::is_valid)
+    /// and [`is_valid_topology_only`](Self::is_valid_topology_only).
+    ///
+    /// Checks connectedness, manifold facet degree, closed boundary, ridge/vertex
+    /// links (when required by the topology guarantee), isolated vertices, and
+    /// Euler characteristic.
+    fn validate_topology_core(&self) -> Result<(), InvariantError> {
         // 1. Connectedness
         //
         // Checked first because it is cheaper than building the facet-to-cells map
@@ -2519,51 +2573,6 @@ where
         let topology_result =
             validate_triangulation_euler_with_facet_to_cells_map(&self.tds, &facet_to_cells);
 
-        if let Some(expected) = topology_result.expected
-            && topology_result.chi != expected
-        {
-            return Err(TriangulationValidationError::EulerCharacteristicMismatch {
-                computed: topology_result.chi,
-                expected,
-                classification: topology_result.classification,
-            }
-            .into());
-        }
-        // Check geometric orientation after manifold/link checks so topology-specific
-        // diagnostics surface first when multiple invariants are violated.
-        self.validate_geometric_cell_orientation()?;
-
-        Ok(())
-    }
-
-    /// Validates topological invariants **without** geometric orientation checks.
-    ///
-    /// This is identical to [`is_valid`](Self::is_valid) but omits the
-    /// `validate_geometric_cell_orientation()` step. It is intended for
-    /// explicit combinatorial construction where the user-provided vertex
-    /// orderings may produce negative determinants that are nonetheless
-    /// topologically valid.
-    pub(crate) fn is_valid_topology_only(&self) -> Result<(), InvariantError> {
-        self.validate_global_connectedness()?;
-
-        let facet_to_cells: FacetToCellsMap = self.tds.build_facet_to_cells_map()?;
-        validate_facet_degree(&facet_to_cells)?;
-        validate_closed_boundary(&self.tds, &facet_to_cells)?;
-
-        if self.topology_guarantee.requires_ridge_links() {
-            validate_ridge_links(&self.tds)?;
-        }
-        if self
-            .topology_guarantee
-            .requires_vertex_links_during_insertion()
-        {
-            validate_vertex_links(&self.tds, &facet_to_cells)?;
-        }
-
-        self.validate_no_isolated_vertices()?;
-
-        let topology_result =
-            validate_triangulation_euler_with_facet_to_cells_map(&self.tds, &facet_to_cells);
         if let Some(expected) = topology_result.expected
             && topology_result.chi != expected
         {
@@ -5595,6 +5604,20 @@ mod tests {
         assert!(!TopologyGuarantee::Pseudomanifold.requires_ridge_links());
         assert!(TopologyGuarantee::PLManifold.requires_ridge_links());
         assert!(TopologyGuarantee::PLManifoldStrict.requires_ridge_links());
+
+        // default_validation_policy
+        assert_eq!(
+            TopologyGuarantee::PLManifoldStrict.default_validation_policy(),
+            ValidationPolicy::Always
+        );
+        assert_eq!(
+            TopologyGuarantee::PLManifold.default_validation_policy(),
+            ValidationPolicy::OnSuspicion
+        );
+        assert_eq!(
+            TopologyGuarantee::Pseudomanifold.default_validation_policy(),
+            ValidationPolicy::OnSuspicion
+        );
 
         for policy in [
             ValidationPolicy::Never,

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -856,7 +856,7 @@ where
             kernel,
             tds: Tds::empty(),
             global_topology: GlobalTopology::DEFAULT,
-            validation_policy: ValidationPolicy::default(),
+            validation_policy: TopologyGuarantee::DEFAULT.default_validation_policy(),
             topology_guarantee: TopologyGuarantee::DEFAULT,
         }
     }
@@ -1055,12 +1055,12 @@ where
 
     #[cfg(test)]
     #[inline]
-    pub(crate) fn new_with_tds(kernel: K, tds: Tds<K::Scalar, U, V, D>) -> Self {
+    pub(crate) const fn new_with_tds(kernel: K, tds: Tds<K::Scalar, U, V, D>) -> Self {
         Self {
             kernel,
             tds,
             global_topology: GlobalTopology::DEFAULT,
-            validation_policy: ValidationPolicy::default(),
+            validation_policy: TopologyGuarantee::DEFAULT.default_validation_policy(),
             topology_guarantee: TopologyGuarantee::DEFAULT,
         }
     }
@@ -2528,6 +2528,36 @@ where
     /// topologically valid.
     pub(crate) fn is_valid_topology_only(&self) -> Result<(), InvariantError> {
         self.validate_topology_core()
+    }
+
+    /// Verifies that no cell is geometrically degenerate (zero-volume simplex).
+    ///
+    /// This is a sign-agnostic check: it flags cells whose exact orientation
+    /// determinant is zero (collinear in 2D, coplanar in 3D, etc.) regardless
+    /// of the sign.  Intended for explicit construction where the user-supplied
+    /// vertex set must form non-degenerate simplices.
+    ///
+    /// Unlike [`validate_geometric_cell_orientation`](Self::validate_geometric_cell_orientation),
+    /// this does **not** reject negative-orientation cells.
+    pub(crate) fn validate_geometric_nondegeneracy(&self) -> Result<(), TdsError> {
+        for (cell_key, cell) in self.tds.cells() {
+            let orientation = self.evaluate_cell_orientation_for_context(
+                cell_key,
+                cell,
+                "geometric nondegeneracy check",
+                "Orientation predicate failed for cell",
+            )?;
+            if orientation == 0 {
+                return Err(TdsError::InconsistentDataStructure {
+                    message: format!(
+                        "Cell {:?} (key {cell_key:?}) is geometrically degenerate \
+                         (zero-volume simplex from collinear/coplanar vertices)",
+                        cell.uuid(),
+                    ),
+                });
+            }
+        }
+        Ok(())
     }
 
     /// Shared Level-3 topology validation sequence used by both [`is_valid`](Self::is_valid)
@@ -5619,6 +5649,13 @@ mod tests {
             ValidationPolicy::OnSuspicion
         );
 
+        // Verify constructors use the centralized mapping.
+        let tri = Triangulation::<FastKernel<f64>, (), (), 2>::new_empty(FastKernel::new());
+        assert_eq!(
+            tri.validation_policy(),
+            TopologyGuarantee::DEFAULT.default_validation_policy()
+        );
+
         for policy in [
             ValidationPolicy::Never,
             ValidationPolicy::OnSuspicion,
@@ -5712,6 +5749,47 @@ mod tests {
         tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
         assert!(tri.validate_at_completion().is_ok());
     }
+    /// Regression test: a negatively oriented but topologically valid simplex
+    /// passes `is_valid_topology_only()` while failing `is_valid()` (which
+    /// includes the geometric orientation check).
+    #[test]
+    fn test_negative_oriented_simplex_topology_only() {
+        // Build a single positively oriented triangle, then swap vertices 0↔1
+        // to make it negatively oriented.
+        let vertices = vec![
+            vertex!([0.0, 0.0]),
+            vertex!([1.0, 0.0]),
+            vertex!([0.0, 1.0]),
+        ];
+        let tds =
+            Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
+        let mut tri =
+            Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
+
+        // Confirm it starts valid.
+        assert!(tri.is_valid().is_ok());
+        assert!(tri.is_valid_topology_only().is_ok());
+
+        // Flip the single cell's vertex order to make it negatively oriented.
+        let cell_key = tri.tds.cell_keys().next().expect("single cell exists");
+        tri.tds
+            .get_cell_by_key_mut(cell_key)
+            .expect("cell exists")
+            .swap_vertex_slots(0, 1);
+
+        // Topology-only validation should still pass (orientation sign is irrelevant).
+        assert!(
+            tri.is_valid_topology_only().is_ok(),
+            "Negatively oriented simplex should pass topology-only validation"
+        );
+
+        // Full validation (which includes geometric orientation) should fail.
+        assert!(
+            tri.is_valid().is_err(),
+            "Negatively oriented simplex should fail full is_valid()"
+        );
+    }
+
     fn build_invalid_vertex_link_tds_2d() -> (Tds<f64, (), (), 2>, VertexKey) {
         // Two triangles sharing only a single vertex produce a disconnected vertex link.
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -683,7 +683,9 @@ impl TopologyGuarantee {
     /// Returns the [`ValidationPolicy`] that should be used by default for this guarantee.
     ///
     /// [`PLManifoldStrict`](Self::PLManifoldStrict) uses [`Always`](ValidationPolicy::Always)
-    /// so that vertex-link validation runs after every insertion; all others default to
+    /// so that full Level-3 global validation (including vertex-link checks) runs
+    /// after every insertion — this is the strongest and slowest setting.
+    /// All other guarantees default to
     /// [`OnSuspicion`](ValidationPolicy::OnSuspicion).
     ///
     /// # Examples
@@ -2548,13 +2550,13 @@ where
                 "Orientation predicate failed for cell",
             )?;
             if orientation == 0 {
-                return Err(TdsError::InconsistentDataStructure {
+                return Err(TdsError::Geometric(GeometricError::DegenerateOrientation {
                     message: format!(
                         "Cell {:?} (key {cell_key:?}) is geometrically degenerate \
                          (zero-volume simplex from collinear/coplanar vertices)",
                         cell.uuid(),
                     ),
-                });
+                }));
             }
         }
         Ok(())

--- a/src/core/triangulation_data_structure.rs
+++ b/src/core/triangulation_data_structure.rs
@@ -1094,7 +1094,7 @@ where
     ///
     /// Returns `TdsError` if neighbor assignment fails due to inconsistent
     /// data structures or invalid facet sharing patterns.
-    fn assign_neighbors(&mut self) -> Result<(), TdsError> {
+    pub(crate) fn assign_neighbors(&mut self) -> Result<(), TdsError> {
         // Build facet mapping with vertex index information using optimized collections
         // facet_key -> [(cell_key, vertex_index_opposite_to_facet)]
         type FacetInfo = (CellKey, usize);

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -3,9 +3,10 @@
 //! These tests exercise the public API from the outside, using only items exposed
 //! through `delaunay::prelude::triangulation` and `delaunay::core::builder`.
 
-use delaunay::core::builder::DelaunayTriangulationBuilder;
+use delaunay::core::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
 use delaunay::core::delaunay_triangulation::{
-    ConstructionOptions, DelaunayTriangulation, InsertionOrderStrategy,
+    ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationConstructionError,
+    InsertionOrderStrategy,
 };
 use delaunay::core::triangulation::TopologyGuarantee;
 use delaunay::vertex;
@@ -380,5 +381,404 @@ fn test_builder_toroidal_periodic_3d_success() {
     assert!(
         dt.tds().is_valid().is_ok(),
         "TDS structural validity should pass for 3D periodic triangulation"
+    );
+}
+
+// =============================================================================
+// Explicit construction (from_vertices_and_cells)
+// =============================================================================
+
+/// 2D: Build two triangles forming a quad from explicit vertices and cells.
+#[test]
+fn test_explicit_2d_two_triangle_quad() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([1.0, 1.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 2], vec![0, 2, 3]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("explicit 2D build should succeed");
+
+    assert_eq!(dt.number_of_vertices(), 4);
+    assert_eq!(dt.number_of_cells(), 2);
+    assert!(
+        dt.tds().is_valid().is_ok(),
+        "TDS should be structurally valid"
+    );
+
+    // Verify neighbor pointers: the two triangles share the edge (0,2) so
+    // each should have the other as a neighbor.
+    let mut neighbor_count = 0;
+    for (_, cell) in dt.cells() {
+        if let Some(neighbors) = cell.neighbors() {
+            for n in neighbors {
+                if n.is_some() {
+                    neighbor_count += 1;
+                }
+            }
+        }
+    }
+    // Two cells sharing one facet → 2 neighbor slots filled (one in each cell).
+    assert!(
+        neighbor_count >= 2,
+        "Shared facet should produce neighbor pointers"
+    );
+}
+
+/// 3D: Build two tetrahedra sharing a face.
+#[test]
+fn test_explicit_3d_two_tetrahedra() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+        vertex!([1.0, 1.0, 1.0]),
+    ];
+    // Two tetrahedra sharing face (0, 1, 2)
+    let cells = vec![vec![0, 1, 2, 3], vec![0, 1, 2, 4]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("explicit 3D build should succeed");
+
+    assert_eq!(dt.number_of_vertices(), 5);
+    assert_eq!(dt.number_of_cells(), 2);
+    assert!(
+        dt.tds().is_valid().is_ok(),
+        "TDS should be structurally valid"
+    );
+}
+
+/// Round-trip: Build via Delaunay → extract → reconstruct via explicit → same structure.
+#[test]
+fn test_explicit_round_trip_2d() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+        vertex!([1.0, 1.0]),
+    ];
+
+    // Build via standard Delaunay.
+    let dt_original = DelaunayTriangulation::new(&vertices).expect("Delaunay build should succeed");
+    let original_vertex_count = dt_original.number_of_vertices();
+    let original_cell_count = dt_original.number_of_cells();
+
+    // Extract vertex keys → index mapping and cell specifications.
+    let tds = dt_original.tds();
+    let vertex_keys: Vec<_> = tds.vertex_keys().collect();
+    let key_to_index: std::collections::HashMap<_, _> = vertex_keys
+        .iter()
+        .enumerate()
+        .map(|(idx, &vk)| (vk, idx))
+        .collect();
+
+    let extracted_vertices: Vec<_> = vertex_keys
+        .iter()
+        .map(|&vk| *tds.get_vertex_by_key(vk).unwrap())
+        .collect();
+
+    let mut cell_specs: Vec<Vec<usize>> = Vec::new();
+    for (_, cell) in tds.cells() {
+        let spec: Vec<usize> = cell.vertices().iter().map(|vk| key_to_index[vk]).collect();
+        cell_specs.push(spec);
+    }
+
+    // Reconstruct via explicit.
+    let dt_reconstructed =
+        DelaunayTriangulationBuilder::from_vertices_and_cells(&extracted_vertices, &cell_specs)
+            .build::<()>()
+            .expect("explicit reconstruction should succeed");
+
+    assert_eq!(dt_reconstructed.number_of_vertices(), original_vertex_count);
+    assert_eq!(dt_reconstructed.number_of_cells(), original_cell_count);
+    assert!(
+        dt_reconstructed.tds().is_valid().is_ok(),
+        "Reconstructed TDS should be structurally valid"
+    );
+}
+
+/// Error: empty cells should fail.
+#[test]
+fn test_explicit_error_empty_cells() {
+    let vertices = vec![vertex!([0.0_f64, 0.0]), vertex!([1.0, 0.0])];
+    let cells: Vec<Vec<usize>> = vec![];
+
+    let result =
+        DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells).build::<()>();
+
+    assert!(result.is_err(), "Empty cells should produce an error");
+}
+
+/// Error: wrong cell arity.
+#[test]
+fn test_explicit_error_wrong_arity() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    // 2D expects 3 vertices per cell, but we provide 2.
+    let cells = vec![vec![0, 1]];
+
+    let result =
+        DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells).build::<()>();
+
+    assert!(result.is_err(), "Wrong arity should produce an error");
+}
+
+/// Error: out-of-bounds vertex index.
+#[test]
+fn test_explicit_error_index_out_of_bounds() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 99]]; // 99 is out of bounds
+
+    let result =
+        DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells).build::<()>();
+
+    assert!(
+        result.is_err(),
+        "Out-of-bounds index should produce an error"
+    );
+}
+
+/// Error: duplicate vertex in cell.
+#[test]
+fn test_explicit_error_duplicate_vertex_in_cell() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 1]]; // Duplicate vertex 1
+
+    let result =
+        DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells).build::<()>();
+
+    assert!(result.is_err(), "Duplicate vertex should produce an error");
+}
+
+/// Error: toroidal + explicit cells is incompatible.
+#[test]
+fn test_explicit_error_toroidal_incompatible() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 2]];
+
+    // Construct with explicit cells then add toroidal.
+    let result = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .toroidal([1.0, 1.0])
+        .build::<()>();
+
+    assert!(
+        result.is_err(),
+        "Toroidal + explicit cells should produce an error"
+    );
+}
+
+/// Minimal case: a single triangle in 2D.
+#[test]
+fn test_explicit_2d_single_triangle() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 2]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("single triangle should succeed");
+
+    assert_eq!(dt.number_of_vertices(), 3);
+    assert_eq!(dt.number_of_cells(), 1);
+    assert!(dt.tds().is_valid().is_ok());
+}
+
+/// Minimal case: a single tetrahedron in 3D.
+#[test]
+fn test_explicit_3d_single_tetrahedron() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 2, 3]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("single tetrahedron should succeed");
+
+    assert_eq!(dt.number_of_vertices(), 4);
+    assert_eq!(dt.number_of_cells(), 1);
+    assert!(dt.tds().is_valid().is_ok());
+}
+
+/// Non-Delaunay mesh: prescribed connectivity that violates the empty-circumsphere
+/// property. Levels 1–3 should pass; Level 4 (Delaunay) should fail.
+///
+/// Geometry: A=(0,0), B=(4,0), C=(4,2), D=(1,2). The circumcircle of ABC has
+/// center (2,1) and radius √5. Point D=(1,2) is at distance √2 < √5 from the
+/// center, so D lies strictly inside the circumcircle of ABC. Using diagonal AC
+/// (cells [0,1,2] and [0,2,3]) is therefore non-Delaunay. The Delaunay
+/// triangulation would use diagonal BD instead.
+#[test]
+fn test_explicit_non_delaunay_mesh() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([4.0, 0.0]),
+        vertex!([4.0, 2.0]),
+        vertex!([1.0, 2.0]),
+    ];
+    // Diagonal AC = (0,0)-(4,2): non-Delaunay because D=(1,2) is inside
+    // the circumcircle of triangle ABC.
+    let cells = vec![vec![0, 1, 2], vec![0, 2, 3]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("non-Delaunay mesh should build successfully (Levels 1-3)");
+
+    assert_eq!(dt.number_of_vertices(), 4);
+    assert_eq!(dt.number_of_cells(), 2);
+    assert!(
+        dt.tds().is_valid().is_ok(),
+        "TDS structural validity (Levels 1-3) should pass"
+    );
+    assert!(
+        dt.is_valid().is_err(),
+        "Delaunay property (Level 4) should fail for non-Delaunay connectivity"
+    );
+}
+
+/// Topology guarantee is propagated through explicit construction.
+#[test]
+fn test_explicit_topology_guarantee_propagated() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 2]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .topology_guarantee(TopologyGuarantee::Pseudomanifold)
+        .build::<()>()
+        .expect("build should succeed");
+
+    assert_eq!(dt.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+}
+
+/// Unreferenced vertices: vertices not used by any cell are still present.
+#[test]
+fn test_explicit_unreferenced_vertices() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+        vertex!([5.0, 5.0]), // Not referenced by any cell
+    ];
+    let cells = vec![vec![0, 1, 2]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("build with unreferenced vertices should succeed");
+
+    assert_eq!(
+        dt.number_of_vertices(),
+        4,
+        "All vertices should be inserted"
+    );
+    assert_eq!(dt.number_of_cells(), 1);
+}
+
+/// Error variant: empty cells returns ExplicitConstruction(EmptyCells).
+#[test]
+fn test_explicit_error_variant_empty_cells() {
+    let vertices = vec![vertex!([0.0_f64, 0.0])];
+    let cells: Vec<Vec<usize>> = vec![];
+
+    let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::EmptyCells
+            )
+        ),
+        "Expected ExplicitConstruction(EmptyCells), got: {err}"
+    );
+}
+
+/// Error variant: wrong arity returns ExplicitConstruction(InvalidCellArity { .. }).
+#[test]
+fn test_explicit_error_variant_wrong_arity() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1]]; // 2D expects 3 vertices
+
+    let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::InvalidCellArity {
+                    cell_index: 0,
+                    actual: 2,
+                    expected: 3
+                }
+            )
+        ),
+        "Expected InvalidCellArity, got: {err}"
+    );
+}
+
+/// Error variant: out-of-bounds returns ExplicitConstruction(IndexOutOfBounds { .. }).
+#[test]
+fn test_explicit_error_variant_index_out_of_bounds() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 99]];
+
+    let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::IndexOutOfBounds {
+                    cell_index: 0,
+                    vertex_index: 99,
+                    bound: 3,
+                }
+            )
+        ),
+        "Expected IndexOutOfBounds, got: {err}"
     );
 }

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -430,6 +430,32 @@ fn test_explicit_2d_two_triangle_quad() {
     );
 }
 
+/// Explicit construction normalizes incoherent local cell orderings.
+///
+/// Swapping two vertices in one cell flips its local orientation relative to an
+/// otherwise valid two-triangle mesh. The builder should repair that internal
+/// ordering detail and still produce a structurally valid TDS.
+#[test]
+fn test_explicit_normalizes_incoherent_cell_order() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([1.0, 1.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let mut cells = vec![vec![0, 1, 2], vec![0, 2, 3]];
+    cells[1].swap(0, 1);
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("explicit build should normalize incoherent cell ordering");
+
+    assert!(
+        dt.tds().is_valid().is_ok(),
+        "builder should canonicalize incoherent cell orderings into a valid TDS"
+    );
+}
+
 /// 3D: Build two tetrahedra sharing a face.
 #[test]
 fn test_explicit_3d_two_tetrahedra() {
@@ -788,9 +814,9 @@ fn test_explicit_validate_delaunay_mesh() {
     );
 }
 
-/// Unreferenced vertices: vertices not used by any cell are still present.
+/// Unreferenced vertices fail Level 3 topology validation (isolated vertex).
 #[test]
-fn test_explicit_unreferenced_vertices() {
+fn test_explicit_unreferenced_vertices_rejected() {
     let vertices = vec![
         vertex!([0.0_f64, 0.0]),
         vertex!([1.0, 0.0]),
@@ -799,16 +825,19 @@ fn test_explicit_unreferenced_vertices() {
     ];
     let cells = vec![vec![0, 1, 2]];
 
-    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+    let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
         .build::<()>()
-        .expect("build with unreferenced vertices should succeed");
+        .unwrap_err();
 
-    assert_eq!(
-        dt.number_of_vertices(),
-        4,
-        "All vertices should be inserted"
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::ValidationFailed { .. }
+            )
+        ),
+        "Unreferenced vertices should produce ValidationFailed, got: {err}"
     );
-    assert_eq!(dt.number_of_cells(), 1);
 }
 
 /// Error variant: empty cells returns ExplicitConstruction(EmptyCells).

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -3,12 +3,19 @@
 //! These tests exercise the public API from the outside, using only items exposed
 //! through `delaunay::prelude::triangulation` and `delaunay::core::builder`.
 
+use std::collections::HashMap;
+
 use delaunay::core::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
 use delaunay::core::delaunay_triangulation::{
     ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationConstructionError,
     InsertionOrderStrategy,
 };
 use delaunay::core::triangulation::TopologyGuarantee;
+use delaunay::core::vertex::{Vertex, VertexBuilder};
+use delaunay::geometry::kernel::RobustKernel;
+use delaunay::geometry::point::Point;
+use delaunay::geometry::traits::coordinate::Coordinate;
+use delaunay::topology::characteristics::euler::{count_simplices, euler_characteristic};
 use delaunay::vertex;
 
 // =============================================================================
@@ -89,7 +96,7 @@ fn test_builder_custom_construction_options() {
 
 /// `DelaunayTriangulation::builder()` convenience method compiles and works.
 #[test]
-fn test_delaunay_triangulation_builder_convenience_method() {
+fn test_builder_convenience() {
     let vertices = vec![
         vertex!([0.0_f64, 0.0]),
         vertex!([1.0, 0.0]),
@@ -104,7 +111,7 @@ fn test_delaunay_triangulation_builder_convenience_method() {
 
 /// `DelaunayTriangulation::builder()` with toroidal wrapping.
 #[test]
-fn test_delaunay_triangulation_builder_toroidal_convenience() {
+fn test_builder_toroidal_convenience() {
     let vertices = vec![
         vertex!([0.2_f64, 0.3]),
         vertex!([1.8, 0.1]), // → (0.8, 0.1)
@@ -284,8 +291,6 @@ fn test_builder_toroidal_larger_point_set_2d() {
 /// `build_with_kernel` with `RobustKernel` works for a 3D toroidal case.
 #[test]
 fn test_builder_toroidal_robust_kernel_3d() {
-    use delaunay::geometry::kernel::RobustKernel;
-
     let vertices = vec![
         vertex!([0.2_f64, 0.3, 0.4]),
         vertex!([0.8, 0.1, 0.2]),
@@ -315,9 +320,6 @@ fn test_builder_toroidal_robust_kernel_3d() {
 /// validity and χ separately.
 #[test]
 fn test_builder_toroidal_periodic_chi_zero_2d() {
-    use delaunay::geometry::kernel::RobustKernel;
-    use delaunay::topology::characteristics::euler::{count_simplices, euler_characteristic};
-
     let vertices = vec![
         vertex!([0.1_f64, 0.2]),
         vertex!([0.4, 0.7]),
@@ -354,8 +356,7 @@ fn test_builder_toroidal_periodic_chi_zero_2d() {
 #[test]
 #[ignore = "Slow (>60s): periodic 3D expands to 3^D image points; run with --ignored"]
 fn test_builder_toroidal_periodic_3d_success() {
-    use delaunay::geometry::kernel::RobustKernel;
-    // Keep this as a smoke/regression test rather than a large stress case.
+    // Keep this
     // The periodic 3D pipeline expands to 3^D image points internally, so runtime grows quickly
     // with input size and can become flaky under CI load. We keep a compact, well-separated set
     // above the algorithm minimum (2*D + 1 = 7 points for D=3).
@@ -454,6 +455,53 @@ fn test_explicit_3d_two_tetrahedra() {
     );
 }
 
+/// Round-trip 3D: Build via Delaunay → extract → reconstruct via explicit → same structure.
+#[test]
+fn test_explicit_round_trip_3d() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+        vertex!([1.0, 1.0, 1.0]),
+    ];
+
+    let dt_original = DelaunayTriangulation::new(&vertices).expect("Delaunay build should succeed");
+    let original_vertex_count = dt_original.number_of_vertices();
+    let original_cell_count = dt_original.number_of_cells();
+
+    let tds = dt_original.tds();
+    let vertex_keys: Vec<_> = tds.vertex_keys().collect();
+    let key_to_index: HashMap<_, _> = vertex_keys
+        .iter()
+        .enumerate()
+        .map(|(idx, &vk)| (vk, idx))
+        .collect();
+
+    let extracted_vertices: Vec<_> = vertex_keys
+        .iter()
+        .map(|&vk| *tds.get_vertex_by_key(vk).unwrap())
+        .collect();
+
+    let mut cell_specs: Vec<Vec<usize>> = Vec::new();
+    for (_, cell) in tds.cells() {
+        let spec: Vec<usize> = cell.vertices().iter().map(|vk| key_to_index[vk]).collect();
+        cell_specs.push(spec);
+    }
+
+    let dt_reconstructed =
+        DelaunayTriangulationBuilder::from_vertices_and_cells(&extracted_vertices, &cell_specs)
+            .build::<()>()
+            .expect("explicit 3D reconstruction should succeed");
+
+    assert_eq!(dt_reconstructed.number_of_vertices(), original_vertex_count);
+    assert_eq!(dt_reconstructed.number_of_cells(), original_cell_count);
+    assert!(
+        dt_reconstructed.tds().is_valid().is_ok(),
+        "Reconstructed 3D TDS should be structurally valid"
+    );
+}
+
 /// Round-trip: Build via Delaunay → extract → reconstruct via explicit → same structure.
 #[test]
 fn test_explicit_round_trip_2d() {
@@ -472,7 +520,7 @@ fn test_explicit_round_trip_2d() {
     // Extract vertex keys → index mapping and cell specifications.
     let tds = dt_original.tds();
     let vertex_keys: Vec<_> = tds.vertex_keys().collect();
-    let key_to_index: std::collections::HashMap<_, _> = vertex_keys
+    let key_to_index: HashMap<_, _> = vertex_keys
         .iter()
         .enumerate()
         .map(|(idx, &vk)| (vk, idx))
@@ -681,6 +729,65 @@ fn test_explicit_topology_guarantee_propagated() {
     assert_eq!(dt.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
 }
 
+/// Explicit construction preserves vertex data (U ≠ ()).
+#[test]
+fn test_explicit_preserves_vertex_data() {
+    let vertices: Vec<Vertex<f64, i32, 2>> = vec![
+        VertexBuilder::default()
+            .point(Point::new([0.0, 0.0]))
+            .data(10_i32)
+            .build()
+            .unwrap(),
+        VertexBuilder::default()
+            .point(Point::new([1.0, 0.0]))
+            .data(20_i32)
+            .build()
+            .unwrap(),
+        VertexBuilder::default()
+            .point(Point::new([0.0, 1.0]))
+            .data(30_i32)
+            .build()
+            .unwrap(),
+    ];
+    let cells = vec![vec![0, 1, 2]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("explicit build with vertex data should succeed");
+
+    let mut data: Vec<i32> = dt
+        .vertices()
+        .filter_map(|(_, v)| v.data().copied())
+        .collect();
+    data.sort_unstable();
+    assert_eq!(
+        data,
+        vec![10, 20, 30],
+        "Vertex data must survive explicit construction"
+    );
+}
+
+/// Full `validate()` (Levels 1–4) on a Delaunay-compatible explicit mesh.
+#[test]
+fn test_explicit_validate_delaunay_mesh() {
+    // Use a known Delaunay configuration: the standard simplex.
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.5, 0.866_025_403_784_438_6]),
+    ];
+    let cells = vec![vec![0, 1, 2]];
+
+    let dt = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .expect("build should succeed");
+
+    assert!(
+        dt.validate().is_ok(),
+        "Full Levels 1-4 validation should pass for Delaunay-compatible explicit mesh"
+    );
+}
+
 /// Unreferenced vertices: vertices not used by any cell are still present.
 #[test]
 fn test_explicit_unreferenced_vertices() {
@@ -751,6 +858,86 @@ fn test_explicit_error_variant_wrong_arity() {
             )
         ),
         "Expected InvalidCellArity, got: {err}"
+    );
+}
+
+/// Error variant: non-manifold facet sharing returns ExplicitConstruction(ValidationFailed { .. }).
+#[test]
+fn test_explicit_error_variant_non_manifold_facet() {
+    // Three triangles sharing the same edge (0,1) — facet shared by 3 cells
+    // violates the 2-manifold property.
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+        vertex!([1.0, 1.0]),
+        vertex!([0.5, -1.0]),
+    ];
+    let cells = vec![vec![0, 1, 2], vec![0, 1, 3], vec![0, 1, 4]];
+
+    let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::ValidationFailed { .. }
+            )
+        ),
+        "Expected ExplicitConstruction(ValidationFailed), got: {err}"
+    );
+}
+
+/// Error variant: duplicate vertex returns ExplicitConstruction(DuplicateVertexInCell { .. }).
+#[test]
+fn test_explicit_error_variant_duplicate_vertex_in_cell() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 1]]; // Duplicate vertex 1
+
+    let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .build::<()>()
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::DuplicateVertexInCell { cell_index: 0 }
+            )
+        ),
+        "Expected DuplicateVertexInCell, got: {err}"
+    );
+}
+
+/// Error variant: toroidal + explicit returns ExplicitConstruction(IncompatibleTopology).
+#[test]
+fn test_explicit_error_variant_incompatible_topology() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+    let cells = vec![vec![0, 1, 2]];
+
+    let err = DelaunayTriangulationBuilder::from_vertices_and_cells(&vertices, &cells)
+        .toroidal([1.0, 1.0])
+        .build::<()>()
+        .unwrap_err();
+
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::IncompatibleTopology
+            )
+        ),
+        "Expected IncompatibleTopology, got: {err}"
     );
 }
 


### PR DESCRIPTION
- Introduce `DelaunayTriangulationBuilder::from_vertices_and_cells` for combinatorial construction bypassing Delaunay insertion
- Add `build_explicit` path that constructs a TDS directly from given vertices and cell index lists, with adjacency and orientation repair
- Define `ExplicitConstructionError` enum with `IndexOutOfBounds`, `InvalidCellArity`, `DuplicateVertexInCell`, `EmptyCells`, and `IncompatibleTopology` variants
- Wire `ExplicitConstruction` variant into `DelaunayTriangulationConstructionError`
- Expose `assign_neighbors` as `pub(crate)` in the TDS
- Add comprehensive integration tests for explicit construction across 2D/3D, round-trip fidelity, error cases, and topology guarantees