### PR TITLE
refactor: rename tds file and move delaunay/builder into triangulation/

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "la-stack"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02154c3637bfc64d8aef80c1ff018cc38585c9f1568d0fd75bb2e4bc88cb5f3"
+checksum = "29642c18844c8b5eb0374363b0f7d0bf1977384db2b5d5496e2bcbad249c58bb"
 dependencies = [
  "num-bigint",
  "num-rational",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -268,7 +268,7 @@ dependencies = [
  "ordered-float",
  "pastey",
  "proptest",
- "rand 0.10.0",
+ "rand 0.10.1",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -723,9 +723,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.1",
@@ -1117,7 +1117,7 @@ checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
- "rand 0.10.0",
+ "rand 0.10.1",
  "serde_core",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ readme = "README.md"
 [dependencies]
 allocation-counter = { version = "0.8.1", optional = true } # for memory profiling
 arc-swap = "1.9.1"
-la-stack = { version = "0.3.0", features = [ "exact" ] }
+la-stack = { version = "0.4.0", features = [ "exact" ] }
 tracing = "0.1.44"
 rustc-hash = "2.1.2" # Fast non-cryptographic hashing for performance
 smallvec = { version = "1.15.1", features = [ "serde" ] } # Stack allocation for small collections

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rustc-hash = "2.1.2" # Fast non-cryptographic hashing for performance
 smallvec = { version = "1.15.1", features = [ "serde" ] } # Stack allocation for small collections
 num-traits = "0.2.19"
 ordered-float = { version = "5.3.0", features = [ "serde" ] }
-rand = "0.10.0"
+rand = "0.10.1"
 serde = { version = "1.0.228", features = [ "derive" ] }
 slotmap = { version = "1.1.1", features = [ "serde" ] }
 thiserror = "2.0.18"

--- a/README.md
+++ b/README.md
@@ -158,10 +158,6 @@ The construction pipeline exposes deterministic controls for experiments and reg
 - Explicit topology/validation configuration via `TopologyGuarantee` and `ValidationPolicy`
 
 ```rust
-use delaunay::core::delaunay_triangulation::{
-    ConstructionOptions, DedupPolicy, InsertionOrderStrategy, RetryPolicy,
-};
-use delaunay::core::triangulation::{TopologyGuarantee, ValidationPolicy};
 use delaunay::prelude::triangulation::*;
 
 let vertices = vec![
@@ -343,4 +339,4 @@ Portions of this library were developed with the assistance of these AI tools:
 [PL-manifold]: https://en.wikipedia.org/wiki/Piecewise_linear_manifold
 [Delaunay repair]: https://link.springer.com/article/10.1007/BF01975867
 [Pachner moves]: https://grokipedia.com/page/pachner_moves
-[`DelaunayTriangulationBuilder`]: https://docs.rs/delaunay/latest/delaunay/core/builder/struct.DelaunayTriangulationBuilder.html
+[`DelaunayTriangulationBuilder`]: https://docs.rs/delaunay/latest/delaunay/triangulation/builder/struct.DelaunayTriangulationBuilder.html

--- a/benches/large_scale_performance.rs
+++ b/benches/large_scale_performance.rs
@@ -77,12 +77,10 @@
 //! **Query performance:** Directly measures `SlotMap` iteration efficiency
 
 use criterion::{BatchSize, Criterion, Throughput, criterion_group, criterion_main};
-use delaunay::core::delaunay_triangulation::{
-    ConstructionOptions, DelaunayTriangulation, RetryPolicy,
-};
 use delaunay::core::vertex::Vertex;
 use delaunay::geometry::kernel::AdaptiveKernel;
 use delaunay::geometry::util::generate_random_points_seeded;
+use delaunay::triangulation::delaunay::{ConstructionOptions, DelaunayTriangulation, RetryPolicy};
 use delaunay::vertex;
 use std::hint::black_box;
 use std::num::NonZeroUsize;

--- a/benches/microbenchmarks.rs
+++ b/benches/microbenchmarks.rs
@@ -12,10 +12,10 @@
 //! completed as part of the Pure Incremental Delaunay Triangulation refactoring project.
 
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
 use delaunay::geometry::kernel::RobustKernel;
 use delaunay::geometry::util::generate_random_points_seeded;
 use delaunay::prelude::query::*;
+use delaunay::triangulation::delaunay::DelaunayTriangulation;
 use delaunay::vertex;
 use std::hint::black_box;
 use std::sync::OnceLock;

--- a/docs/ORIENTATION_SPEC.md
+++ b/docs/ORIENTATION_SPEC.md
@@ -80,7 +80,7 @@ We already have `simplex_orientation()` in `src/geometry/predicates.rs` that com
 **Strategy**: When creating a cell, ensure vertices are ordered to produce **positive orientation**.
 
 ```rust
-// In src/core/triangulation_data_structure.rs
+// In src/core/tds.rs
 
 /// Ensure vertices are ordered to produce positive orientation.
 /// Returns vertices in canonical (positive orientation) order.

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -169,14 +169,12 @@ delaunay/
 │   │   │   └── uuid.rs
 │   │   ├── adjacency.rs
 │   │   ├── boundary.rs
-│   │   ├── builder.rs
 │   │   ├── cell.rs
-│   │   ├── delaunay_triangulation.rs
 │   │   ├── edge.rs
 │   │   ├── facet.rs
 │   │   ├── operations.rs
+│   │   ├── tds.rs
 │   │   ├── triangulation.rs
-│   │   ├── triangulation_data_structure.rs
 │   │   └── vertex.rs
 │   ├── geometry/
 │   │   ├── algorithms/
@@ -210,6 +208,8 @@ delaunay/
 │   │   │   └── topological_space.rs
 │   │   └── manifold.rs
 │   ├── triangulation/
+│   │   ├── builder.rs
+│   │   ├── delaunay.rs
 │   │   ├── delaunayize.rs
 │   │   └── flips.rs
 │   └── lib.rs
@@ -365,9 +365,7 @@ The `benchmark-utils` CLI provides integrated benchmark workflow functionality, 
 
 **`src/core/`** - Triangulation data structures and algorithms:
 
-- `triangulation_data_structure.rs` - Main `Tds` struct
-- `delaunay_triangulation.rs` - DelaunayTriangulation implementation (top layer)
-- `builder.rs` - Fluent builder API for Euclidean and toroidal/periodic construction
+- `tds.rs` - Main `Tds` struct
 - `triangulation.rs` - Generic Triangulation layer with kernel
 - `vertex.rs`, `cell.rs`, `facet.rs` - Core geometric primitives
 - `edge.rs` - Canonical `EdgeKey` for topology traversal
@@ -411,6 +409,8 @@ The `benchmark-utils` CLI provides integrated benchmark workflow functionality, 
 
 **`src/triangulation/`** - Triangulation-facing public APIs:
 
+- `builder.rs` - Fluent builder API for Euclidean and toroidal/periodic construction
+- `delaunay.rs` - `DelaunayTriangulation` implementation (top layer) with incremental insertion
 - `delaunayize.rs` - End-to-end "repair then delaunayize" workflow (`delaunayize_by_flips`);
   bounded topology repair + flip-based Delaunay repair + optional fallback rebuild
 - `flips.rs` - High-level bistellar flip (Pachner move) trait and supporting public types; delegates to `core::algorithms::flips`

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -19,7 +19,7 @@ in release builds.
 |---|---|---|---|
 | `DELAUNAY_INSERT_TRACE` | presence | `triangulation.rs` | Per-insertion summary (vertex index, location, conflict size, suspicion flags) |
 | `DELAUNAY_DEBUG_SHUFFLE` | presence | `triangulation.rs` | Logs vertex shuffle order during batch construction |
-| `DELAUNAY_DUPLICATE_METRICS` | presence | `delaunay_triangulation.rs` | Duplicate-detection metrics (spatial hash grid stats) |
+| `DELAUNAY_DUPLICATE_METRICS` | presence | `triangulation/delaunay.rs` | Duplicate-detection metrics (spatial hash grid stats) |
 
 ## Point Location
 
@@ -73,7 +73,7 @@ in release builds.
 
 | Variable | Activation | Module | Description |
 |---|---|---|---|
-| `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` | presence | `delaunay_triangulation.rs` | Cross-validates insphere results between fast and exact predicates |
+| `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` | presence | `triangulation/delaunay.rs` | Cross-validates insphere results between fast and exact predicates |
 | `DELAUNAY_DEBUG_LU_FALLBACK` | presence | `circumsphere.rs` | Logs when circumsphere computation falls back to LU decomposition |
 
 ## Point Generation

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -243,7 +243,7 @@ paths inline. This keeps code readable and consistent.
 Prefer:
 
 ```rust
-use crate::core::triangulation_data_structure::TdsError;
+use crate::core::tds::TdsError;
 
 fn check(err: &TdsError) -> bool { ... }
 ```
@@ -251,13 +251,13 @@ fn check(err: &TdsError) -> bool { ... }
 Instead of:
 
 ```rust
-fn check(err: &crate::core::triangulation_data_structure::TdsError) -> bool { ... }
+fn check(err: &crate::core::tds::TdsError) -> bool { ... }
 ```
 
 Group imports from the same module into a single `use` statement with braces:
 
 ```rust
-use crate::core::triangulation_data_structure::{
+use crate::core::tds::{
     CellKey, EntityKind, Tds, TdsError, VertexKey,
 };
 ```

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -69,7 +69,7 @@ Key combinatorial objects:
   vertex.
 - **Adjacency / neighbors**: two cells are neighbors if they share a facet. The triangulation data
   structure (TDS) stores neighbor pointers across facets (see
-  [`src/core/triangulation_data_structure.rs`](../src/core/triangulation_data_structure.rs) and CGAL’s
+  [`src/core/tds.rs`](../src/core/tds.rs) and CGAL’s
   [TDS_3](https://doc.cgal.org/latest/TDS_3/index.html)).[^cgal-tds3][^impl-tds]
 - **Boundary vs interior facets**:
   - An **interior facet** is incident to exactly two cells.
@@ -347,7 +347,7 @@ For the project-wide bibliography (including references not cited here), see [`R
 
 [^edelsbrunner2001]: Herbert Edelsbrunner. *Geometry and Topology for Mesh Generation*. Cambridge University Press, 2001. DOI: <https://doi.org/10.1017/CBO9780511530067>.
 [^cgal-tds3]: CGAL Project. *Triangulation Data Structure* (TDS_3) documentation. <https://doc.cgal.org/latest/TDS_3/index.html>.
-[^impl-tds]: Implementation: [src/core/triangulation_data_structure.rs](../src/core/triangulation_data_structure.rs).
+[^impl-tds]: Implementation: [src/core/tds.rs](../src/core/tds.rs).
 [^deberg2008]: Mark de Berg, Otfried Cheong, Marc van Kreveld, Mark Overmars. *Computational Geometry: Algorithms and Applications*, 3rd ed. Springer, 2008. DOI: <https://doi.org/10.1007/978-3-540-77974-2>.
 [^shewchuk1997]: Jonathan Richard Shewchuk. “Adaptive Precision Floating-Point Arithmetic and Fast Robust Geometric Predicates.” *Discrete & Computational Geometry* 18(3), 1997. DOI: <https://doi.org/10.1007/PL00009321>.
 [^edelshah1996]: Herbert Edelsbrunner and Nimish R. Shah. “Incremental Topological Flipping Works for Regular Triangulations.” *Algorithmica* 15(3), 1996. DOI: <https://doi.org/10.1007/BF01975867>.

--- a/docs/numerical_robustness_guide.md
+++ b/docs/numerical_robustness_guide.md
@@ -238,7 +238,7 @@ computed during Hilbert index generation).  It removes the vast majority of exac
 near-duplicate vertices before any insertion occurs, regardless of `DedupPolicy`.
 
 See `order_vertices_hilbert` (called from `order_vertices_by_strategy`) in
-[`src/core/delaunay_triangulation.rs`](../src/core/delaunay_triangulation.rs).
+[`src/triangulation/delaunay.rs`](../src/triangulation/delaunay.rs).
 
 ### Layer 2: Per-insertion duplicate coordinate check
 
@@ -273,7 +273,7 @@ If violated, the error is
 `TdsError::DuplicateCoordinatesInCell { cell_id, message }`.
 
 See `validate_cell_coordinate_uniqueness` in
-[`src/core/triangulation_data_structure.rs`](../src/core/triangulation_data_structure.rs).
+[`src/core/tds.rs`](../src/core/tds.rs).
 
 ### User-facing dedup utilities
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -548,8 +548,8 @@ converge, consider the opt-in heuristic rebuild fallback via
 |-------|--------|--------|------------|
 | 1 | `Cell::is_valid()` | `core::cell` | O(1) |
 | 1 | `Vertex::is_valid()` | `core::vertex` | O(1) |
-| 2 | `Tds::is_valid()` | `core::triangulation_data_structure` | O(N×D²) |
-| 2 | `Tds::validate()` | `core::triangulation_data_structure` | O(N×D²) |
+| 2 | `Tds::is_valid()` | `core::tds` | O(N×D²) |
+| 2 | `Tds::validate()` | `core::tds` | O(N×D²) |
 | 3 | `Triangulation::is_valid()` | `core::triangulation` | O(N×D²) |
 | 3 | `Triangulation::validate()` | `core::triangulation` | O(N×D²) |
 | 4 | `DelaunayTriangulation::is_valid()` | `core::delaunay_triangulation` | O(cells) |

--- a/examples/pachner_roundtrip_4d.rs
+++ b/examples/pachner_roundtrip_4d.rs
@@ -14,10 +14,10 @@
 //! ```
 
 use ::uuid::Uuid;
-use delaunay::core::delaunay_triangulation::{ConstructionOptions, InsertionOrderStrategy};
 use delaunay::geometry::kernel::RobustKernel;
 use delaunay::prelude::triangulation::Vertex;
 use delaunay::prelude::triangulation::flips::*;
+use delaunay::triangulation::delaunay::{ConstructionOptions, InsertionOrderStrategy};
 use std::time::Instant;
 
 type Dt4 = DelaunayTriangulation<RobustKernel<f64>, (), (), 4>;

--- a/examples/zero_allocation_iterator_demo.rs
+++ b/examples/zero_allocation_iterator_demo.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // NOTE: The (n_points, bounds, seed) triple matches the 4D configuration used in
     // `test_generate_random_triangulation_dimensions` so that this example exercises
     // a realistic 4D triangulation without triggering extreme Delaunay repair in CI.
-    let dt: delaunay::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 4> =
+    let dt: delaunay::triangulation::delaunay::DelaunayTriangulation<_, (), (), 4> =
         generate_random_triangulation(
             12,          // Number of points (fewer for faster demo)
             (-1.0, 1.0), // Coordinate bounds

--- a/src/core/adjacency.rs
+++ b/src/core/adjacency.rs
@@ -15,7 +15,7 @@ use crate::core::collections::{
     FastHashMap, MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer, VertexToCellsMap,
 };
 use crate::core::edge::EdgeKey;
-use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+use crate::core::tds::{CellKey, VertexKey};
 use thiserror::Error;
 
 /// Errors that can occur while building an [`AdjacencyIndex`].
@@ -24,7 +24,7 @@ use thiserror::Error;
 ///
 /// ```rust
 /// use delaunay::core::adjacency::AdjacencyIndexBuildError;
-/// use delaunay::core::triangulation_data_structure::{CellKey, VertexKey};
+/// use delaunay::core::tds::{CellKey, VertexKey};
 /// use slotmap::KeyData;
 ///
 /// let cell_key = CellKey::from(KeyData::from_ffi(1));
@@ -381,7 +381,7 @@ mod tests {
 
     #[test]
     fn adjacency_index_query_helpers_are_consistent() {
-        use crate::core::delaunay_triangulation::DelaunayTriangulation;
+        use crate::triangulation::delaunay::DelaunayTriangulation;
         use crate::vertex;
 
         // Two tetrahedra sharing a triangular facet.

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -38,9 +38,9 @@ use crate::core::collections::{
 use crate::core::edge::EdgeKey;
 use crate::core::facet::{AllFacetsIter, FacetHandle, facet_key_from_vertices};
 use crate::core::operations::TopologicalOperation;
+use crate::core::tds::{CellKey, Tds, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::TopologyGuarantee;
-use crate::core::triangulation_data_structure::{CellKey, Tds, VertexKey};
 use crate::core::util::stable_hash_u64_slice;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
@@ -1057,7 +1057,7 @@ pub enum FlipError {
 /// ```rust
 /// use delaunay::core::algorithms::flips::{BistellarFlipKind, FlipDirection, FlipInfo};
 /// use delaunay::core::collections::{CellKeyBuffer, SmallBuffer, MAX_PRACTICAL_DIMENSION_SIZE};
-/// use delaunay::core::triangulation_data_structure::{CellKey, VertexKey};
+/// use delaunay::core::tds::{CellKey, VertexKey};
 /// use slotmap::KeyData;
 ///
 /// let mut removed_cells = CellKeyBuffer::new();
@@ -1130,7 +1130,7 @@ pub(crate) struct FlipContextDyn<const D: usize> {
 ///
 /// ```rust
 /// use delaunay::core::algorithms::flips::TriangleHandle;
-/// use delaunay::core::triangulation_data_structure::VertexKey;
+/// use delaunay::core::tds::VertexKey;
 /// use slotmap::KeyData;
 ///
 /// let a = VertexKey::from(KeyData::from_ffi(1));
@@ -1155,7 +1155,7 @@ impl TriangleHandle {
     ///
     /// ```rust
     /// use delaunay::core::algorithms::flips::TriangleHandle;
-    /// use delaunay::core::triangulation_data_structure::VertexKey;
+    /// use delaunay::core::tds::VertexKey;
     /// use slotmap::KeyData;
     ///
     /// let a = VertexKey::from(KeyData::from_ffi(10));
@@ -1188,7 +1188,7 @@ impl TriangleHandle {
 ///
 /// ```rust
 /// use delaunay::core::algorithms::flips::RidgeHandle;
-/// use delaunay::core::triangulation_data_structure::CellKey;
+/// use delaunay::core::tds::CellKey;
 /// use slotmap::KeyData;
 ///
 /// let cell_key = CellKey::from(KeyData::from_ffi(7));
@@ -5077,8 +5077,8 @@ mod tests {
     use super::*;
     use crate::core::algorithms::incremental_insertion::repair_neighbor_pointers;
     use crate::core::collections::Uuid;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
     use crate::geometry::kernel::{AdaptiveKernel, FastKernel};
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
 

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -33,11 +33,11 @@ use crate::core::collections::{
     VertexKeyBuffer,
 };
 use crate::core::facet::FacetHandle;
+use crate::core::tds::{CellKey, EntityKind, Tds, TdsError, VertexKey};
 use crate::core::traits::boundary_analysis::BoundaryAnalysis;
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::TriangulationConstructionError;
 use crate::core::triangulation::TriangulationValidationError;
-use crate::core::triangulation_data_structure::{CellKey, EntityKind, Tds, TdsError, VertexKey};
 use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
 use crate::geometry::predicates::Orientation;
@@ -173,7 +173,7 @@ pub enum InsertionError {
     DelaunayValidationFailed {
         /// The structured Level 4 validation error.
         #[source]
-        source: Box<crate::core::delaunay_triangulation::DelaunayTriangulationValidationError>,
+        source: Box<crate::triangulation::delaunay::DelaunayTriangulationValidationError>,
     },
 
     /// Flip-based Delaunay repair failed.
@@ -703,7 +703,7 @@ where
 /// ```rust
 /// use delaunay::core::algorithms::incremental_insertion::wire_cavity_neighbors;
 /// use delaunay::core::collections::CellKeyBuffer;
-/// use delaunay::core::triangulation_data_structure::Tds;
+/// use delaunay::core::tds::Tds;
 ///
 /// let mut tds: Tds<f64, (), (), 3> = Tds::empty();
 /// let new_cells = CellKeyBuffer::new();
@@ -1503,8 +1503,8 @@ where
 ///
 /// ```rust
 /// use delaunay::core::algorithms::incremental_insertion::extend_hull;
-/// use delaunay::core::triangulation_data_structure::Tds;
-/// use delaunay::core::triangulation_data_structure::VertexKey;
+/// use delaunay::core::tds::Tds;
+/// use delaunay::core::tds::VertexKey;
 /// use delaunay::geometry::kernel::FastKernel;
 /// use delaunay::geometry::point::Point;
 /// use delaunay::geometry::traits::coordinate::Coordinate;
@@ -2350,11 +2350,11 @@ where
 mod tests {
     use super::*;
     use crate::core::collections::CellKeyBuffer;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
-    use crate::core::triangulation_data_structure::GeometricError;
+    use crate::core::tds::GeometricError;
     use crate::geometry::kernel::FastKernel;
     use crate::geometry::traits::coordinate::{Coordinate, CoordinateConversionError};
     use crate::topology::characteristics::euler::TopologyClassification;
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
     use slotmap::KeyData;
 

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -22,8 +22,8 @@ use crate::core::collections::{
     FastHashSet, FastHasher, MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer,
 };
 use crate::core::facet::FacetHandle;
+use crate::core::tds::{CellKey, Tds, VertexKey};
 use crate::core::traits::data_type::DataType;
-use crate::core::triangulation_data_structure::{CellKey, Tds, VertexKey};
 use crate::core::util::canonical_points::{sorted_cell_points, sorted_facet_points_with_extra};
 use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
@@ -58,7 +58,7 @@ fn conflict_debug_config() -> &'static ConflictDebugConfig {
 ///
 /// ```rust
 /// use delaunay::core::algorithms::locate::LocateResult;
-/// use delaunay::core::triangulation_data_structure::VertexKey;
+/// use delaunay::core::tds::VertexKey;
 /// use slotmap::KeyData;
 ///
 /// let vertex = VertexKey::from(KeyData::from_ffi(2));
@@ -117,7 +117,7 @@ pub enum LocateError {
 ///
 /// ```rust
 /// use delaunay::core::algorithms::locate::ConflictError;
-/// use delaunay::core::triangulation_data_structure::CellKey;
+/// use delaunay::core::tds::CellKey;
 /// use slotmap::KeyData;
 ///
 /// let cell_key = CellKey::from(KeyData::from_ffi(5));
@@ -276,7 +276,7 @@ pub struct LocateFallback {
 ///
 /// ```rust
 /// use delaunay::core::algorithms::locate::LocateStats;
-/// use delaunay::core::triangulation_data_structure::CellKey;
+/// use delaunay::core::tds::CellKey;
 /// use slotmap::KeyData;
 ///
 /// let stats = LocateStats {
@@ -568,11 +568,11 @@ where
 /// - `cell.vertices()[facet_idx]` is the vertex opposite the facet
 /// - The facet consists of all vertices EXCEPT `vertices[facet_idx]`
 /// - This invariant is documented in [`Cell`](crate::core::cell::Cell) and enforced by
-///   [`Tds::assign_neighbors`](crate::core::triangulation_data_structure::Tds::assign_neighbors).
+///   [`Tds::assign_neighbors`](crate::core::tds::Tds::assign_neighbors).
 ///
 /// It is validated as part of Level 2 structural validation via
-/// [`Tds::is_valid`](crate::core::triangulation_data_structure::Tds::is_valid)
-/// (or cumulatively via [`Tds::validate`](crate::core::triangulation_data_structure::Tds::validate)).
+/// [`Tds::is_valid`](crate::core::tds::Tds::is_valid)
+/// (or cumulatively via [`Tds::validate`](crate::core::tds::Tds::validate)).
 ///
 /// This correspondence is essential for the canonical ordering used in orientation tests.
 /// If this invariant is violated, point location will produce incorrect results.
@@ -1048,7 +1048,7 @@ where
 /// ```rust
 /// use delaunay::core::algorithms::locate::extract_cavity_boundary;
 /// use delaunay::core::collections::CellKeyBuffer;
-/// use delaunay::core::triangulation_data_structure::Tds;
+/// use delaunay::core::tds::Tds;
 ///
 /// let tds: Tds<f64, (), (), 3> = Tds::empty();
 /// let boundary = extract_cavity_boundary(&tds, &CellKeyBuffer::new()).unwrap();

--- a/src/core/algorithms/pl_manifold_repair.rs
+++ b/src/core/algorithms/pl_manifold_repair.rs
@@ -29,8 +29,8 @@
 use crate::core::cell::Cell;
 use crate::core::collections::{CellKeySet, SmallBuffer, fast_hash_set_with_capacity};
 use crate::core::facet::FacetHandle;
+use crate::core::tds::{CellKey, Tds, TdsError, VertexKey};
 use crate::core::traits::data_type::DataType;
-use crate::core::triangulation_data_structure::{CellKey, Tds, TdsError, VertexKey};
 use crate::core::vertex::Vertex;
 use crate::geometry::traits::coordinate::CoordinateScalar;
 use crate::geometry::util::norms::hypot;
@@ -460,7 +460,7 @@ fn remove_orphaned_vertices<T, U, V, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
 
     // =============================================================================

--- a/src/core/boundary.rs
+++ b/src/core/boundary.rs
@@ -7,8 +7,8 @@
 
 use super::{
     facet::{BoundaryFacetsIter, FacetView},
+    tds::{Tds, TdsError},
     traits::{boundary_analysis::BoundaryAnalysis, data_type::DataType},
-    triangulation_data_structure::{Tds, TdsError},
 };
 use crate::prelude::CoordinateScalar;
 
@@ -35,7 +35,7 @@ where
     /// Any facet shared by 0, 3, or more cells indicates a topological error in the triangulation.
     ///
     /// For a comprehensive discussion of all topological invariants in Delaunay triangulations,
-    /// see the [Topological Invariants](crate::core::triangulation_data_structure#topological-invariants)
+    /// see the [Topological Invariants](crate::core::tds#topological-invariants)
     /// section in the triangulation data structure documentation.
     ///
     /// # Returns
@@ -71,7 +71,7 @@ where
     /// // TDS-level API (fallible): returns `TdsError` on corruption.
     /// let count = dt.tds().boundary_facets()?.count();
     /// assert_eq!(count, 4);
-    /// # Ok::<(), delaunay::core::triangulation_data_structure::TdsError>(())
+    /// # Ok::<(), delaunay::core::tds::TdsError>(())
     /// ```
     fn boundary_facets(&self) -> Result<BoundaryFacetsIter<'_, T, U, V, D>, TdsError> {
         // Build a map from facet keys to the cells that contain them
@@ -207,7 +207,7 @@ where
     ///
     /// // A single tetrahedron has 4 boundary facets
     /// assert_eq!(dt.tds().number_of_boundary_facets()?, 4);
-    /// # Ok::<(), delaunay::core::triangulation_data_structure::TdsError>(())
+    /// # Ok::<(), delaunay::core::tds::TdsError>(())
     /// ```
     fn number_of_boundary_facets(&self) -> Result<usize, TdsError> {
         self.build_facet_to_cells_map()
@@ -218,11 +218,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::BoundaryAnalysis;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
     use crate::core::facet::FacetError;
-    use crate::core::triangulation_data_structure::TdsError;
+    use crate::core::tds::TdsError;
     use crate::core::vertex::Vertex;
     use crate::geometry::{point::Point, traits::coordinate::Coordinate};
+    use crate::triangulation::delaunay::DelaunayTriangulation;
 
     #[cfg(feature = "bench")]
     use num_traits::cast::cast;

--- a/src/core/cell.rs
+++ b/src/core/cell.rs
@@ -1675,6 +1675,7 @@ mod tests {
 
     use crate::geometry::kernel::AdaptiveKernel;
     use crate::prelude::DelaunayTriangulation;
+    use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
     // =============================================================================
     // DIMENSION-PARAMETERIZED TEST MACRO
@@ -3817,8 +3818,6 @@ mod tests {
 
     #[test]
     fn test_cell_data_accessor() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices = [
             vertex!([0.0, 0.0]),
             vertex!([1.0, 0.0]),

--- a/src/core/cell.rs
+++ b/src/core/cell.rs
@@ -46,8 +46,8 @@
 use super::vertex::Vertex;
 use super::{
     facet::FacetError,
+    tds::{CellKey, Tds, VertexKey},
     traits::DataType,
-    triangulation_data_structure::{CellKey, Tds, VertexKey},
     util::{UuidValidationError, make_uuid, validate_uuid},
     vertex::VertexValidationError,
 };
@@ -173,7 +173,7 @@ impl From<crate::geometry::matrix::StackMatrixDispatchError> for CellValidationE
 /// - `uuid`: Universally unique identifier for the cell.
 /// - `neighbors`: Optional keys to neighboring cells (opposite each vertex). Access via `neighbors()` method.
 /// - `data`: Optional user data associated with the cell. Read via [`data()`](Self::data),
-///   mutate via [`Tds::set_cell_data`](crate::core::triangulation_data_structure::Tds::set_cell_data).
+///   mutate via [`Tds::set_cell_data`](crate::core::tds::Tds::set_cell_data).
 ///
 /// # Accessing Vertices
 ///
@@ -898,7 +898,7 @@ where
     ///
     /// **Internal API**: This method is `pub(crate)` to enforce that all neighbor
     /// modifications go through validated TDS methods. External code should use
-    /// [`Tds::clear_all_neighbors()`](crate::core::triangulation_data_structure::Tds::clear_all_neighbors)
+    /// [`Tds::clear_all_neighbors()`](crate::core::tds::Tds::clear_all_neighbors)
     /// which properly invalidates caches and maintains triangulation consistency.
     ///
     /// This method sets the `neighbors` field to `None`, effectively removing all
@@ -2744,8 +2744,7 @@ mod tests {
         assert!(serialized.contains("cells"));
 
         // Deserialize back to DT via from_tds (AdaptiveKernel has no auto-Deserialize).
-        let tds: crate::core::triangulation_data_structure::Tds<f64, (), (), 3> =
-            serde_json::from_str(&serialized).unwrap();
+        let tds: crate::core::tds::Tds<f64, (), (), 3> = serde_json::from_str(&serialized).unwrap();
         let deserialized = DelaunayTriangulation::from_tds(tds, AdaptiveKernel::new());
 
         // Verify DT properties match
@@ -3818,7 +3817,7 @@ mod tests {
 
     #[test]
     fn test_cell_data_accessor() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices = [
             vertex!([0.0, 0.0]),

--- a/src/core/collections/aliases.rs
+++ b/src/core/collections/aliases.rs
@@ -160,7 +160,7 @@ pub use std::collections::hash_map::Entry;
 /// **Phase 1**: Internal operations (key-based for performance):
 /// ```rust
 /// use delaunay::core::collections::{CellKeySet, FastHashSet};
-/// use delaunay::core::triangulation_data_structure::CellKey;
+/// use delaunay::core::tds::CellKey;
 ///
 /// // For internal algorithms, prefer direct key-based collections
 /// let mut internal_set: CellKeySet = CellKeySet::default();

--- a/src/core/collections/buffers.rs
+++ b/src/core/collections/buffers.rs
@@ -1,6 +1,6 @@
 use super::{MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer, Uuid};
 use crate::core::facet::FacetHandle;
-use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+use crate::core::tds::{CellKey, VertexKey};
 
 // =============================================================================
 // ALGORITHM-SPECIFIC BUFFER TYPES
@@ -181,7 +181,7 @@ pub type VertexKeyBuffer = SimplexVertexBuffer<VertexKey>;
 ///
 /// ```rust
 /// use delaunay::core::collections::NeighborBuffer;
-/// use delaunay::core::triangulation_data_structure::CellKey;
+/// use delaunay::core::tds::CellKey;
 ///
 /// let mut neighbors: NeighborBuffer<Option<CellKey>> = NeighborBuffer::new();
 /// assert!(neighbors.is_empty());

--- a/src/core/collections/helpers.rs
+++ b/src/core/collections/helpers.rs
@@ -50,7 +50,7 @@ pub fn fast_hash_map_with_capacity<K, V>(capacity: usize) -> FastHashMap<K, V> {
 /// **Phase 1**: Internal operations (key-based for better performance):
 /// ```rust
 /// use delaunay::core::collections::fast_hash_set_with_capacity;
-/// use delaunay::core::triangulation_data_structure::CellKey;
+/// use delaunay::core::tds::CellKey;
 ///
 /// let set = fast_hash_set_with_capacity::<CellKey>(500);
 /// // Can insert up to ~375 CellKeys without rehashing, avoids UUID→Key lookups

--- a/src/core/collections/key_maps.rs
+++ b/src/core/collections/key_maps.rs
@@ -1,5 +1,5 @@
 use super::{FastHashMap, FastHashSet, Uuid};
-use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+use crate::core::tds::{CellKey, VertexKey};
 
 // =============================================================================
 // GEOMETRIC ALGORITHM TYPES
@@ -214,7 +214,7 @@ pub type KeyBasedVertexMap<V> = FastHashMap<VertexKey, V>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+    use crate::core::tds::{CellKey, VertexKey};
     use slotmap::SlotMap;
 
     #[test]

--- a/src/core/collections/secondary_maps.rs
+++ b/src/core/collections/secondary_maps.rs
@@ -1,4 +1,4 @@
-use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+use crate::core::tds::{CellKey, VertexKey};
 use slotmap::SparseSecondaryMap;
 
 // =============================================================================

--- a/src/core/collections/spatial_hash_grid.rs
+++ b/src/core/collections/spatial_hash_grid.rs
@@ -17,7 +17,7 @@
 //! by updating the index only after the full higher-level operation commits).
 
 use super::{FastHashMap, SmallBuffer};
-use crate::core::triangulation_data_structure::VertexKey;
+use crate::core::tds::VertexKey;
 use crate::geometry::traits::coordinate::CoordinateScalar;
 use std::hash::{Hash, Hasher};
 
@@ -68,7 +68,7 @@ where
 /// The grid uses a fixed `cell_size` and indexes vertices by the floored cell
 /// coordinates `floor(coord / cell_size)`.
 #[derive(Clone, Debug)]
-pub(in crate::core) struct HashGridIndex<T, const D: usize, K = VertexKey>
+pub struct HashGridIndex<T, const D: usize, K = VertexKey>
 where
     T: CoordinateScalar,
 {
@@ -83,7 +83,7 @@ where
     K: Copy,
 {
     /// Create a new grid index with the given cell size.
-    pub(in crate::core) fn new(cell_size: T) -> Self {
+    pub fn new(cell_size: T) -> Self {
         let usable = D <= MAX_HASH_GRID_DIMENSION && cell_size.is_finite() && cell_size > T::zero();
         Self {
             cell_size,
@@ -91,24 +91,24 @@ where
             cells: FastHashMap::default(),
         }
     }
-    pub(in crate::core) const fn is_usable(&self) -> bool {
+    pub const fn is_usable(&self) -> bool {
         self.usable
     }
-    pub(in crate::core) const fn cell_size(&self) -> T
+    pub const fn cell_size(&self) -> T
     where
         T: Copy,
     {
         self.cell_size
     }
 
-    pub(in crate::core) fn clear(&mut self) {
+    pub fn clear(&mut self) {
         self.cells.clear();
     }
 
     const fn disable(&mut self) {
         self.usable = false;
     }
-    pub(in crate::core) fn can_key_coords(&self, coords: &[T; D]) -> bool {
+    pub fn can_key_coords(&self, coords: &[T; D]) -> bool {
         self.key_for_coords(coords).is_some()
     }
 
@@ -116,7 +116,7 @@ where
     ///
     /// If the index is not usable, or the point cannot be keyed robustly, the
     /// index is disabled (so callers can fall back to linear scans).
-    pub(in crate::core) fn insert_vertex(&mut self, vertex_key: K, coords: &[T; D]) {
+    pub fn insert_vertex(&mut self, vertex_key: K, coords: &[T; D]) {
         if !self.usable {
             return;
         }
@@ -133,11 +133,7 @@ where
     ///
     /// Returns `true` if the index was used for the query (even if it yielded zero
     /// candidates). Returns `false` if the index was unusable for this query.
-    pub(in crate::core) fn for_each_candidate_vertex_key<F>(
-        &self,
-        coords: &[T; D],
-        mut f: F,
-    ) -> bool
+    pub fn for_each_candidate_vertex_key<F>(&self, coords: &[T; D], mut f: F) -> bool
     where
         F: FnMut(K) -> bool,
     {
@@ -227,7 +223,7 @@ where
 mod tests {
     use super::*;
     use crate::core::collections::FastHashSet;
-    use crate::core::triangulation_data_structure::VertexKey;
+    use crate::core::tds::VertexKey;
     use slotmap::SlotMap;
 
     #[test]

--- a/src/core/collections/triangulation_maps.rs
+++ b/src/core/collections/triangulation_maps.rs
@@ -3,7 +3,7 @@ use super::{
     MAX_PRACTICAL_DIMENSION_SIZE, NeighborBuffer, SmallBuffer, Uuid, VertexUuidSet,
 };
 use crate::core::facet::FacetHandle;
-use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+use crate::core::tds::{CellKey, VertexKey};
 
 // =============================================================================
 // TRIANGULATION-SPECIFIC OPTIMIZED TYPES
@@ -178,7 +178,7 @@ pub type CellToVertexUuidsMap = FastHashMap<Uuid, CellVertexUuidBuffer>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+    use crate::core::tds::{CellKey, VertexKey};
     use slotmap::SlotMap;
 
     #[test]

--- a/src/core/edge.rs
+++ b/src/core/edge.rs
@@ -16,7 +16,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::core::triangulation_data_structure::VertexKey;
+use crate::core::tds::VertexKey;
 use slotmap::Key;
 
 /// Canonical identifier for an (undirected) edge.
@@ -25,7 +25,7 @@ use slotmap::Key;
 ///
 /// ```rust
 /// use delaunay::core::edge::EdgeKey;
-/// use delaunay::core::triangulation_data_structure::VertexKey;
+/// use delaunay::core::tds::VertexKey;
 /// use slotmap::KeyData;
 ///
 /// let a = VertexKey::from(KeyData::from_ffi(1));

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -28,7 +28,7 @@
 //! construction and validation phases.
 //!
 //! For a comprehensive discussion of all topological invariants in Delaunay triangulations,
-//! see the [Topological Invariants](crate::core::triangulation_data_structure#topological-invariants)
+//! see the [Topological Invariants](crate::core::tds#topological-invariants)
 //! section in the triangulation data structure documentation.
 //!
 //! # Examples
@@ -60,7 +60,7 @@ use super::traits::data_type::DataType;
 use super::util::{stable_hash_u64_slice, usize_to_u8};
 use super::{
     cell::Cell,
-    triangulation_data_structure::{CellKey, Tds, TdsError, VertexKey},
+    tds::{CellKey, Tds, TdsError, VertexKey},
     vertex::Vertex,
 };
 use crate::geometry::traits::coordinate::CoordinateScalar;
@@ -353,7 +353,7 @@ impl FacetHandle {
 ///
 /// ```rust,no_run
 /// use delaunay::core::facet::FacetView;
-/// use delaunay::core::triangulation_data_structure::{Tds, CellKey};
+/// use delaunay::core::tds::{Tds, CellKey};
 ///
 /// // This is a conceptual example showing FacetView usage
 /// // In practice, tds and cell_key would come from your triangulation
@@ -1058,7 +1058,7 @@ where
 ///
 /// ```
 /// use delaunay::core::facet::facet_key_from_vertices;
-/// use delaunay::core::triangulation_data_structure::VertexKey;
+/// use delaunay::core::tds::VertexKey;
 /// use slotmap::Key;
 ///
 /// // Create some vertex keys (normally these would come from a TDS)
@@ -1112,8 +1112,8 @@ pub fn facet_key_from_vertices(vertices: &[VertexKey]) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
-    use crate::core::triangulation_data_structure::VertexKey;
+    use crate::core::tds::VertexKey;
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
 
     // =============================================================================

--- a/src/core/operations.rs
+++ b/src/core/operations.rs
@@ -10,9 +10,9 @@
 #![forbid(unsafe_code)]
 
 use crate::core::algorithms::incremental_insertion::InsertionError;
-use crate::core::delaunay_triangulation::{DelaunayCheckPolicy, DelaunayRepairPolicy};
+use crate::core::tds::CellKey;
 use crate::core::triangulation::TopologyGuarantee;
-use crate::core::triangulation_data_structure::CellKey;
+use crate::triangulation::delaunay::{DelaunayCheckPolicy, DelaunayRepairPolicy};
 
 /// Semantic classification of topological modifications to a triangulation.
 ///
@@ -292,9 +292,9 @@ pub enum InsertionOutcome {
     /// The vertex was inserted successfully.
     Inserted {
         /// Key of the inserted vertex.
-        vertex_key: crate::core::triangulation_data_structure::VertexKey,
+        vertex_key: crate::core::tds::VertexKey,
         /// Optional cell key that can be used as a hint for subsequent insertions.
-        hint: Option<crate::core::triangulation_data_structure::CellKey>,
+        hint: Option<crate::core::tds::CellKey>,
     },
     /// The vertex was intentionally not inserted.
     ///

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -5474,10 +5474,16 @@ where
 mod tests {
     use super::*;
     use crate::core::algorithms::incremental_insertion::InsertionError;
+    use crate::core::cell::Cell;
+    use crate::core::triangulation::TriangulationValidationError;
     use crate::core::vertex::VertexBuilder;
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::Coordinate;
-    use crate::triangulation::delaunay::DelaunayTriangulation;
+    use crate::topology::characteristics::euler::TopologyClassification;
+    use crate::triangulation::builder::DelaunayTriangulationBuilder;
+    use crate::triangulation::delaunay::{
+        DelaunayTriangulation, DelaunayTriangulationValidationError,
+    };
     use crate::vertex;
     use slotmap::KeyData;
 
@@ -5676,7 +5682,6 @@ mod tests {
     fn test_repair_degenerate_cells() {
         // Exercise the repair primitive by creating a cell with a neighbor pointer
         // to a missing cell key.
-        use crate::core::cell::Cell;
 
         let vertices = [
             vertex!([0.0, 0.0]),
@@ -7404,9 +7409,6 @@ mod tests {
 
     #[test]
     fn test_invariant_error_from_tds_and_triangulation() {
-        use crate::core::triangulation::TriangulationValidationError;
-        use crate::topology::characteristics::euler::TopologyClassification;
-
         let tds_err = TdsError::InconsistentDataStructure {
             message: "test".to_string(),
         };
@@ -7424,8 +7426,6 @@ mod tests {
 
     #[test]
     fn test_invariant_error_from_delaunay_validation_error() {
-        use crate::triangulation::delaunay::DelaunayTriangulationValidationError;
-
         let dt_err = DelaunayTriangulationValidationError::VerificationFailed {
             message: "test".to_string(),
         };
@@ -7508,8 +7508,6 @@ mod tests {
 
     #[test]
     fn test_is_connected_returns_false_for_isolated_cells() {
-        use crate::core::cell::Cell;
-
         // Build a TDS with two triangles that have no neighbor wiring between them.
         // Since neither cell's `neighbors` field is populated, BFS from either cell
         // cannot reach the other → is_connected() must return false.
@@ -7616,8 +7614,6 @@ mod tests {
 
     #[test]
     fn test_normalize_coherent_orientation_produces_coherent_result() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7659,8 +7655,6 @@ mod tests {
 
     #[test]
     fn test_remove_duplicate_cells_removes_exact_duplicates() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7694,8 +7688,6 @@ mod tests {
 
     #[test]
     fn test_validate_vertex_incidence_detects_dangling_incident_cell() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7715,8 +7707,6 @@ mod tests {
 
     #[test]
     fn test_validate_cell_coordinate_uniqueness_rejects_duplicate_coords() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         // Two distinct vertex keys with identical coordinates
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
@@ -7735,8 +7725,6 @@ mod tests {
 
     #[test]
     fn test_validate_facet_sharing_rejects_triple_shared_facet() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7765,8 +7753,6 @@ mod tests {
 
     #[test]
     fn test_validate_no_duplicate_cells_detects_dupes() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7882,8 +7868,6 @@ mod tests {
 
     #[test]
     fn test_validation_report_accumulates_violations() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7913,8 +7897,6 @@ mod tests {
 
     #[test]
     fn test_insert_cell_with_mapping_registers_uuid_mapping() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7931,8 +7913,6 @@ mod tests {
 
     #[test]
     fn test_insert_cell_with_mapping_rejects_missing_vertex() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7949,8 +7929,6 @@ mod tests {
 
     #[test]
     fn test_insert_cell_with_mapping_rejects_duplicate_uuid() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7973,8 +7951,6 @@ mod tests {
 
     #[test]
     fn test_get_cell_vertices_errors_on_missing_vertex_key() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -7998,8 +7974,6 @@ mod tests {
 
     #[test]
     fn test_validate_vertex_incidence_detects_inconsistent_incident_cell() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -8023,8 +7997,6 @@ mod tests {
 
     #[test]
     fn test_validate_vertex_incidence_detects_dangling_cell_key() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -8048,8 +8020,6 @@ mod tests {
 
     #[test]
     fn test_find_cells_containing_vertex_fallback_when_no_incident_cell() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -8110,8 +8080,6 @@ mod tests {
 
     #[test]
     fn test_assign_incident_cells_errors_on_dangling_vertex_key() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -8194,8 +8162,6 @@ mod tests {
 
     #[test]
     fn test_remove_duplicate_cells_removes_actual_duplicates() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -8230,8 +8196,6 @@ mod tests {
 
     #[test]
     fn test_validate_neighbor_topology_rejects_wrong_length() {
-        use crate::core::cell::Cell;
-
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
         let v1 = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
@@ -8254,8 +8218,6 @@ mod tests {
 
     #[test]
     fn test_set_vertex_data_replaces_existing() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 10i32),
             vertex!([1.0, 0.0], 20),
@@ -8299,8 +8261,6 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_on_empty_cell() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices = [
             vertex!([0.0, 0.0]),
             vertex!([1.0, 0.0]),
@@ -8319,8 +8279,6 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_replaces_existing() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices = [
             vertex!([0.0, 0.0]),
             vertex!([1.0, 0.0]),
@@ -8347,8 +8305,6 @@ mod tests {
 
     #[test]
     fn test_set_vertex_data_preserves_triangulation_validity() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 1i32),
             vertex!([1.0, 0.0], 2),
@@ -8376,8 +8332,6 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_preserves_triangulation_validity() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices = [
             vertex!([0.0, 0.0]),
             vertex!([1.0, 0.0]),
@@ -8407,8 +8361,6 @@ mod tests {
 
     #[test]
     fn test_set_vertex_data_via_triangulation_wrapper() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 10i32),
             vertex!([1.0, 0.0], 20),
@@ -8432,8 +8384,6 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_via_triangulation_wrapper() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices = [
             vertex!([0.0, 0.0]),
             vertex!([1.0, 0.0]),
@@ -8457,8 +8407,6 @@ mod tests {
 
     #[test]
     fn test_set_data_via_dt_does_not_invalidate_locate_hint() {
-        use crate::triangulation::builder::DelaunayTriangulationBuilder;
-
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 0i32),
             vertex!([1.0, 0.0], 0),

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -148,8 +148,8 @@
 //! [`Cell::is_valid()`]: crate::core::cell::Cell::is_valid
 //! [`Vertex::is_valid()`]: crate::core::vertex::Vertex::is_valid
 //! [`Triangulation::is_valid()`]: crate::core::triangulation::Triangulation::is_valid
-//! [`DelaunayTriangulation::is_valid()`]: crate::core::delaunay_triangulation::DelaunayTriangulation::is_valid
-//! [`DelaunayTriangulation::validation_report()`]: crate::core::delaunay_triangulation::DelaunayTriangulation::validation_report
+//! [`DelaunayTriangulation::is_valid()`]: crate::triangulation::delaunay::DelaunayTriangulation::is_valid
+//! [`DelaunayTriangulation::validation_report()`]: crate::triangulation::delaunay::DelaunayTriangulation::validation_report
 //!
 //! # Examples
 //!
@@ -725,7 +725,7 @@ pub enum InvariantError {
 
     /// Level 4 (Delaunay property).
     #[error(transparent)]
-    Delaunay(#[from] crate::core::delaunay_triangulation::DelaunayTriangulationValidationError),
+    Delaunay(#[from] crate::triangulation::delaunay::DelaunayTriangulationValidationError),
 }
 
 /// A single invariant violation recorded during validation diagnostics.
@@ -757,12 +757,12 @@ pub struct InvariantViolation {
 /// [`DelaunayTriangulation::validation_report()`]
 /// to surface all failed invariants at once for debugging and test diagnostics.
 ///
-/// [`DelaunayTriangulation::validation_report()`]: crate::core::delaunay_triangulation::DelaunayTriangulation::validation_report
+/// [`DelaunayTriangulation::validation_report()`]: crate::triangulation::delaunay::DelaunayTriangulation::validation_report
 ///
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::triangulation_data_structure::TriangulationValidationReport;
+/// use delaunay::core::tds::TriangulationValidationReport;
 ///
 /// let report = TriangulationValidationReport { violations: Vec::new() };
 /// assert!(report.is_empty());
@@ -872,7 +872,7 @@ new_key_type! {
 ///
 /// `Tds` is the low-level topology container used by
 /// [`Triangulation`](crate::core::triangulation::Triangulation) and
-/// [`DelaunayTriangulation`](crate::core::delaunay_triangulation::DelaunayTriangulation).
+/// [`DelaunayTriangulation`](crate::triangulation::delaunay::DelaunayTriangulation).
 ///
 /// Most users should construct triangulations via `DelaunayTriangulation` and access the
 /// underlying `Tds` via `dt.tds()`. Use [`Tds::empty`](Self::empty) for low-level or test
@@ -1412,7 +1412,7 @@ where
     /// Count vertices in an empty triangulation:
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::core::tds::Tds;
     ///
     /// let tds = Tds::<f64, (), (), 3>::empty();
     /// assert_eq!(tds.number_of_vertices(), 0);
@@ -1467,7 +1467,7 @@ where
     /// Dimension of an empty triangulation:
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::core::tds::Tds;
     /// use delaunay::geometry::point::Point;
     /// use delaunay::geometry::traits::coordinate::Coordinate;
     ///
@@ -1585,7 +1585,7 @@ where
     /// Empty triangulation has no cells:
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::core::tds::Tds;
     ///
     /// let tds = Tds::<f64, (), (), 3>::empty();
     /// assert_eq!(tds.number_of_cells(), 0); // No cells for empty input
@@ -1693,7 +1693,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::core::tds::Tds;
     ///
     /// let tds: Tds<f64, (), (), 2> = Tds::empty();
     /// assert_eq!(tds.generation(), 0);
@@ -1993,7 +1993,7 @@ where
     /// Returns `None` for non-existent UUID:
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::core::tds::Tds;
     /// use uuid::Uuid;
     ///
     /// let tds: Tds<f64, (), (), 3> = Tds::empty();
@@ -2053,7 +2053,7 @@ where
     /// Returns `None` for non-existent UUID:
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::core::tds::Tds;
     /// use uuid::Uuid;
     ///
     /// let tds: Tds<f64, (), (), 3> = Tds::empty();
@@ -3431,7 +3431,7 @@ where
     ///
     ///
     /// This function creates an empty triangulation with no vertices and no cells.
-    /// Use [`DelaunayTriangulation::empty()`](crate::core::delaunay_triangulation::DelaunayTriangulation::empty)
+    /// Use [`DelaunayTriangulation::empty()`](crate::triangulation::delaunay::DelaunayTriangulation::empty)
     /// for the high-level API, or this method for low-level Tds construction.
     ///
     /// # Returns
@@ -3445,8 +3445,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
-    /// use delaunay::core::triangulation_data_structure::TriangulationConstructionState;
+    /// use delaunay::core::tds::Tds;
+    /// use delaunay::core::tds::TriangulationConstructionState;
     ///
     /// let tds: Tds<f64, (), (), 3> = Tds::empty();
     /// assert_eq!(tds.number_of_vertices(), 0);
@@ -3732,7 +3732,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::core::tds::Tds;
     ///
     /// let mut tds: Tds<f64, (), (), 2> = Tds::empty();
     /// let removed = tds.remove_duplicate_cells().unwrap();
@@ -3806,7 +3806,7 @@ where
     ///
     /// This corresponds to [`InvariantKind::VertexMappings`], which is included in
     /// [`Tds::is_valid`](Self::is_valid) and [`Tds::validate`](Self::validate), and is also surfaced by
-    /// [`DelaunayTriangulation::validation_report()`](crate::core::delaunay_triangulation::DelaunayTriangulation::validation_report).
+    /// [`DelaunayTriangulation::validation_report()`](crate::triangulation::delaunay::DelaunayTriangulation::validation_report).
     ///
     /// # Errors
     ///
@@ -3874,7 +3874,7 @@ where
     /// [`Tds::is_valid`](Self::is_valid) and [`Tds::validate`](Self::validate), and is also surfaced by
     /// [`DelaunayTriangulation::validation_report()`].
     ///
-    /// [`DelaunayTriangulation::validation_report()`]: crate::core::delaunay_triangulation::DelaunayTriangulation::validation_report
+    /// [`DelaunayTriangulation::validation_report()`]: crate::triangulation::delaunay::DelaunayTriangulation::validation_report
     ///
     /// # Errors
     ///
@@ -4011,7 +4011,7 @@ where
     /// [`Tds::is_valid`](Self::is_valid) and [`Tds::validate`](Self::validate), and is also surfaced by
     /// [`DelaunayTriangulation::validation_report()`].
     ///
-    /// [`DelaunayTriangulation::validation_report()`]: crate::core::delaunay_triangulation::DelaunayTriangulation::validation_report
+    /// [`DelaunayTriangulation::validation_report()`]: crate::triangulation::delaunay::DelaunayTriangulation::validation_report
     fn validate_no_duplicate_cells(&self) -> Result<(), TdsError> {
         // Include periodic per-vertex offsets in the duplicate key so periodic quotient cells
         // with identical vertex sets but distinct lattice offsets are not collapsed.
@@ -4122,7 +4122,7 @@ where
     /// [`Tds::is_valid`](Self::is_valid) and [`Tds::validate`](Self::validate), and is also surfaced by
     /// [`DelaunayTriangulation::validation_report()`].
     ///
-    /// [`DelaunayTriangulation::validation_report()`]: crate::core::delaunay_triangulation::DelaunayTriangulation::validation_report
+    /// [`DelaunayTriangulation::validation_report()`]: crate::triangulation::delaunay::DelaunayTriangulation::validation_report
     pub(crate) fn validate_facet_sharing(&self) -> Result<(), TdsError> {
         // Build a map from facet keys to the cells that contain them.
         // Use the strict version to ensure we catch any missing vertex keys.
@@ -4775,7 +4775,7 @@ where
     /// [`Tds::is_valid`](Self::is_valid) and [`Tds::validate`](Self::validate), and is also surfaced by
     /// [`DelaunayTriangulation::validation_report()`].
     ///
-    /// [`DelaunayTriangulation::validation_report()`]: crate::core::delaunay_triangulation::DelaunayTriangulation::validation_report
+    /// [`DelaunayTriangulation::validation_report()`]: crate::triangulation::delaunay::DelaunayTriangulation::validation_report
     ///
     /// Note: callers provide `facet_to_cells` so `is_valid()` and `validation_report()` can share
     /// the precomputed facet map between validators.
@@ -5474,9 +5474,10 @@ where
 mod tests {
     use super::*;
     use crate::core::algorithms::incremental_insertion::InsertionError;
-    use crate::core::{delaunay_triangulation::DelaunayTriangulation, vertex::VertexBuilder};
+    use crate::core::vertex::VertexBuilder;
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::Coordinate;
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
     use slotmap::KeyData;
 
@@ -7423,7 +7424,7 @@ mod tests {
 
     #[test]
     fn test_invariant_error_from_delaunay_validation_error() {
-        use crate::core::delaunay_triangulation::DelaunayTriangulationValidationError;
+        use crate::triangulation::delaunay::DelaunayTriangulationValidationError;
 
         let dt_err = DelaunayTriangulationValidationError::VerificationFailed {
             message: "test".to_string(),
@@ -8253,7 +8254,7 @@ mod tests {
 
     #[test]
     fn test_set_vertex_data_replaces_existing() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 10i32),
@@ -8298,7 +8299,7 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_on_empty_cell() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices = [
             vertex!([0.0, 0.0]),
@@ -8318,7 +8319,7 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_replaces_existing() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices = [
             vertex!([0.0, 0.0]),
@@ -8346,7 +8347,7 @@ mod tests {
 
     #[test]
     fn test_set_vertex_data_preserves_triangulation_validity() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 1i32),
@@ -8375,7 +8376,7 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_preserves_triangulation_validity() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices = [
             vertex!([0.0, 0.0]),
@@ -8406,7 +8407,7 @@ mod tests {
 
     #[test]
     fn test_set_vertex_data_via_triangulation_wrapper() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 10i32),
@@ -8431,7 +8432,7 @@ mod tests {
 
     #[test]
     fn test_set_cell_data_via_triangulation_wrapper() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices = [
             vertex!([0.0, 0.0]),
@@ -8456,7 +8457,7 @@ mod tests {
 
     #[test]
     fn test_set_data_via_dt_does_not_invalidate_locate_hint() {
-        use crate::core::builder::DelaunayTriangulationBuilder;
+        use crate::triangulation::builder::DelaunayTriangulationBuilder;
 
         let vertices: [Vertex<f64, i32, 2>; 3] = [
             vertex!([0.0, 0.0], 0i32),

--- a/src/core/traits/boundary_analysis.rs
+++ b/src/core/traits/boundary_analysis.rs
@@ -2,8 +2,8 @@
 
 use crate::core::{
     facet::{BoundaryFacetsIter, FacetView},
+    tds::TdsError,
     traits::data_type::DataType,
-    triangulation_data_structure::TdsError,
 };
 use crate::geometry::traits::coordinate::CoordinateScalar;
 
@@ -167,7 +167,7 @@ where
     /// }
     /// ```
     ///
-    /// [`build_facet_to_cells_map`]: crate::core::triangulation_data_structure::Tds::build_facet_to_cells_map
+    /// [`build_facet_to_cells_map`]: crate::core::tds::Tds::build_facet_to_cells_map
     fn is_boundary_facet_with_map(
         &self,
         facet: &FacetView<'_, T, U, V, D>,

--- a/src/core/traits/facet_cache.rs
+++ b/src/core/traits/facet_cache.rs
@@ -7,7 +7,7 @@
 use super::data_type::DataType;
 use crate::core::{
     collections::FacetToCellsMap,
-    triangulation_data_structure::{Tds, TdsError},
+    tds::{Tds, TdsError},
 };
 use crate::geometry::traits::coordinate::ScalarAccumulative;
 use arc_swap::ArcSwapOption;
@@ -34,7 +34,7 @@ use std::sync::{
 ///
 /// ```
 /// use delaunay::core::traits::facet_cache::FacetCacheProvider;
-/// use delaunay::core::triangulation_data_structure::Tds;
+/// use delaunay::core::tds::Tds;
 /// use delaunay::geometry::traits::coordinate::ScalarAccumulative;
 /// use delaunay::core::traits::data_type::DataType;
 /// use std::sync::Arc;
@@ -327,10 +327,10 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
-    use crate::core::triangulation_data_structure::Tds;
+    use crate::core::tds::Tds;
     use crate::core::vertex;
     use crate::geometry::kernel::AdaptiveKernel;
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use std::sync::Arc;
     use std::sync::Barrier;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -39,11 +39,11 @@
 //! Use [`Triangulation::validate()`](crate::core::triangulation::Triangulation::validate) for cumulative Levels 1–3.
 //!
 //! ## Level 4: Delaunay Property
-//! - **Method**: [`DelaunayTriangulation::is_valid()`](crate::core::delaunay_triangulation::DelaunayTriangulation::is_valid)
+//! - **Method**: [`DelaunayTriangulation::is_valid()`](crate::triangulation::delaunay::DelaunayTriangulation::is_valid)
 //! - **Checks**: Empty circumsphere property (no vertex inside any cell's circumsphere)
 //! - **Cost**: O(N×V) where N = cells, V = vertices
 //!
-//! Use [`DelaunayTriangulation::validate()`](crate::core::delaunay_triangulation::DelaunayTriangulation::validate) for cumulative Levels 1–4.
+//! Use [`DelaunayTriangulation::validate()`](crate::triangulation::delaunay::DelaunayTriangulation::validate) for cumulative Levels 1–4.
 //!
 //! ## Usage Guidelines
 //!
@@ -76,8 +76,8 @@
 //!
 //! [`Cell::is_valid()`]: crate::core::cell::Cell::is_valid
 //! [`Vertex::is_valid()`]: crate::core::vertex::Vertex::is_valid
-//! [`Tds::is_valid()`]: crate::core::triangulation_data_structure::Tds::is_valid
-//! [`Tds::validate()`]: crate::core::triangulation_data_structure::Tds::validate
+//! [`Tds::is_valid()`]: crate::core::tds::Tds::is_valid
+//! [`Tds::validate()`]: crate::core::tds::Tds::validate
 //!
 //! ## Topology guarantees
 //!
@@ -130,11 +130,11 @@ use crate::core::facet::{AllFacetsIter, BoundaryFacetsIter, FacetHandle, facet_k
 use crate::core::operations::{
     InsertionOutcome, InsertionResult, InsertionStatistics, SuspicionFlags,
 };
-use crate::core::traits::data_type::DataType;
-use crate::core::triangulation_data_structure::{
+use crate::core::tds::{
     CellKey, GeometricError, InvariantError, InvariantKind, InvariantViolation, Tds,
     TdsConstructionError, TdsError, TriangulationValidationReport, VertexKey,
 };
+use crate::core::traits::data_type::DataType;
 use crate::core::util::canonical_points::sorted_cell_points;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
@@ -243,7 +243,7 @@ pub(crate) fn record_duplicate_detection_metrics(
 /// - `TopologyValidation(source)` → `InvariantError::Tds(source)` (Level 1–2 preserved)
 /// - `TopologyValidationFailed { source }` → `InvariantError::Triangulation(*source)` (Level 3 preserved)
 /// - All other variants → `InvariantError::Tds(InconsistentDataStructure { .. })` with `context`
-pub(in crate::core) fn insertion_error_to_invariant_error(
+pub(crate) fn insertion_error_to_invariant_error(
     error: InsertionError,
     context: &str,
 ) -> InvariantError {
@@ -335,7 +335,7 @@ pub enum TriangulationConstructionError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::triangulation_data_structure::InvariantError;
+/// use delaunay::core::tds::InvariantError;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -2186,7 +2186,7 @@ where
     ///
     /// Periodic-lifted cells are validated in lifted coordinates using per-vertex periodic
     /// offsets and toroidal domain periods.
-    pub(in crate::core) fn validate_geometric_cell_orientation(&self) -> Result<(), TdsError> {
+    pub(crate) fn validate_geometric_cell_orientation(&self) -> Result<(), TdsError> {
         for (cell_key, cell) in self.tds.cells() {
             let orientation = self.evaluate_cell_orientation_for_context(
                 cell_key,
@@ -2361,7 +2361,7 @@ where
     /// 2. Canonicalize the global sign — for a connected orientable manifold all cells
     ///    share the same sign after normalization, so a single global flip resolves it.
     /// 3. Fall back to bounded per-cell promotion passes for FP-precision edge cases.
-    pub(in crate::core) fn normalize_and_promote_positive_orientation(
+    pub(crate) fn normalize_and_promote_positive_orientation(
         &mut self,
     ) -> Result<(), InsertionError> {
         // Phase 1: make all adjacencies coherent
@@ -2755,7 +2755,7 @@ where
     /// Performs cumulative validation for Levels 1–3.
     ///
     /// This validates:
-    /// - **Level 1–2** via [`Tds::validate`](crate::core::triangulation_data_structure::Tds::validate)
+    /// - **Level 1–2** via [`Tds::validate`](crate::core::tds::Tds::validate)
     /// - **Level 3** via [`Triangulation::is_valid`](Self::is_valid)
     /// - **Completion-time PL-manifold check** via [`Triangulation::validate_at_completion`](Self::validate_at_completion)
     ///
@@ -3174,7 +3174,7 @@ where
     ///
     /// This is intended for bulk-construction paths that maintain a local index to
     /// accelerate duplicate detection and locate-hint selection.
-    pub(in crate::core) fn insert_with_statistics_seeded_indexed(
+    pub(crate) fn insert_with_statistics_seeded_indexed(
         &mut self,
         vertex: Vertex<K::Scalar, U, D>,
         conflict_cells: Option<&CellKeyBuffer>,
@@ -5591,13 +5591,13 @@ mod tests {
     use super::*;
     use crate::core::collections::NeighborBuffer;
     use crate::core::collections::spatial_hash_grid::HashGridIndex;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
     use crate::core::vertex::VertexBuilder;
     use crate::geometry::kernel::{AdaptiveKernel, FastKernel};
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
     use crate::topology::characteristics::validation::validate_triangulation_euler;
     use crate::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
 
     use slotmap::KeyData;
@@ -6308,9 +6308,7 @@ mod tests {
             DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
         dt.set_validation_policy(ValidationPolicy::Never);
-        dt.set_delaunay_repair_policy(
-            crate::core::delaunay_triangulation::DelaunayRepairPolicy::Never,
-        );
+        dt.set_delaunay_repair_policy(crate::triangulation::delaunay::DelaunayRepairPolicy::Never);
 
         for (i, point) in points.into_iter().enumerate() {
             let vertex = VertexBuilder::default().point(point).build().unwrap();
@@ -8925,7 +8923,7 @@ mod tests {
 
     #[test]
     fn test_invariant_error_to_insertion_error_delaunay_arm() {
-        use crate::core::delaunay_triangulation::DelaunayTriangulationValidationError;
+        use crate::triangulation::delaunay::DelaunayTriangulationValidationError;
         let inv =
             InvariantError::Delaunay(DelaunayTriangulationValidationError::VerificationFailed {
                 message: "test".to_string(),
@@ -9852,7 +9850,7 @@ mod tests {
 
         // Delaunay arm
         let dt_err = InvariantError::Delaunay(
-            crate::core::delaunay_triangulation::DelaunayTriangulationValidationError::VerificationFailed {
+            crate::triangulation::delaunay::DelaunayTriangulationValidationError::VerificationFailed {
                 message: "test violation".to_string(),
             },
         );

--- a/src/core/util/canonical_points.rs
+++ b/src/core/util/canonical_points.rs
@@ -21,8 +21,8 @@
 
 use crate::core::cell::Cell;
 use crate::core::collections::{MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer};
+use crate::core::tds::{Tds, VertexKey};
 use crate::core::traits::DataType;
-use crate::core::triangulation_data_structure::{Tds, VertexKey};
 use crate::geometry::point::Point;
 use crate::geometry::traits::coordinate::CoordinateScalar;
 use slotmap::Key;

--- a/src/core/util/delaunay_validation.rs
+++ b/src/core/util/delaunay_validation.rs
@@ -4,8 +4,8 @@
 
 use crate::core::cell::CellValidationError;
 use crate::core::collections::ViolationBuffer;
+use crate::core::tds::{CellKey, Tds, TdsError, VertexKey};
 use crate::core::traits::data_type::DataType;
-use crate::core::triangulation_data_structure::{CellKey, Tds, TdsError, VertexKey};
 use crate::geometry::point::Point;
 use crate::geometry::predicates::InSphere;
 use crate::geometry::robust_predicates::robust_insphere;
@@ -18,7 +18,7 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::triangulation_data_structure::CellKey;
+/// use delaunay::core::tds::CellKey;
 /// use delaunay::core::util::DelaunayValidationError;
 /// use slotmap::KeyData;
 ///
@@ -373,7 +373,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::triangulation_data_structure::Tds;
+/// use delaunay::core::tds::Tds;
 /// use delaunay::core::util::debug_print_first_delaunay_violation;
 ///
 /// let tds: Tds<f64, (), (), 3> = Tds::empty();
@@ -583,8 +583,7 @@ mod tests {
             vertex!([0.0, 0.0, 1.0]),
         ];
 
-        let dt =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt = crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let tds = &dt.as_triangulation().tds;
 
         // Basic Delaunay helpers should report no violations.

--- a/src/core/util/facet_keys.rs
+++ b/src/core/util/facet_keys.rs
@@ -3,8 +3,8 @@
 #![forbid(unsafe_code)]
 
 use crate::core::facet::FacetError;
+use crate::core::tds::{CellKey, Tds, VertexKey};
 use crate::core::traits::data_type::DataType;
-use crate::core::triangulation_data_structure::{CellKey, Tds, VertexKey};
 use crate::core::util::hashing::stable_hash_u64_slice;
 use crate::geometry::traits::coordinate::CoordinateScalar;
 use slotmap::Key;
@@ -206,7 +206,7 @@ pub(crate) fn periodic_facet_key_from_lifted_vertices<const D: usize>(
 ///
 /// ```rust,no_run
 /// use delaunay::core::util::verify_facet_index_consistency;
-/// use delaunay::core::triangulation_data_structure::Tds;
+/// use delaunay::core::tds::Tds;
 ///
 /// fn validate_neighbor_consistency(
 ///     tds: &Tds<f64, (), (), 3>,
@@ -422,8 +422,7 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]),
             vertex!([0.0, 0.0, 1.0]),
         ];
-        let dt =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt = crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let tds = &dt.as_triangulation().tds;
 
         // Test 1: Basic functionality - successful key derivation
@@ -563,8 +562,7 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]),
             vertex!([0.0, 0.0, 1.0]),
         ];
-        let dt =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt = crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let tds = &dt.as_triangulation().tds;
         let cell_key = tds.cell_keys().next().unwrap();
         assert!(verify_facet_index_consistency(tds, cell_key, cell_key, 0).unwrap());

--- a/src/core/util/facet_utils.rs
+++ b/src/core/util/facet_utils.rs
@@ -37,7 +37,7 @@ use crate::geometry::traits::coordinate::CoordinateScalar;
 /// ```rust,no_run
 /// use delaunay::core::facet::{FacetView, FacetError};
 /// use delaunay::core::util::facet_views_are_adjacent;
-/// use delaunay::core::triangulation_data_structure::Tds;
+/// use delaunay::core::tds::Tds;
 ///
 /// // This is a conceptual example - in practice you would get these from a real TDS
 /// fn example(tds: &Tds<f64, (), (), 3>) -> Result<bool, FacetError> {
@@ -107,7 +107,7 @@ where
 /// ```rust,no_run
 /// use delaunay::core::facet::FacetView;
 /// use delaunay::core::util::facet_view_to_vertices;
-/// use delaunay::core::triangulation_data_structure::Tds;
+/// use delaunay::core::tds::Tds;
 ///
 /// fn extract_vertices_example(
 ///     tds: &Tds<f64, (), (), 3>,
@@ -232,7 +232,7 @@ mod tests {
     use super::*;
 
     use crate::core::collections::FastHashSet;
-    use crate::core::delaunay_triangulation::DelaunayTriangulation;
+    use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
     use std::time::Instant;
 

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -3,8 +3,8 @@
 #![forbid(unsafe_code)]
 
 use crate::core::facet::{FacetError, FacetView};
+use crate::core::tds::Tds;
 use crate::core::traits::data_type::DataType;
-use crate::core::triangulation_data_structure::Tds;
 use crate::geometry::algorithms::convex_hull::ConvexHull;
 use crate::geometry::point::Point;
 use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
@@ -388,7 +388,7 @@ where
 ///
 /// ```
 /// use delaunay::core::util::extract_hull_facet_set;
-/// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+/// use delaunay::triangulation::delaunay::DelaunayTriangulation;
 /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
 /// use delaunay::vertex;
 ///
@@ -601,7 +601,7 @@ macro_rules! assert_jaccard_gte {
 mod tests {
     use super::*;
 
-    use crate::core::triangulation_data_structure::{Tds, VertexKey};
+    use crate::core::tds::{Tds, VertexKey};
     use crate::geometry::traits::coordinate::Coordinate;
     use crate::vertex;
     use approx::assert_relative_eq;
@@ -665,8 +665,7 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]),
             vertex!([0.0, 0.0, 1.0]),
         ];
-        let dt =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt = crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let tds = &dt.as_triangulation().tds;
 
         // Sub-test: Vertex coordinate extraction
@@ -687,7 +686,7 @@ mod tests {
 
         // Sub-test: Hull facet extraction
         let dt_hull =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let tri = dt_hull.as_triangulation();
         let hull = ConvexHull::from_triangulation(tri).unwrap();
         let hull_facet_set = extract_hull_facet_set(&hull, tri).unwrap();
@@ -704,8 +703,7 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]),
             vertex!([0.0, 0.0, 1.0]),
         ];
-        let mut dt =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let mut dt = crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
 
         let cell_key = dt.as_triangulation().tds.cell_keys().next().unwrap();
         let invalid_vkey = VertexKey::from(KeyData::from_ffi(u64::MAX));
@@ -732,8 +730,7 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]),
             vertex!([0.0, 0.0, 1.0]),
         ];
-        let mut dt =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let mut dt = crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
 
         let cell_key = dt.as_triangulation().tds.cell_keys().next().unwrap();
         let invalid_vkey = VertexKey::from(KeyData::from_ffi(u64::MAX));
@@ -777,8 +774,7 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]),
             vertex!([0.0, 0.0, 1.0]),
         ];
-        let dt =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt = crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let tri = dt.as_triangulation();
         let hull = ConvexHull::from_triangulation(tri).unwrap();
 

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -31,8 +31,8 @@
 #![forbid(unsafe_code)]
 
 use super::{
+    tds::CellKey,
     traits::DataType,
-    triangulation_data_structure::CellKey,
     util::{UuidValidationError, make_uuid, validate_uuid},
 };
 use crate::geometry::{
@@ -281,7 +281,7 @@ pub use crate::vertex;
 /// - **`uuid`**: A universally unique identifier for the vertex (auto-generated)
 /// - **`incident_cell`**: Optional reference to a containing cell (managed by TDS)
 /// - **`data`**: Optional user-defined data associated with the vertex. Read via [`data()`](Self::data),
-///   mutate via [`Tds::set_vertex_data`](crate::core::triangulation_data_structure::Tds::set_vertex_data)
+///   mutate via [`Tds::set_vertex_data`](crate::core::tds::Tds::set_vertex_data)
 ///
 /// # Constraints
 ///
@@ -866,7 +866,7 @@ where
 mod tests {
     use super::*;
     use crate::core::collections::{FastHashMap, FastHashSet};
-    use crate::core::triangulation_data_structure::CellKey;
+    use crate::core::tds::CellKey;
     use crate::core::util::{UuidValidationError, make_uuid, usize_to_u8};
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::Coordinate;

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -33,11 +33,11 @@ use crate::core::collections::{
     FacetToCellsMap, FastHashMap, MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer,
 };
 use crate::core::facet::{FacetError, FacetHandle, FacetView};
+use crate::core::tds::TdsError;
 use crate::core::traits::boundary_analysis::BoundaryAnalysis;
 use crate::core::traits::data_type::DataType;
 use crate::core::traits::facet_cache::FacetCacheProvider;
 use crate::core::triangulation::Triangulation;
-use crate::core::triangulation_data_structure::TdsError;
 use crate::core::util::checked_facet_key_from_vertex_keys;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
@@ -237,7 +237,7 @@ pub enum ConvexHullConstructionError {
 /// Use `is_valid_for_triangulation()` to check if a hull is still valid for a given TDS:
 ///
 /// ```rust
-/// # use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+/// # use delaunay::triangulation::delaunay::DelaunayTriangulation;
 /// # use delaunay::geometry::algorithms::convex_hull::ConvexHull;
 /// # use delaunay::vertex;
 /// # let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vec![
@@ -264,7 +264,7 @@ pub enum ConvexHullConstructionError {
 /// ## Example: Correct Usage Pattern
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+/// use delaunay::triangulation::delaunay::DelaunayTriangulation;
 /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
 /// use delaunay::vertex;
 ///
@@ -370,7 +370,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -405,7 +405,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -435,7 +435,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -472,7 +472,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -504,7 +504,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -555,7 +555,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -634,7 +634,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -696,7 +696,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -822,7 +822,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::geometry::point::Point;
     /// use delaunay::geometry::traits::coordinate::Coordinate;
@@ -1207,7 +1207,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::geometry::point::Point;
     /// use delaunay::geometry::traits::coordinate::Coordinate;
@@ -1283,7 +1283,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::geometry::point::Point;
     /// use delaunay::geometry::traits::coordinate::Coordinate;
@@ -1405,7 +1405,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::geometry::point::Point;
     /// use delaunay::geometry::traits::coordinate::Coordinate;
@@ -1451,7 +1451,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -1601,14 +1601,14 @@ pub type ConvexHull4D<K, U, V> = ConvexHull<K, U, V, 4>;
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::delaunay_triangulation::{
-        DelaunayTriangulation, DelaunayTriangulationConstructionError,
-    };
+    use crate::core::tds::TdsError;
     use crate::core::traits::facet_cache::FacetCacheProvider;
     use crate::core::triangulation::TriangulationConstructionError;
-    use crate::core::triangulation_data_structure::TdsError;
     use crate::core::util::{checked_facet_key_from_vertex_keys, facet_view_to_vertices};
     use crate::geometry::kernel::AdaptiveKernel;
+    use crate::triangulation::delaunay::{
+        DelaunayTriangulation, DelaunayTriangulationConstructionError,
+    };
     use crate::vertex;
     use std::error::Error;
     use std::sync::atomic::Ordering;
@@ -3231,7 +3231,7 @@ mod tests {
     fn test_from_triangulation_no_cells_error() {
         // Create a manually constructed TDS with vertices but no cells
         // Note: We need to use the underlying TDS directly for this edge case test
-        let mut tds = crate::core::triangulation_data_structure::Tds::<f64, (), (), 3>::empty();
+        let mut tds = crate::core::tds::Tds::<f64, (), (), 3>::empty();
         let vertex = vertex!([0.0, 0.0, 0.0]);
         tds.insert_vertex_with_mapping(vertex).unwrap();
 

--- a/src/geometry/kernel.rs
+++ b/src/geometry/kernel.rs
@@ -241,7 +241,7 @@ impl<T: CoordinateScalar> ExactPredicates for AdaptiveKernel<T> {}
 ///
 /// Use [`AdaptiveKernel`] (the default) for all 3D+ work. `FastKernel` remains
 /// suitable for 2D triangulations with well-conditioned input, or when explicitly
-/// opted into via [`DelaunayTriangulation::with_kernel`](crate::core::delaunay_triangulation::DelaunayTriangulation::with_kernel) for advanced use cases
+/// opted into via [`DelaunayTriangulation::with_kernel`](crate::triangulation::delaunay::DelaunayTriangulation::with_kernel) for advanced use cases
 /// where the caller has verified the input is non-degenerate.
 ///
 /// # Performance
@@ -443,7 +443,7 @@ where
 /// This is the **default kernel** for [`DelaunayTriangulation`] convenience
 /// constructors (`new`, `empty`, `new_with_options`, etc.).
 ///
-/// [`DelaunayTriangulation`]: crate::core::delaunay_triangulation::DelaunayTriangulation
+/// [`DelaunayTriangulation`]: crate::triangulation::delaunay::DelaunayTriangulation
 ///
 /// # When to use `AdaptiveKernel`
 ///

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -35,9 +35,9 @@
 
 use crate::core::{
     collections::{MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer},
+    tds::CellKey,
     traits::data_type::DataType,
     triangulation::Triangulation,
-    triangulation_data_structure::CellKey,
 };
 use crate::geometry::{
     kernel::Kernel,
@@ -397,12 +397,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::delaunay_triangulation::{
-        DelaunayTriangulation, DelaunayTriangulationConstructionError,
-    };
     use crate::core::triangulation::TriangulationConstructionError;
     use crate::geometry::kernel::AdaptiveKernel;
     use crate::geometry::traits::coordinate::Coordinate;
+    use crate::triangulation::delaunay::{
+        DelaunayTriangulation, DelaunayTriangulationConstructionError,
+    };
     use crate::vertex;
     use approx::assert_relative_eq;
 

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -1260,8 +1260,8 @@ mod tests {
             vertex!([0.0, 0.0, 1.0]), // v4
         ];
 
-        let dt: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 3> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 3> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
 
         // Find the facet opposite to v4 (contains vertices v1, v2, v3)
@@ -1304,8 +1304,8 @@ mod tests {
             vertex!([1.0, 1.0, 1.0]), // v5
         ];
 
-        let dt: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 3> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 3> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
 
         // Take first two boundary facets for testing
@@ -1641,8 +1641,8 @@ mod tests {
             vertex!([0.0, 1.0, 0.0]), // v3
             vertex!([0.0, 0.0, 1.0]), // v4
         ];
-        let dt1: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 3> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices1).unwrap();
+        let dt1: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 3> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices1).unwrap();
         let boundary_facets1: Vec<_> = dt1.tds().boundary_facets().unwrap().collect();
 
         // Find the facet opposite to v4 (triangle with v1, v2, v3) - area = 0.5
@@ -1673,8 +1673,8 @@ mod tests {
             vertex!([0.0, 8.0, 0.0]), // v7
             vertex!([0.0, 0.0, 1.0]), // v8
         ];
-        let dt2: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 3> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices2).unwrap();
+        let dt2: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 3> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices2).unwrap();
         let boundary_facets2: Vec<_> = dt2.tds().boundary_facets().unwrap().collect();
 
         // Find the facet opposite to v8 (triangle with v5, v6, v7) - area = 24.0
@@ -1719,8 +1719,8 @@ mod tests {
             vertex!([0.0, 4.0]), // v3
         ];
 
-        let dt: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 2> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 2> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
 
         // In 2D, boundary facets are edges
@@ -1743,8 +1743,8 @@ mod tests {
             vertex!([0.0, 0.0, 0.0, 1.0]), // v5
         ];
 
-        let dt: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 4> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 4> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
 
         let total_surface = surface_measure(&boundary_facets).unwrap();
@@ -1774,8 +1774,8 @@ mod tests {
             vertex!([0.0, 0.0, 1.0]), // v4
         ];
 
-        let dt: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 3> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 3> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
 
         // Test with valid facets - should work
@@ -1835,8 +1835,8 @@ mod tests {
             vertex!([0.0, 0.0, 2.0]),
         ];
 
-        let dt: crate::core::delaunay_triangulation::DelaunayTriangulation<_, (), (), 3> =
-            crate::core::delaunay_triangulation::DelaunayTriangulation::new(&vertices).unwrap();
+        let dt: crate::triangulation::delaunay::DelaunayTriangulation<_, (), (), 3> =
+            crate::triangulation::delaunay::DelaunayTriangulation::new(&vertices).unwrap();
         let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
 
         // Tetrahedron has exactly 4 boundary facets

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -6,16 +6,16 @@
 #![forbid(unsafe_code)]
 
 use super::point_generation::{generate_random_points, generate_random_points_seeded};
-use crate::core::delaunay_triangulation::{
-    ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationConstructionError,
-    InsertionOrderStrategy, RetryPolicy,
-};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::{TopologyGuarantee, TriangulationConstructionError};
 use crate::core::vertex::{Vertex, VertexBuilder};
 use crate::geometry::kernel::AdaptiveKernel;
 use crate::geometry::point::Point;
 use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
+use crate::triangulation::delaunay::{
+    ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationConstructionError,
+    InsertionOrderStrategy, RetryPolicy,
+};
 use rand::SeedableRng;
 use rand::distr::uniform::SampleUniform;
 use rand::rngs::StdRng;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,9 +142,9 @@
 //!
 //!   These checks are surfaced via [`Vertex::is_valid`](crate::core::vertex::Vertex::is_valid) and
 //!   [`Cell::is_valid`](crate::core::cell::Cell::is_valid), and are automatically run by
-//!   [`Tds::validate`](crate::core::triangulation_data_structure::Tds::validate) (Levels 1–2).
+//!   [`Tds::validate`](crate::core::tds::Tds::validate) (Levels 1–2).
 //!
-//! - [`Tds`](crate::core::triangulation_data_structure::Tds) (Triangulation Data Structure)
+//! - [`Tds`](crate::core::tds::Tds) (Triangulation Data Structure)
 //!   stores the **combinatorial / structural** representation.
 //!   Level 2 (structural) validation checks invariants such as:
 //!   - **Vertex mappings** – every vertex UUID has a corresponding key and vice versa.
@@ -153,10 +153,10 @@
 //!   - **Facet sharing** – each facet is shared by at most 2 cells (1 on the boundary, 2 in the interior).
 //!   - **Neighbor consistency** – neighbor relationships are mutual and reference a shared facet.
 //!
-//!   These checks are surfaced via [`Tds::is_valid`](crate::core::triangulation_data_structure::Tds::is_valid)
-//!   (structural only) and [`Tds::validate`](crate::core::triangulation_data_structure::Tds::validate)
+//!   These checks are surfaced via [`Tds::is_valid`](crate::core::tds::Tds::is_valid)
+//!   (structural only) and [`Tds::validate`](crate::core::tds::Tds::validate)
 //!   (Levels 1–2, elements + structural). For cumulative diagnostics across the full stack,
-//!   use [`DelaunayTriangulation::validation_report`](core::delaunay_triangulation::DelaunayTriangulation::validation_report).
+//!   use [`DelaunayTriangulation::validation_report`](triangulation::delaunay::DelaunayTriangulation::validation_report).
 //!
 //! - [`Triangulation`](crate::core::triangulation::Triangulation) builds on the TDS and validates
 //!   **manifold topology**.
@@ -167,11 +167,11 @@
 //!     exactly 1 cell (boundary) or exactly 2 cells (interior).
 //!   - Checks the **Euler characteristic** of the triangulation (using the topology module).
 //!
-//! - [`DelaunayTriangulation`](crate::core::delaunay_triangulation::DelaunayTriangulation) builds on
+//! - [`DelaunayTriangulation`](crate::triangulation::delaunay::DelaunayTriangulation) builds on
 //!   `Triangulation` and validates the **geometric** Delaunay condition.
 //!   Level 4 (Delaunay property) validation is performed by
-//!   [`DelaunayTriangulation::is_valid`](core::delaunay_triangulation::DelaunayTriangulation::is_valid) (Level 4 only) and
-//!   [`DelaunayTriangulation::validate`](core::delaunay_triangulation::DelaunayTriangulation::validate) (Levels 1–4).
+//!   [`DelaunayTriangulation::is_valid`](triangulation::delaunay::DelaunayTriangulation::is_valid) (Level 4 only) and
+//!   [`DelaunayTriangulation::validate`](triangulation::delaunay::DelaunayTriangulation::validate) (Levels 1–4).
 //!   Construction is designed to satisfy the Delaunay property, but in rare cases it may be violated for
 //!   near-degenerate inputs (see [Issue #120](https://github.com/acgetchell/delaunay/issues/120)).
 //!
@@ -323,8 +323,6 @@ pub mod core {
 
     pub mod adjacency;
     pub mod boundary;
-    /// Fluent builder for [`DelaunayTriangulation`] with optional toroidal topology.
-    pub mod builder;
     pub mod cell;
     /// High-performance collection types optimized for computational geometry operations.
     ///
@@ -440,15 +438,13 @@ pub mod core {
         pub use secondary_maps::*;
         pub use triangulation_maps::*;
     }
-    /// Delaunay triangulation layer with incremental insertion.
-    pub mod delaunay_triangulation;
     pub mod edge;
     pub mod facet;
     /// Semantic classification and telemetry for topological operations
     pub mod operations;
+    pub mod tds;
     /// Generic triangulation combining kernel + Tds.
     pub mod triangulation;
-    pub mod triangulation_data_structure;
 
     /// General utility functions organized by functionality.
     pub mod util {
@@ -488,14 +484,14 @@ pub mod core {
     }
 
     // Re-export the `core` modules.
+    pub use crate::triangulation::builder::DelaunayTriangulationBuilder;
+    pub use crate::triangulation::delaunay::*;
     pub use adjacency::*;
-    pub use builder::DelaunayTriangulationBuilder;
     pub use cell::*;
-    pub use delaunay_triangulation::*;
     pub use edge::*;
     pub use facet::*;
+    pub use tds::*;
     pub use traits::*;
-    pub use triangulation_data_structure::*;
     pub use util::*;
     pub use vertex::*;
 
@@ -740,14 +736,19 @@ pub mod geometry {
 /// This module groups public APIs that operate on triangulations, such as explicit
 /// bistellar (Pachner) flip operations.
 pub mod triangulation {
+    /// Fluent builder for [`DelaunayTriangulation`] with optional toroidal topology.
+    pub mod builder;
+    /// Delaunay triangulation layer with incremental insertion.
+    pub mod delaunay;
     /// End-to-end "repair then delaunayize" workflow.
     pub mod delaunayize;
     /// Triangulation editing operations (bistellar flips).
     pub mod flips;
 
     // Re-export commonly used triangulation types for discoverability.
-    pub use crate::core::delaunay_triangulation::DelaunayTriangulation;
     pub use crate::core::triangulation::Triangulation;
+    pub use crate::triangulation::builder::DelaunayTriangulationBuilder;
+    pub use crate::triangulation::delaunay::DelaunayTriangulation;
 }
 
 /// Topology analysis and validation for triangulated spaces.
@@ -839,14 +840,14 @@ pub mod prelude {
     pub use crate::core::{
         adjacency::*,
         cell::*,
-        delaunay_triangulation::*,
         edge::*,
         facet::*,
+        tds::*,
         traits::{boundary_analysis::*, data_type::*},
         triangulation::*,
-        triangulation_data_structure::*,
         vertex::*,
     };
+    pub use crate::triangulation::delaunay::*;
 
     // Re-export utility items, but avoid exporting the util module names themselves.
     //
@@ -888,18 +889,18 @@ pub mod prelude {
 
     /// Focused exports for triangulation construction and inspection.
     pub mod triangulation {
-        pub use crate::core::builder::DelaunayTriangulationBuilder;
         pub use crate::core::{
             adjacency::*,
             cell::*,
-            delaunay_triangulation::*,
             edge::*,
             facet::*,
+            tds::*,
             traits::{boundary_analysis::*, data_type::*},
             triangulation::*,
-            triangulation_data_structure::*,
             vertex::*,
         };
+        pub use crate::triangulation::builder::DelaunayTriangulationBuilder;
+        pub use crate::triangulation::delaunay::*;
 
         pub use crate::core::algorithms::incremental_insertion::InsertionError;
         pub use crate::core::operations::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
@@ -912,8 +913,8 @@ pub mod prelude {
 
         /// Bistellar (Pachner) flips for explicit triangulation editing.
         pub mod flips {
-            pub use crate::core::delaunay_triangulation::DelaunayTriangulation;
             pub use crate::core::triangulation::{TopologyGuarantee, Triangulation};
+            pub use crate::triangulation::delaunay::DelaunayTriangulation;
             pub use crate::triangulation::flips::*;
 
             // Convenience macro (commonly used in docs/examples).
@@ -926,7 +927,7 @@ pub mod prelude {
         /// import brings in [`DelaunayTriangulation`], [`vertex!`], and all
         /// delaunayize-specific types.
         pub mod delaunayize {
-            pub use crate::core::delaunay_triangulation::DelaunayTriangulation;
+            pub use crate::triangulation::delaunay::DelaunayTriangulation;
             pub use crate::triangulation::delaunayize::*;
 
             // Convenience macro (commonly used in docs/examples).
@@ -983,10 +984,10 @@ pub mod prelude {
     pub mod query {
         // Core read-only traversal / adjacency
         pub use crate::core::adjacency::{AdjacencyIndex, AdjacencyIndexBuildError};
-        pub use crate::core::delaunay_triangulation::DelaunayTriangulation;
         pub use crate::core::edge::EdgeKey;
+        pub use crate::core::tds::{CellKey, VertexKey};
         pub use crate::core::triangulation::Triangulation;
-        pub use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+        pub use crate::triangulation::delaunay::DelaunayTriangulation;
 
         // Common input/output types (kept intentionally small)
         pub use crate::core::facet::FacetView;
@@ -1050,12 +1051,12 @@ pub const fn is_normal<T: Sized + Send + Sync + Unpin>() -> bool {
 mod tests {
     use crate::{
         core::{
-            adjacency::AdjacencyIndex, cell::Cell, delaunay_triangulation::DelaunayTriangulation,
-            edge::EdgeKey, triangulation::Triangulation, triangulation_data_structure::Tds,
-            vertex::Vertex,
+            adjacency::AdjacencyIndex, cell::Cell, edge::EdgeKey, tds::Tds,
+            triangulation::Triangulation, vertex::Vertex,
         },
         geometry::{Point, algorithms::convex_hull::ConvexHull, kernel::FastKernel},
         is_normal,
+        triangulation::delaunay::DelaunayTriangulation,
     };
 
     // =============================================================================

--- a/src/topology/characteristics/euler.rs
+++ b/src/topology/characteristics/euler.rs
@@ -30,8 +30,8 @@ use crate::core::{
         VertexKeyBuffer, fast_hash_map_with_capacity, fast_hash_set_with_capacity,
     },
     edge::EdgeKey,
+    tds::{Tds, VertexKey},
     traits::{BoundaryAnalysis, DataType},
-    triangulation_data_structure::{Tds, VertexKey},
 };
 use crate::geometry::traits::coordinate::CoordinateScalar;
 use crate::topology::traits::topological_space::TopologyError;

--- a/src/topology/characteristics/validation.rs
+++ b/src/topology/characteristics/validation.rs
@@ -5,9 +5,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::core::{
-    collections::FacetToCellsMap, traits::DataType, triangulation_data_structure::Tds,
-};
+use crate::core::{collections::FacetToCellsMap, tds::Tds, traits::DataType};
 use crate::geometry::traits::coordinate::CoordinateScalar;
 use crate::topology::{
     characteristics::euler::{

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -92,8 +92,8 @@ use crate::core::{
     },
     edge::EdgeKey,
     facet::facet_key_from_vertices,
+    tds::{CellKey, Tds, TdsError, VertexKey},
     traits::DataType,
-    triangulation_data_structure::{CellKey, Tds, TdsError, VertexKey},
     util::hashing::stable_hash_u64_slice,
 };
 use crate::geometry::traits::coordinate::CoordinateScalar;

--- a/src/topology/traits/topological_space.rs
+++ b/src/topology/traits/topological_space.rs
@@ -167,6 +167,22 @@ impl<const D: usize> GlobalTopology<D> {
         }
     }
 
+    /// Returns `true` for Euclidean global topology metadata.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::topology::traits::topological_space::GlobalTopology;
+    ///
+    /// let topo = GlobalTopology::<3>::Euclidean;
+    /// assert!(topo.is_euclidean());
+    /// assert!(!topo.is_toroidal());
+    /// ```
+    #[must_use]
+    pub const fn is_euclidean(self) -> bool {
+        matches!(self, Self::Euclidean)
+    }
+
     /// Returns `true` for toroidal global topology metadata.
     #[must_use]
     pub const fn is_toroidal(self) -> bool {

--- a/src/topology/traits/topological_space.rs
+++ b/src/topology/traits/topological_space.rs
@@ -432,3 +432,202 @@ pub trait TopologicalSpace {
     /// to match the triangulation's scalar type instead of hardcoding `f64`.
     fn fundamental_domain(&self) -> Option<&[f64]>;
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_topology_error_display() {
+        let counting = TopologyError::Counting("test message".to_string());
+        assert_eq!(
+            counting.to_string(),
+            "Failed to count simplices: test message"
+        );
+
+        let classification = TopologyError::Classification("another test".to_string());
+        assert_eq!(
+            classification.to_string(),
+            "Failed to classify triangulation: another test"
+        );
+
+        let euler = TopologyError::EulerMismatch {
+            computed: 2,
+            expected: 1,
+            topology_type: "sphere".to_string(),
+        };
+        assert_eq!(
+            euler.to_string(),
+            "Euler characteristic mismatch: computed χ=2, expected χ=1 for sphere"
+        );
+    }
+
+    #[test]
+    fn test_topology_error_equality() {
+        let err1 = TopologyError::Counting("msg".to_string());
+        let err2 = TopologyError::Counting("msg".to_string());
+        let err3 = TopologyError::Counting("different".to_string());
+
+        assert_eq!(err1, err2);
+        assert_ne!(err1, err3);
+        assert_ne!(err1, TopologyError::Classification("msg".to_string()));
+    }
+
+    #[test]
+    fn test_topology_kind_debug() {
+        assert_eq!(format!("{:?}", TopologyKind::Euclidean), "Euclidean");
+        assert_eq!(format!("{:?}", TopologyKind::Toroidal), "Toroidal");
+        assert_eq!(format!("{:?}", TopologyKind::Spherical), "Spherical");
+        assert_eq!(format!("{:?}", TopologyKind::Hyperbolic), "Hyperbolic");
+    }
+
+    #[test]
+    fn test_toroidal_construction_mode_debug() {
+        assert_eq!(
+            format!("{:?}", ToroidalConstructionMode::Canonicalized),
+            "Canonicalized"
+        );
+        assert_eq!(
+            format!("{:?}", ToroidalConstructionMode::PeriodicImagePoint),
+            "PeriodicImagePoint"
+        );
+        assert_eq!(
+            format!("{:?}", ToroidalConstructionMode::Explicit),
+            "Explicit"
+        );
+    }
+
+    #[test]
+    fn test_global_topology_default() {
+        let default_topo: GlobalTopology<3> = GlobalTopology::default();
+        assert_eq!(default_topo, GlobalTopology::Euclidean);
+        assert_eq!(GlobalTopology::<3>::DEFAULT, GlobalTopology::Euclidean);
+    }
+
+    #[test]
+    fn test_global_topology_kind() {
+        assert_eq!(
+            GlobalTopology::<2>::Euclidean.kind(),
+            TopologyKind::Euclidean
+        );
+        assert_eq!(
+            GlobalTopology::<3>::Spherical.kind(),
+            TopologyKind::Spherical
+        );
+        assert_eq!(
+            GlobalTopology::<4>::Hyperbolic.kind(),
+            TopologyKind::Hyperbolic
+        );
+
+        let toroidal = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 2.0],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        assert_eq!(toroidal.kind(), TopologyKind::Toroidal);
+    }
+
+    #[test]
+    fn test_global_topology_allows_boundary() {
+        assert!(GlobalTopology::<3>::Euclidean.allows_boundary());
+        assert!(!GlobalTopology::<3>::Spherical.allows_boundary());
+        assert!(!GlobalTopology::<3>::Hyperbolic.allows_boundary());
+
+        let toroidal = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 1.0],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        assert!(!toroidal.allows_boundary());
+    }
+
+    #[test]
+    fn test_global_topology_is_euclidean() {
+        assert!(GlobalTopology::<3>::Euclidean.is_euclidean());
+        assert!(!GlobalTopology::<3>::Spherical.is_euclidean());
+        assert!(!GlobalTopology::<3>::Hyperbolic.is_euclidean());
+
+        let toroidal = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 1.0],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        assert!(!toroidal.is_euclidean());
+    }
+
+    #[test]
+    fn test_global_topology_is_toroidal() {
+        assert!(!GlobalTopology::<3>::Euclidean.is_toroidal());
+        assert!(!GlobalTopology::<3>::Spherical.is_toroidal());
+        assert!(!GlobalTopology::<3>::Hyperbolic.is_toroidal());
+
+        let toroidal = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 1.0],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        assert!(toroidal.is_toroidal());
+    }
+
+    #[test]
+    fn test_global_topology_is_periodic() {
+        assert!(!GlobalTopology::<3>::Euclidean.is_periodic());
+        assert!(!GlobalTopology::<3>::Spherical.is_periodic());
+        assert!(!GlobalTopology::<3>::Hyperbolic.is_periodic());
+
+        // Test different toroidal modes
+        let canonicalized = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 1.0],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        assert!(!canonicalized.is_periodic());
+
+        let periodic = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 1.0],
+            mode: ToroidalConstructionMode::PeriodicImagePoint,
+        };
+        assert!(periodic.is_periodic());
+
+        let explicit = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 1.0],
+            mode: ToroidalConstructionMode::Explicit,
+        };
+        assert!(!explicit.is_periodic());
+    }
+
+    #[test]
+    fn test_global_topology_equality() {
+        let topo1 = GlobalTopology::<3>::Euclidean;
+        let topo2 = GlobalTopology::<3>::Euclidean;
+        let topo3 = GlobalTopology::<3>::Spherical;
+
+        assert_eq!(topo1, topo2);
+        assert_ne!(topo1, topo3);
+
+        let toroidal1 = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 2.0],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        let toroidal2 = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 2.0],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        let toroidal3 = GlobalTopology::<2>::Toroidal {
+            domain: [1.0, 2.0],
+            mode: ToroidalConstructionMode::PeriodicImagePoint,
+        };
+
+        assert_eq!(toroidal1, toroidal2);
+        assert_ne!(toroidal1, toroidal3);
+    }
+
+    #[test]
+    fn test_global_topology_debug() {
+        assert_eq!(format!("{:?}", GlobalTopology::<3>::Euclidean), "Euclidean");
+
+        let toroidal = GlobalTopology::<2>::Toroidal {
+            domain: [1.5, 2.5],
+            mode: ToroidalConstructionMode::Canonicalized,
+        };
+        let debug_str = format!("{toroidal:?}");
+        assert!(debug_str.contains("Toroidal"));
+        assert!(debug_str.contains("domain"));
+        assert!(debug_str.contains("mode"));
+    }
+}

--- a/src/triangulation/builder.rs
+++ b/src/triangulation/builder.rs
@@ -32,7 +32,7 @@
 //! ## Standard Euclidean construction
 //!
 //! ```rust
-//! use delaunay::core::builder::DelaunayTriangulationBuilder;
+//! use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
 //! use delaunay::vertex;
 //!
 //! let vertices = vec![
@@ -51,7 +51,7 @@
 //! ## Toroidal construction (Phase 1: canonicalization only)
 //!
 //! ```rust
-//! use delaunay::core::builder::DelaunayTriangulationBuilder;
+//! use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
 //! use delaunay::vertex;
 //!
 //! // Vertices that fall outside [0, 1)² are wrapped before triangulation.
@@ -76,7 +76,7 @@
 //! where boundary facets are identified and neighbor pointers are rewired periodically.
 //!
 //! ```rust,no_run
-//! use delaunay::core::builder::DelaunayTriangulationBuilder;
+//! use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
 //! use delaunay::geometry::kernel::RobustKernel;
 //! use delaunay::vertex;
 //!
@@ -105,16 +105,10 @@
 
 use crate::core::cell::Cell;
 use crate::core::collections::{FastHashMap, Uuid, VertexKeySet};
-use crate::core::delaunay_triangulation::{
-    ConstructionOptions, DelaunayRepairPolicy, DelaunayTriangulation,
-    DelaunayTriangulationConstructionError, InitialSimplexStrategy, RetryPolicy,
-};
 use crate::core::operations::InsertionOutcome;
+use crate::core::tds::{CellKey, Tds, TriangulationConstructionState, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::{TopologyGuarantee, TriangulationConstructionError};
-use crate::core::triangulation_data_structure::{
-    CellKey, Tds, TriangulationConstructionState, VertexKey,
-};
 use crate::core::util::periodic_facet_key_from_lifted_vertices;
 use crate::core::vertex::{Vertex, VertexBuilder};
 use crate::geometry::kernel::{AdaptiveKernel, Kernel};
@@ -125,6 +119,10 @@ use crate::topology::traits::global_topology_model::{
     GlobalTopologyModel, GlobalTopologyModelError,
 };
 use crate::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+use crate::triangulation::delaunay::{
+    ConstructionOptions, DelaunayRepairPolicy, DelaunayTriangulation,
+    DelaunayTriangulationConstructionError, InitialSimplexStrategy, RetryPolicy,
+};
 use num_traits::ToPrimitive;
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -295,13 +293,13 @@ fn search_closed_2d_selection(
 /// Only low-level TDS insertion failures (vertex/cell creation) flow through
 /// [`TriangulationConstructionError`].
 ///
-/// [`DelaunayTriangulationConstructionError::ExplicitConstruction`]: crate::core::delaunay_triangulation::DelaunayTriangulationConstructionError::ExplicitConstruction
+/// [`DelaunayTriangulationConstructionError::ExplicitConstruction`]: crate::triangulation::delaunay::DelaunayTriangulationConstructionError::ExplicitConstruction
 ///
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
-/// use delaunay::core::delaunay_triangulation::DelaunayTriangulationConstructionError;
+/// use delaunay::triangulation::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
+/// use delaunay::triangulation::delaunay::DelaunayTriangulationConstructionError;
 /// use delaunay::vertex;
 ///
 /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
@@ -361,7 +359,7 @@ pub enum ExplicitConstructionError {
     /// only to the Delaunay point-insertion path and are not meaningful for
     /// explicit cell construction.
     ///
-    /// [`ConstructionOptions`]: crate::core::delaunay_triangulation::ConstructionOptions
+    /// [`ConstructionOptions`]: crate::triangulation::delaunay::ConstructionOptions
     #[error(
         "ConstructionOptions are not applicable to explicit cell construction \
          and must be left at their default values"
@@ -400,8 +398,8 @@ pub enum ExplicitConstructionError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::builder::DelaunayTriangulationBuilder;
-/// use delaunay::core::delaunay_triangulation::ConstructionOptions;
+/// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
+/// use delaunay::triangulation::delaunay::ConstructionOptions;
 /// use delaunay::core::triangulation::TopologyGuarantee;
 /// use delaunay::vertex;
 ///
@@ -518,7 +516,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -565,7 +563,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::core::vertex::{Vertex, VertexBuilder};
     /// use delaunay::geometry::point::Point;
     /// use delaunay::geometry::traits::coordinate::Coordinate;
@@ -609,7 +607,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::core::vertex::{Vertex, VertexBuilder};
     /// use delaunay::geometry::point::Point;
     /// use delaunay::geometry::traits::coordinate::Coordinate;
@@ -655,7 +653,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -702,7 +700,7 @@ where
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::geometry::kernel::RobustKernel;
     /// use delaunay::vertex;
     ///
@@ -739,7 +737,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::core::triangulation::TopologyGuarantee;
     /// use delaunay::vertex;
     ///
@@ -779,7 +777,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
     /// use delaunay::vertex;
     ///
@@ -813,8 +811,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::core::delaunay_triangulation::{ConstructionOptions, InsertionOrderStrategy};
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::delaunay::{ConstructionOptions, InsertionOrderStrategy};
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -998,7 +996,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -1049,7 +1047,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
     /// use delaunay::geometry::kernel::RobustKernel;
     /// use delaunay::vertex;
     ///
@@ -2365,11 +2363,16 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::geometry::kernel::RobustKernel;
     use crate::topology::traits::global_topology_model::{
-        GlobalTopologyModel, GlobalTopologyModelError,
+        EuclideanModel, GlobalTopologyModel, GlobalTopologyModelError, ToroidalModel,
     };
-    use crate::topology::traits::topological_space::TopologyKind;
+    use crate::topology::traits::topological_space::{
+        GlobalTopology, TopologyKind, ToroidalConstructionMode,
+    };
+    use crate::triangulation::delaunay::InsertionOrderStrategy;
     use crate::vertex;
+    use approx::assert_relative_eq;
     use slotmap::Key;
 
     #[derive(Clone, Copy, Debug)]
@@ -2560,7 +2563,6 @@ mod tests {
 
     #[test]
     fn test_builder_custom_options_propagated() {
-        use crate::core::delaunay_triangulation::InsertionOrderStrategy;
         let vertices = vec![
             vertex!([0.0, 0.0]),
             vertex!([1.0, 0.0]),
@@ -2625,9 +2627,6 @@ mod tests {
 
     #[test]
     fn test_builder_toroidal_build_succeeds_2d() {
-        use crate::topology::traits::topological_space::{
-            GlobalTopology, ToroidalConstructionMode,
-        };
         let vertices = vec![
             vertex!([0.2, 0.3]),
             vertex!([0.8, 0.1]),
@@ -2726,11 +2725,6 @@ mod tests {
 
     #[test]
     fn test_builder_toroidal_periodic_2d_smoke() {
-        use crate::geometry::kernel::RobustKernel;
-        use crate::topology::traits::topological_space::{
-            GlobalTopology, ToroidalConstructionMode,
-        };
-
         let vertices = vec![
             vertex!([0.1_f64, 0.2]),
             vertex!([0.4, 0.7]),
@@ -2828,7 +2822,6 @@ mod tests {
 
     #[test]
     fn test_builder_with_robust_kernel() {
-        use crate::geometry::kernel::RobustKernel;
         let vertices = vec![
             vertex!([0.0, 0.0, 0.0]),
             vertex!([1.0, 0.0, 0.0]),
@@ -2849,7 +2842,6 @@ mod tests {
 
     #[test]
     fn test_validate_topology_model_accepts_valid_toroidal() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let model = ToroidalModel::<2>::new([2.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let result = DelaunayTriangulationBuilder::<f64, (), 2>::validate_topology_model(&model);
         assert!(result.is_ok());
@@ -2904,7 +2896,6 @@ mod tests {
 
     #[test]
     fn test_validate_topology_model_rejects_zero_period() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let model = ToroidalModel::<2>::new([0.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let result = DelaunayTriangulationBuilder::<f64, (), 2>::validate_topology_model(&model);
         assert!(result.is_err());
@@ -2921,7 +2912,6 @@ mod tests {
 
     #[test]
     fn test_validate_topology_model_rejects_negative_period() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let model =
             ToroidalModel::<3>::new([2.0, -1.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let result = DelaunayTriangulationBuilder::<f64, (), 3>::validate_topology_model(&model);
@@ -2933,7 +2923,6 @@ mod tests {
 
     #[test]
     fn test_validate_topology_model_rejects_infinite_period() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let model = ToroidalModel::<2>::new(
             [f64::INFINITY, 3.0],
             ToroidalConstructionMode::Canonicalized,
@@ -2946,7 +2935,6 @@ mod tests {
 
     #[test]
     fn test_validate_topology_model_rejects_nan_period() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let model =
             ToroidalModel::<2>::new([f64::NAN, 3.0], ToroidalConstructionMode::Canonicalized);
         let result = DelaunayTriangulationBuilder::<f64, (), 2>::validate_topology_model(&model);
@@ -2957,7 +2945,6 @@ mod tests {
 
     #[test]
     fn test_validate_topology_model_accepts_euclidean() {
-        use crate::topology::traits::global_topology_model::EuclideanModel;
         let model = EuclideanModel;
         let result = DelaunayTriangulationBuilder::<f64, (), 2>::validate_topology_model(&model);
         assert!(result.is_ok());
@@ -2975,7 +2962,6 @@ mod tests {
 
     #[test]
     fn test_canonicalize_vertices_preserves_uuids() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let vertices = vec![
             vertex!([2.5, 3.7]),
             vertex!([1.8, -0.5]),
@@ -2994,7 +2980,6 @@ mod tests {
 
     #[test]
     fn test_canonicalize_vertices_preserves_data() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let vertices: Vec<Vertex<f64, i32, 2>> = vec![
             VertexBuilder::default()
                 .point(Point::new([2.5_f64, 3.7]))
@@ -3025,8 +3010,6 @@ mod tests {
 
     #[test]
     fn test_canonicalize_vertices_transforms_coordinates() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
-        use approx::assert_relative_eq;
         let vertices = vec![
             vertex!([2.5, 3.7]),  // → (0.5, 0.7)
             vertex!([1.8, -0.5]), // → (1.8, 2.5)
@@ -3084,8 +3067,6 @@ mod tests {
 
     #[test]
     fn test_canonicalize_vertices_euclidean_identity() {
-        use crate::topology::traits::global_topology_model::EuclideanModel;
-        use approx::assert_relative_eq;
         let vertices = vec![
             vertex!([1.5, 2.5]),
             vertex!([3.7, 4.2]),
@@ -3105,7 +3086,6 @@ mod tests {
 
     #[test]
     fn test_canonicalize_vertices_propagates_nan_error() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let vertices = vec![
             VertexBuilder::default()
                 .point(Point::new([0.5_f64, 0.5]))
@@ -3138,7 +3118,6 @@ mod tests {
 
     #[test]
     fn test_canonicalize_vertices_propagates_infinity_error() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let vertices = vec![
             VertexBuilder::default()
                 .point(Point::new([0.5_f64, 0.5]))
@@ -3165,7 +3144,6 @@ mod tests {
 
     #[test]
     fn test_canonicalize_vertices_includes_original_coords_in_error() {
-        use crate::topology::traits::global_topology_model::ToroidalModel;
         let vertices = vec![
             VertexBuilder::default()
                 .point(Point::new([f64::NAN, 1.5_f64]))

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -11,8 +11,7 @@ use crate::core::algorithms::flips::{
     repair_delaunay_local_single_pass, repair_delaunay_with_flips_k2_k3,
 };
 use crate::core::algorithms::incremental_insertion::InsertionError;
-use crate::core::builder::DelaunayTriangulationBuilder;
-use crate::core::cell::Cell;
+use crate::core::cell::{Cell, CellValidationError};
 use crate::core::collections::spatial_hash_grid::HashGridIndex;
 use crate::core::collections::{CellKeyBuffer, FastHashMap, FastHasher, SmallBuffer};
 use crate::core::edge::EdgeKey;
@@ -21,14 +20,14 @@ use crate::core::operations::{
     DelaunayInsertionState, InsertionOutcome, InsertionStatistics, RepairDecision,
     TopologicalOperation,
 };
+use crate::core::tds::{
+    CellKey, InvariantError, InvariantKind, InvariantViolation, Tds, TdsConstructionError,
+    TdsError, TriangulationValidationReport, VertexKey,
+};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::{
     TopologyGuarantee, Triangulation, TriangulationConstructionError, TriangulationValidationError,
     ValidationPolicy, insertion_error_to_invariant_error, record_duplicate_detection_metrics,
-};
-use crate::core::triangulation_data_structure::{
-    CellKey, InvariantError, InvariantKind, InvariantViolation, Tds, TdsConstructionError,
-    TdsError, TriangulationValidationReport, VertexKey,
 };
 use crate::core::util::{
     coords_equal_exact, coords_within_epsilon, hilbert_indices_prequantized, hilbert_quantize,
@@ -39,6 +38,7 @@ use crate::geometry::kernel::{AdaptiveKernel, ExactPredicates, Kernel, RobustKer
 use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
 use crate::topology::manifold::validate_ridge_links_for_cells;
 use crate::topology::traits::topological_space::{GlobalTopology, TopologyKind};
+use crate::triangulation::builder::DelaunayTriangulationBuilder;
 use core::cmp::Ordering;
 use num_traits::{NumCast, ToPrimitive, Zero};
 use rand::SeedableRng;
@@ -96,7 +96,7 @@ impl Drop for HeuristicRebuildRecursionGuard {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::DelaunayTriangulationConstructionError;
+/// use delaunay::triangulation::delaunay::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -119,12 +119,12 @@ pub enum DelaunayTriangulationConstructionError {
 
     /// Input validation error from explicit combinatorial construction.
     ///
-    /// Returned by [`DelaunayTriangulationBuilder::from_vertices_and_cells`](crate::core::builder::DelaunayTriangulationBuilder::from_vertices_and_cells)
+    /// Returned by [`DelaunayTriangulationBuilder::from_vertices_and_cells`](crate::triangulation::builder::DelaunayTriangulationBuilder::from_vertices_and_cells)
     /// when the caller-provided vertices/cells fail validation (wrong arity,
     /// out-of-bounds indices, etc.). TDS assembly errors flow through the
     /// [`Triangulation`](Self::Triangulation) variant instead.
     #[error(transparent)]
-    ExplicitConstruction(#[from] crate::core::builder::ExplicitConstructionError),
+    ExplicitConstruction(#[from] crate::triangulation::builder::ExplicitConstructionError),
 }
 
 /// Errors that can occur during Delaunay triangulation validation and repair.
@@ -146,7 +146,7 @@ pub enum DelaunayTriangulationConstructionError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::DelaunayTriangulationValidationError;
+/// use delaunay::triangulation::delaunay::DelaunayTriangulationValidationError;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -213,7 +213,7 @@ pub enum DelaunayTriangulationValidationError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::{ConstructionOptions, InsertionOrderStrategy};
+/// use delaunay::triangulation::delaunay::{ConstructionOptions, InsertionOrderStrategy};
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -269,7 +269,7 @@ pub enum InsertionOrderStrategy {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::{ConstructionOptions, DedupPolicy};
+/// use delaunay::triangulation::delaunay::{ConstructionOptions, DedupPolicy};
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -329,7 +329,7 @@ pub enum InitialSimplexStrategy {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::{ConstructionOptions, RetryPolicy};
+/// use delaunay::triangulation::delaunay::{ConstructionOptions, RetryPolicy};
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -395,7 +395,7 @@ impl Default for RetryPolicy {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::{
+/// use delaunay::triangulation::delaunay::{
 ///     ConstructionOptions, DedupPolicy, InsertionOrderStrategy, RetryPolicy,
 /// };
 ///
@@ -1458,7 +1458,7 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::{
+    /// use delaunay::triangulation::delaunay::{
     ///     ConstructionOptions, DedupPolicy, InsertionOrderStrategy,
     /// };
     /// use delaunay::prelude::triangulation::*;
@@ -1754,7 +1754,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::kernel::RobustKernel;
     /// use delaunay::vertex;
     ///
@@ -1844,7 +1844,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::{
+    /// use delaunay::triangulation::delaunay::{
     ///     ConstructionOptions, DedupPolicy, InsertionOrderStrategy,
     /// };
     /// use delaunay::core::triangulation::TopologyGuarantee;
@@ -2632,7 +2632,7 @@ where
             return Err(DelaunayTriangulationConstructionErrorWithStatistics {
                 error: TriangulationConstructionError::InsufficientVertices {
                     dimension: D,
-                    source: crate::core::cell::CellValidationError::InsufficientVertices {
+                    source: CellValidationError::InsufficientVertices {
                         actual: vertices.len(),
                         expected: D + 1,
                         dimension: D,
@@ -3454,7 +3454,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -3480,7 +3480,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -3508,7 +3508,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -3678,7 +3678,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -3724,7 +3724,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -4056,7 +4056,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayRepairHeuristicConfig;
+    /// use delaunay::triangulation::delaunay::DelaunayRepairHeuristicConfig;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -4149,8 +4149,6 @@ where
     where
         K: ExactPredicates,
     {
-        use rand::{SeedableRng, seq::SliceRandom};
-
         let base_vertices = self.collect_vertices_for_rebuild();
 
         let mut last_error: Option<String> = None;
@@ -4356,6 +4354,16 @@ where
     // -------------------------------------------------------------------------
 
     /// Returns the topology guarantee used for Level 3 topology validation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::triangulation::*;
+    ///
+    /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
+    /// ```
     #[inline]
     #[must_use]
     pub const fn topology_guarantee(&self) -> TopologyGuarantee {
@@ -4363,6 +4371,16 @@ where
     }
 
     /// Returns runtime global topology metadata associated with this triangulation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::triangulation::*;
+    ///
+    /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// assert!(dt.global_topology().is_euclidean());
+    /// ```
     #[inline]
     #[must_use]
     pub const fn global_topology(&self) -> GlobalTopology<D> {
@@ -4370,6 +4388,16 @@ where
     }
 
     /// Returns the high-level topology kind (`Euclidean`, `Toroidal`, etc.).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::triangulation::*;
+    ///
+    /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// assert_eq!(dt.topology_kind(), TopologyKind::Euclidean);
+    /// ```
     #[inline]
     #[must_use]
     pub const fn topology_kind(&self) -> TopologyKind {
@@ -4377,6 +4405,17 @@ where
     }
 
     /// Sets runtime global topology metadata on this triangulation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::triangulation::*;
+    ///
+    /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// dt.set_global_topology(GlobalTopology::Euclidean);
+    /// assert!(dt.global_topology().is_euclidean());
+    /// ```
     #[inline]
     pub const fn set_global_topology(&mut self, global_topology: GlobalTopology<D>) {
         self.tri.set_global_topology(global_topology);
@@ -4412,7 +4451,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -4442,7 +4481,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -4837,7 +4876,7 @@ where
     /// Using batch construction (traditional approach):
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// // Create initial triangulation with 5 vertices (4-simplex)
@@ -5533,8 +5572,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
-    /// use delaunay::core::triangulation_data_structure::Tds;
+    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::core::tds::Tds;
     /// use delaunay::geometry::kernel::FastKernel;
     /// use delaunay::vertex;
     ///
@@ -5667,7 +5706,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::DelaunayRepairPolicy;
+/// use delaunay::triangulation::delaunay::DelaunayRepairPolicy;
 /// use std::num::NonZeroUsize;
 ///
 /// let policy = DelaunayRepairPolicy::EveryN(NonZeroUsize::new(4).unwrap());
@@ -5708,7 +5747,7 @@ impl DelaunayRepairPolicy {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::DelaunayRepairHeuristicConfig;
+/// use delaunay::triangulation::delaunay::DelaunayRepairHeuristicConfig;
 ///
 /// let mut config = DelaunayRepairHeuristicConfig::default();
 /// config.shuffle_seed = Some(7);
@@ -5769,7 +5808,7 @@ impl DelaunayRepairHeuristicConfig {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::DelaunayRepairHeuristicSeeds;
+/// use delaunay::triangulation::delaunay::DelaunayRepairHeuristicSeeds;
 ///
 /// let seeds = DelaunayRepairHeuristicSeeds {
 ///     shuffle_seed: 1,
@@ -5791,7 +5830,7 @@ pub struct DelaunayRepairHeuristicSeeds {
 ///
 /// ```rust
 /// use delaunay::core::algorithms::flips::DelaunayRepairStats;
-/// use delaunay::core::delaunay_triangulation::DelaunayRepairOutcome;
+/// use delaunay::triangulation::delaunay::DelaunayRepairOutcome;
 ///
 /// let outcome = DelaunayRepairOutcome {
 ///     stats: DelaunayRepairStats::default(),
@@ -5828,7 +5867,7 @@ impl DelaunayRepairOutcome {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::delaunay_triangulation::DelaunayCheckPolicy;
+/// use delaunay::triangulation::delaunay::DelaunayCheckPolicy;
 /// use std::num::NonZeroUsize;
 ///
 /// let policy = DelaunayCheckPolicy::EveryN(NonZeroUsize::new(3).unwrap());
@@ -5867,13 +5906,17 @@ mod tests {
         DelaunayRepairDiagnostics, DelaunayRepairError, FlipError, RepairQueueOrder,
         verify_delaunay_via_flip_predicates,
     };
-    use crate::core::algorithms::incremental_insertion::repair_neighbor_pointers;
-    use crate::core::triangulation_data_structure::{EntityKind, GeometricError};
+    use crate::core::algorithms::incremental_insertion::{
+        HullExtensionReason, repair_neighbor_pointers,
+    };
+    use crate::core::algorithms::locate::{ConflictError, LocateError};
+    use crate::core::tds::{EntityKind, GeometricError};
     use crate::geometry::kernel::{AdaptiveKernel, FastKernel, RobustKernel};
     use crate::geometry::traits::coordinate::Coordinate;
     use crate::topology::characteristics::euler::TopologyClassification;
     use crate::triangulation::flips::BistellarFlips;
     use crate::vertex;
+    use rand::{RngExt, SeedableRng};
 
     pub(super) fn force_repair_nonconvergent_enabled() -> bool {
         FORCE_REPAIR_NONCONVERGENT.with(std::cell::Cell::get)
@@ -5896,7 +5939,6 @@ mod tests {
             }),
         }
     }
-    use rand::{RngExt, SeedableRng};
     fn init_tracing() {
         static INIT: std::sync::Once = std::sync::Once::new();
         INIT.call_once(|| {
@@ -8121,7 +8163,6 @@ mod tests {
     /// immediately without attempting global repair.
     #[test]
     fn test_try_d_lt4_global_repair_fallback_disabled_returns_error() {
-        use crate::core::algorithms::flips::{DelaunayRepairDiagnostics, RepairQueueOrder};
         init_tracing();
 
         let vertices = vec![
@@ -8171,7 +8212,6 @@ mod tests {
     /// global repair succeeds and the helper returns `Ok(())`.
     #[test]
     fn test_try_d_lt4_global_repair_fallback_enabled_succeeds_on_valid_tds() {
-        use crate::core::algorithms::flips::{DelaunayRepairDiagnostics, RepairQueueOrder};
         init_tracing();
 
         let vertices = vec![
@@ -8427,9 +8467,6 @@ mod tests {
 
     #[test]
     fn test_map_orientation_canonicalization_error_geometry_variants_are_degeneracy() {
-        use crate::core::algorithms::incremental_insertion::HullExtensionReason;
-        use crate::core::algorithms::locate::LocateError;
-
         let geometry_errors: Vec<InsertionError> = vec![
             InsertionError::Location(LocateError::EmptyTriangulation),
             InsertionError::NonManifoldTopology {
@@ -8564,17 +8601,12 @@ mod tests {
 
     #[test]
     fn test_map_insertion_error_geometry_variants_are_degeneracy() {
-        use crate::core::algorithms::incremental_insertion::HullExtensionReason;
-        use crate::core::algorithms::locate::LocateError;
-
         let geometry_errors: Vec<InsertionError> = vec![
-            InsertionError::ConflictRegion(
-                crate::core::algorithms::locate::ConflictError::OpenBoundary {
-                    facet_count: 2,
-                    ridge_vertex_count: 1,
-                    open_cell: CellKey::from(slotmap::KeyData::from_ffi(1)),
-                },
-            ),
+            InsertionError::ConflictRegion(ConflictError::OpenBoundary {
+                facet_count: 2,
+                ridge_vertex_count: 1,
+                open_cell: CellKey::from(slotmap::KeyData::from_ffi(1)),
+            }),
             InsertionError::Location(LocateError::EmptyTriangulation),
             InsertionError::NonManifoldTopology {
                 facet_hash: 0,
@@ -8808,8 +8840,6 @@ mod tests {
 
     #[test]
     fn test_map_orientation_canonicalization_error_conflict_region_is_degeneracy() {
-        use crate::core::algorithms::locate::ConflictError;
-
         let error = InsertionError::ConflictRegion(ConflictError::NonManifoldFacet {
             facet_hash: 0x123,
             cell_count: 3,

--- a/src/triangulation/delaunayize.rs
+++ b/src/triangulation/delaunayize.rs
@@ -54,11 +54,11 @@ use crate::core::algorithms::flips::DelaunayRepairError;
 use crate::core::algorithms::pl_manifold_repair::{
     PlManifoldRepairConfig, repair_facet_oversharing,
 };
-use crate::core::delaunay_triangulation::{DelaunayRepairHeuristicConfig, DelaunayTriangulation};
 use crate::core::traits::data_type::DataType;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::{ExactPredicates, Kernel};
 use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
+use crate::triangulation::delaunay::{DelaunayRepairHeuristicConfig, DelaunayTriangulation};
 use thiserror::Error;
 
 // =============================================================================
@@ -298,7 +298,7 @@ where
                     Err(rebuild_err) => {
                         return Err(DelaunayizeError::TopologyRepairFailed(
                             PlManifoldRepairError::Tds(
-                                crate::core::triangulation_data_structure::TdsError::InconsistentDataStructure {
+                                crate::core::tds::TdsError::InconsistentDataStructure {
                                     message: format!(
                                         "topology repair failed ({topo_err}); fallback rebuild also failed: {rebuild_err}"
                                     ),

--- a/src/triangulation/flips.rs
+++ b/src/triangulation/flips.rs
@@ -3,8 +3,8 @@
 //! This module exposes **high-level** flip methods for explicit triangulation editing.
 //! These operations do **not** automatically restore the Delaunay property.
 //! For Delaunay construction/removal, use
-//! [`crate::core::delaunay_triangulation::DelaunayTriangulation::insert`] and
-//! [`crate::core::delaunay_triangulation::DelaunayTriangulation::remove_vertex`].
+//! [`crate::triangulation::delaunay::DelaunayTriangulation::insert`] and
+//! [`crate::triangulation::delaunay::DelaunayTriangulation::remove_vertex`].
 
 #![forbid(unsafe_code)]
 
@@ -13,18 +13,18 @@ pub use crate::core::algorithms::flips::{
 };
 pub use crate::core::edge::EdgeKey;
 pub use crate::core::facet::FacetHandle;
-pub use crate::core::triangulation_data_structure::{CellKey, VertexKey};
+pub use crate::core::tds::{CellKey, VertexKey};
 
 use crate::core::algorithms::flips::{
     apply_bistellar_flip_dynamic, apply_bistellar_flip_k1, apply_bistellar_flip_k1_inverse,
     apply_bistellar_flip_k2, apply_bistellar_flip_k3, build_k2_flip_context,
     build_k2_flip_context_from_edge, build_k3_flip_context, build_k3_flip_context_from_triangle,
 };
-use crate::core::delaunay_triangulation::DelaunayTriangulation;
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
+use crate::triangulation::delaunay::DelaunayTriangulation;
 /// High-level triangulation editing operations via bistellar flips.
 ///
 /// # Example

--- a/tests/COVERAGE.md
+++ b/tests/COVERAGE.md
@@ -85,7 +85,7 @@ Generated on 2026-03-24 using `cargo tarpaulin --lib` (v0.7.3, lib unit tests on
 - **Data structures** (`cell`, `vertex`, `facet`, `edge`, `boundary`): 91–100%
 - **TDS** (`tds`): 81%
 - **Triangulation layer** (`triangulation`): 70%
-- **Delaunay layer** (`delaunay_triangulation`): 67%
+- **Delaunay layer** (`triangulation::delaunay`): 67%
 - **Algorithms** (`flips`, `incremental_insertion`, `locate`): 54–66%
 - **Builder**: 56%
 - **Utilities** (`canonical_points`, `facet_keys`, `hashing`, `uuid`): 95–100%

--- a/tests/COVERAGE.md
+++ b/tests/COVERAGE.md
@@ -41,7 +41,7 @@ Generated on 2026-03-24 using `cargo tarpaulin --lib` (v0.7.3, lib unit tests on
 | `src/core/collections/spatial_hash_grid.rs` | 85.29% | 58/68 | 68 |
 | `src/topology/characteristics/validation.rs` | 84.62% | 22/26 | 26 |
 | `src/geometry/util/point_generation.rs` | 83.33% | 145/174 | 174 |
-| `src/core/triangulation_data_structure.rs` | 81.34% | 1,077/1,324 | 1,324 |
+| `src/core/tds.rs` | 81.34% | 1,077/1,324 | 1,324 |
 | `src/geometry/algorithms/convex_hull.rs` | 80.29% | 224/279 | 279 |
 | `src/geometry/util/circumsphere.rs` | 79.69% | 51/64 | 64 |
 | `src/core/operations.rs` | 76.32% | 29/38 | 38 |
@@ -54,7 +54,7 @@ Generated on 2026-03-24 using `cargo tarpaulin --lib` (v0.7.3, lib unit tests on
 
 | File | Coverage | Lines Covered | Total Lines |
 |------|----------|---------------|-------------|
-| `src/core/delaunay_triangulation.rs` | 66.56% | 1,192/1,791 | 1,791 |
+| `src/triangulation/delaunay.rs` | 66.56% | 1,192/1,791 | 1,791 |
 | `src/geometry/robust_predicates.rs` | 66.36% | 73/110 | 110 |
 | `src/core/algorithms/flips.rs` | 66.33% | 1,440/2,171 | 2,171 |
 | `src/geometry/quality.rs` | 65.88% | 56/85 | 85 |
@@ -62,7 +62,7 @@ Generated on 2026-03-24 using `cargo tarpaulin --lib` (v0.7.3, lib unit tests on
 | `src/core/traits/facet_cache.rs` | 62.50% | 35/56 | 56 |
 | `src/geometry/matrix.rs` | 61.54% | 8/13 | 13 |
 | `src/core/algorithms/locate.rs` | 60.43% | 252/417 | 417 |
-| `src/core/builder.rs` | 55.89% | 441/789 | 789 |
+| `src/triangulation/builder.rs` | 55.89% | 441/789 | 789 |
 | `src/geometry/kernel.rs` | 55.45% | 61/110 | 110 |
 | `src/geometry/predicates.rs` | 54.84% | 102/186 | 186 |
 | `src/core/algorithms/incremental_insertion.rs` | 54.19% | 569/1,050 | 1,050 |
@@ -83,7 +83,7 @@ Generated on 2026-03-24 using `cargo tarpaulin --lib` (v0.7.3, lib unit tests on
 ### Core Module: 69.09% (6,960/10,072 lines)
 
 - **Data structures** (`cell`, `vertex`, `facet`, `edge`, `boundary`): 91–100%
-- **TDS** (`triangulation_data_structure`): 81%
+- **TDS** (`tds`): 81%
 - **Triangulation layer** (`triangulation`): 70%
 - **Delaunay layer** (`delaunay_triangulation`): 67%
 - **Algorithms** (`flips`, `incremental_insertion`, `locate`): 54–66%

--- a/tests/dedup_batch_construction.rs
+++ b/tests/dedup_batch_construction.rs
@@ -9,12 +9,12 @@
 //!
 //! Dimension coverage: 2D–5D via `gen_dedup_batch_tests!`.
 
-use delaunay::core::delaunay_triangulation::{
+use delaunay::core::triangulation::TriangulationConstructionError;
+use delaunay::prelude::triangulation::*;
+use delaunay::triangulation::delaunay::{
     ConstructionOptions, DedupPolicy, DelaunayTriangulationConstructionError,
     InsertionOrderStrategy,
 };
-use delaunay::core::triangulation::TriangulationConstructionError;
-use delaunay::prelude::triangulation::*;
 
 // =============================================================================
 // HELPERS

--- a/tests/euler_characteristic.rs
+++ b/tests/euler_characteristic.rs
@@ -219,8 +219,8 @@ fn test_5d_single_simplex() {
 
 #[test]
 fn test_2d_toroidal_explicit_construction_chi_zero() {
-    use delaunay::core::builder::DelaunayTriangulationBuilder;
     use delaunay::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+    use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
 
     // 3×3 periodic grid torus (T²): 9 vertices, 18 triangles.
     // Each quad (i,j) is split into two triangles with periodic wrapping.
@@ -275,8 +275,8 @@ fn test_2d_toroidal_explicit_construction_chi_zero() {
 
 #[test]
 fn test_3d_toroidal_explicit_construction_chi_zero() {
-    use delaunay::core::builder::DelaunayTriangulationBuilder;
     use delaunay::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+    use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
 
     // 3×3×3 periodic Freudenthal triangulation of T³.
     //

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -52,15 +52,15 @@
 
 #![forbid(unsafe_code)]
 
-use delaunay::core::delaunay_triangulation::{
-    ConstructionOptions, ConstructionStatistics, DelaunayRepairHeuristicConfig,
-    DelaunayTriangulationConstructionErrorWithStatistics,
-};
 use delaunay::geometry::kernel::RobustKernel;
 use delaunay::geometry::util::{
     generate_random_points_in_ball_seeded, generate_random_points_seeded,
 };
 use delaunay::prelude::triangulation::*;
+use delaunay::triangulation::delaunay::{
+    ConstructionOptions, ConstructionStatistics, DelaunayRepairHeuristicConfig,
+    DelaunayTriangulationConstructionErrorWithStatistics,
+};
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 use std::num::NonZeroUsize;
 use std::time::{Duration, Instant};

--- a/tests/proptest_orientation.rs
+++ b/tests/proptest_orientation.rs
@@ -10,10 +10,10 @@
 
 #![forbid(unsafe_code)]
 
-use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
-use delaunay::core::triangulation_data_structure::{Tds, TdsError};
+use delaunay::core::tds::{Tds, TdsError};
 use delaunay::prelude::geometry::*;
 use delaunay::prelude::triangulation::*;
+use delaunay::triangulation::delaunay::DelaunayTriangulation;
 use proptest::prelude::*;
 
 /// Strategy for generating finite `f64` coordinates in a reasonable range.

--- a/tests/proptest_tds.rs
+++ b/tests/proptest_tds.rs
@@ -21,7 +21,7 @@
 //!
 //! All tests use `dt.tds().is_valid()` (Level 2 structural validation).
 
-use delaunay::core::triangulation_data_structure::Tds;
+use delaunay::core::tds::Tds;
 use delaunay::core::util::jaccard::jaccard_index;
 use delaunay::prelude::query::*;
 use proptest::prelude::*;

--- a/tests/tds_orientation.rs
+++ b/tests/tds_orientation.rs
@@ -2,8 +2,8 @@
 
 #![forbid(unsafe_code)]
 
-use delaunay::core::delaunay_triangulation::DelaunayTriangulation;
-use delaunay::core::triangulation_data_structure::{Tds, TdsError};
+use delaunay::core::tds::{Tds, TdsError};
+use delaunay::triangulation::delaunay::DelaunayTriangulation;
 use delaunay::vertex;
 macro_rules! coherent_orientation_test {
     ($name:ident, $dim:literal, $vertices:expr) => {

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -1,16 +1,11 @@
 //! Integration tests for [`DelaunayTriangulationBuilder`].
 //!
 //! These tests exercise the public API from the outside, using only items exposed
-//! through `delaunay::prelude::triangulation` and `delaunay::core::builder`.
+//! through `delaunay::prelude::triangulation` and `delaunay::triangulation::builder`.
 
 use std::collections::HashMap;
 use std::f64::consts::TAU;
 
-use delaunay::core::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
-use delaunay::core::delaunay_triangulation::{
-    ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationConstructionError,
-    InsertionOrderStrategy,
-};
 use delaunay::core::triangulation::TopologyGuarantee;
 use delaunay::core::vertex::{Vertex, VertexBuilder};
 use delaunay::geometry::kernel::RobustKernel;
@@ -18,6 +13,11 @@ use delaunay::geometry::point::Point;
 use delaunay::geometry::traits::coordinate::Coordinate;
 use delaunay::topology::characteristics::euler::{count_simplices, euler_characteristic};
 use delaunay::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+use delaunay::triangulation::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
+use delaunay::triangulation::delaunay::{
+    ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationConstructionError,
+    InsertionOrderStrategy,
+};
 use delaunay::vertex;
 
 // =============================================================================


### PR DESCRIPTION
- Rename src/core/triangulation_data_structure.rs → src/core/tds.rs
- Move src/core/delaunay_triangulation.rs → src/triangulation/delaunay.rs
- Move src/core/builder.rs → src/triangulation/builder.rs
- Widen pub(in crate::core) → pub(crate) for cross-module access
- Preserve public API via re-exports in core {}
- Add GlobalTopology::is_euclidean() for API symmetry with is_toroidal()
- Add doctests for topology_guarantee, global_topology, topology_kind, set_global_topology accessors
- Hoist in-function test imports to module-level per project convention
- Shorten fully-qualified paths (CellValidationError, ConflictError, etc.)
- Bump la-stack 0.3.0 → 0.4.0 (integer-only Bareiss, stack-backed exact arithmetic, custom f64→BigRational via IEEE 754 bit decomposition)
- Update README, code_organization.md, debug_env_vars.md, rust.md, numerical_robustness_guide.md, COVERAGE.md, and other active docs
- Archive docs left unchanged (historical state)

Closes #288
Refs #256, #310