### PR TITLE
refactor!: remove ScalarAccumulative and ScalarSummable traits (#316)

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -43,7 +43,7 @@ env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
   BENCHMARK_TIMEOUT: 7200 # 2 hours is sufficient when compare runs in --dev mode
-  DELAUNAY_BENCH_SEED_SEARCH_LIMIT: 4096 # allows ci_performance_suite to skip pathological deterministic seeds
+  DELAUNAY_BENCH_DISCOVER_SEEDS_LIMIT: 256 # fallback only; ci_performance_suite uses pre-computed seeds
 
 jobs:
   performance-regression:

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -42,13 +42,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  BENCHMARK_TIMEOUT: 7200 # 2 hours is sufficient when compare runs in --dev mode
+  BENCHMARK_TIMEOUT: 1800 # 30 min; pre-computed seeds + reduced 5D counts keep runtime well under this
   DELAUNAY_BENCH_DISCOVER_SEEDS_LIMIT: 256 # fallback only; ci_performance_suite uses pre-computed seeds
 
 jobs:
   performance-regression:
     runs-on: macos-15
-    timeout-minutes: 135 # Allow 90min benchmark timeout + 15min for setup/teardown
+    timeout-minutes: 45 # Allow 30min benchmark timeout + 15min for setup/teardown
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -25,6 +25,12 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Seed search limit for both old (pre-v0.8) and current env var names.
+  # Old tags read DELAUNAY_BENCH_SEED_SEARCH_LIMIT; current code reads
+  # DELAUNAY_BENCH_DISCOVER_SEEDS_LIMIT. Setting both ensures backward
+  # compatibility when generating baselines for older releases.
+  DELAUNAY_BENCH_SEED_SEARCH_LIMIT: 256
+  DELAUNAY_BENCH_DISCOVER_SEEDS_LIMIT: 256
 
 jobs:
   generate-baseline:
@@ -114,9 +120,11 @@ jobs:
           echo "🚀 Generating performance baseline for tag ${TAG_NAME}"
 
           # Generate baseline using fixed tooling (this checkout) against the tag checkout.
+          # Use --dev mode to match the comparison workflow (benchmarks.yml) settings.
           uv run benchmark-utils generate-baseline \
             --project-root bench-target \
-            --tag "${TAG_NAME}"
+            --tag "${TAG_NAME}" \
+            --dev
 
           echo "✅ Baseline generated successfully"
 

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -32,11 +32,85 @@ use delaunay::prelude::{ConstructionOptions, DelaunayTriangulation, RetryPolicy}
 use delaunay::vertex;
 use std::hint::black_box;
 use std::num::NonZeroUsize;
-use tracing::error;
+use tracing::{error, warn};
 
-/// Common sample sizes used across all CI performance benchmarks
+/// Default point counts for 2D–4D benchmarks.
 const COUNTS: &[usize] = &[10, 25, 50];
+/// Reduced point counts for 5D (50-point construction is prohibitively slow).
+const COUNTS_5D: &[usize] = &[10, 25];
 type SeedSearchResult<const D: usize> = Option<(u64, Vec<Point<f64, D>>, Vec<Vertex<f64, (), D>>)>;
+
+/// Pre-computed seeds for each (dimension, count) pair.
+///
+/// These were discovered using `DELAUNAY_BENCH_SEED_SEARCH=1` and eliminate
+/// the expensive runtime seed search from the benchmark hot path.
+///
+/// To refresh seeds (e.g. after algorithm changes that invalidate them), run:
+///
+/// ```bash
+/// DELAUNAY_BENCH_DISCOVER_SEEDS=1 cargo bench --bench ci_performance_suite
+/// ```
+///
+/// (Use a Criterion filter for individual cases, e.g.
+///  `-- "tds_new_5d/tds_new/25"`)
+const KNOWN_SEEDS: &[(usize, usize, u64)] = &[
+    // 2D
+    (2, 10, 52),
+    (2, 25, 67),
+    (2, 50, 92),
+    // 3D
+    (3, 10, 133),
+    (3, 25, 148),
+    (3, 50, 173),
+    // 4D
+    (4, 10, 466),
+    (4, 25, 481),
+    (4, 50, 506),
+    // 5D (50-point case excluded — too slow for CI)
+    (5, 10, 799),
+    (5, 25, 816),
+];
+
+fn known_seed(dim: usize, count: usize) -> Option<u64> {
+    KNOWN_SEEDS
+        .iter()
+        .find(|&&(d, c, _)| d == dim && c == count)
+        .map(|&(_, _, seed)| seed)
+}
+
+/// Prepare benchmark inputs by looking up a pre-computed seed, falling back
+/// to a runtime search only if the known seed is missing or invalid.
+fn prepare_benchmark_data<const D: usize>(
+    dim_seed: u64,
+    count: usize,
+    bounds: (f64, f64),
+    attempts: NonZeroUsize,
+) -> (u64, Vec<Point<f64, D>>, Vec<Vertex<f64, (), D>>) {
+    // Fast path: use the pre-computed seed (single verification construction)
+    if let Some(seed) = known_seed(D, count) {
+        if let Some(result) = find_seed_and_vertices::<D>(seed, count, bounds, 1, attempts) {
+            return result;
+        }
+        warn!(
+            known_seed = seed,
+            dim = D,
+            count,
+            "known seed failed, falling back to runtime search"
+        );
+    }
+
+    // Slow fallback: runtime search from the base seed
+    let base_seed = dim_seed.wrapping_add(count as u64);
+    let search_limit = bench_seed_search_limit();
+    find_seed_and_vertices::<D>(base_seed, count, bounds, search_limit, attempts).unwrap_or_else(
+        || {
+            panic!(
+                "No stable benchmark seed found for {D}D/{count}: \
+                 start_seed={base_seed}; search_limit={search_limit}; bounds={bounds:?}"
+            )
+        },
+    )
+}
 
 fn find_seed_and_vertices<const D: usize>(
     start_seed: u64,
@@ -72,14 +146,14 @@ fn bench_logging_enabled() -> bool {
         .unwrap_or(false)
 }
 
-fn bench_seed_search_enabled() -> bool {
-    std::env::var("DELAUNAY_BENCH_SEED_SEARCH")
+fn bench_discover_seeds_enabled() -> bool {
+    std::env::var("DELAUNAY_BENCH_DISCOVER_SEEDS")
         .map(|value| value != "0")
         .unwrap_or(false)
 }
 
 fn bench_seed_search_limit() -> usize {
-    std::env::var("DELAUNAY_BENCH_SEED_SEARCH_LIMIT")
+    std::env::var("DELAUNAY_BENCH_DISCOVER_SEEDS_LIMIT")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .unwrap_or(2000)
@@ -92,14 +166,10 @@ fn bench_seed_search_limit() -> usize {
 ///
 /// Macro to reduce duplication in dimensional benchmark functions
 macro_rules! benchmark_tds_new_dimension {
-    ($dim:literal, $func_name:ident, $seed:literal) => {
+    ($dim:literal, $func_name:ident, $seed:literal, $counts:expr) => {
         /// Benchmark triangulation creation for D-dimensional triangulations
-        #[expect(
-            clippy::too_many_lines,
-            reason = "Keep benchmark configuration, seed search, and error reporting together"
-        )]
         fn $func_name(c: &mut Criterion) {
-            let counts = COUNTS;
+            let counts = $counts;
 
             // Opt-in helper for discovering stable seeds without paying Criterion warmup/
             // measurement cost per seed.
@@ -116,7 +186,7 @@ macro_rules! benchmark_tds_new_dimension {
             //
             // We avoid `std::process::exit` here so that destructors run and Criterion
             // can clean up state on both success and failure.
-            if bench_seed_search_enabled() {
+            if bench_discover_seeds_enabled() {
                 let bounds = (-100.0, 100.0);
                 let filters: Vec<String> = std::env::args()
                     .skip(1)
@@ -174,33 +244,11 @@ macro_rules! benchmark_tds_new_dimension {
                 group.bench_with_input(BenchmarkId::new("tds_new", count), &count, |b, &count| {
                     // Reduce variance: pre-generate deterministic inputs outside the measured loop,
                     // then benchmark only triangulation construction.
-                    //
-                    // Note: Use per-count seeds so that each benchmark case has its own deterministic
-                    // point set. This avoids a single pathological input (e.g. 3D/50) aborting the
-                    // entire suite.
                     let bounds = (-100.0, 100.0);
-                    let base_seed = ($seed as u64).wrapping_add(count as u64);
-                    let search_limit = bench_seed_search_limit();
                     let attempts =
                         NonZeroUsize::new(6).expect("retry attempts must be non-zero");
-                    let selected = find_seed_and_vertices::<$dim>(
-                        base_seed,
-                        count,
-                        bounds,
-                        search_limit,
-                        attempts,
-                    );
-
-                    let (seed, points, vertices) = selected.unwrap_or_else(|| {
-                        panic!(
-                            "No stable benchmark seed found for {}D case: dim={}; count={}; start_seed={}; search_limit={}; bounds={bounds:?}",
-                            $dim,
-                            $dim,
-                            count,
-                            base_seed,
-                            search_limit
-                        )
-                    });
+                    let (seed, points, vertices) =
+                        prepare_benchmark_data::<$dim>($seed, count, bounds, attempts);
                     let sample_points = points.iter().take(5).collect::<Vec<_>>();
 
                     // In benchmarks we compile in release mode, where the default retry policy is
@@ -253,10 +301,10 @@ macro_rules! benchmark_tds_new_dimension {
 }
 
 // Generate benchmark functions using the macro
-benchmark_tds_new_dimension!(2, benchmark_tds_new_2d, 42);
-benchmark_tds_new_dimension!(3, benchmark_tds_new_3d, 123);
-benchmark_tds_new_dimension!(4, benchmark_tds_new_4d, 456);
-benchmark_tds_new_dimension!(5, benchmark_tds_new_5d, 789);
+benchmark_tds_new_dimension!(2, benchmark_tds_new_2d, 42, COUNTS);
+benchmark_tds_new_dimension!(3, benchmark_tds_new_3d, 123, COUNTS);
+benchmark_tds_new_dimension!(4, benchmark_tds_new_4d, 456, COUNTS);
+benchmark_tds_new_dimension!(5, benchmark_tds_new_5d, 789, COUNTS_5D);
 
 criterion_group!(
     name = benches;

--- a/benches/ci_performance_suite.rs
+++ b/benches/ci_performance_suite.rs
@@ -42,7 +42,7 @@ type SeedSearchResult<const D: usize> = Option<(u64, Vec<Point<f64, D>>, Vec<Ver
 
 /// Pre-computed seeds for each (dimension, count) pair.
 ///
-/// These were discovered using `DELAUNAY_BENCH_SEED_SEARCH=1` and eliminate
+/// These were discovered using `DELAUNAY_BENCH_DISCOVER_SEEDS=1` and eliminate
 /// the expensive runtime seed search from the benchmark hot path.
 ///
 /// To refresh seeds (e.g. after algorithm changes that invalidate them), run:

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -126,6 +126,17 @@ These variables configure property tests in `tests/proptest_*.rs`.
 | `DELAUNAY_PROPTEST_MIN_ACCEPTANCE_PCT_{D}D` | **value** | Per-dimension acceptance override |
 | `DELAUNAY_ALLOW_SLOW_COSPHERICAL_FILTER` | presence | Allow slow cospherical point filtering |
 
+## Benchmarks
+
+These variables configure `benches/ci_performance_suite.rs` and run in
+release builds only.
+
+| Variable | Activation | Description |
+|---|---|---|
+| `DELAUNAY_BENCH_LOG` | presence | Enable error logging inside Criterion measurement loops |
+| `DELAUNAY_BENCH_DISCOVER_SEEDS` | presence | Seed-discovery mode: find and print stable seeds instead of running benchmarks |
+| `DELAUNAY_BENCH_DISCOVER_SEEDS_LIMIT` | **value** (integer) | Maximum seeds to try per (dim, count) pair during discovery or fallback (default: 2000) |
+
 ## Miscellaneous
 
 | Variable | Activation | Module | Description |

--- a/examples/topology_editing_2d_3d.rs
+++ b/examples/topology_editing_2d_3d.rs
@@ -22,7 +22,7 @@ use delaunay::core::edge::EdgeKey;
 use delaunay::geometry::Coordinate;
 use delaunay::geometry::kernel::Kernel;
 use delaunay::geometry::point::Point;
-use delaunay::geometry::traits::coordinate::ScalarAccumulative;
+use delaunay::geometry::traits::coordinate::CoordinateScalar;
 use delaunay::geometry::util::{circumcenter, hypot};
 use delaunay::prelude::triangulation::flips::*;
 use delaunay::prelude::triangulation::*;
@@ -490,7 +490,7 @@ fn edit_api_3d_k3() {
 
 fn print_stats_2d<K: Kernel<2>>(dt: &DelaunayTriangulation<K, (), (), 2>)
 where
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
 {
     println!(
         "  Vertices: {}, Triangles: {}",
@@ -501,7 +501,7 @@ where
 
 fn print_stats_3d<K: Kernel<3>>(dt: &DelaunayTriangulation<K, (), (), 3>)
 where
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
 {
     println!(
         "  Vertices: {}, Tetrahedra: {}",
@@ -514,7 +514,7 @@ fn find_interior_facet_2d<K: Kernel<2>>(
     dt: &DelaunayTriangulation<K, (), (), 2>,
 ) -> Option<FacetHandle>
 where
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
 {
     for (cell_key, cell) in dt.cells() {
         if let Some(neighbors) = cell.neighbors() {
@@ -533,7 +533,7 @@ fn find_interior_facet_3d<K: Kernel<3>>(
     dt: &DelaunayTriangulation<K, (), (), 3>,
 ) -> Option<FacetHandle>
 where
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
 {
     for (cell_key, cell) in dt.cells() {
         if let Some(neighbors) = cell.neighbors() {
@@ -552,7 +552,7 @@ fn find_flippable_ridge_3d<K: Kernel<3>>(
     dt: &DelaunayTriangulation<K, (), (), 3>,
 ) -> Option<RidgeHandle>
 where
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
 {
     // Try to find any ridge (edge in 3D shared by multiple tetrahedra)
     for (cell_key, cell) in dt.cells() {

--- a/examples/triangulation_3d_100_points.rs
+++ b/examples/triangulation_3d_100_points.rs
@@ -25,7 +25,7 @@
 //! - Boundary analysis
 //! - Performance metrics
 
-use delaunay::geometry::traits::coordinate::ScalarAccumulative;
+use delaunay::geometry::traits::coordinate::CoordinateScalar;
 use delaunay::geometry::util::generate_random_triangulation;
 use delaunay::prelude::query::*;
 use delaunay::topology::characteristics::validation as topology_validation;
@@ -128,7 +128,7 @@ fn main() {
 fn analyze_triangulation<K, U, V, const D: usize>(dt: &DelaunayTriangulation<K, U, V, D>)
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {
@@ -207,7 +207,7 @@ where
 fn validate_triangulation<K, U, V, const D: usize>(dt: &DelaunayTriangulation<K, U, V, D>)
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {
@@ -299,7 +299,7 @@ where
 fn analyze_boundary_properties<K, U, V, const D: usize>(dt: &DelaunayTriangulation<K, U, V, D>)
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {
@@ -351,7 +351,7 @@ where
 fn performance_analysis<K, U, V, const D: usize>(dt: &DelaunayTriangulation<K, U, V, D>)
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {

--- a/src/core/algorithms/pl_manifold_repair.rs
+++ b/src/core/algorithms/pl_manifold_repair.rs
@@ -87,13 +87,8 @@ impl Default for PlManifoldRepairConfig {
 /// assert!(stats.removed_vertices.is_empty());
 /// assert!(!stats.succeeded);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PlManifoldRepairStats<T, U, V, const D: usize>
-where
-    T: CoordinateScalar,
-    U: DataType,
-    V: DataType,
-{
+#[derive(Debug, Clone)]
+pub struct PlManifoldRepairStats<T, U, V, const D: usize> {
     /// Number of repair iterations executed.
     pub iterations: usize,
     /// Total number of cells removed.
@@ -106,6 +101,29 @@ where
     pub removed_vertices: Vec<Vertex<T, U, D>>,
     /// Whether the facet-degree invariant was satisfied at termination.
     pub succeeded: bool,
+}
+
+impl<T, U, V, const D: usize> PartialEq for PlManifoldRepairStats<T, U, V, D>
+where
+    T: CoordinateScalar,
+    U: DataType,
+    V: DataType,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.iterations == other.iterations
+            && self.cells_removed == other.cells_removed
+            && self.removed_cells == other.removed_cells
+            && self.removed_vertices == other.removed_vertices
+            && self.succeeded == other.succeeded
+    }
+}
+
+impl<T, U, V, const D: usize> Eq for PlManifoldRepairStats<T, U, V, D>
+where
+    T: CoordinateScalar,
+    U: DataType,
+    V: DataType,
+{
 }
 
 impl<T, U, V, const D: usize> Default for PlManifoldRepairStats<T, U, V, D>

--- a/src/core/cell.rs
+++ b/src/core/cell.rs
@@ -199,11 +199,7 @@ impl From<crate::geometry::matrix::StackMatrixDispatchError> for CellValidationE
 ///     assert!(vertex.uuid() != Uuid::nil());
 /// }
 /// ```
-pub struct Cell<T, U, V, const D: usize>
-where
-    U: DataType,
-    V: DataType,
-{
+pub struct Cell<T, U, V, const D: usize> {
     /// Keys to the vertices forming this cell.
     /// Phase 3A: Changed from `Vec<Vertex>` to `CellVertexBuffer` for:
     /// - Zero heap allocation for D ≤ 7 (stack-allocated)

--- a/src/core/collections/spatial_hash_grid.rs
+++ b/src/core/collections/spatial_hash_grid.rs
@@ -68,10 +68,7 @@ where
 /// The grid uses a fixed `cell_size` and indexes vertices by the floored cell
 /// coordinates `floor(coord / cell_size)`.
 #[derive(Clone, Debug)]
-pub struct HashGridIndex<T, const D: usize, K = VertexKey>
-where
-    T: CoordinateScalar,
-{
+pub struct HashGridIndex<T: CoordinateScalar, const D: usize, K = VertexKey> {
     cell_size: T,
     usable: bool,
     cells: FastHashMap<GridKey<T, D>, SmallBuffer<K, BUCKET_INLINE_CAPACITY>>,

--- a/src/core/collections/spatial_hash_grid.rs
+++ b/src/core/collections/spatial_hash_grid.rs
@@ -34,9 +34,7 @@ const BUCKET_INLINE_CAPACITY: usize = 8;
 /// type used for points. We avoid casting to an integer type to keep the index
 /// generic over coordinate scalar types.
 #[derive(Clone, Copy, Debug)]
-struct GridKey<T, const D: usize>([T; D])
-where
-    T: CoordinateScalar;
+struct GridKey<T, const D: usize>([T; D]);
 
 impl<T, const D: usize> PartialEq for GridKey<T, D>
 where
@@ -68,7 +66,7 @@ where
 /// The grid uses a fixed `cell_size` and indexes vertices by the floored cell
 /// coordinates `floor(coord / cell_size)`.
 #[derive(Clone, Debug)]
-pub struct HashGridIndex<T: CoordinateScalar, const D: usize, K = VertexKey> {
+pub struct HashGridIndex<T, const D: usize, K = VertexKey> {
     cell_size: T,
     usable: bool,
     cells: FastHashMap<GridKey<T, D>, SmallBuffer<K, BUCKET_INLINE_CAPACITY>>,
@@ -91,10 +89,7 @@ where
     pub const fn is_usable(&self) -> bool {
         self.usable
     }
-    pub const fn cell_size(&self) -> T
-    where
-        T: Copy,
-    {
+    pub const fn cell_size(&self) -> T {
         self.cell_size
     }
 

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -374,12 +374,7 @@ impl FacetHandle {
 ///     Ok(())
 /// }
 /// ```
-pub struct FacetView<'tds, T, U, V, const D: usize>
-where
-    T: CoordinateScalar,
-    U: DataType,
-    V: DataType,
-{
+pub struct FacetView<'tds, T, U, V, const D: usize> {
     /// Reference to the triangulation data structure.
     tds: &'tds Tds<T, U, V, D>,
     /// Key of the cell containing this facet.
@@ -819,12 +814,7 @@ where
 /// assert_eq!(count, 4);
 /// ```
 #[derive(Clone)]
-pub struct AllFacetsIter<'tds, T, U, V, const D: usize>
-where
-    T: CoordinateScalar,
-    U: DataType,
-    V: DataType,
-{
+pub struct AllFacetsIter<'tds, T, U, V, const D: usize> {
     tds: &'tds Tds<T, U, V, D>,
     cell_keys: std::vec::IntoIter<CellKey>,
     current_cell_key: Option<CellKey>,
@@ -953,12 +943,7 @@ where
 /// assert_eq!(count, 4);
 /// ```
 #[derive(Clone)]
-pub struct BoundaryFacetsIter<'tds, T, U, V, const D: usize>
-where
-    T: CoordinateScalar,
-    U: DataType,
-    V: DataType,
-{
+pub struct BoundaryFacetsIter<'tds, T, U, V, const D: usize> {
     all_facets: AllFacetsIter<'tds, T, U, V, D>,
     facet_to_cells_map: crate::core::collections::FacetToCellsMap,
 }

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -895,11 +895,7 @@ new_key_type! {
 /// assert_eq!(dt.number_of_cells(), 1);
 /// assert_eq!(dt.number_of_vertices(), 3);
 /// ```
-pub struct Tds<T, U, V, const D: usize>
-where
-    U: DataType,
-    V: DataType,
-{
+pub struct Tds<T, U, V, const D: usize> {
     /// Storage map for vertices, allowing stable keys and efficient access.
     vertices: StorageMap<VertexKey, Vertex<T, U, D>>,
 

--- a/src/core/traits/facet_cache.rs
+++ b/src/core/traits/facet_cache.rs
@@ -9,7 +9,7 @@ use crate::core::{
     collections::FacetToCellsMap,
     tds::{Tds, TdsError},
 };
-use crate::geometry::traits::coordinate::ScalarAccumulative;
+use crate::geometry::traits::coordinate::CoordinateScalar;
 use arc_swap::ArcSwapOption;
 use std::sync::{
     Arc,
@@ -35,7 +35,7 @@ use std::sync::{
 /// ```
 /// use delaunay::core::traits::facet_cache::FacetCacheProvider;
 /// use delaunay::core::tds::Tds;
-/// use delaunay::geometry::traits::coordinate::ScalarAccumulative;
+/// use delaunay::geometry::traits::coordinate::CoordinateScalar;
 /// use delaunay::core::traits::data_type::DataType;
 /// use std::sync::Arc;
 /// use std::sync::atomic::{AtomicU64, Ordering};
@@ -58,7 +58,7 @@ use std::sync::{
 ///
 /// impl<T, U, V, const D: usize> FacetCacheProvider<T, U, V, D> for MyAlgorithm
 /// where
-///     T: ScalarAccumulative,
+///     T: CoordinateScalar,
 ///     U: DataType,
 ///     V: DataType,
 /// {
@@ -73,7 +73,7 @@ use std::sync::{
 /// ```
 pub trait FacetCacheProvider<T, U, V, const D: usize>
 where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -142,7 +142,7 @@ use crate::geometry::point::Point;
 use crate::geometry::predicates::Orientation;
 use crate::geometry::quality::radius_ratio;
 use crate::geometry::robust_predicates::robust_orientation;
-use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar, ScalarAccumulative};
+use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
 use crate::geometry::util::safe_scalar_to_f64;
 use crate::topology::characteristics::euler::{TopologyClassification, expected_chi_for};
 use crate::topology::characteristics::validation::validate_triangulation_euler_with_facet_to_cells_map;
@@ -744,12 +744,7 @@ impl TopologyGuarantee {
 /// assert_eq!(tri.number_of_vertices(), 0);
 /// ```
 #[derive(Clone, Debug)]
-pub struct Triangulation<K, U, V, const D: usize>
-where
-    K: Kernel<D>,
-    U: DataType,
-    V: DataType,
-{
+pub struct Triangulation<K: Kernel<D>, U, V, const D: usize> {
     /// The geometric kernel for predicates.
     pub(crate) kernel: K,
     /// The combinatorial triangulation data structure.
@@ -2913,7 +2908,7 @@ where
 impl<K, U, V, const D: usize> Triangulation<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {

--- a/src/core/util/delaunay_validation.rs
+++ b/src/core/util/delaunay_validation.rs
@@ -9,7 +9,7 @@ use crate::core::traits::data_type::DataType;
 use crate::geometry::point::Point;
 use crate::geometry::predicates::InSphere;
 use crate::geometry::robust_predicates::robust_insphere;
-use crate::geometry::traits::coordinate::{CoordinateConversionError, ScalarAccumulative};
+use crate::geometry::traits::coordinate::{CoordinateConversionError, CoordinateScalar};
 use smallvec::SmallVec;
 use thiserror::Error;
 
@@ -80,7 +80,7 @@ fn validate_cell_delaunay<T, U, V, const D: usize>(
     cell_vertex_points: &mut SmallVec<[Point<T, D>; 8]>,
 ) -> Result<Option<CellKey>, DelaunayValidationError>
 where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -226,7 +226,7 @@ pub(crate) fn is_delaunay_property_only<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
 ) -> Result<(), DelaunayValidationError>
 where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -298,7 +298,7 @@ pub fn find_delaunay_violations<T, U, V, const D: usize>(
     cells_to_check: Option<&[CellKey]>,
 ) -> Result<ViolationBuffer, DelaunayValidationError>
 where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -388,7 +388,7 @@ pub fn debug_print_first_delaunay_violation<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     cells_subset: Option<&[CellKey]>,
 ) where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -7,7 +7,7 @@ use crate::core::tds::Tds;
 use crate::core::traits::data_type::DataType;
 use crate::geometry::algorithms::convex_hull::ConvexHull;
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
+use crate::geometry::traits::coordinate::CoordinateScalar;
 use std::collections::HashSet;
 use thiserror::Error;
 
@@ -341,7 +341,7 @@ pub fn extract_facet_identifier_set<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
 ) -> Result<HashSet<u64>, FacetError>
 where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -411,7 +411,7 @@ pub fn extract_hull_facet_set<K, U, V, const D: usize>(
 ) -> Result<HashSet<u64>, FacetError>
 where
     K: crate::geometry::kernel::Kernel<D>,
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -141,10 +141,7 @@ pub enum VertexBuilderError {
 ///     .build()
 ///     .unwrap();
 /// ```
-pub struct VertexBuilder<T, U, const D: usize>
-where
-    U: DataType,
-{
+pub struct VertexBuilder<T, U, const D: usize> {
     point: Option<Point<T, D>>,
     data: Option<U>,
 }
@@ -299,10 +296,7 @@ pub use crate::vertex;
 ///
 /// let vertex: Vertex<f64, i32, 3> = vertex!([1.0, 2.0, 3.0], 42);
 /// ```
-pub struct Vertex<T, U, const D: usize>
-where
-    U: DataType,
-{
+pub struct Vertex<T, U, const D: usize> {
     /// The coordinates of the vertex as a D-dimensional Point.
     point: Point<T, D>,
     /// A universally unique identifier for the vertex.

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -326,7 +326,7 @@ pub enum ConvexHullConstructionError {
 /// - Seidel, R. "The Upper Bound Theorem for Polytopes: An Easy Proof of Its Asymptotic Version."
 ///   *Computational Geometry* 5, no. 2 (1995): 115-116. DOI: [10.1016/0925-7721(95)00013-Y](https://doi.org/10.1016/0925-7721(95)00013-Y)
 #[derive(Debug)]
-pub struct ConvexHull<K: Kernel<D>, U, V, const D: usize> {
+pub struct ConvexHull<K, U, V, const D: usize> {
     /// The boundary facets that form the convex hull
     /// Stored as `FacetHandle` tuples (`CellKey`, `facet_index`) to enable reconstruction of `FacetView`
     ///

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -44,7 +44,7 @@ use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
 use crate::geometry::predicates::simplex_orientation;
 use crate::geometry::traits::coordinate::{
-    Coordinate, CoordinateConversionError, CoordinateScalar, ScalarAccumulative,
+    Coordinate, CoordinateConversionError, CoordinateScalar,
 };
 use crate::geometry::util::{safe_usize_to_scalar, squared_norm};
 use arc_swap::ArcSwapOption;
@@ -326,12 +326,7 @@ pub enum ConvexHullConstructionError {
 /// - Seidel, R. "The Upper Bound Theorem for Polytopes: An Easy Proof of Its Asymptotic Version."
 ///   *Computational Geometry* 5, no. 2 (1995): 115-116. DOI: [10.1016/0925-7721(95)00013-Y](https://doi.org/10.1016/0925-7721(95)00013-Y)
 #[derive(Debug)]
-pub struct ConvexHull<K, U, V, const D: usize>
-where
-    K: Kernel<D>,
-    U: DataType,
-    V: DataType,
-{
+pub struct ConvexHull<K: Kernel<D>, U, V, const D: usize> {
     /// The boundary facets that form the convex hull
     /// Stored as `FacetHandle` tuples (`CellKey`, `facet_index`) to enable reconstruction of `FacetView`
     ///
@@ -670,7 +665,7 @@ where
 impl<K, U, V, const D: usize> ConvexHull<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + Sub<Output = K::Scalar> + DivAssign + Copy,
+    K::Scalar: CoordinateScalar + Sub<Output = K::Scalar> + DivAssign + Copy,
     U: DataType,
     V: DataType,
 {
@@ -1560,7 +1555,7 @@ where
 impl<K, U, V, const D: usize> FacetCacheProvider<K::Scalar, U, V, D> for ConvexHull<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -42,7 +42,7 @@ use crate::core::{
 use crate::geometry::{
     kernel::Kernel,
     point::Point,
-    traits::coordinate::{CoordinateScalar, ScalarAccumulative},
+    traits::coordinate::CoordinateScalar,
     util::{circumradius, hypot, inradius as simplex_inradius, simplex_volume},
 };
 use num_traits::{NumCast, One};
@@ -93,7 +93,7 @@ fn cell_points<K, U, V, const D: usize>(
 ) -> Result<SmallBuffer<Point<K::Scalar, D>, MAX_PRACTICAL_DIMENSION_SIZE>, QualityError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -236,7 +236,7 @@ pub fn radius_ratio<K, U, V, const D: usize>(
 ) -> Result<K::Scalar, QualityError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + Div<Output = K::Scalar>,
+    K::Scalar: CoordinateScalar + Div<Output = K::Scalar>,
     U: DataType,
     V: DataType,
 {
@@ -332,7 +332,7 @@ pub fn normalized_volume<K, U, V, const D: usize>(
 ) -> Result<K::Scalar, QualityError>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + Div<Output = K::Scalar>,
+    K::Scalar: CoordinateScalar + Div<Output = K::Scalar>,
     U: DataType,
     V: DataType,
 {

--- a/src/geometry/traits/coordinate.rs
+++ b/src/geometry/traits/coordinate.rs
@@ -548,6 +548,9 @@ pub trait CoordinateScalar:
     + Debug
     + Serialize
     + DeserializeOwned
+    + AddAssign
+    + SubAssign
+    + Sum
 {
     /// Returns the appropriate default tolerance for this coordinate scalar type.
     ///
@@ -615,21 +618,6 @@ pub trait CoordinateScalar:
     /// ```
     fn mantissa_digits() -> u32;
 }
-
-/// Trait for coordinate scalars that support summation operations.
-///
-/// This supertrait is a semantic alias for the common bound `CoordinateScalar + Sum`.
-pub trait ScalarSummable: CoordinateScalar + Sum {}
-
-/// Trait for coordinate scalars that support in-place accumulation.
-///
-/// This supertrait is a semantic alias for the common bound
-/// `CoordinateScalar + AddAssign + SubAssign + Sum`.
-pub trait ScalarAccumulative: CoordinateScalar + AddAssign + SubAssign + Sum {}
-
-// Blanket implementations so any suitable scalar automatically implements these supertraits.
-impl<T> ScalarSummable for T where T: CoordinateScalar + Sum {}
-impl<T> ScalarAccumulative for T where T: CoordinateScalar + AddAssign + SubAssign + Sum {}
 
 // Specific implementations for f32 and f64
 impl CoordinateScalar for f32 {

--- a/src/geometry/traits/coordinate.rs
+++ b/src/geometry/traits/coordinate.rs
@@ -512,21 +512,24 @@ impl_hash_coordinate!(float: f32, f64);
 /// Consolidated trait for the scalar type requirements in coordinate systems.
 ///
 /// This trait captures all the trait bounds required for a scalar type `T` to be used
-/// in coordinate systems. It consolidates the requirements from line 116 of the
-/// `Coordinate` trait definition to reduce code duplication.
+/// in coordinate systems. It consolidates the requirements from the `Coordinate` trait
+/// definition to reduce code duplication.
 ///
 /// # Required Traits
 ///
-/// - `Float`: Floating-point arithmetic operations
+/// - `Float`: Floating-point arithmetic operations (includes `Copy`, `PartialOrd`, etc.)
 /// - `Zero`: Zero value construction
 /// - `OrderedEq`: NaN-aware equality comparison
+/// - `OrderedCmp`: NaN-aware ordering comparison
 /// - `HashCoordinate`: Consistent hashing of floating-point values
 /// - `FiniteCheck`: Validation of coordinate values
 /// - `Default`: Default value construction
-/// - `Copy`: Copy semantics for efficient operations
 /// - `Debug`: Debug formatting
 /// - `Serialize`: Serialization support
 /// - `DeserializeOwned`: Deserialization support
+/// - `AddAssign`: In-place addition (`+=`) for accumulation loops
+/// - `SubAssign`: In-place subtraction (`-=`) for accumulation loops
+/// - `Sum`: Iterator summation via `iter.sum()`
 ///
 /// # Usage
 ///
@@ -534,7 +537,8 @@ impl_hash_coordinate!(float: f32, f64);
 /// use delaunay::geometry::traits::coordinate::CoordinateScalar;
 ///
 /// fn process_coordinate<T: CoordinateScalar>(value: T) {
-///     // T has all the necessary bounds for coordinate operations
+///     // T has all the necessary bounds for coordinate operations,
+///     // including accumulation via AddAssign, SubAssign, and Sum.
 /// }
 /// ```
 pub trait CoordinateScalar:

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -11,7 +11,7 @@ use crate::core::facet::FacetView;
 use crate::core::traits::data_type::DataType;
 use crate::geometry::matrix::{Matrix, matrix_get, matrix_set};
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar, ScalarAccumulative};
+use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
 use la_stack::{DEFAULT_SINGULAR_TOL, LaError};
 use num_traits::Float;
 use std::ops::AddAssign;
@@ -724,7 +724,7 @@ pub fn surface_measure<T, U, V, const D: usize>(
     facets: &[FacetView<'_, T, U, V, D>],
 ) -> Result<T, SurfaceMeasureError>
 where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -11,7 +11,7 @@ use crate::core::triangulation::{TopologyGuarantee, TriangulationConstructionErr
 use crate::core::vertex::{Vertex, VertexBuilder};
 use crate::geometry::kernel::AdaptiveKernel;
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
+use crate::geometry::traits::coordinate::CoordinateScalar;
 use crate::triangulation::delaunay::{
     ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationConstructionError,
     InsertionOrderStrategy, RetryPolicy,
@@ -30,7 +30,7 @@ fn validate_random_triangulation<K, U, V, const D: usize>(
 ) -> Result<DelaunayTriangulation<K, U, V, D>, DelaunayTriangulationConstructionError>
 where
     K: crate::geometry::kernel::Kernel<D>,
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -48,7 +48,7 @@ fn random_triangulation_is_acceptable<K, U, V, const D: usize>(
 ) -> bool
 where
     K: crate::geometry::kernel::Kernel<D>,
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -63,7 +63,7 @@ fn random_triangulation_try_build<K, T, U, V, const D: usize>(
 ) -> Option<DelaunayTriangulation<K, U, V, D>>
 where
     K: crate::geometry::kernel::Kernel<D, Scalar = T>,
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -119,7 +119,7 @@ where
 ///
 /// All code paths that build a non-empty triangulation should use this factory
 /// so they share the same kernel type.
-const fn make_adaptive_kernel<T: ScalarAccumulative>() -> AdaptiveKernel<T> {
+const fn make_adaptive_kernel<T: CoordinateScalar>() -> AdaptiveKernel<T> {
     AdaptiveKernel::new()
 }
 
@@ -130,7 +130,7 @@ fn random_triangulation_try_with_vertices<T, U, V, const D: usize>(
     topology_guarantee: TopologyGuarantee,
 ) -> Option<DelaunayTriangulation<AdaptiveKernel<T>, U, V, D>>
 where
-    T: ScalarAccumulative,
+    T: CoordinateScalar,
     U: DataType,
     V: DataType,
 {
@@ -177,7 +177,7 @@ where
 ///
 /// # Type Parameters
 ///
-/// * `T` - Coordinate scalar type (must implement `ScalarAccumulative + SampleUniform`)
+/// * `T` - Coordinate scalar type (must implement `CoordinateScalar + SampleUniform`)
 /// * `U` - Vertex data type (must implement `DataType`)
 /// * `V` - Cell data type (must implement `DataType`)
 /// * `D` - Dimensionality (const generic parameter)
@@ -300,7 +300,7 @@ pub fn generate_random_triangulation<T, U, V, const D: usize>(
     seed: Option<u64>,
 ) -> Result<DelaunayTriangulation<AdaptiveKernel<T>, U, V, D>, DelaunayTriangulationConstructionError>
 where
-    T: ScalarAccumulative + SampleUniform,
+    T: CoordinateScalar + SampleUniform,
     U: DataType,
     V: DataType,
 {
@@ -363,7 +363,7 @@ pub fn generate_random_triangulation_with_topology_guarantee<T, U, V, const D: u
     topology_guarantee: TopologyGuarantee,
 ) -> Result<DelaunayTriangulation<AdaptiveKernel<T>, U, V, D>, DelaunayTriangulationConstructionError>
 where
-    T: ScalarAccumulative + SampleUniform,
+    T: CoordinateScalar + SampleUniform,
     U: DataType,
     V: DataType,
 {
@@ -503,7 +503,7 @@ pub struct RandomTriangulationBuilder<T> {
 
 impl<T> RandomTriangulationBuilder<T>
 where
-    T: ScalarAccumulative + SampleUniform,
+    T: CoordinateScalar + SampleUniform,
 {
     /// Creates a new builder with the specified number of points and coordinate bounds.
     ///

--- a/src/topology/traits/global_topology_model.rs
+++ b/src/topology/traits/global_topology_model.rs
@@ -318,7 +318,7 @@ impl<const D: usize> GlobalTopologyModel<D> for ToroidalModel<D> {
                     value: offset_value,
                 },
             )?;
-            coords[axis] = coords[axis] + offset_scalar * period_scalar;
+            coords[axis] += offset_scalar * period_scalar;
         }
         Ok(coords)
     }

--- a/src/topology/traits/topological_space.rs
+++ b/src/topology/traits/topological_space.rs
@@ -369,10 +369,6 @@ pub trait TopologicalSpace {
     /// space.canonicalize_point(&mut point);
     /// assert_eq!(point, [0.5, 0.7]); // Wrapped into [0, 1)
     /// ```
-    ///
-    /// TODO: When implementing full topology support, consider making this generic:
-    /// `fn canonicalize_point<T: CoordinateScalar>(&self, coords: &mut [T])`
-    /// to match the triangulation's scalar type instead of hardcoding `f64`.
     fn canonicalize_point(&self, coords: &mut [f64]);
 
     /// Returns the fundamental domain for periodic topologies.
@@ -426,10 +422,6 @@ pub trait TopologicalSpace {
     /// let euclidean = DummySpace { domain: None };
     /// assert_eq!(euclidean.fundamental_domain(), None);
     /// ```
-    ///
-    /// TODO: When implementing full topology support, consider making this generic:
-    /// `fn fundamental_domain<T: CoordinateScalar>(&self) -> Option<&[T]>`
-    /// to match the triangulation's scalar type instead of hardcoding `f64`.
     fn fundamental_domain(&self) -> Option<&[f64]>;
 }
 

--- a/src/triangulation/builder.rs
+++ b/src/triangulation/builder.rs
@@ -113,7 +113,7 @@ use crate::core::util::periodic_facet_key_from_lifted_vertices;
 use crate::core::vertex::{Vertex, VertexBuilder};
 use crate::geometry::kernel::{AdaptiveKernel, Kernel};
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar, ScalarAccumulative};
+use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
 use crate::topology::spaces::toroidal::ToroidalSpace;
 use crate::topology::traits::global_topology_model::{
     GlobalTopologyModel, GlobalTopologyModelError,
@@ -418,11 +418,7 @@ pub enum ExplicitConstructionError {
 ///
 /// assert_eq!(dt.number_of_vertices(), 4);
 /// ```
-pub struct DelaunayTriangulationBuilder<'v, T, U, const D: usize>
-where
-    T: CoordinateScalar,
-    U: DataType,
-{
+pub struct DelaunayTriangulationBuilder<'v, T, U, const D: usize> {
     vertices: &'v [Vertex<T, U, D>],
     /// Optional toroidal (periodic) topology for the construction.
     ///
@@ -1020,7 +1016,7 @@ where
         DelaunayTriangulationConstructionError,
     >
     where
-        T: ScalarAccumulative,
+        T: CoordinateScalar,
         V: DataType,
     {
         self.build_with_kernel(&AdaptiveKernel::new())
@@ -1071,7 +1067,7 @@ where
     ) -> Result<DelaunayTriangulation<K, U, V, D>, DelaunayTriangulationConstructionError>
     where
         K: Kernel<D, Scalar = T>,
-        K::Scalar: ScalarAccumulative,
+        K::Scalar: CoordinateScalar,
         V: DataType,
     {
         // Explicit-cells path: bypass Delaunay insertion entirely.
@@ -1384,7 +1380,7 @@ where
     ) -> Result<DelaunayTriangulation<K, U, V, D>, DelaunayTriangulationConstructionError>
     where
         K: Kernel<D, Scalar = T>,
-        K::Scalar: ScalarAccumulative,
+        K::Scalar: CoordinateScalar,
         V: DataType,
         M: GlobalTopologyModel<D>,
     {

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -35,7 +35,7 @@ use crate::core::util::{
 };
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::{AdaptiveKernel, ExactPredicates, Kernel, RobustKernel};
-use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
+use crate::geometry::traits::coordinate::CoordinateScalar;
 use crate::topology::manifold::validate_ridge_links_for_cells;
 use crate::topology::traits::topological_space::{GlobalTopology, TopologyKind};
 use crate::triangulation::builder::DelaunayTriangulationBuilder;
@@ -619,11 +619,7 @@ impl ConstructionStatistics {
 // =============================================================================
 
 type VertexBuffer<T, U, const D: usize> = Vec<Vertex<T, U, D>>;
-struct PreprocessVertices<T, U, const D: usize>
-where
-    T: CoordinateScalar,
-    U: DataType,
-{
+struct PreprocessVertices<T, U, const D: usize> {
     primary: Option<VertexBuffer<T, U, D>>,
     fallback: Option<VertexBuffer<T, U, D>>,
     grid_cell_size: Option<T>,
@@ -642,10 +638,7 @@ where
         self.fallback.as_deref()
     }
 
-    const fn grid_cell_size(&self) -> Option<T>
-    where
-        T: Copy,
-    {
+    const fn grid_cell_size(&self) -> Option<T> {
         self.grid_cell_size
     }
 }
@@ -958,7 +951,7 @@ where
             let mut dist_sq = T::zero();
             for i in 0..D {
                 let diff = coords[i] - existing_coords[i];
-                dist_sq = dist_sq + diff * diff;
+                dist_sq += diff * diff;
             }
             if dist_sq < epsilon_sq {
                 duplicate = true;
@@ -1301,12 +1294,7 @@ where
 /// assert_eq!(dt.number_of_cells(), 1);
 /// ```
 #[derive(Clone, Debug)]
-pub struct DelaunayTriangulation<K, U, V, const D: usize>
-where
-    K: Kernel<D>,
-    U: DataType,
-    V: DataType,
-{
+pub struct DelaunayTriangulation<K: Kernel<D>, U, V, const D: usize> {
     /// The underlying generic triangulation.
     pub(crate) tri: Triangulation<K, U, V, D>,
     /// Ephemeral insertion/repair state (hint caching + repair scheduling).
@@ -1644,12 +1632,12 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
 // =============================================================================
 //
 // Batch and incremental constructors, preprocessing, Hilbert ordering, spatial
-// hashing, and deduplication — all require `ScalarAccumulative + NumCast`.
+// hashing, and deduplication — all require `CoordinateScalar + NumCast`.
 
 impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {
@@ -3435,7 +3423,7 @@ where
 //
 // Methods that only need `K: Kernel<D>` — no scalar arithmetic.  Downstream
 // generic code (e.g. `delaunayize_by_flips`) does not need to carry
-// `ScalarAccumulative + NumCast` bounds when calling these methods.
+// `CoordinateScalar + NumCast` bounds when calling these methods.
 //
 // Follows the precedent of the existing PURE STRUCT ASSEMBLY impl block.
 
@@ -4027,12 +4015,12 @@ where
 // =============================================================================
 //
 // `repair_delaunay_with_flips_advanced` can fall back to `rebuild_with_heuristic`,
-// which constructs a new triangulation and therefore requires `ScalarAccumulative`.
+// which constructs a new triangulation and therefore requires `CoordinateScalar`.
 
 impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {
@@ -4785,13 +4773,13 @@ where
 // =============================================================================
 //
 // Incremental insertion, removal, and post-insertion repair/check helpers.
-// These require `ScalarAccumulative + NumCast` for spatial-index construction,
+// These require `CoordinateScalar + NumCast` for spatial-index construction,
 // Triangulation-layer insertion, and Triangulation-layer removal.
 
 impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D>
 where
     K: Kernel<D>,
-    K::Scalar: ScalarAccumulative + NumCast,
+    K::Scalar: CoordinateScalar + NumCast,
     U: DataType,
     V: DataType,
 {

--- a/src/triangulation/delaunayize.rs
+++ b/src/triangulation/delaunayize.rs
@@ -57,7 +57,7 @@ use crate::core::algorithms::pl_manifold_repair::{
 use crate::core::traits::data_type::DataType;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::{ExactPredicates, Kernel};
-use crate::geometry::traits::coordinate::{CoordinateScalar, ScalarAccumulative};
+use crate::geometry::traits::coordinate::CoordinateScalar;
 use crate::triangulation::delaunay::{DelaunayRepairHeuristicConfig, DelaunayTriangulation};
 use thiserror::Error;
 
@@ -256,7 +256,7 @@ pub fn delaunayize_by_flips<K, U, V, const D: usize>(
 ) -> Result<DelaunayizeOutcome<K::Scalar, U, V, D>, DelaunayizeError>
 where
     K: Kernel<D> + ExactPredicates,
-    K::Scalar: ScalarAccumulative,
+    K::Scalar: CoordinateScalar,
     U: DataType,
     V: DataType,
 {

--- a/src/triangulation/delaunayize.rs
+++ b/src/triangulation/delaunayize.rs
@@ -139,12 +139,7 @@ impl Default for DelaunayizeConfig {
 /// ```
 #[derive(Debug, Clone)]
 #[non_exhaustive]
-pub struct DelaunayizeOutcome<T, U, V, const D: usize>
-where
-    T: CoordinateScalar,
-    U: DataType,
-    V: DataType,
-{
+pub struct DelaunayizeOutcome<T, U, V, const D: usize> {
     /// Statistics from the PL-manifold topology repair pass.
     pub topology_repair: PlManifoldRepairStats<T, U, V, D>,
     /// Statistics from the flip-based Delaunay repair pass.


### PR DESCRIPTION
- Absorb AddAssign, SubAssign, and Sum bounds into CoordinateScalar
- Remove ScalarAccumulative and ScalarSummable traits and their blanket impls
- Replace all ScalarAccumulative bounds with CoordinateScalar across 20 files
- Simplify operator usage (e.g. coords[axis] += … instead of manual add-assign)

BREAKING CHANGE: ScalarAccumulative and ScalarSummable are removed; downstream code using these traits must switch to CoordinateScalar.