### PR TITLE
feat: add diagnostic infrastructure for v0.7.6 investigation (#306, #…

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,8 +1,11 @@
 # TODO — Weaknesses & Risks
 
-Identified during a full codebase evaluation (v0.7.4, branch
-`feat/diagnostic-infrastructure-v076`). Items are grouped by category and
-prioritized by severity.
+**As of:** 2026-04-09 · v0.7.4 (main) · diagnostic infrastructure targeting v0.7.6
+
+Identified during a full codebase evaluation. Items are grouped by category
+and prioritized by severity. Scoping notes reference the *next patch release
+after the current diagnostic work* — version numbers will be updated when
+the release target is finalized.
 
 Legend: **🔴 High** · **🟡 Medium** · **🟢 Low**
 
@@ -148,9 +151,10 @@ The dual Voronoi diagram is a natural extension but not yet implemented.
 
 ---
 
-## v0.7.5 Release Candidates
+## Next Patch Release Candidates
 
-Items feasible for the v0.7.5 release, ordered by impact:
+Items feasible for the next patch release (tentatively v0.7.5), ordered by
+impact:
 
 1. **Diagnostic infrastructure for #306/#307** — already in progress on
    this branch. Ship improved conflict-region verification and orientation

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,169 @@
+# TODO — Weaknesses & Risks
+
+Identified during a full codebase evaluation (v0.7.4, branch
+`feat/diagnostic-infrastructure-v076`). Items are grouped by category and
+prioritized by severity.
+
+Legend: **🔴 High** · **🟡 Medium** · **🟢 Low**
+
+---
+
+## 1 · Correctness
+
+### 🔴 3D flip-cycle non-convergence (#306, #204)
+
+Flip-based Delaunay repair enters cycles at ≥35 vertices (seed-dependent).
+SoS eliminates predicate ambiguity; root cause is cavity/topology
+interactions. This is the primary open correctness issue.
+
+**v0.7.5 scope:** the `feat/diagnostic-infrastructure-v076` branch adds
+conflict-region completeness verification and orientation audits. A fix is
+unlikely for v0.7.5 but improved diagnostics will ship, narrowing the root
+cause for a subsequent release.
+
+### 🔴 4D bulk construction vertex skipping (#307, #204)
+
+Batch 4D construction (100 points, specific seed) produces a
+negative-orientation cell early, causing 88% of subsequent insertions to be
+skipped as degeneracies. Incremental insertion is a viable workaround.
+
+**v0.7.5 scope:** same diagnostic branch. Orientation-audit improvements
+may expose the root cause but a fix is unlikely for this release.
+
+---
+
+## 2 · Performance
+
+### 🟡 Exact predicate fast-filter rejection rate (#256)
+
+The provable `det_errbound()` bounds correctly reject more cases to exact
+Bareiss than the old heuristic, causing ~47 proptests to exceed CI
+timeouts. A Shewchuk-style multi-stage adaptive expansion would reduce
+exact-path frequency without sacrificing correctness.
+
+**v0.7.5 scope:** not feasible — requires upstream `la-stack` work or a
+new adaptive expansion layer. Track in #256.
+
+### 🟡 3D triangulation performance (#310)
+
+General 3D construction and query performance. Profiling and targeted
+optimization needed.
+
+**v0.7.5 scope:** profiling can begin; targeted fixes possible if
+bottlenecks are clear.
+
+---
+
+## 3 · Codebase Complexity
+
+### 🟡 Monolithic implementation blocks (#302)
+
+`DelaunayTriangulation` has large `impl` blocks with broad trait bounds
+that make the code harder to navigate and increase compile times.
+
+**v0.7.5 scope:** feasible — mechanical refactor to split `impl` blocks by
+concern (construction, query, mutation, validation). Low risk.
+
+### 🟡 Module structure (#288)
+
+`delaunay_triangulation.rs` and `builder.rs` live under `core/` but could
+be moved to `triangulation/` for clearer layering.
+
+**v0.7.5 scope:** not recommended for a patch release — high churn, no
+functional benefit.
+
+### 🟢 Builder function size
+
+`builder.rs` has `#[expect(clippy::too_many_lines)]` suppressions on
+`search_closed_2d_selection` and related functions. These should be
+decomposed into smaller helpers.
+
+**v0.7.5 scope:** feasible — localized refactor with low risk.
+
+---
+
+## 4 · API & Ergonomics
+
+### 🟡 Prelude nesting depth
+
+The prelude has 7+ sub-modules (`triangulation`, `geometry`, `query`,
+`collections`, `topology::validation`, `triangulation::flips`,
+`triangulation::delaunayize`). New users may struggle to find the right
+import path.
+
+**v0.7.5 scope:** documentation improvements are feasible (e.g., a
+"which import do I need?" section in the crate docs). Structural changes
+should wait for a minor release.
+
+### 🟡 Doctest migration to builder API (#214)
+
+Many doctests still use `DelaunayTriangulation::new()` directly. Migrating
+to `DelaunayTriangulationBuilder` would dogfood the recommended API.
+
+**v0.7.5 scope:** feasible — mechanical, low risk, improves documentation
+quality.
+
+### 🟢 Unified Pachner move API (#252)
+
+The current flip API has separate methods for each k value. A unified
+`flip(move)` entry point would simplify the surface.
+
+**v0.7.5 scope:** not for a patch release — API design work needed.
+
+---
+
+## 5 · Testing Gaps
+
+### 🟡 Disabled proptests (~47 tests, #256)
+
+Property tests disabled due to exact-predicate timeouts. These represent
+real coverage gaps for near-degenerate inputs.
+
+**v0.7.5 scope:** blocked by predicate performance (#256). Could
+selectively re-enable the fastest subset.
+
+### 🟢 Constrained Delaunay triangulations (#299)
+
+No CDT support yet. This is a feature gap rather than a bug, but it limits
+applicability for mesh generation workflows.
+
+**v0.7.5 scope:** out of scope — significant new feature.
+
+---
+
+## 6 · Infrastructure
+
+### 🟢 Visualization (#64)
+
+No built-in visualization for debugging or user inspection. Third-party
+tools (e.g., plotting point sets) are the current workaround.
+
+**v0.7.5 scope:** out of scope.
+
+### 🟢 Voronoi diagrams (#63)
+
+The dual Voronoi diagram is a natural extension but not yet implemented.
+
+**v0.7.5 scope:** out of scope — new feature.
+
+---
+
+## v0.7.5 Release Candidates
+
+Items feasible for the v0.7.5 release, ordered by impact:
+
+1. **Diagnostic infrastructure for #306/#307** — already in progress on
+   this branch. Ship improved conflict-region verification and orientation
+   audits.
+2. **Split monolithic `impl` blocks (#302)** — mechanical refactor,
+   improves maintainability and compile times.
+3. **Builder function decomposition** — eliminate `too_many_lines`
+   suppressions in `builder.rs`.
+4. **Doctest migration to builder API (#214)** — improves documentation
+   quality and dogfoods the recommended API.
+5. **Prelude import guidance** — add a "which import?" section to crate-level
+   docs.
+6. **Selectively re-enable fastest proptests** — partial recovery of
+   coverage from #256 disabled tests.
+7. **3D performance profiling (#310)** — begin profiling; ship fixes if
+   bottlenecks are clear.

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -41,7 +41,7 @@ in release builds.
 
 | Variable | Activation | Module | Description |
 |---|---|---|---|
-| `DELAUNAY_DEBUG_CAVITY` | presence | `incremental_insertion.rs` | Cavity boundary analysis, cell creation provenance with orientation |
+| `DELAUNAY_DEBUG_CAVITY` | presence | `incremental_insertion.rs`, `locate.rs` | Cavity boundary diagnostics, cell creation provenance with orientation |
 | `DELAUNAY_DEBUG_HULL` | presence | `incremental_insertion.rs` | Hull extension visibility, locate stats, neighbor summary |
 | `DELAUNAY_DEBUG_HULL_DETAIL` | presence | `incremental_insertion.rs` | Per-facet orientation details during visibility computation |
 

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -1,0 +1,133 @@
+# Debug Environment Variables
+
+Comprehensive reference for all `DELAUNAY_*` environment variables used for
+runtime diagnostics and debugging. All variables are **debug-only** unless
+noted — they are gated behind `#[cfg(debug_assertions)]` and have no effect
+in release builds.
+
+**Activation**: most variables are presence-activated (any value works, e.g.
+`DELAUNAY_DEBUG_CAVITY=1`). Variables that read a **value** are marked below.
+
+**Output**: all diagnostic output uses the `tracing` crate. Enable with a
+`tracing-subscriber` (e.g. `RUST_LOG=debug`).
+
+---
+
+## Construction & Insertion
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_INSERT_TRACE` | presence | `triangulation.rs` | Per-insertion summary (vertex index, location, conflict size, suspicion flags) |
+| `DELAUNAY_DEBUG_SHUFFLE` | presence | `triangulation.rs` | Logs vertex shuffle order during batch construction |
+| `DELAUNAY_DUPLICATE_METRICS` | presence | `delaunay_triangulation.rs` | Duplicate-detection metrics (spatial hash grid stats) |
+
+## Point Location
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_DEBUG_LOCATE` | presence | `triangulation.rs` | Locate stats (walk steps, hint usage, fallback) |
+| `DELAUNAY_DEBUG_VALIDATE_LOCATE` | presence | `locate.rs` | Cross-validates locate result against brute-force scan |
+
+## Conflict Region
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_DEBUG_CONFLICT` | presence | `locate.rs` | Per-cell insphere classification during BFS, including BFS boundary cells |
+| `DELAUNAY_DEBUG_CONFLICT_PROGRESS` | presence | `locate.rs` | Periodic progress during large BFS traversals |
+| `DELAUNAY_DEBUG_CONFLICT_PROGRESS_EVERY` | **value** (integer) | `locate.rs` | Interval for progress logging (default: dimension-dependent) |
+| `DELAUNAY_DEBUG_CONFLICT_VERIFY` | presence | `triangulation.rs` | Brute-force verification of BFS conflict-region completeness with reachability analysis |
+
+## Cavity & Hull
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_DEBUG_CAVITY` | presence | `incremental_insertion.rs` | Cavity boundary analysis, cell creation provenance with orientation |
+| `DELAUNAY_DEBUG_HULL` | presence | `incremental_insertion.rs` | Hull extension visibility, locate stats, neighbor summary |
+| `DELAUNAY_DEBUG_HULL_DETAIL` | presence | `incremental_insertion.rs` | Per-facet orientation details during visibility computation |
+
+## Orientation
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_DEBUG_ORIENTATION` | presence | `triangulation.rs` | Negative-orientation cell canonicalization and post-insertion audit |
+
+## Neighbor Wiring
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_DEBUG_NEIGHBORS` | presence | `incremental_insertion.rs`, `triangulation.rs` | Neighbor symmetry checks after cavity wiring and hull extension |
+| `DELAUNAY_DEBUG_RIDGE_LINK` | presence | `incremental_insertion.rs`, `triangulation.rs` | Ridge-link validation after wiring; skipped external facet matches |
+
+## Flip Repair
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_REPAIR_TRACE` | presence | `flips.rs` | Per-flip trace: enqueue, skip, apply, context details |
+| `DELAUNAY_REPAIR_DEBUG_FACETS` | presence | `flips.rs` | Facet-level flip skip reasons (degenerate, duplicate, non-manifold, existing simplex) |
+| `DELAUNAY_REPAIR_DEBUG_PREDICATES` | presence | `flips.rs` | Insphere classification details for k=2 and k=3 violation checks |
+| `DELAUNAY_REPAIR_DEBUG_RIDGE` | presence | `flips.rs` | Ridge context snapshots during k=3 repair |
+| `DELAUNAY_REPAIR_DEBUG_RIDGE_LIMIT` | **value** (integer) | `flips.rs` | Maximum ridge debug snapshots (default: 64) |
+| `DELAUNAY_REPAIR_DEBUG_SUMMARY` | presence | `flips.rs` | Per-attempt repair summary (flips, checks, cycles, ambiguous, skips) |
+
+## Predicates & Validation
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` | presence | `delaunay_triangulation.rs` | Cross-validates insphere results between fast and exact predicates |
+| `DELAUNAY_DEBUG_LU_FALLBACK` | presence | `circumsphere.rs` | Logs when circumsphere computation falls back to LU decomposition |
+
+## Point Generation
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_DEBUG_RANDOM_BUILDER` | presence | `triangulation_generation.rs` | Random triangulation builder diagnostics (point generation, retry logic) |
+| `DELAUNAY_DEBUG_RANDOM_POINTSET_RETRIES` | presence | `point_generation.rs` | Retry attempts during random point set generation |
+
+## Large-Scale Debug Test Harness
+
+These variables configure `tests/large_scale_debug.rs` and run in both debug
+and release builds.
+
+| Variable | Activation | Description |
+|---|---|---|
+| `DELAUNAY_LARGE_DEBUG_N` | **value** | Number of vertices (global default) |
+| `DELAUNAY_LARGE_DEBUG_N_{D}D` | **value** | Per-dimension vertex count override (e.g. `_N_3D=35`) |
+| `DELAUNAY_LARGE_DEBUG_SEED` | **value** (hex) | Master RNG seed |
+| `DELAUNAY_LARGE_DEBUG_CASE_SEED` | **value** (hex) | Per-case RNG seed (global default) |
+| `DELAUNAY_LARGE_DEBUG_CASE_SEED_{D}D` | **value** (hex) | Per-dimension case seed override |
+| `DELAUNAY_LARGE_DEBUG_DISTRIBUTION` | **value** | `ball` or `box` |
+| `DELAUNAY_LARGE_DEBUG_BALL_RADIUS` | **value** | Radius for ball distribution |
+| `DELAUNAY_LARGE_DEBUG_BOX_HALF_WIDTH` | **value** | Half-width for box distribution |
+| `DELAUNAY_LARGE_DEBUG_CONSTRUCTION_MODE` | **value** | `new` (batch) or `incremental` |
+| `DELAUNAY_LARGE_DEBUG_DEBUG_MODE` | **value** | `cadenced` or `strict` |
+| `DELAUNAY_LARGE_DEBUG_SHUFFLE_SEED` | **value** | Vertex shuffle seed |
+| `DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY` | **value** | Progress logging interval |
+| `DELAUNAY_LARGE_DEBUG_VALIDATE_EVERY` | **value** | Validation interval |
+| `DELAUNAY_LARGE_DEBUG_REPAIR_EVERY` | **value** | Repair interval |
+| `DELAUNAY_LARGE_DEBUG_REPAIR_MAX_FLIPS` | **value** | Flip budget override |
+| `DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS` | **value** | Timeout (0 = no cap) |
+| `DELAUNAY_LARGE_DEBUG_ALLOW_SKIPS` | presence | Allow vertex insertion skips |
+| `DELAUNAY_LARGE_DEBUG_SKIP_FINAL_REPAIR` | presence | Skip final global repair pass |
+| `DELAUNAY_LARGE_DEBUG_PREFIX_TOTAL` | **value** | Total prefix probes for bisect mode |
+| `DELAUNAY_LARGE_DEBUG_PREFIX_MAX_PROBES` | **value** | Max probes per bisect run |
+| `DELAUNAY_LARGE_DEBUG_PREFIX_MAX_RUNTIME_SECS` | **value** | Bisect probe timeout |
+
+## Proptest Configuration
+
+These variables configure property tests in `tests/proptest_*.rs`.
+
+| Variable | Activation | Description |
+|---|---|---|
+| `DELAUNAY_PROPTEST_CONSTRUCTION_ERRORS` | presence | Log construction errors during proptests |
+| `DELAUNAY_PROPTEST_INSERT_ERRORS` | presence | Log insertion errors during proptests |
+| `DELAUNAY_PROPTEST_REJECT_STATS` | presence | Log rejection statistics |
+| `DELAUNAY_PROPTEST_COVERAGE_LOGS` | presence | Log coverage statistics |
+| `DELAUNAY_PROPTEST_MIN_ACCEPTANCE_PCT` | **value** | Minimum acceptance percentage |
+| `DELAUNAY_PROPTEST_MIN_ACCEPTANCE_PCT_{D}D` | **value** | Per-dimension acceptance override |
+| `DELAUNAY_ALLOW_SLOW_COSPHERICAL_FILTER` | presence | Allow slow cospherical point filtering |
+
+## Miscellaneous
+
+| Variable | Activation | Module | Description |
+|---|---|---|---|
+| `DELAUNAY_DEBUG_UNUSED_IMPORTS` | presence | `triangulation.rs` | Internal: suppress unused-import warnings in conditional compilation |

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -607,6 +607,39 @@ where
                     message: format!("Failed to insert cell: {e}"),
                 })?;
 
+        // Cell creation provenance: log each newly created cell with its
+        // vertex ordering, geometric orientation, and source boundary facet.
+        // Helps trace which insertion step produces negative-orientation cells.
+        #[cfg(debug_assertions)]
+        if std::env::var_os("DELAUNAY_DEBUG_CAVITY").is_some()
+            && let Some(created_cell) = tds.get_cell(cell_key)
+        {
+            let cell_points: SmallBuffer<Point<T, D>, MAX_PRACTICAL_DIMENSION_SIZE> = created_cell
+                .vertices()
+                .iter()
+                .filter_map(|&vk| tds.get_vertex_by_key(vk).map(|v| *v.point()))
+                .collect();
+            let orientation = if cell_points.len() == D + 1 {
+                robust_orientation(&cell_points)
+                    .map(|o| match o {
+                        Orientation::POSITIVE => 1,
+                        Orientation::NEGATIVE => -1,
+                        Orientation::DEGENERATE => 0,
+                    })
+                    .unwrap_or(0)
+            } else {
+                0
+            };
+            tracing::debug!(
+                cell_key = ?cell_key,
+                vertex_keys = ?created_cell.vertices(),
+                orientation,
+                source_boundary_cell = ?facet_handle.cell_key(),
+                source_facet_index = usize::from(facet_handle.facet_index()),
+                "fill_cavity: created cell provenance"
+            );
+        }
+
         new_cells.push(cell_key);
     }
 

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -619,21 +619,28 @@ where
                 .iter()
                 .filter_map(|&vk| tds.get_vertex_by_key(vk).map(|v| *v.point()))
                 .collect();
-            let orientation = if cell_points.len() == D + 1 {
-                robust_orientation(&cell_points)
-                    .map(|o| match o {
-                        Orientation::POSITIVE => 1,
-                        Orientation::NEGATIVE => -1,
-                        Orientation::DEGENERATE => 0,
-                    })
-                    .unwrap_or(0)
+            let orientation: Option<i32> = if cell_points.len() == D + 1 {
+                match robust_orientation(&cell_points) {
+                    Ok(Orientation::POSITIVE) => Some(1),
+                    Ok(Orientation::NEGATIVE) => Some(-1),
+                    Ok(Orientation::DEGENERATE) => Some(0),
+                    Err(ref e) => {
+                        tracing::warn!(
+                            cell_key = ?cell_key,
+                            vertex_keys = ?created_cell.vertices(),
+                            error = %e,
+                            "fill_cavity: robust_orientation failed for created cell"
+                        );
+                        None
+                    }
+                }
             } else {
-                0
+                Some(0)
             };
             tracing::debug!(
                 cell_key = ?cell_key,
                 vertex_keys = ?created_cell.vertices(),
-                orientation,
+                orientation = ?orientation,
                 source_boundary_cell = ?facet_handle.cell_key(),
                 source_facet_index = usize::from(facet_handle.facet_index()),
                 "fill_cavity: created cell provenance"

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -635,7 +635,14 @@ where
                     }
                 }
             } else {
-                Some(0)
+                tracing::warn!(
+                    cell_key = ?cell_key,
+                    vertex_keys = ?created_cell.vertices(),
+                    actual_len = cell_points.len(),
+                    expected_len = D + 1,
+                    "fill_cavity: incomplete vertex data for orientation (missing vertices)"
+                );
+                None
             };
             tracing::debug!(
                 cell_key = ?cell_key,

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -858,8 +858,25 @@ where
                     }
                 }
             }
+        } else {
+            // Cell is NOT in conflict (sign < 0): BFS boundary.
+            // Log boundary cells so investigators can see exactly where
+            // and why the BFS stopped expanding.
+            #[cfg(debug_assertions)]
+            if debug_config.log_conflict {
+                let neighbor_keys: SmallBuffer<Option<CellKey>, MAX_PRACTICAL_DIMENSION_SIZE> =
+                    cell.neighbors()
+                        .map(|ns| ns.iter().copied().collect())
+                        .unwrap_or_default();
+                tracing::debug!(
+                    cell_key = ?cell_key,
+                    vertex_keys = ?cell.vertices(),
+                    sign,
+                    neighbors = ?neighbor_keys,
+                    "find_conflict_region: BFS boundary (non-conflict)"
+                );
+            }
         }
-        // If sign < 0, cell is not in conflict, don't explore further in this direction
     }
 
     #[cfg(debug_assertions)]
@@ -874,6 +891,111 @@ where
     }
 
     Ok(conflict_cells)
+}
+
+/// Verify that a BFS-found conflict region is complete by brute-force scanning all cells.
+///
+/// This debug-only function compares the conflict region found by BFS traversal against
+/// a full scan of every cell in the TDS using insphere tests. Any cell that the BFS missed
+/// (i.e., the point is inside its circumsphere but the cell was not found by BFS) is logged
+/// as a "missed" cell.
+///
+/// Activated by setting `DELAUNAY_DEBUG_CONFLICT_VERIFY=1`.
+///
+/// Returns the number of missed cells (0 means the BFS result is complete).
+#[cfg(debug_assertions)]
+pub fn verify_conflict_region_completeness<K, U, V, const D: usize>(
+    tds: &Tds<K::Scalar, U, V, D>,
+    kernel: &K,
+    point: &Point<K::Scalar, D>,
+    bfs_conflict_cells: &CellKeyBuffer,
+) -> usize
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    use crate::core::util::canonical_points::sorted_cell_points;
+
+    let bfs_set: FastHashSet<CellKey> = bfs_conflict_cells.iter().copied().collect();
+    let mut missed_count = 0usize;
+    let mut brute_force_count = 0usize;
+
+    for (cell_key, cell) in tds.cells() {
+        let Some(simplex_points) = sorted_cell_points(tds, cell) else {
+            continue;
+        };
+        if simplex_points.len() != D + 1 {
+            continue;
+        }
+
+        let Ok(sign) = kernel.in_sphere(&simplex_points, point) else {
+            continue;
+        };
+
+        if sign >= 0 {
+            brute_force_count += 1;
+            if !bfs_set.contains(&cell_key) {
+                missed_count += 1;
+
+                // Reachability analysis: determine WHY BFS missed this cell.
+                // Check if any TDS neighbor of the missed cell is in the BFS
+                // conflict set.  This distinguishes two root causes:
+                //   - Reachable: a neighbor IS in bfs_set, so BFS reached a
+                //     neighbor but an intermediate insphere test rejected it
+                //   - Unreachable: NO neighbors are in bfs_set, indicating
+                //     broken neighbor pointers or a disconnected pocket
+                let (neighbor_in_bfs, neighbor_total, neighbor_none) =
+                    cell.neighbors().map_or((0, 0, 0), |neighbors| {
+                        let total = neighbors.len();
+                        let none_count = neighbors.iter().filter(|n| n.is_none()).count();
+                        let in_bfs = neighbors
+                            .iter()
+                            .filter_map(|n| *n)
+                            .filter(|nk| bfs_set.contains(nk))
+                            .count();
+                        (in_bfs, total, none_count)
+                    });
+
+                let reachability = if neighbor_in_bfs > 0 {
+                    "REACHABLE_BUT_REJECTED"
+                } else {
+                    "UNREACHABLE"
+                };
+
+                tracing::warn!(
+                    cell_key = ?cell_key,
+                    vertex_keys = ?cell.vertices(),
+                    sign,
+                    reachability,
+                    neighbor_in_bfs,
+                    neighbor_total,
+                    neighbor_none,
+                    bfs_conflict_len = bfs_conflict_cells.len(),
+                    brute_force_conflict_so_far = brute_force_count,
+                    "verify_conflict_region: BFS MISSED conflicting cell"
+                );
+            }
+        }
+    }
+
+    if missed_count > 0 {
+        tracing::warn!(
+            bfs_conflict = bfs_conflict_cells.len(),
+            brute_force_conflict = brute_force_count,
+            missed = missed_count,
+            query_point = ?point,
+            "verify_conflict_region: INCOMPLETE conflict region detected"
+        );
+    } else {
+        tracing::debug!(
+            bfs_conflict = bfs_conflict_cells.len(),
+            brute_force_conflict = brute_force_count,
+            "verify_conflict_region: conflict region is COMPLETE"
+        );
+    }
+
+    missed_count
 }
 
 /// Extract boundary facets of a conflict region (cavity).

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -2672,6 +2672,50 @@ mod tests {
         assert_eq!(missed, 0, "Outside point should produce zero missed cells");
     }
 
+    /// Truncated multi-cell BFS result detects missed conflict cells.
+    ///
+    /// Builds a 2D triangulation with 4 vertices (2 triangles sharing an edge),
+    /// finds a multi-cell conflict region, then drops one cell from the BFS
+    /// result and verifies that `verify_conflict_region_completeness` catches
+    /// the omission.  Because the two triangles are adjacent, the dropped cell
+    /// has a neighbor still in the truncated BFS set, so the internal
+    /// classification logs `REACHABLE_BUT_REJECTED` (observable via tracing).
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_verify_conflict_region_completeness_truncated_multi_cell_detects_missed() {
+        // Four corners of a rectangle — DT produces 2 triangles sharing a diagonal.
+        // All 4 points are co-circular, so a center-ish query point is strictly
+        // inside both circumcircles → conflict region has 2 cells.
+        let vertices = vec![
+            vertex!([0.0, 0.0]),
+            vertex!([4.0, 0.0]),
+            vertex!([4.0, 3.0]),
+            vertex!([0.0, 3.0]),
+        ];
+        let dt = DelaunayTriangulation::new(&vertices).unwrap();
+        let kernel = FastKernel::<f64>::new();
+
+        let start_cell = dt.tds().cell_keys().next().unwrap();
+        let point = Point::new([2.0, 1.5]);
+
+        let full_conflict = find_conflict_region(dt.tds(), &kernel, &point, start_cell).unwrap();
+        assert!(
+            full_conflict.len() >= 2,
+            "Expected ≥2 conflict cells for center query in 2-triangle mesh, got {}",
+            full_conflict.len()
+        );
+
+        // Truncate: keep only the first cell, drop the rest.
+        let mut truncated = CellKeyBuffer::new();
+        truncated.push(full_conflict[0]);
+
+        let missed = verify_conflict_region_completeness(dt.tds(), &kernel, &point, &truncated);
+        assert!(
+            missed >= 1,
+            "Truncated BFS should detect at least 1 missed conflict cell, got {missed}"
+        );
+    }
+
     #[test]
     fn test_extract_cavity_boundary_rejects_ridge_fan_2d() {
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -915,21 +915,34 @@ where
     U: DataType,
     V: DataType,
 {
-    use crate::core::util::canonical_points::sorted_cell_points;
-
     let bfs_set: FastHashSet<CellKey> = bfs_conflict_cells.iter().copied().collect();
     let mut missed_count = 0usize;
     let mut brute_force_count = 0usize;
+    let mut malformed_cells = 0usize;
+    let mut predicate_errors = 0usize;
 
     for (cell_key, cell) in tds.cells() {
         let Some(simplex_points) = sorted_cell_points(tds, cell) else {
+            malformed_cells += 1;
+            tracing::debug!(
+                cell_key = ?cell_key,
+                vertex_keys = ?cell.vertices(),
+                "verify_conflict_region: skipping malformed cell (sorted_cell_points returned None)"
+            );
             continue;
         };
         if simplex_points.len() != D + 1 {
+            malformed_cells += 1;
             continue;
         }
 
         let Ok(sign) = kernel.in_sphere(&simplex_points, point) else {
+            predicate_errors += 1;
+            tracing::debug!(
+                cell_key = ?cell_key,
+                vertex_keys = ?cell.vertices(),
+                "verify_conflict_region: in_sphere predicate failed"
+            );
             continue;
         };
 
@@ -979,13 +992,15 @@ where
         }
     }
 
-    if missed_count > 0 {
+    if missed_count > 0 || malformed_cells > 0 || predicate_errors > 0 {
         tracing::warn!(
             bfs_conflict = bfs_conflict_cells.len(),
             brute_force_conflict = brute_force_count,
             missed = missed_count,
+            malformed_cells,
+            predicate_errors,
             query_point = ?point,
-            "verify_conflict_region: INCOMPLETE conflict region detected"
+            "verify_conflict_region: INCOMPLETE — missed cells or evaluation failures"
         );
     } else {
         tracing::debug!(
@@ -2512,6 +2527,149 @@ mod tests {
         assert!(matches!(result, LocateResult::InsideCell(_)));
         assert!(!stats.used_hint, "None hint should set used_hint = false");
         assert!(!stats.fell_back_to_scan());
+    }
+
+    // =============================================================================
+    // VERIFY CONFLICT REGION COMPLETENESS TESTS
+    // =============================================================================
+    // The function under test is #[cfg(debug_assertions)], so these tests are
+    // also gated to avoid compilation errors in release/bench builds.
+
+    #[cfg(debug_assertions)]
+    /// Macro to test `verify_conflict_region_completeness` across dimensions.
+    /// Builds a single-simplex Delaunay triangulation, finds the conflict region
+    /// for an interior point via BFS, then verifies the brute-force check agrees.
+    macro_rules! test_verify_conflict_region_complete_dimension {
+        ($dim:literal, $inside_point:expr, $($coords:expr),+ $(,)?) => {{
+            let vertices: Vec<_> = vec![
+                $(vertex!($coords)),+
+            ];
+            let dt = DelaunayTriangulation::new(&vertices).unwrap();
+            let kernel = FastKernel::<f64>::new();
+
+            let start_cell = dt.tds().cell_keys().next().unwrap();
+            let point = Point::new($inside_point);
+
+            let conflict_cells = find_conflict_region(dt.tds(), &kernel, &point, start_cell).unwrap();
+            assert!(
+                !conflict_cells.is_empty(),
+                "BFS should find at least 1 conflict cell for interior point in {}D",
+                $dim
+            );
+
+            let missed = verify_conflict_region_completeness(
+                dt.tds(),
+                &kernel,
+                &point,
+                &conflict_cells,
+            );
+            assert_eq!(
+                missed, 0,
+                "BFS conflict region should be complete for interior point in {}D",
+                $dim
+            );
+        }};
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_verify_conflict_region_completeness_2d() {
+        test_verify_conflict_region_complete_dimension!(
+            2,
+            [0.3, 0.3],
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_verify_conflict_region_completeness_3d() {
+        test_verify_conflict_region_complete_dimension!(
+            3,
+            [0.25, 0.25, 0.25],
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_verify_conflict_region_completeness_4d() {
+        test_verify_conflict_region_complete_dimension!(
+            4,
+            [0.2, 0.2, 0.2, 0.2],
+            [0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        );
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_verify_conflict_region_completeness_5d() {
+        test_verify_conflict_region_complete_dimension!(
+            5,
+            [0.15, 0.15, 0.15, 0.15, 0.15],
+            [0.0, 0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0, 0.0],
+            [0.0, 0.0, 0.0, 0.0, 1.0],
+        );
+    }
+
+    /// An empty BFS result should detect all conflict cells as missed.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_verify_conflict_region_completeness_empty_bfs_detects_missed() {
+        let vertices = vec![
+            vertex!([0.0, 0.0]),
+            vertex!([1.0, 0.0]),
+            vertex!([0.0, 1.0]),
+        ];
+        let dt = DelaunayTriangulation::new(&vertices).unwrap();
+        let kernel = FastKernel::<f64>::new();
+
+        // Point inside the circumcircle — the single cell should be in conflict.
+        let point = Point::new([0.3, 0.3]);
+        let empty_bfs = CellKeyBuffer::new();
+
+        let missed = verify_conflict_region_completeness(dt.tds(), &kernel, &point, &empty_bfs);
+        assert!(
+            missed > 0,
+            "Empty BFS result should detect missed conflict cells"
+        );
+    }
+
+    /// Point far outside produces no conflict cells; verify returns 0 missed.
+    #[cfg(debug_assertions)]
+    #[test]
+    fn test_verify_conflict_region_completeness_outside_point_zero_missed() {
+        let vertices = vec![
+            vertex!([0.0, 0.0, 0.0]),
+            vertex!([1.0, 0.0, 0.0]),
+            vertex!([0.0, 1.0, 0.0]),
+            vertex!([0.0, 0.0, 1.0]),
+        ];
+        let dt = DelaunayTriangulation::new(&vertices).unwrap();
+        let kernel = FastKernel::<f64>::new();
+
+        let start_cell = dt.tds().cell_keys().next().unwrap();
+        let point = Point::new([10.0, 10.0, 10.0]);
+
+        let conflict_cells = find_conflict_region(dt.tds(), &kernel, &point, start_cell).unwrap();
+        assert!(conflict_cells.is_empty());
+
+        let missed =
+            verify_conflict_region_completeness(dt.tds(), &kernel, &point, &conflict_cells);
+        assert_eq!(missed, 0, "Outside point should produce zero missed cells");
     }
 
     #[test]

--- a/src/core/operations.rs
+++ b/src/core/operations.rs
@@ -412,4 +412,42 @@ mod tests {
             }
         ));
     }
+
+    #[test]
+    fn test_repair_policy_decide_inadmissible_under_pseudomanifold() {
+        // CavityFlip requires PLManifold; under Pseudomanifold it should be inadmissible.
+        let op = TopologicalOperation::CavityFlip;
+        let decision =
+            DelaunayRepairPolicy::EveryInsertion.decide(1, TopologyGuarantee::Pseudomanifold, op);
+        assert!(matches!(
+            decision,
+            RepairDecision::Skip {
+                reason: RepairSkipReason::Inadmissible {
+                    operation: TopologicalOperation::CavityFlip,
+                    required: TopologyGuarantee::PLManifold,
+                    found: TopologyGuarantee::Pseudomanifold,
+                }
+            }
+        ));
+    }
+
+    #[test]
+    fn test_required_topology_returns_correct_guarantee() {
+        assert_eq!(
+            TopologicalOperation::CavityFlip.required_topology(),
+            TopologyGuarantee::PLManifold
+        );
+        assert_eq!(
+            TopologicalOperation::FacetFlip.required_topology(),
+            TopologyGuarantee::Pseudomanifold
+        );
+        assert_eq!(
+            TopologicalOperation::InsertVertex.required_topology(),
+            TopologyGuarantee::Pseudomanifold
+        );
+        assert_eq!(
+            TopologicalOperation::DeleteVertex.required_topology(),
+            TopologyGuarantee::Pseudomanifold
+        );
+    }
 }

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -2425,6 +2425,8 @@ where
         cells: &CellKeyBuffer,
     ) -> Result<(), InsertionError> {
         #[cfg(debug_assertions)]
+        let debug_orientation = std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some();
+        #[cfg(debug_assertions)]
         let mut orientation_warn_count = 0_usize;
 
         for &cell_key in cells {
@@ -2454,8 +2456,7 @@ where
                 // Capture pre-swap vertices only when the debug env var is set,
                 // so release and non-debug runs avoid the allocation entirely.
                 #[cfg(debug_assertions)]
-                let pre_swap_vertices = if std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some()
-                {
+                let pre_swap_vertices = if debug_orientation {
                     self.tds.get_cell(cell_key).map(|c| c.vertices().to_vec())
                 } else {
                     None
@@ -2480,7 +2481,7 @@ where
                 cell.swap_vertex_slots(0, 1);
 
                 #[cfg(debug_assertions)]
-                if std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some() {
+                if debug_orientation {
                     orientation_warn_count += 1;
                     // Log full detail for the first 3 occurrences; suppress the rest.
                     if orientation_warn_count <= 3 {
@@ -2530,7 +2531,7 @@ where
         }
 
         #[cfg(debug_assertions)]
-        if orientation_warn_count > 3 && std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some() {
+        if orientation_warn_count > 3 && debug_orientation {
             let suppressed = orientation_warn_count - 3;
             tracing::warn!(
                 total_negative = orientation_warn_count,

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -2206,7 +2206,7 @@ where
                     cell.neighbors()
                         .map(|n| n.iter().copied().collect())
                         .unwrap_or_default();
-                tracing::warn!(
+                tracing::debug!(
                     cell_uuid = %cell.uuid(),
                     ?cell_key,
                     ?vertex_keys,
@@ -2416,10 +2416,17 @@ where
     ///
     /// This preserves cell-local slot alignment (vertices/neighbors/periodic offsets) by using
     /// `swap_vertex_slots(0, 1)` for negatively oriented cells.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "debug-only orientation diagnostics with dedup add conditional branches"
+    )]
     fn canonicalize_positive_orientation_for_cells(
         &mut self,
         cells: &CellKeyBuffer,
     ) -> Result<(), InsertionError> {
+        #[cfg(debug_assertions)]
+        let mut orientation_warn_count = 0_usize;
+
         for &cell_key in cells {
             let orientation = {
                 let cell = self
@@ -2474,48 +2481,62 @@ where
 
                 #[cfg(debug_assertions)]
                 if std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some() {
-                    // Re-evaluate orientation after swap to confirm it worked.
-                    // Handle the Result locally so verification failures are
-                    // observational only and never promote to insertion errors.
-                    let post_orientation = self.tds.get_cell(cell_key).map(|c| {
-                        self.evaluate_cell_orientation_for_context(
-                            cell_key,
-                            c,
-                            "orientation swap verification",
-                            "orientation predicate failed during swap verification",
-                        )
-                    });
-                    match post_orientation {
-                        Some(Ok(post_o)) => {
-                            tracing::warn!(
-                                cell_key = ?cell_key,
-                                pre_swap_vertices = ?pre_swap_vertices,
-                                pre_swap_orientation = orientation,
-                                post_swap_orientation = post_o,
-                                swap_fixed = post_o > 0,
-                                "canonicalize_positive_orientation: negative-orientation cell swapped"
-                            );
-                        }
-                        Some(Err(ref e)) => {
-                            tracing::warn!(
-                                cell_key = ?cell_key,
-                                pre_swap_vertices = ?pre_swap_vertices,
-                                pre_swap_orientation = orientation,
-                                error = %e,
-                                "canonicalize_positive_orientation: post-swap verification failed"
-                            );
-                        }
-                        None => {
-                            tracing::warn!(
-                                cell_key = ?cell_key,
-                                pre_swap_vertices = ?pre_swap_vertices,
-                                pre_swap_orientation = orientation,
-                                "canonicalize_positive_orientation: cell not found after swap"
-                            );
+                    orientation_warn_count += 1;
+                    // Log full detail for the first 3 occurrences; suppress the rest.
+                    if orientation_warn_count <= 3 {
+                        // Re-evaluate orientation after swap to confirm it worked.
+                        // Handle the Result locally so verification failures are
+                        // observational only and never promote to insertion errors.
+                        let post_orientation = self.tds.get_cell(cell_key).map(|c| {
+                            self.evaluate_cell_orientation_for_context(
+                                cell_key,
+                                c,
+                                "orientation swap verification",
+                                "orientation predicate failed during swap verification",
+                            )
+                        });
+                        match post_orientation {
+                            Some(Ok(post_o)) => {
+                                tracing::warn!(
+                                    cell_key = ?cell_key,
+                                    pre_swap_vertices = ?pre_swap_vertices,
+                                    pre_swap_orientation = orientation,
+                                    post_swap_orientation = post_o,
+                                    swap_fixed = post_o > 0,
+                                    "canonicalize_positive_orientation: negative-orientation cell swapped"
+                                );
+                            }
+                            Some(Err(ref e)) => {
+                                tracing::warn!(
+                                    cell_key = ?cell_key,
+                                    pre_swap_vertices = ?pre_swap_vertices,
+                                    pre_swap_orientation = orientation,
+                                    error = %e,
+                                    "canonicalize_positive_orientation: post-swap verification failed"
+                                );
+                            }
+                            None => {
+                                tracing::warn!(
+                                    cell_key = ?cell_key,
+                                    pre_swap_vertices = ?pre_swap_vertices,
+                                    pre_swap_orientation = orientation,
+                                    "canonicalize_positive_orientation: cell not found after swap"
+                                );
+                            }
                         }
                     }
                 }
             }
+        }
+
+        #[cfg(debug_assertions)]
+        if orientation_warn_count > 3 && std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some() {
+            let suppressed = orientation_warn_count - 3;
+            tracing::warn!(
+                total_negative = orientation_warn_count,
+                suppressed,
+                "canonicalize_positive_orientation: suppressed {suppressed} additional negative-orientation warnings (see first 3 above)"
+            );
         }
 
         Ok(())

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -2444,8 +2444,15 @@ where
             }
 
             if orientation < 0 {
+                // Capture pre-swap vertices only when the debug env var is set,
+                // so release and non-debug runs avoid the allocation entirely.
                 #[cfg(debug_assertions)]
-                let pre_swap_vertices = self.tds.get_cell(cell_key).map(|c| c.vertices().to_vec());
+                let pre_swap_vertices = if std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some()
+                {
+                    self.tds.get_cell(cell_key).map(|c| c.vertices().to_vec())
+                } else {
+                    None
+                };
 
                 let cell = self.tds.get_cell_by_key_mut(cell_key).ok_or_else(|| {
                     TdsError::CellNotFound {
@@ -2467,27 +2474,46 @@ where
 
                 #[cfg(debug_assertions)]
                 if std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some() {
-                    // Re-evaluate orientation after swap to confirm it worked
-                    let post_orientation = self
-                        .tds
-                        .get_cell(cell_key)
-                        .map(|c| {
-                            self.evaluate_cell_orientation_for_context(
-                                cell_key,
-                                c,
-                                "orientation swap verification",
-                                "orientation predicate failed during swap verification",
-                            )
-                        })
-                        .transpose()?;
-                    tracing::warn!(
-                        cell_key = ?cell_key,
-                        pre_swap_vertices = ?pre_swap_vertices,
-                        pre_swap_orientation = orientation,
-                        post_swap_orientation = ?post_orientation,
-                        swap_fixed = post_orientation.is_some_and(|o| o > 0),
-                        "canonicalize_positive_orientation: negative-orientation cell swapped"
-                    );
+                    // Re-evaluate orientation after swap to confirm it worked.
+                    // Handle the Result locally so verification failures are
+                    // observational only and never promote to insertion errors.
+                    let post_orientation = self.tds.get_cell(cell_key).map(|c| {
+                        self.evaluate_cell_orientation_for_context(
+                            cell_key,
+                            c,
+                            "orientation swap verification",
+                            "orientation predicate failed during swap verification",
+                        )
+                    });
+                    match post_orientation {
+                        Some(Ok(post_o)) => {
+                            tracing::warn!(
+                                cell_key = ?cell_key,
+                                pre_swap_vertices = ?pre_swap_vertices,
+                                pre_swap_orientation = orientation,
+                                post_swap_orientation = post_o,
+                                swap_fixed = post_o > 0,
+                                "canonicalize_positive_orientation: negative-orientation cell swapped"
+                            );
+                        }
+                        Some(Err(ref e)) => {
+                            tracing::warn!(
+                                cell_key = ?cell_key,
+                                pre_swap_vertices = ?pre_swap_vertices,
+                                pre_swap_orientation = orientation,
+                                error = %e,
+                                "canonicalize_positive_orientation: post-swap verification failed"
+                            );
+                        }
+                        None => {
+                            tracing::warn!(
+                                cell_key = ?cell_key,
+                                pre_swap_vertices = ?pre_swap_vertices,
+                                pre_swap_orientation = orientation,
+                                "canonicalize_positive_orientation: cell not found after swap"
+                            );
+                        }
+                    }
                 }
             }
         }
@@ -4211,6 +4237,7 @@ where
             let mut pos = 0_usize;
             let mut neg = 0_usize;
             let mut deg = 0_usize;
+            let mut fail = 0_usize;
             for &ck in &new_cells {
                 if let Some(c) = self.tds.get_cell(ck) {
                     match self.evaluate_cell_orientation_for_context(
@@ -4221,17 +4248,26 @@ where
                     ) {
                         Ok(o) if o > 0 => pos += 1,
                         Ok(o) if o < 0 => neg += 1,
-                        Ok(_) | Err(_) => deg += 1,
+                        Ok(_) => deg += 1,
+                        Err(ref e) => {
+                            fail += 1;
+                            tracing::warn!(
+                                cell_key = ?ck,
+                                error = %e,
+                                "post-insertion orientation audit: evaluation failed"
+                            );
+                        }
                     }
                 }
             }
-            if neg > 0 {
+            if neg > 0 || fail > 0 {
                 tracing::warn!(
                     new_cells = new_cells.len(),
                     positive = pos,
                     negative = neg,
                     degenerate = deg,
-                    "post-insertion orientation audit: NEGATIVE cells remain after canonicalization"
+                    eval_errors = fail,
+                    "post-insertion orientation audit: NEGATIVE cells or evaluation errors after canonicalization"
                 );
             } else {
                 tracing::debug!(

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -112,12 +112,12 @@ use crate::core::algorithms::incremental_insertion::{
     HullExtensionReason, InsertionError, extend_hull, external_facets_for_boundary, fill_cavity,
     repair_neighbor_pointers, wire_cavity_neighbors,
 };
-#[cfg(debug_assertions)]
-use crate::core::algorithms::locate::locate_with_stats;
 use crate::core::algorithms::locate::{
     ConflictError, LocateResult, extract_cavity_boundary, find_conflict_region, locate,
     locate_by_scan,
 };
+#[cfg(debug_assertions)]
+use crate::core::algorithms::locate::{locate_with_stats, verify_conflict_region_completeness};
 use crate::core::cell::{Cell, CellValidationError};
 use crate::core::collections::spatial_hash_grid::HashGridIndex;
 use crate::core::collections::{
@@ -2444,6 +2444,9 @@ where
             }
 
             if orientation < 0 {
+                #[cfg(debug_assertions)]
+                let pre_swap_vertices = self.tds.get_cell(cell_key).map(|c| c.vertices().to_vec());
+
                 let cell = self.tds.get_cell_by_key_mut(cell_key).ok_or_else(|| {
                     TdsError::CellNotFound {
                         cell_key,
@@ -2461,6 +2464,31 @@ where
                     .into());
                 }
                 cell.swap_vertex_slots(0, 1);
+
+                #[cfg(debug_assertions)]
+                if std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some() {
+                    // Re-evaluate orientation after swap to confirm it worked
+                    let post_orientation = self
+                        .tds
+                        .get_cell(cell_key)
+                        .map(|c| {
+                            self.evaluate_cell_orientation_for_context(
+                                cell_key,
+                                c,
+                                "orientation swap verification",
+                                "orientation predicate failed during swap verification",
+                            )
+                        })
+                        .transpose()?;
+                    tracing::warn!(
+                        cell_key = ?cell_key,
+                        pre_swap_vertices = ?pre_swap_vertices,
+                        pre_swap_orientation = orientation,
+                        post_swap_orientation = ?post_orientation,
+                        swap_fixed = post_orientation.is_some_and(|o| o > 0),
+                        "canonicalize_positive_orientation: negative-orientation cell swapped"
+                    );
+                }
             }
         }
 
@@ -4176,6 +4204,45 @@ where
         let new_cells = fill_cavity(&mut self.tds, v_key, &boundary_facets)?;
         self.canonicalize_positive_orientation_for_cells(&new_cells)?;
 
+        // Post-insertion orientation audit: verify that canonicalization
+        // actually produced all-positive orientations among the new cells.
+        #[cfg(debug_assertions)]
+        if std::env::var_os("DELAUNAY_DEBUG_ORIENTATION").is_some() {
+            let mut pos = 0_usize;
+            let mut neg = 0_usize;
+            let mut deg = 0_usize;
+            for &ck in &new_cells {
+                if let Some(c) = self.tds.get_cell(ck) {
+                    match self.evaluate_cell_orientation_for_context(
+                        ck,
+                        c,
+                        "post-insertion orientation audit",
+                        "orientation predicate failed during post-insertion audit",
+                    ) {
+                        Ok(o) if o > 0 => pos += 1,
+                        Ok(o) if o < 0 => neg += 1,
+                        Ok(_) | Err(_) => deg += 1,
+                    }
+                }
+            }
+            if neg > 0 {
+                tracing::warn!(
+                    new_cells = new_cells.len(),
+                    positive = pos,
+                    negative = neg,
+                    degenerate = deg,
+                    "post-insertion orientation audit: NEGATIVE cells remain after canonicalization"
+                );
+            } else {
+                tracing::debug!(
+                    new_cells = new_cells.len(),
+                    positive = pos,
+                    degenerate = deg,
+                    "post-insertion orientation audit: all cells positive"
+                );
+            }
+        }
+
         // Wire neighbors (while both old and new cells exist)
         let external_facets =
             external_facets_for_boundary(&self.tds, &conflict_cells, &boundary_facets)?;
@@ -4521,6 +4588,28 @@ where
                 // Fallback: treat the containing cell as the conflict region, effectively performing
                 // a star-split of that cell to keep the simplicial complex connected.
                 let computed = find_conflict_region(&self.tds, &self.kernel, &point, start_cell)?;
+
+                #[cfg(debug_assertions)]
+                if std::env::var_os("DELAUNAY_DEBUG_CONFLICT_VERIFY").is_some() {
+                    let missed = verify_conflict_region_completeness(
+                        &self.tds,
+                        &self.kernel,
+                        &point,
+                        &computed,
+                    );
+                    if missed > 0 {
+                        tracing::warn!(
+                            missed,
+                            bfs_conflict = computed.len(),
+                            start_cell = ?start_cell,
+                            point = ?point,
+                            num_vertices = self.tds.number_of_vertices(),
+                            num_cells = self.tds.number_of_cells(),
+                            "try_insert_impl: INCOMPLETE conflict region at insertion"
+                        );
+                    }
+                }
+
                 if computed.is_empty() {
                     suspicion.empty_conflict_region = true;
                     suspicion.fallback_star_split = true;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -851,6 +851,11 @@ pub mod prelude {
     pub use crate::core::algorithms::incremental_insertion::InsertionError;
     pub use crate::core::operations::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
 
+    // Re-export diagnostic types for scientific analysis of construction and repair
+    pub use crate::core::algorithms::flips::{
+        DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats, RepairQueueOrder,
+    };
+
     // Re-export commonly used collection types from core::collections
     // These are frequently used in advanced examples and downstream code
     pub use crate::core::collections::{
@@ -882,6 +887,11 @@ pub mod prelude {
 
         pub use crate::core::algorithms::incremental_insertion::InsertionError;
         pub use crate::core::operations::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
+
+        // Diagnostic types for scientific analysis of construction and repair
+        pub use crate::core::algorithms::flips::{
+            DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats, RepairQueueOrder,
+        };
         pub use crate::topology::traits::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
 
         /// Bistellar (Pachner) flips for explicit triangulation editing.

--- a/tests/conflict_region_verification.rs
+++ b/tests/conflict_region_verification.rs
@@ -1,0 +1,112 @@
+//! Smoke test for conflict-region completeness verification.
+//!
+//! Exercises `verify_conflict_region_completeness` using the known-failing 3D
+//! seed from #306 to confirm the diagnostic tooling works end-to-end.
+//!
+//! These tests are `#[ignore]` by default — run with:
+//! ```bash
+//! cargo test --test conflict_region_verification -- --ignored --nocapture
+//! ```
+
+#![forbid(unsafe_code)]
+
+use delaunay::core::algorithms::locate::{LocateResult, find_conflict_region, locate};
+use delaunay::geometry::kernel::AdaptiveKernel;
+use delaunay::geometry::util::generate_random_points_in_ball_seeded;
+use delaunay::prelude::triangulation::*;
+
+/// Verify that `verify_conflict_region_completeness` runs without panicking on
+/// the known-failing 3D case (35 vertices, seed 0xE30C78582376677C, ball
+/// radius 100) and reports any missed cells.
+///
+/// This test does NOT assert that the conflict region is complete — it's a
+/// diagnostic smoke test that confirms the verification tooling is functional.
+#[test]
+#[ignore = "diagnostic test: exercises conflict-region verification tooling (#306)"]
+fn verify_conflict_region_diagnostic_3d_35v() {
+    // Same parameters as the #306 minimal reproducer.
+    let seed: u64 = 0xE30C_7858_2376_677C;
+    let n_points: usize = 35;
+    let radius: f64 = 100.0;
+
+    let points = generate_random_points_in_ball_seeded::<f64, 3>(n_points, radius, seed)
+        .expect("point generation should succeed");
+
+    let vertices: Vec<Vertex<f64, (), 3>> = points
+        .iter()
+        .map(|p| vertex!([p.coords()[0], p.coords()[1], p.coords()[2]]))
+        .collect();
+
+    // Build a triangulation from the first D+1 = 4 vertices, then insert the
+    // rest one at a time while running conflict-region verification.
+    let initial = &vertices[..4];
+    let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 3> =
+        DelaunayTriangulation::new(initial).expect("initial simplex should succeed");
+
+    let kernel = AdaptiveKernel::<f64>::new();
+    let mut total_missed = 0_usize;
+    let mut insertions_checked = 0_usize;
+
+    for (i, v) in vertices[4..].iter().enumerate() {
+        let point = *v.point();
+
+        // Locate the point in the current triangulation.
+        let Ok(location) = locate(dt.tds(), &kernel, &point, None) else {
+            println!("[{i}] locate failed — skipping verification for this vertex");
+            let _ = dt.insert(*v);
+            continue;
+        };
+
+        // Only verify interior insertions (the common case for #306).
+        if let LocateResult::InsideCell(start_cell) = location {
+            match find_conflict_region(dt.tds(), &kernel, &point, start_cell) {
+                Ok(conflict_cells) => {
+                    #[cfg(debug_assertions)]
+                    {
+                        let missed =
+                            delaunay::core::algorithms::locate::verify_conflict_region_completeness(
+                                dt.tds(),
+                                &kernel,
+                                &point,
+                                &conflict_cells,
+                            );
+                        if missed > 0 {
+                            println!(
+                                "[{i}] INCOMPLETE conflict region: {missed} cells missed \
+                                 (BFS found {}, brute-force found more)",
+                                conflict_cells.len()
+                            );
+                        }
+                        total_missed += missed;
+                        insertions_checked += 1;
+                    }
+                    #[cfg(not(debug_assertions))]
+                    {
+                        let _ = conflict_cells;
+                        insertions_checked += 1;
+                    }
+                }
+                Err(e) => {
+                    println!("[{i}] find_conflict_region failed: {e}");
+                }
+            }
+        }
+
+        // Perform the actual insertion (may succeed or fail).
+        let _ = dt.insert(*v);
+    }
+
+    println!(
+        "=== conflict-region verification summary ===\n\
+         insertions checked: {insertions_checked}\n\
+         total missed cells: {total_missed}\n\
+         final vertices:     {}\n\
+         final cells:        {}",
+        dt.number_of_vertices(),
+        dt.number_of_cells(),
+    );
+
+    // Structural sanity: the test should not panic.
+    // The missed count is informational — it tells investigators whether
+    // the BFS conflict region is incomplete for this seed.
+}

--- a/tests/conflict_region_verification.rs
+++ b/tests/conflict_region_verification.rs
@@ -46,6 +46,7 @@ fn verify_conflict_region_diagnostic_3d_35v() {
     let kernel = AdaptiveKernel::<f64>::new();
     let mut total_missed = 0_usize;
     let mut insertions_checked = 0_usize;
+    let mut insert_errors: Vec<String> = Vec::new();
 
     for (i, v) in vertices[4..].iter().enumerate() {
         let point = *v.point();
@@ -53,7 +54,9 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         // Locate the point in the current triangulation.
         let Ok(location) = locate(dt.tds(), &kernel, &point, None) else {
             println!("[{i}] locate failed — skipping verification for this vertex");
-            let _ = dt.insert(*v);
+            if let Err(e) = dt.insert(*v) {
+                insert_errors.push(format!("[{i}] insert after locate failure: {e}"));
+            }
             continue;
         };
 
@@ -92,21 +95,30 @@ fn verify_conflict_region_diagnostic_3d_35v() {
             }
         }
 
-        // Perform the actual insertion (may succeed or fail).
-        let _ = dt.insert(*v);
+        // Perform the actual insertion; record failures for the summary.
+        if let Err(e) = dt.insert(*v) {
+            insert_errors.push(format!("[{i}] insert: {e}"));
+        }
     }
 
     println!(
         "=== conflict-region verification summary ===\n\
          insertions checked: {insertions_checked}\n\
          total missed cells: {total_missed}\n\
+         insertion errors:   {}\n\
          final vertices:     {}\n\
          final cells:        {}",
+        insert_errors.len(),
         dt.number_of_vertices(),
         dt.number_of_cells(),
     );
+    for err in &insert_errors {
+        println!("  {err}");
+    }
 
-    // Structural sanity: the test should not panic.
-    // The missed count is informational — it tells investigators whether
-    // the BFS conflict region is incomplete for this seed.
+    // The verification path must have been exercised at least once.
+    assert!(
+        insertions_checked > 0,
+        "no insertions checked — verification path not exercised"
+    );
 }


### PR DESCRIPTION
…307)

- Enhance conflict-region verifier with neighbor-reachability analysis
- Add BFS boundary logging to find_conflict_region
- Add orientation tracing and post-insertion audit (DELAUNAY_DEBUG_ORIENTATION)
- Add cell creation provenance logging to fill_cavity
- Re-export diagnostic types (DelaunayRepairDiagnostics, etc.) in prelude
- Create comprehensive debug env var reference (docs/dev/debug_env_vars.md)