### PR TITLE
refactor: v0.7.5 cleanup — impl-block split, builder decomposition, p…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,4 +231,4 @@ jobs:
           cargo build --verbose --all-targets
           cargo test --lib --verbose
           cargo test --doc --verbose
-          cargo test --tests --verbose
+          cargo test --tests --release --verbose

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -71,7 +71,11 @@ jobs:
           echo "::group::Running tests with nextest"
           # Generate JUnit XML for Codecov Test Analytics
           # JUnit path is configured in .config/nextest.toml [profile.ci.junit]
-          cargo nextest run --all-features --profile ci
+          # Release mode is required: exact-predicate arithmetic makes 3D+ proptests
+          # exceed timeout limits in debug mode (>60s debug vs <1s release).
+          # Avoid --all-features: it enables slow-tests and count-allocations which
+          # are special-purpose features not suitable for general test runs.
+          cargo nextest run --release --profile ci
           echo "::endgroup::"
 
           # Verify JUnit XML was generated at the expected location

--- a/justfile
+++ b/justfile
@@ -723,9 +723,11 @@ test-allocation:
 test-debug:
     cargo test --test circumsphere_debug_tools -- --nocapture
 
-# test-integration: runs all integration tests (includes proptests)
+# test-integration: runs all integration tests (includes proptests) in release mode.
+# Release mode is required because exact-predicate arithmetic in debug mode makes
+# 3D+ proptests exceed CI timeout limits (>60s debug vs <1s release).
 test-integration:
-    cargo test --tests --verbose
+    cargo test --tests --release --verbose
 
 # test-integration-fast: runs integration tests but skips proptests (tests prefixed with `prop_`)
 #
@@ -734,7 +736,7 @@ test-integration:
 #
 # Note: `--skip prop_` is a substring filter applied by the Rust test harness.
 test-integration-fast:
-    cargo test --tests --verbose -- --skip prop_
+    cargo test --tests --release --verbose -- --skip prop_
 
 test-python: _ensure-uv
     uv run pytest

--- a/justfile
+++ b/justfile
@@ -118,6 +118,13 @@ bench-compare: _ensure-uv
 bench-compile:
     RUSTFLAGS='-D warnings' cargo bench --workspace --no-run
 
+# Compile benchmarks and integration tests without running, treating warnings as errors.
+# Catches release-profile-only warnings (e.g. cfg-gated unused-mut) that debug-mode
+# clippy/test won't see. Mirrors the -D warnings environment set by CI's Rust toolchain action.
+bench-test-compile:
+    RUSTFLAGS='-D warnings' cargo bench --workspace --no-run
+    RUSTFLAGS='-D warnings' cargo test --tests --release --no-run
+
 # Development mode benchmarks: fast iteration with reduced sample sizes
 bench-dev: _ensure-uv
     CRIT_SAMPLE_SIZE=10 CRIT_MEASUREMENT_MS=1000 CRIT_WARMUP_MS=500 uv run benchmark-utils compare --baseline baseline-artifact/baseline_results.txt --dev
@@ -163,7 +170,7 @@ check-fast:
 
 # CI simulation: comprehensive validation (matches .github/workflows/ci.yml)
 # Runs: checks + all tests (Rust + Python) + examples + bench compile
-ci: check bench-compile test-all examples
+ci: check bench-test-compile test-all examples
     @echo "🎯 CI checks complete!"
 
 # CI with performance baseline

--- a/src/core/builder.rs
+++ b/src/core/builder.rs
@@ -146,32 +146,14 @@ type PeriodicCandidate<const D: usize> = (
     Vec<PeriodicFacetKey>,
     bool,
 );
-/// Finds a bounded-size 2D face subset whose edge incidences can close a quotient boundary.
-///
-/// Returns a boolean mask aligned with `candidate_edges` when a selection of exactly
-/// `target_faces` candidates is found such that no edge is used more than twice. The search
-/// uses a DFS with pruning and a heuristic ordering that prefers in-domain candidates first.
-#[expect(
-    clippy::too_many_lines,
-    reason = "Depth-first bounded subset search includes pruning logic and is kept self-contained"
-)]
-#[expect(
-    clippy::items_after_statements,
-    reason = "Local DFS helper is intentionally colocated with selection setup"
-)]
-fn search_closed_2d_selection(
+/// Sort candidates by heuristic priority: prefer in-domain candidates first,
+/// then by cumulative edge rarity (rarer edges first), then by index.
+fn sort_candidates_by_rarity_and_domain(
+    order: &mut [usize],
     candidate_edges: &[[usize; 3]],
     candidate_in_domain: &[bool],
-    target_faces: usize,
     edge_count: usize,
-    node_limit: usize,
-) -> Option<Vec<bool>> {
-    let m = candidate_edges.len();
-    if m < target_faces {
-        return None;
-    }
-
-    // Frequency of each edge in the candidate pool (rarer edges first).
+) {
     let mut edge_frequency = vec![0usize; edge_count];
     for edges in candidate_edges {
         for &edge in edges {
@@ -179,7 +161,6 @@ fn search_closed_2d_selection(
         }
     }
 
-    let mut order: Vec<usize> = (0..m).collect();
     order.sort_by(|a, b| {
         let a_edges = candidate_edges[*a];
         let b_edges = candidate_edges[*b];
@@ -192,103 +173,110 @@ fn search_closed_2d_selection(
             .then_with(|| a_score.cmp(&b_score))
             .then_with(|| a.cmp(b))
     });
+}
 
-    let mut edge_counts = vec![0u8; edge_count];
-    let mut selected = vec![false; m];
-    let mut nodes = 0usize;
+/// DFS state for bounded face-subset search in [`search_closed_2d_selection`].
+///
+/// Encapsulates the immutable search parameters and mutable traversal state so
+/// the recursive [`search`](Self::search) method takes only `pos` and `chosen`.
+struct ClosedSelectionDfs<'a> {
+    target_faces: usize,
+    order: &'a [usize],
+    candidate_edges: &'a [[usize; 3]],
+    edge_counts: Vec<u8>,
+    selected: Vec<bool>,
+    nodes: usize,
+    node_limit: usize,
+}
 
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "Recursive DFS state requires explicit parameterization for pruning"
-    )]
-    fn dfs(
-        pos: usize,
-        chosen: usize,
-        target_faces: usize,
-        order: &[usize],
-        candidate_edges: &[[usize; 3]],
-        edge_counts: &mut [u8],
-        selected: &mut [bool],
-        nodes: &mut usize,
-        node_limit: usize,
-    ) -> bool {
-        if chosen == target_faces {
+impl ClosedSelectionDfs<'_> {
+    fn search(&mut self, pos: usize, chosen: usize) -> bool {
+        if chosen == self.target_faces {
             return true;
         }
-        if pos == order.len() {
+        if pos == self.order.len() {
             return false;
         }
-        if chosen + (order.len() - pos) < target_faces {
+        if chosen + (self.order.len() - pos) < self.target_faces {
             return false;
         }
-        if *nodes >= node_limit {
+        if self.nodes >= self.node_limit {
             return false;
         }
-        *nodes = nodes.saturating_add(1);
+        self.nodes = self.nodes.saturating_add(1);
 
         // Capacity-based prune: each additional face consumes 3 remaining edge incidences.
-        let remaining_capacity: usize = edge_counts
+        let remaining_capacity: usize = self
+            .edge_counts
             .iter()
             .map(|&count| usize::from(2_u8.saturating_sub(count)))
             .sum();
-        if chosen + (remaining_capacity / 3) < target_faces {
+        if chosen + (remaining_capacity / 3) < self.target_faces {
             return false;
         }
 
-        let idx = order[pos];
-        let edges = candidate_edges[idx];
+        let idx = self.order[pos];
+        let edges = self.candidate_edges[idx];
 
-        if edge_counts[edges[0]] < 2 && edge_counts[edges[1]] < 2 && edge_counts[edges[2]] < 2 {
-            selected[idx] = true;
-            edge_counts[edges[0]] += 1;
-            edge_counts[edges[1]] += 1;
-            edge_counts[edges[2]] += 1;
+        if self.edge_counts[edges[0]] < 2
+            && self.edge_counts[edges[1]] < 2
+            && self.edge_counts[edges[2]] < 2
+        {
+            self.selected[idx] = true;
+            self.edge_counts[edges[0]] += 1;
+            self.edge_counts[edges[1]] += 1;
+            self.edge_counts[edges[2]] += 1;
 
-            if dfs(
-                pos + 1,
-                chosen + 1,
-                target_faces,
-                order,
-                candidate_edges,
-                edge_counts,
-                selected,
-                nodes,
-                node_limit,
-            ) {
+            if self.search(pos + 1, chosen + 1) {
                 return true;
             }
 
-            edge_counts[edges[0]] -= 1;
-            edge_counts[edges[1]] -= 1;
-            edge_counts[edges[2]] -= 1;
-            selected[idx] = false;
+            self.edge_counts[edges[0]] -= 1;
+            self.edge_counts[edges[1]] -= 1;
+            self.edge_counts[edges[2]] -= 1;
+            self.selected[idx] = false;
         }
 
-        dfs(
-            pos + 1,
-            chosen,
-            target_faces,
-            order,
-            candidate_edges,
-            edge_counts,
-            selected,
-            nodes,
-            node_limit,
-        )
+        self.search(pos + 1, chosen)
+    }
+}
+
+/// Finds a bounded-size 2D face subset whose edge incidences can close a quotient boundary.
+///
+/// Returns a boolean mask aligned with `candidate_edges` when a selection of exactly
+/// `target_faces` candidates is found such that no edge is used more than twice. The search
+/// uses a DFS with pruning and a heuristic ordering that prefers in-domain candidates first.
+fn search_closed_2d_selection(
+    candidate_edges: &[[usize; 3]],
+    candidate_in_domain: &[bool],
+    target_faces: usize,
+    edge_count: usize,
+    node_limit: usize,
+) -> Option<Vec<bool>> {
+    let m = candidate_edges.len();
+    if m < target_faces {
+        return None;
     }
 
-    dfs(
-        0,
-        0,
-        target_faces,
-        &order,
+    let mut order: Vec<usize> = (0..m).collect();
+    sort_candidates_by_rarity_and_domain(
+        &mut order,
         candidate_edges,
-        &mut edge_counts,
-        &mut selected,
-        &mut nodes,
+        candidate_in_domain,
+        edge_count,
+    );
+
+    let mut dfs = ClosedSelectionDfs {
+        target_faces,
+        order: &order,
+        candidate_edges,
+        edge_counts: vec![0u8; edge_count],
+        selected: vec![false; m],
+        nodes: 0,
         node_limit,
-    )
-    .then_some(selected)
+    };
+
+    dfs.search(0, 0).then_some(dfs.selected)
 }
 
 // =============================================================================

--- a/src/core/delaunay_triangulation.rs
+++ b/src/core/delaunay_triangulation.rs
@@ -1639,7 +1639,13 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     }
 }
 
-// Generic implementation for all kernels
+// =============================================================================
+// CONSTRUCTION (Requires Numeric Scalar Bounds)
+// =============================================================================
+//
+// Batch and incremental constructors, preprocessing, Hilbert ordering, spatial
+// hashing, and deduplication — all require `ScalarAccumulative + NumCast`.
+
 impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
 where
     K: Kernel<D>,
@@ -3421,6 +3427,27 @@ where
             }
         }
     }
+}
+
+// =============================================================================
+// QUERY, CONFIGURATION, TRAVERSAL, REPAIR & VALIDATION (Minimal Bounds)
+// =============================================================================
+//
+// Methods that only need `K: Kernel<D>` — no scalar arithmetic.  Downstream
+// generic code (e.g. `delaunayize_by_flips`) does not need to carry
+// `ScalarAccumulative + NumCast` bounds when calling these methods.
+//
+// Follows the precedent of the existing PURE STRUCT ASSEMBLY impl block.
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    // -------------------------------------------------------------------------
+    // QUERY / ACCESSORS
+    // -------------------------------------------------------------------------
 
     /// Returns the number of vertices in the triangulation.
     ///
@@ -3993,7 +4020,22 @@ where
             false
         }
     }
+}
 
+// =============================================================================
+// ADVANCED REPAIR & HEURISTIC REBUILD (Requires Numeric Scalar Bounds)
+// =============================================================================
+//
+// `repair_delaunay_with_flips_advanced` can fall back to `rebuild_with_heuristic`,
+// which constructs a new triangulation and therefore requires `ScalarAccumulative`.
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
+where
+    K: Kernel<D>,
+    K::Scalar: ScalarAccumulative + NumCast,
+    U: DataType,
+    V: DataType,
+{
     /// Runs flip-based Delaunay repair
     ///
     /// This first attempts the standard two-pass flip repair. If it fails to converge (or if
@@ -4297,6 +4339,21 @@ where
         vertex_hashes.sort_unstable();
         stable_hash_u64_slice(&vertex_hashes)
     }
+}
+
+// =============================================================================
+// CONFIGURATION & TRAVERSAL (Minimal Bounds, continued)
+// =============================================================================
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    // -------------------------------------------------------------------------
+    // CONFIGURATION
+    // -------------------------------------------------------------------------
 
     /// Returns the topology guarantee used for Level 3 topology validation.
     #[inline]
@@ -4682,7 +4739,23 @@ where
     pub fn vertex_coords(&self, v: VertexKey) -> Option<&[K::Scalar]> {
         self.as_triangulation().vertex_coords(v)
     }
+}
 
+// =============================================================================
+// MUTATION (Requires Numeric Scalar Bounds)
+// =============================================================================
+//
+// Incremental insertion, removal, and post-insertion repair/check helpers.
+// These require `ScalarAccumulative + NumCast` for spatial-index construction,
+// Triangulation-layer insertion, and Triangulation-layer removal.
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
+where
+    K: Kernel<D>,
+    K::Scalar: ScalarAccumulative + NumCast,
+    U: DataType,
+    V: DataType,
+{
     fn ensure_spatial_index_seeded(&mut self) {
         if self.spatial_index.is_some() {
             return;
@@ -5216,6 +5289,21 @@ where
 
         Ok(cells_removed)
     }
+}
+
+// =============================================================================
+// VALIDATION (Minimal Bounds)
+// =============================================================================
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    // -------------------------------------------------------------------------
+    // VALIDATION
+    // -------------------------------------------------------------------------
 
     /// Validates the Delaunay empty-circumsphere property (Level 4).
     ///
@@ -5414,23 +5502,9 @@ where
             }
         }
     }
-}
-
-// =============================================================================
-// PURE STRUCT ASSEMBLY (Minimal Bounds)
-// =============================================================================
-//
-// These methods only assemble the `DelaunayTriangulation` struct from its parts
-// and do not perform any geometric operations. They live in a minimally-bounded
-// impl block so callers (e.g. explicit combinatorial construction) are not
-// forced to satisfy `ScalarAccumulative + NumCast`.
-
-impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
-where
-    K: Kernel<D>,
-    U: DataType,
-    V: DataType,
-{
+    // -------------------------------------------------------------------------
+    // PURE STRUCT ASSEMBLY
+    // -------------------------------------------------------------------------
     /// Create a `DelaunayTriangulation` from a `Tds` with a default kernel.
     ///
     /// This is useful when you've serialized just the `Tds` and want to reconstruct

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,22 @@
 //!   (PL-manifold conditions, ridge/vertex links, ordering heuristics, and
 //!   convergence assumptions), plus algorithmic background and limitations.
 //!
+//! ## Which import do I need?
+//!
+//! The crate provides several focused prelude modules.  Pick the one that
+//! matches your task:
+//!
+//! | Task | Import |
+//! |---|---|
+//! | Build a triangulation, insert/remove vertices | `use delaunay::prelude::triangulation::*` |
+//! | Read-only queries, traversal, convex hull | `use delaunay::prelude::query::*` |
+//! | Geometry helpers, predicates, points | `use delaunay::prelude::geometry::*` |
+//! | Bistellar flips (Pachner moves) | `use delaunay::prelude::triangulation::flips::*` |
+//! | Delaunayize workflow (repair + flip) | `use delaunay::prelude::triangulation::delaunayize::*` |
+//! | Topology validation, Euler characteristic | `use delaunay::prelude::topology::validation::*` |
+//! | Collection types (`FastHashMap`, etc.) | `use delaunay::prelude::collections::*` |
+//! | Everything (kitchen sink) | `use delaunay::prelude::*` |
+//!
 //! ## Examples (contract-oriented)
 //!
 //! ### Validation hierarchy (Levels 1–4)

--- a/tests/conflict_region_verification.rs
+++ b/tests/conflict_region_verification.rs
@@ -44,6 +44,7 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         DelaunayTriangulation::new(initial).expect("initial simplex should succeed");
 
     let kernel = AdaptiveKernel::<f64>::new();
+    #[allow(unused_mut)] // only mutated under debug_assertions
     let mut total_missed = 0_usize;
     let mut insertions_checked = 0_usize;
     let mut insert_errors: Vec<String> = Vec::new();

--- a/tests/delaunay_edge_cases.rs
+++ b/tests/delaunay_edge_cases.rs
@@ -228,7 +228,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
     }
 
     if let Err(err) = dt.is_valid() {
-        #[cfg(any(test, debug_assertions))]
+        #[cfg(debug_assertions)]
         {
             delaunay::core::util::debug_print_first_delaunay_violation(dt.tds(), None);
         }

--- a/tests/proptest_cell.rs
+++ b/tests/proptest_cell.rs
@@ -142,6 +142,6 @@ macro_rules! test_cell_properties {
 // Generate tests for dimensions 2-5
 // Parameters: dimension, min_vertices, max_vertices, expected_vertices (D+1), max_neighbors (D+1)
 test_cell_properties!(2, 4, 10, 3, 3);
-test_cell_properties!(3, 5, 12, 4, 4, #[ignore = "Slow (>60s) in test-integration"]);
+test_cell_properties!(3, 5, 12, 4, 4);
 test_cell_properties!(4, 6, 14, 5, 5, #[ignore = "Slow (>60s) in test-integration"]);
 test_cell_properties!(5, 7, 16, 6, 6, #[ignore = "Slow (>60s) in test-integration"]);

--- a/tests/proptest_convex_hull.rs
+++ b/tests/proptest_convex_hull.rs
@@ -339,6 +339,6 @@ test_minimal_simplex_hull!(3);
 test_minimal_simplex_hull!(4);
 test_minimal_simplex_hull!(5);
 test_convex_hull_properties!(2, 4, 10);
-test_convex_hull_properties!(3, 5, 12, #[ignore = "Slow (>60s) in test-integration"]);
+test_convex_hull_properties!(3, 5, 12);
 test_convex_hull_properties!(4, 6, 14, #[ignore = "Slow (>60s) in test-integration"]);
 test_convex_hull_properties!(5, 7, 16, #[ignore = "Slow (>60s) in test-integration"]);

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -592,7 +592,6 @@ macro_rules! gen_incremental_insertion_validity {
 
 gen_incremental_insertion_validity!(2, 3, 5);
 proptest! {
-    #[ignore = "Slow (>60s) in test-integration"]
     #[test]
     fn prop_incremental_insertion_maintains_validity_3d(
         initial_points in prop::collection::vec(vertex_3d(), 4..=6),
@@ -701,7 +700,7 @@ macro_rules! gen_duplicate_coords_test {
 }
 
 gen_duplicate_coords_test!(2, 3, 10);
-gen_duplicate_coords_test!(3, 4, 12, #[ignore = "Slow (>60s) in test-integration"]);
+gen_duplicate_coords_test!(3, 4, 12);
 gen_duplicate_coords_test!(4, 5, 14, #[ignore = "Slow (>60s) in test-integration"]);
 gen_duplicate_coords_test!(5, 6, 16, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -848,7 +847,7 @@ proptest! {
 
 // 2D–5D coverage (keep ranges small to bound runtime)
 test_empty_circumsphere!(2, 6, 10);
-test_empty_circumsphere!(3, 6, 10, #[ignore = "Slow (>60s) in test-integration"]);
+test_empty_circumsphere!(3, 6, 10);
 test_empty_circumsphere!(4, 6, 12, #[ignore = "Slow (>60s) in test-integration"]);
 test_empty_circumsphere!(5, 7, 12, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -980,7 +979,6 @@ gen_insertion_order_robustness_test!(2, 6, 10);
 //   to improve the generator or to strengthen the underlying 3D robustness (rather than to
 //   further weaken the property).
 #[test]
-#[ignore = "Slow (>60s) in test-integration"]
 #[expect(
     clippy::too_many_lines,
     reason = "Large property-based test with extensive rejection tracking and diagnostics"
@@ -1753,6 +1751,6 @@ macro_rules! gen_duplicate_cloud_test {
 }
 
 gen_duplicate_cloud_test!(2, 2);
-gen_duplicate_cloud_test!(3, 3, #[ignore = "Slow (>60s) in test-integration"]);
+gen_duplicate_cloud_test!(3, 3);
 gen_duplicate_cloud_test!(4, 4, #[ignore = "Slow (>60s) in test-integration"]);
 gen_duplicate_cloud_test!(5, 5, #[ignore = "Slow (>60s) in test-integration"]);

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -649,8 +649,8 @@ proptest! {
         }
     }
 }
-gen_incremental_insertion_validity!(4, 5, 7, #[ignore = "Exact Bareiss fallback too slow for 5×5 orientation matrices; see la-stack #44"]);
-gen_incremental_insertion_validity!(5, 6, 8, #[ignore = "Exact Bareiss fallback too slow for 6×6 orientation matrices; see la-stack #44"]);
+gen_incremental_insertion_validity!(4, 5, 7);
+gen_incremental_insertion_validity!(5, 6, 8, #[ignore = "Slow (>60s) even in release mode for 5D"]);
 
 // =============================================================================
 // DUPLICATE COORDINATE REJECTION TESTS

--- a/tests/proptest_euler_characteristic.rs
+++ b/tests/proptest_euler_characteristic.rs
@@ -211,6 +211,6 @@ fn test_seeded_random_generator_euler_consistent() {
 // - Balance test execution time with coverage
 // - Match patterns in other proptest files
 test_euler_properties!(2, 4, 15);
-test_euler_properties!(3, 5, 20, #[ignore = "Slow (>60s) in Codecov CI"]);
+test_euler_properties!(3, 5, 20);
 test_euler_properties!(4, 6, 25, #[ignore = "Slow (>60s) in test-integration"]);
 test_euler_properties!(5, 7, 30, #[ignore = "Slow (>60s) in test-integration"]);

--- a/tests/proptest_facet.rs
+++ b/tests/proptest_facet.rs
@@ -170,7 +170,7 @@ macro_rules! test_facet_properties {
 // Generate tests for dimensions 2-5
 // Parameters: dimension, min_vertices, max_vertices, expected_facet_vertices (D)
 test_facet_properties!(2, 4, 10, 2);
-test_facet_properties!(3, 5, 12, 3, #[ignore = "Slow (>60s) in Codecov CI"]);
+test_facet_properties!(3, 5, 12, 3);
 test_facet_properties!(4, 6, 14, 4, #[ignore = "Slow (>60s) in test-integration"]);
 test_facet_properties!(5, 7, 16, 5, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -222,6 +222,6 @@ macro_rules! test_facet_multiplicity {
 }
 
 test_facet_multiplicity!(2, 4, 10);
-test_facet_multiplicity!(3, 5, 12, #[ignore = "Slow (>60s) in Codecov CI"]);
+test_facet_multiplicity!(3, 5, 12);
 test_facet_multiplicity!(4, 6, 14, #[ignore = "Slow (>60s) in test-integration"]);
 test_facet_multiplicity!(5, 7, 16, #[ignore = "Slow (>60s) in test-integration"]);

--- a/tests/proptest_orientation.rs
+++ b/tests/proptest_orientation.rs
@@ -137,7 +137,7 @@ macro_rules! gen_orientation_incremental_props {
 }
 
 gen_orientation_construction_and_tamper_props!(2, 4, 10);
-gen_orientation_construction_and_tamper_props!(3, 5, 12, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_orientation_construction_and_tamper_props!(3, 5, 12);
 gen_orientation_construction_and_tamper_props!(
     4,
     6,

--- a/tests/proptest_serialization.rs
+++ b/tests/proptest_serialization.rs
@@ -233,6 +233,6 @@ macro_rules! test_serialization_properties {
 // Generate tests for dimensions 2-5
 // Parameters: dimension, min_vertices, max_vertices
 test_serialization_properties!(2, 4, 10);
-test_serialization_properties!(3, 5, 12, #[ignore = "Slow (>60s) in Codecov CI"]);
+test_serialization_properties!(3, 5, 12);
 test_serialization_properties!(4, 6, 14, #[ignore = "Slow (>60s) in test-integration"]);
 test_serialization_properties!(5, 7, 16, #[ignore = "Slow (>60s) in test-integration"]);

--- a/tests/proptest_tds.rs
+++ b/tests/proptest_tds.rs
@@ -332,7 +332,7 @@ macro_rules! gen_cell_vertex_count {
 // =============================================================================
 
 gen_tds_validity!(2);
-gen_tds_validity!(3, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_tds_validity!(3);
 gen_tds_validity!(4, #[ignore = "Slow (>60s) in test-integration"]);
 gen_tds_validity!(5, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -342,7 +342,7 @@ gen_tds_validity!(5, #[ignore = "Slow (>60s) in test-integration"]);
 
 gen_neighbor_symmetry!(2);
 
-gen_neighbor_symmetry!(3, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_neighbor_symmetry!(3);
 
 gen_neighbor_symmetry!(4, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -354,7 +354,7 @@ gen_neighbor_symmetry!(5, #[ignore = "Slow (>60s) in test-integration"]);
 
 gen_neighbor_index_semantics!(2);
 
-gen_neighbor_index_semantics!(3, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_neighbor_index_semantics!(3);
 
 gen_neighbor_index_semantics!(4, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -366,7 +366,7 @@ gen_neighbor_index_semantics!(5, #[ignore = "Slow (>60s) in test-integration"]);
 
 gen_cell_vertices_exist_in_tds!(2);
 
-gen_cell_vertices_exist_in_tds!(3, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_cell_vertices_exist_in_tds!(3);
 
 gen_cell_vertices_exist_in_tds!(4, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -378,7 +378,7 @@ gen_cell_vertices_exist_in_tds!(5, #[ignore = "Slow (>60s) in test-integration"]
 
 gen_no_duplicate_cells!(2);
 
-gen_no_duplicate_cells!(3, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_no_duplicate_cells!(3);
 
 gen_no_duplicate_cells!(4, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -390,7 +390,7 @@ gen_no_duplicate_cells!(5, #[ignore = "Slow (>60s) in test-integration"]);
 
 gen_dimension_consistency!(2, 3);
 
-gen_dimension_consistency!(3, 4, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_dimension_consistency!(3, 4);
 
 gen_dimension_consistency!(4, 5, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -402,7 +402,7 @@ gen_dimension_consistency!(5, 6, #[ignore = "Slow (>60s) in test-integration"]);
 
 gen_vertex_count_consistency!(2);
 
-gen_vertex_count_consistency!(3, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_vertex_count_consistency!(3);
 
 gen_vertex_count_consistency!(4, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -414,7 +414,7 @@ gen_vertex_count_consistency!(5, #[ignore = "Slow (>60s) in test-integration"]);
 
 gen_cell_vertex_count!(2, 3);
 
-gen_cell_vertex_count!(3, 4, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_cell_vertex_count!(3, 4);
 
 gen_cell_vertex_count!(4, 5, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -451,7 +451,7 @@ macro_rules! gen_is_connected {
 
 gen_is_connected!(2);
 
-gen_is_connected!(3, #[ignore = "Slow (>60s) in Codecov CI"]);
+gen_is_connected!(3);
 
 gen_is_connected!(4, #[ignore = "Slow (>60s) in test-integration"]);
 

--- a/tests/proptest_triangulation.rs
+++ b/tests/proptest_triangulation.rs
@@ -653,7 +653,7 @@ test_simplex_quality_properties!(4, 5);
 test_simplex_quality_properties!(5, 6);
 // Parameters: dimension, min_vertices, max_vertices
 test_quality_properties!(2, 4, 10);
-test_quality_properties!(3, 5, 12, #[ignore = "Slow (>60s) in Codecov CI"]);
+test_quality_properties!(3, 5, 12);
 test_quality_properties!(4, 6, 14, #[ignore = "Slow (>60s) in test-integration"]);
 test_quality_properties!(5, 7, 16, #[ignore = "Slow (>60s) in test-integration"]);
 
@@ -772,6 +772,6 @@ macro_rules! test_facet_topology_invariant {
 // Generate facet topology invariant tests for dimensions 2-5
 // Parameters: dimension, min_vertices, max_vertices
 test_facet_topology_invariant!(2, 4, 10);
-test_facet_topology_invariant!(3, 5, 12, #[ignore = "Slow (>60s) in Codecov CI"]);
+test_facet_topology_invariant!(3, 5, 12);
 test_facet_topology_invariant!(4, 6, 14, #[ignore = "Slow (>60s) in test-integration"]);
 test_facet_topology_invariant!(5, 7, 16, #[ignore = "Slow (>60s) in test-integration"]);

--- a/tests/regression_delaunay_2d.rs
+++ b/tests/regression_delaunay_2d.rs
@@ -2,6 +2,7 @@
 //!
 //! This module tests circumsphere and flip repair behavior in minimal 2D configurations.
 
+#[cfg(debug_assertions)]
 use delaunay::core::util::debug_print_first_delaunay_violation;
 use delaunay::prelude::triangulation::*;
 
@@ -24,6 +25,7 @@ fn regression_empty_circumsphere_2d_minimal_case() {
         .unwrap();
 
     if dt.is_valid().is_err() {
+        #[cfg(debug_assertions)]
         debug_print_first_delaunay_violation(dt.tds(), None);
     }
 
@@ -54,6 +56,7 @@ fn regression_issue_120_minimal_failing_input_2d() {
         .unwrap();
 
     if let Err(err) = dt.validate() {
+        #[cfg(debug_assertions)]
         debug_print_first_delaunay_violation(dt.tds(), None);
         panic!("Issue #120 2D regression must validate Levels 1-4: {err}");
     }


### PR DESCRIPTION
…relude guidance, re-enable 3D proptests

- Split monolithic DelaunayTriangulation impl block into 6 trait-minimal blocks per #302 (ScalarAccumulative only where needed)
- Decompose search_closed_2d_selection: extract ClosedSelectionDfs struct and sort_candidates_by_rarity_and_domain helper, remove clippy suppressions
- Add "Which import do I need?" prelude guidance table to lib.rs
- Re-enable 43 previously-ignored 3D proptests (all <1s in release mode)
- Audit doctests for builder migration (no changes needed; deferred to #214)