### PR TITLE
fix: unify flip-repair and retry constants across build profiles (#306)

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -125,10 +125,7 @@ robustness settings. **Currently, this is up to three attempts**:
 3. Attempt 3: FIFO queue order again (alternate ordering), still with robust predicates enabled
    for ambiguous boundary classifications.
 
-Note: in debug/test builds for D ≥ 3, attempt 1 may also enable robust predicates for ambiguous
-boundary classifications.
-
-After an attempt completes, the algorithm verifies the Delaunay postcondition via local flip
+After an attempt completes
 predicates. A postcondition failure is treated similarly to non-convergence and triggers retries.
 
 If repair fails to converge within the flip budget, you get

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -7112,28 +7112,4 @@ mod tests {
         assert!(stats.facets_checked > 0);
         assert!(tds.is_valid().is_ok());
     }
-
-    /// Regression test for #306: the 35-vertex 3D seed `0xE30C78582376677C`
-    /// produces a flip-repair sequence that legitimately requires >32 repeated
-    /// signatures to converge.  With `MAX_REPEAT_SIGNATURE = 32` (the former
-    /// release-mode value), construction failed.  This test verifies that
-    /// construction succeeds with the unified threshold of 128.
-    #[test]
-    fn test_max_repeat_signature_allows_convergence_issue_306() {
-        use crate::geometry::util::generate_random_points_in_ball_seeded;
-
-        let seed: u64 = 0xE30C_7858_2376_677C;
-        let points = generate_random_points_in_ball_seeded::<f64, 3>(35, 100.0, seed)
-            .expect("point generation should succeed");
-        let vertices: Vec<Vertex<f64, (), 3>> = points.into_iter().map(|p| vertex!(p)).collect();
-
-        let dt: Result<DelaunayTriangulation<_, (), (), 3>, _> =
-            DelaunayTriangulation::new(&vertices);
-        assert!(
-            dt.is_ok(),
-            "35-vertex 3D construction with seed 0x{seed:X} should succeed \
-             (requires MAX_REPEAT_SIGNATURE > 32); got: {}",
-            dt.unwrap_err()
-        );
-    }
 }

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -2842,7 +2842,6 @@ where
     // pointers (which subsequent flips re-establish); checking here — after the
     // complete repair pass — catches any genuine disconnection that the flip sequence
     // failed to reconnect.
-    #[cfg(debug_assertions)]
     if !tds.is_connected() {
         return Err(DelaunayRepairError::PostconditionFailed {
             message: format!(
@@ -3183,13 +3182,10 @@ where
 const AMBIGUOUS_SAMPLE_LIMIT: usize = 16;
 const CYCLE_SAMPLE_LIMIT: usize = 16;
 const FLIP_SIGNATURE_WINDOW: usize = 4096;
-// Allow extended repeats under test/debug to capture diagnostics in long-running repairs.
-#[cfg(any(test, debug_assertions))]
+// Allow extended repeats to capture diagnostics in long-running repairs.  A threshold of
+// 32 caused false non-convergence on valid 3D inputs (see #306); 128 still bounds
+// pathological cases while giving legitimate repair sequences room to converge.
 const MAX_REPEAT_SIGNATURE: usize = 128;
-// Release builds use a lower threshold to cap repeated signatures while still avoiding
-// false positives in higher-dimensional near-degenerate repair cases.
-#[cfg(not(any(test, debug_assertions)))]
-const MAX_REPEAT_SIGNATURE: usize = 32;
 
 #[derive(Debug, Default)]
 struct RepairDiagnostics {
@@ -3489,20 +3485,16 @@ fn default_max_flips<const D: usize>(cell_count: usize) -> usize {
     //   flip repair; correctness is ensured by the robust conflict-region detection in
     //   find_conflict_region and the is_delaunay_property_only() check in
     //   build_with_shuffled_retries.
-    #[cfg(any(test, debug_assertions))]
     if D >= 4 {
         return cell_count
             .saturating_mul(D.saturating_add(1))
             .saturating_mul(4)
             .max(4096);
     }
-    #[cfg(any(test, debug_assertions))]
     let multiplier = match D {
         3 => 8,
         _ => 4, // D<=2
     };
-    #[cfg(not(any(test, debug_assertions)))]
-    let multiplier = 4;
     let base = cell_count
         .saturating_mul(D.saturating_add(1))
         .saturating_mul(multiplier);

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -7112,4 +7112,30 @@ mod tests {
         assert!(stats.facets_checked > 0);
         assert!(tds.is_valid().is_ok());
     }
+
+    /// Regression test for #306: the 35-vertex 3D seed `0xE30C78582376677C`
+    /// produces a flip-repair sequence that legitimately requires >32 repeated
+    /// signatures to converge.  With `MAX_REPEAT_SIGNATURE = 32` (the former
+    /// release-mode value), construction failed.  This test verifies that
+    /// construction succeeds with the unified threshold of 128.
+    #[test]
+    fn test_max_repeat_signature_allows_convergence_issue_306() {
+        use crate::geometry::util::generate_random_points_in_ball_seeded;
+
+        let seed: u64 = 0xE30C_7858_2376_677C;
+        let points =
+            generate_random_points_in_ball_seeded::<f64, 3>(35, 100.0, seed)
+                .expect("point generation should succeed");
+        let vertices: Vec<Vertex<f64, (), 3>> =
+            points.into_iter().map(|p| vertex!(p)).collect();
+
+        let dt: Result<DelaunayTriangulation<_, (), (), 3>, _> =
+            DelaunayTriangulation::new(&vertices);
+        assert!(
+            dt.is_ok(),
+            "35-vertex 3D construction with seed 0x{seed:X} should succeed \
+             (requires MAX_REPEAT_SIGNATURE > 32); got: {}",
+            dt.unwrap_err()
+        );
+    }
 }

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -7123,11 +7123,9 @@ mod tests {
         use crate::geometry::util::generate_random_points_in_ball_seeded;
 
         let seed: u64 = 0xE30C_7858_2376_677C;
-        let points =
-            generate_random_points_in_ball_seeded::<f64, 3>(35, 100.0, seed)
-                .expect("point generation should succeed");
-        let vertices: Vec<Vertex<f64, (), 3>> =
-            points.into_iter().map(|p| vertex!(p)).collect();
+        let points = generate_random_points_in_ball_seeded::<f64, 3>(35, 100.0, seed)
+            .expect("point generation should succeed");
+        let vertices: Vec<Vertex<f64, (), 3>> = points.into_iter().map(|p| vertex!(p)).collect();
 
         let dt: Result<DelaunayTriangulation<_, (), (), 3>, _> =
             DelaunayTriangulation::new(&vertices);

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -321,8 +321,10 @@ pub enum InitialSimplexStrategy {
 /// Policy controlling deterministic "retry with alternative insertion orders" during batch
 /// construction.
 ///
-/// If enabled, the constructor deterministically retries construction with alternative insertion
-/// orders (shuffles) when the final Delaunay property check fails.
+/// When enabled, the constructor deterministically retries construction with alternative insertion
+/// orders (shuffles) when the initial attempt fails (e.g. flip-repair cycling on co-spherical
+/// configurations).  The default is [`Shuffled`](Self::Shuffled) with 6 attempts, which is
+/// essential for robust 3D+ construction.  Use [`Disabled`](Self::Disabled) to opt out.
 ///
 /// # Examples
 ///
@@ -354,11 +356,14 @@ pub enum RetryPolicy {
         /// Optional base seed. If `None`, a deterministic seed is derived from the vertex set.
         base_seed: Option<u64>,
     },
-    /// In debug/test builds, retry construction with a small number of deterministic shuffles if the
-    /// final Delaunay property check fails.
+    /// Retry construction with a small number of deterministic shuffles if the
+    /// final Delaunay property check fails, but only in debug/test builds.
     ///
-    /// In release builds, this is treated as [`RetryPolicy::Disabled`]. Prefer
-    /// [`RetryPolicy::Shuffled`] if you want retries in all build modes.
+    /// In release builds, this is treated as [`RetryPolicy::Disabled`].
+    ///
+    /// Note: [`RetryPolicy::default()`] now returns [`Shuffled`](Self::Shuffled)
+    /// in all build modes, so this variant is only useful when you explicitly
+    /// want retries restricted to debug/test builds.
     DebugOnlyShuffled {
         /// Number of shuffled reconstruction attempts (excluding the original-order attempt).
         attempts: NonZeroUsize,
@@ -8835,6 +8840,32 @@ mod tests {
             ),
             "ConflictRegion should map to GeometricDegeneracy, got: {mapped:?}"
         );
+    }
+
+    // ---- RetryPolicy default regression test (#306) ----
+
+    /// Verify that `RetryPolicy::default()` returns `Shuffled` with the expected
+    /// attempt count in all build profiles.  Previously the default was `Disabled`
+    /// in release builds, causing #306.
+    #[test]
+    fn test_retry_policy_default_is_shuffled_in_all_profiles() {
+        let policy = RetryPolicy::default();
+        match policy {
+            RetryPolicy::Shuffled {
+                attempts,
+                base_seed,
+            } => {
+                assert_eq!(
+                    attempts.get(),
+                    DELAUNAY_SHUFFLE_ATTEMPTS,
+                    "default retry attempts should equal DELAUNAY_SHUFFLE_ATTEMPTS"
+                );
+                assert_eq!(base_seed, None, "default base_seed should be None");
+            }
+            other => panic!(
+                "RetryPolicy::default() should be Shuffled, got {other:?}"
+            ),
+        }
     }
 
     // ---- is_non_retryable_construction_error tests ----

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -51,14 +51,12 @@ use std::time::Instant;
 use thiserror::Error;
 use uuid::Uuid;
 
-#[cfg(any(test, debug_assertions))]
 const DELAUNAY_SHUFFLE_ATTEMPTS: usize = 6;
 const DELAUNAY_SHUFFLE_SEED_SALT: u64 = 0x9E37_79B9_7F4A_7C15;
 
-#[cfg(any(test, debug_assertions))]
+// Heuristic rebuild attempts must be consistent across build profiles to avoid
+// release-only construction failures (see #306).
 const HEURISTIC_REBUILD_ATTEMPTS: usize = 6;
-#[cfg(not(any(test, debug_assertions)))]
-const HEURISTIC_REBUILD_ATTEMPTS: usize = 2;
 
 thread_local! {
     static HEURISTIC_REBUILD_DEPTH: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
@@ -369,21 +367,17 @@ pub enum RetryPolicy {
     },
 }
 
-#[cfg(any(test, debug_assertions))]
 impl Default for RetryPolicy {
     fn default() -> Self {
-        Self::DebugOnlyShuffled {
+        // Shuffled retries are essential for correctness: certain Hilbert-sorted
+        // insertion orders produce co-spherical configurations that cause flip-repair
+        // cycling.  Retrying with a different order avoids the problematic sequence.
+        // Previously disabled in release builds, which caused #306.
+        Self::Shuffled {
             attempts: NonZeroUsize::new(DELAUNAY_SHUFFLE_ATTEMPTS)
                 .expect("DELAUNAY_SHUFFLE_ATTEMPTS must be non-zero"),
             base_seed: None,
         }
-    }
-}
-
-#[cfg(not(any(test, debug_assertions)))]
-impl Default for RetryPolicy {
-    fn default() -> Self {
-        Self::Disabled
     }
 }
 

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -1773,7 +1773,7 @@ where
     /// [`TopologyGuarantee::PLManifoldStrict`] for per-insertion vertex-link checks.
     ///
     /// # Shuffled Retries
-    /// For `D >= 3` with more than `D + 1` vertices, the constructor retries
+    /// For `D >= 2` with more than `D + 1` vertices, the constructor retries
     /// construction with up to 6 shuffled insertion orders if the Delaunay
     /// property check fails (see [`RetryPolicy::default()`]).  To disable
     /// retries, pass [`ConstructionOptions::default().with_retry_policy(RetryPolicy::Disabled)`](Self::with_topology_guarantee_and_options).

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -8862,9 +8862,7 @@ mod tests {
                 );
                 assert_eq!(base_seed, None, "default base_seed should be None");
             }
-            other => panic!(
-                "RetryPolicy::default() should be Shuffled, got {other:?}"
-            ),
+            other => panic!("RetryPolicy::default() should be Shuffled, got {other:?}"),
         }
     }
 

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -1772,10 +1772,11 @@ where
     /// construction and validates vertex-links at completion. Use
     /// [`TopologyGuarantee::PLManifoldStrict`] for per-insertion vertex-link checks.
     ///
-    /// # Debug/Test Behavior
-    /// In debug/test builds (for `D >= 3` with more than `D + 1` vertices), the constructor may
-    /// retry construction with a handful of shuffled insertion orders if the Delaunay property
-    /// check fails. Release builds skip these shuffled reconstruction attempts.
+    /// # Shuffled Retries
+    /// For `D >= 3` with more than `D + 1` vertices, the constructor retries
+    /// construction with up to 6 shuffled insertion orders if the Delaunay
+    /// property check fails (see [`RetryPolicy::default()`]).  To disable
+    /// retries, pass [`ConstructionOptions::default().with_retry_policy(RetryPolicy::Disabled)`](Self::with_topology_guarantee_and_options).
     ///
     /// # Errors
     /// Returns error if construction fails or if the requested topology guarantee

--- a/tests/regression_issue_306.rs
+++ b/tests/regression_issue_306.rs
@@ -1,0 +1,36 @@
+//! Regression test for issue #306: 3D flip-repair cycling in release builds.
+//!
+//! This test lives in an integration test crate (not `#[cfg(test)]` unit tests)
+//! so the library is compiled *without* `cfg(test)`.  This is essential because
+//! the original bug used `cfg(any(test, debug_assertions))` to gate repair
+//! constants — unit tests would always see the permissive values even in
+//! `--release` mode.
+
+use delaunay::geometry::util::generate_random_points_in_ball_seeded;
+use delaunay::prelude::triangulation::*;
+
+/// The 35-vertex 3D seed `0xE30C78582376677C` produces a Hilbert-ordered
+/// insertion sequence where vertex 23 triggers flip-repair cycling on
+/// co-spherical configurations.
+///
+/// With the former release-mode `MAX_REPEAT_SIGNATURE = 32` and
+/// `RetryPolicy::Disabled`, construction failed deterministically.
+/// The fix (#306) unified these constants so the repair has sufficient
+/// patience and shuffled retries are always available.
+///
+/// Run with `cargo test --release` to exercise the release profile.
+#[test]
+fn regression_issue_306_3d_construction_succeeds() {
+    let seed: u64 = 0xE30C_7858_2376_677C;
+    let points = generate_random_points_in_ball_seeded::<f64, 3>(35, 100.0, seed)
+        .expect("point generation should succeed");
+    let vertices: Vec<Vertex<f64, (), 3>> = points.into_iter().map(|p| vertex!(p)).collect();
+
+    let dt: Result<DelaunayTriangulation<_, (), (), 3>, _> = DelaunayTriangulation::new(&vertices);
+    assert!(
+        dt.is_ok(),
+        "35-vertex 3D construction with seed 0x{seed:X} should succeed \
+         (requires unified repair constants); got: {}",
+        dt.unwrap_err()
+    );
+}


### PR DESCRIPTION
Several flip-repair and construction-retry constants were split by cfg(any(test, debug_assertions)), causing release builds to fail on valid 3D inputs that debug/test builds handled correctly.

Primary fix: RetryPolicy::default() was Disabled in release but DebugOnlyShuffled { attempts: 6 } in debug/test.  When the initial Hilbert-ordered insertion hits a co-spherical flip cycle, shuffled retries find a working vertex ordering.  Without retries, the first failure was fatal.  Changed to Shuffled { attempts: 6 } unconditionally.

Secondary fixes in flips.rs:
- Unify MAX_REPEAT_SIGNATURE to 128 (was 32 in release)
- Unify default_max_flips 3D multiplier to 8x (was 4x in release)
- Make is_connected() postcondition check unconditional

Also in delaunay.rs:
- Unify HEURISTIC_REBUILD_ATTEMPTS to 6 (was 2 in release)
- Remove cfg-gated DELAUNAY_SHUFFLE_ATTEMPTS constant