### PR TITLE
fix: periodic-aware Delaunay verification (Level 4) for toroidal tria…

### DIFF
--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -522,14 +522,18 @@ brief comment explaining **why they exist** — what problem they solve or
 what invariant they maintain.  The *what* is often clear from the
 signature; the *why* is not.
 
-Prefer:
+Prefer a normal comment when the helper is private:
 
 ```rust
-/// Aligns a periodic vertex offset from a source cell's frame into a
-/// target cell's frame so that cross-cell insphere predicates see
-/// consistent lifted coordinates.
+// Aligns a periodic vertex offset from a source cell's frame into a
+// target cell's frame so that cross-cell insphere predicates see
+// consistent lifted coordinates.
 fn align_periodic_offset<const D: usize>(...) -> Result<[i8; D], FlipError>
 ```
+
+Doc comments (`///`) are also acceptable for private helpers such as
+`align_periodic_offset` when the project intentionally documents private items,
+for example with `cargo doc --document-private-items`.
 
 A bare signature with no context forces readers to reverse-engineer
 intent from the implementation.

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -515,6 +515,25 @@ Example:
 pub fn insert_vertex(...)
 ```
 
+### Private functions
+
+Private functions do not require full doc comments, but they should have a
+brief comment explaining **why they exist** — what problem they solve or
+what invariant they maintain.  The *what* is often clear from the
+signature; the *why* is not.
+
+Prefer:
+
+```rust
+/// Aligns a periodic vertex offset from a source cell's frame into a
+/// target cell's frame so that cross-cell insphere predicates see
+/// consistent lifted coordinates.
+fn align_periodic_offset<const D: usize>(...) -> Result<[i8; D], FlipError>
+```
+
+A bare signature with no context forces readers to reverse-engineer
+intent from the implementation.
+
 After Rust changes, verify documentation builds:
 
 ```bash

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -504,7 +504,8 @@ Avoid giant catch‑all preludes.
 
 ## Documentation
 
-All public items must have documentation.
+All public items must have documentation. Public functions must include a
+doctest in their documentation.
 
 Example:
 
@@ -512,28 +513,45 @@ Example:
 /// Inserts a vertex into the triangulation.
 ///
 /// Returns the key of the inserted vertex.
+///
+/// # Examples
+///
+/// ```rust
+/// # use delaunay::prelude::triangulation::*;
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let mut triangulation = DelaunayTriangulation::<_, _, _, 2>::default();
+/// let key = triangulation.insert_vertex([0.0, 0.0])?;
+/// assert!(triangulation.contains_vertex(key));
+/// # Ok(())
+/// # }
+/// ```
 pub fn insert_vertex(...)
 ```
 
 ### Private functions
 
-Private functions do not require full doc comments, but they should have a
-brief comment explaining **why they exist** — what problem they solve or
-what invariant they maintain.  The *what* is often clear from the
-signature; the *why* is not.
+Private functions must have a brief doc comment (`///`) explaining **why they
+exist** — what problem they solve or what invariant they maintain. The *what*
+is often clear from the signature; the *why* is not.
 
-Prefer a normal comment when the helper is private:
+Prefer:
 
 ```rust
-// Aligns a periodic vertex offset from a source cell's frame into a
-// target cell's frame so that cross-cell insphere predicates see
-// consistent lifted coordinates.
+/// Aligns source-cell periodic offsets into the target-cell frame so
+/// cross-cell insphere predicates see consistent lifted coordinates.
 fn align_periodic_offset<const D: usize>(...) -> Result<[i8; D], FlipError>
 ```
 
-Doc comments (`///`) are also acceptable for private helpers such as
-`align_periodic_offset` when the project intentionally documents private items,
-for example with `cargo doc --document-private-items`.
+Use normal comments (`//`) for documentation inside function bodies or other
+implementation-local notes:
+
+```rust
+fn align_periodic_offset<const D: usize>(...) -> Result<[i8; D], FlipError> {
+    // Compare deltas in each coordinate so conflicting frame translations are
+    // rejected before lifted coordinates are constructed.
+    ...
+}
+```
 
 A bare signature with no context forces readers to reverse-engineer
 intent from the implementation.

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -53,6 +53,7 @@ use crate::topology::traits::global_topology_model::{
 };
 use crate::topology::traits::topological_space::GlobalTopology;
 use slotmap::Key;
+use std::borrow::Cow;
 use std::collections::VecDeque;
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -2972,6 +2973,7 @@ where
         &mut queues.facet_queue,
         &config,
         &mut diagnostics,
+        mode,
     )?;
     verify_postcondition_k3_ridges(
         tds,
@@ -2980,6 +2982,7 @@ where
         &mut queues.ridge_queue,
         &config,
         &mut diagnostics,
+        mode,
     )?;
     verify_postcondition_inverse_k2_edges(
         tds,
@@ -3018,6 +3021,21 @@ where
     Ok(())
 }
 
+/// Centralizes Strict/Repair handling so inconclusive predicates fail validation
+/// while remaining skippable during best-effort repair passes.
+fn handle_postcondition_predicate_failure(
+    mode: PostconditionMode,
+    context: &str,
+    error: &FlipError,
+) -> Result<(), DelaunayRepairError> {
+    match mode {
+        PostconditionMode::Repair => Ok(()),
+        PostconditionMode::Strict => Err(DelaunayRepairError::PostconditionFailed {
+            message: format!("{context} predicate failed in strict mode: {error}"),
+        }),
+    }
+}
+
 /// Rechecks queued facets after repair so unresolved k=2 violations surface as
 /// postcondition failures instead of latent invalid triangulations.
 fn verify_postcondition_k2_facets<K, U, V, const D: usize>(
@@ -3027,6 +3045,7 @@ fn verify_postcondition_k2_facets<K, U, V, const D: usize>(
     queue: &mut VecDeque<(FacetHandle, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
+    mode: PostconditionMode,
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
@@ -3052,8 +3071,12 @@ where
             Ok(true) => {
                 let flip_degenerate = match k2_flip_would_create_degenerate_cell(tds, &context) {
                     Ok(degenerate) => degenerate,
-                    Err(FlipError::PredicateFailure { .. }) => {
-                        // Inconclusive due to numeric degeneracy; skip.
+                    Err(error @ FlipError::PredicateFailure { .. }) => {
+                        handle_postcondition_predicate_failure(
+                            mode,
+                            "local k=2 degeneracy verification",
+                            &error,
+                        )?;
                         continue;
                     }
                     Err(e) => {
@@ -3101,8 +3124,15 @@ where
                 }
                 return Err(DelaunayRepairError::PostconditionFailed { message });
             }
-            Ok(false) | Err(FlipError::PredicateFailure { .. }) => {
-                // No violation detected, or inconclusive due to numeric degeneracy.
+            Ok(false) => {
+                // No violation detected.
+            }
+            Err(error @ FlipError::PredicateFailure { .. }) => {
+                handle_postcondition_predicate_failure(
+                    mode,
+                    "local k=2 postcondition verification",
+                    &error,
+                )?;
             }
             Err(e) => {
                 return Err(DelaunayRepairError::PostconditionFailed {
@@ -3124,6 +3154,7 @@ fn verify_postcondition_k3_ridges<K, U, V, const D: usize>(
     queue: &mut VecDeque<(RidgeHandle, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
+    mode: PostconditionMode,
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
@@ -3152,8 +3183,12 @@ where
                     &context.inserted_face_vertices,
                 ) {
                     Ok(degenerate) => degenerate,
-                    Err(FlipError::PredicateFailure { .. }) => {
-                        // Inconclusive due to numeric degeneracy; skip.
+                    Err(error @ FlipError::PredicateFailure { .. }) => {
+                        handle_postcondition_predicate_failure(
+                            mode,
+                            "local k=3 degeneracy verification",
+                            &error,
+                        )?;
                         continue;
                     }
                     Err(e) => {
@@ -3180,8 +3215,15 @@ where
                     message: format!("local k=3 violation remains after repair (ridge={ridge:?})"),
                 });
             }
-            Ok(false) | Err(FlipError::PredicateFailure { .. }) => {
-                // No violation detected, or inconclusive due to numeric degeneracy.
+            Ok(false) => {
+                // No violation detected.
+            }
+            Err(error @ FlipError::PredicateFailure { .. }) => {
+                handle_postcondition_predicate_failure(
+                    mode,
+                    "local k=3 postcondition verification",
+                    &error,
+                )?;
             }
             Err(e) => {
                 return Err(DelaunayRepairError::PostconditionFailed {
@@ -3244,8 +3286,12 @@ where
             diagnostics,
         ) {
             Ok(violates) => violates,
-            Err(FlipError::PredicateFailure { .. }) => {
-                // Inconclusive due to numeric degeneracy; skip.
+            Err(error @ FlipError::PredicateFailure { .. }) => {
+                handle_postcondition_predicate_failure(
+                    mode,
+                    "local inverse k=2 postcondition verification",
+                    &error,
+                )?;
                 continue;
             }
             Err(e) => {
@@ -3323,8 +3369,12 @@ where
             diagnostics,
         ) {
             Ok(violates) => violates,
-            Err(FlipError::PredicateFailure { .. }) => {
-                // Inconclusive due to numeric degeneracy; skip.
+            Err(error @ FlipError::PredicateFailure { .. }) => {
+                handle_postcondition_predicate_failure(
+                    mode,
+                    "local inverse k=3 postcondition verification",
+                    &error,
+                )?;
                 continue;
             }
             Err(e) => {
@@ -4930,10 +4980,7 @@ where
         .ok_or(FlipError::MissingCell {
             cell_key: target_cell_key,
         })?;
-    let Some(target_offsets) = target_cell.periodic_vertex_offsets() else {
-        return vertex_point_with_optional_lift(tds, topology_model, vertex_key, None);
-    };
-    validate_periodic_offset_len(target_cell_key, target_cell, target_offsets)?;
+    let target_offsets = periodic_offsets_or_zero_frame(target_cell_key, target_cell)?;
 
     for &source_cell_key in source_cells {
         let Some(source_cell) = tds.get_cell(source_cell_key) else {
@@ -4942,14 +4989,7 @@ where
         if !source_cell.contains_vertex(vertex_key) {
             continue;
         }
-        let Some(source_offsets) = source_cell.periodic_vertex_offsets() else {
-            return Err(FlipError::InvalidFlipContext {
-                message: format!(
-                    "cannot align periodic vertex {vertex_key:?} from cell {source_cell_key:?} into frame {target_cell_key:?}: source cell has no periodic offsets"
-                ),
-            });
-        };
-        validate_periodic_offset_len(source_cell_key, source_cell, source_offsets)?;
+        let source_offsets = periodic_offsets_or_zero_frame(source_cell_key, source_cell)?;
         let Some(source_vertex_index) = source_cell
             .vertices()
             .iter()
@@ -4957,15 +4997,31 @@ where
         else {
             continue;
         };
-        if let Some((target_shared_index, source_shared_index)) =
-            shared_vertex_indices(target_cell, source_cell)
-        {
+        let shared_indices = shared_vertex_indices(target_cell, source_cell);
+        if shared_indices.is_empty() {
+            continue;
+        }
+        let source_vertex_offset = source_offsets[source_vertex_index];
+        let mut aligned_offset: Option<[i8; D]> = None;
+        for (target_shared_index, source_shared_index) in shared_indices {
             let target_offset = target_offsets[target_shared_index];
             let source_offset = source_offsets[source_shared_index];
-            let source_vertex_offset = source_offsets[source_vertex_index];
-            let aligned_offset =
+            let candidate_offset =
                 align_periodic_offset(source_vertex_offset, source_offset, target_offset)?;
-            return lift_vertex_point(tds, topology_model, vertex_key, Some(aligned_offset));
+            if let Some(expected_offset) = aligned_offset {
+                if candidate_offset != expected_offset {
+                    return Err(FlipError::InvalidFlipContext {
+                        message: format!(
+                            "conflicting periodic frame translations while aligning vertex {vertex_key:?} from cell {source_cell_key:?} into frame {target_cell_key:?}: expected {expected_offset:?}, got {candidate_offset:?}"
+                        ),
+                    });
+                }
+            } else {
+                aligned_offset = Some(candidate_offset);
+            }
+        }
+        if let Some(offset) = aligned_offset {
+            return lift_vertex_point(tds, topology_model, vertex_key, Some(offset));
         }
     }
 
@@ -5016,15 +5072,32 @@ where
     let cell = tds
         .get_cell(cell_key)
         .ok_or(FlipError::MissingCell { cell_key })?;
-    let Some(offsets) = cell.periodic_vertex_offsets() else {
-        return Ok(None);
-    };
-    validate_periodic_offset_len(cell_key, cell, offsets)?;
+    let offsets = periodic_offsets_or_zero_frame(cell_key, cell)?;
     Ok(cell
         .vertices()
         .iter()
         .position(|&vkey| vkey == vertex_key)
         .map(|index| offsets[index]))
+}
+
+/// Borrows stored periodic offsets, or treats a periodic cell without explicit
+/// offsets as a zero-offset frame.
+fn periodic_offsets_or_zero_frame<T, U, V, const D: usize>(
+    cell_key: CellKey,
+    cell: &Cell<T, U, V, D>,
+) -> Result<Cow<'_, [[i8; D]]>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    let offsets = cell.periodic_vertex_offsets().map_or_else(
+        // The fallback frame is synthesized locally, so `Cow::Owned` keeps the
+        // temporary vector alive while the stored-offset path can stay borrowed.
+        || Cow::Owned(vec![[0_i8; D]; cell.number_of_vertices()]),
+        Cow::Borrowed,
+    );
+    validate_periodic_offset_len(cell_key, cell, offsets.as_ref())?;
+    Ok(offsets)
 }
 
 /// Rejects malformed quotient cells before offset indexing can desynchronize
@@ -5050,27 +5123,27 @@ where
     })
 }
 
-/// Finds a common vertex to act as the reference point for aligning two
+/// Finds every common vertex to act as a consistency check when aligning two
 /// periodic cell frames.
 fn shared_vertex_indices<T, U, V, const D: usize>(
     target_cell: &Cell<T, U, V, D>,
     source_cell: &Cell<T, U, V, D>,
-) -> Option<(usize, usize)>
+) -> SmallBuffer<(usize, usize), MAX_PRACTICAL_DIMENSION_SIZE>
 where
     U: DataType,
     V: DataType,
 {
-    target_cell
-        .vertices()
-        .iter()
-        .enumerate()
-        .find_map(|(target_index, &target_vertex)| {
-            source_cell
-                .vertices()
-                .iter()
-                .position(|&source_vertex| source_vertex == target_vertex)
-                .map(|source_index| (target_index, source_index))
-        })
+    let mut shared = SmallBuffer::new();
+    for (target_index, &target_vertex) in target_cell.vertices().iter().enumerate() {
+        if let Some(source_index) = source_cell
+            .vertices()
+            .iter()
+            .position(|&source_vertex| source_vertex == target_vertex)
+        {
+            shared.push((target_index, source_index));
+        }
+    }
+    shared
 }
 
 /// Aligns a periodic vertex offset from a source cell's frame into a target
@@ -8002,7 +8075,7 @@ mod tests {
                 }
 
                 #[test]
-                fn [<test_periodic_lift_rejects_missing_source_offsets_ $dim d>]() {
+                fn [<test_periodic_lift_treats_missing_source_offsets_as_zero_frame_ $dim d>]() {
                     let mut tds: Tds<f64, (), (), $dim> = Tds::empty();
                     let shared_vertex = tds
                         .insert_vertex_with_mapping(vertex!([0.0; $dim]))
@@ -8035,7 +8108,65 @@ mod tests {
                         Some(target_cell),
                         &[source_cell],
                     );
-                    assert!(matches!(result, Err(FlipError::InvalidFlipContext { .. })));
+                    let lifted = result.unwrap();
+                    assert_relative_eq!(
+                        lifted.coords().as_slice(),
+                        unit_vector::<$dim>(0).as_slice()
+                    );
+                }
+
+                #[test]
+                fn [<test_periodic_lift_rejects_conflicting_shared_translations_ $dim d>]() {
+                    let mut tds: Tds<f64, (), (), $dim> = Tds::empty();
+                    let shared_a = tds
+                        .insert_vertex_with_mapping(vertex!([0.0; $dim]))
+                        .unwrap();
+                    let mut shared_b_coords = [0.0; $dim];
+                    shared_b_coords[0] = 0.2;
+                    let shared_b = tds
+                        .insert_vertex_with_mapping(vertex!(shared_b_coords))
+                        .unwrap();
+                    let lifted_vertex = tds
+                        .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(0)))
+                        .unwrap();
+
+                    let mut target_vertices = Vec::with_capacity($dim + 1);
+                    target_vertices.push(shared_a);
+                    target_vertices.push(shared_b);
+                    target_vertices.extend(periodic_helper_vertices::<$dim>(&mut tds, $dim - 1));
+                    let mut target_offsets = vec![[0_i8; $dim]; target_vertices.len()];
+                    target_offsets[1][0] = 1;
+                    let target_cell =
+                        insert_periodic_cell_with_offsets(&mut tds, target_vertices, target_offsets);
+
+                    let mut source_vertices = Vec::with_capacity($dim + 1);
+                    source_vertices.push(shared_a);
+                    source_vertices.push(shared_b);
+                    source_vertices.push(lifted_vertex);
+                    source_vertices.extend(periodic_helper_vertices::<$dim>(
+                        &mut tds,
+                        $dim - 2,
+                    ));
+                    let source_offsets = vec![[0_i8; $dim]; source_vertices.len()];
+                    let source_cell =
+                        insert_periodic_cell_with_offsets(&mut tds, source_vertices, source_offsets);
+                    let topology_model = toroidal_periodic_model::<$dim>();
+
+                    let result = vertex_point_lifted_into_cell(
+                        &tds,
+                        &topology_model,
+                        lifted_vertex,
+                        Some(target_cell),
+                        &[source_cell],
+                    );
+                    assert!(
+                        matches!(
+                            result,
+                            Err(FlipError::InvalidFlipContext { ref message })
+                                if message.contains("conflicting periodic frame translations")
+                        ),
+                        "conflicting shared translations should be rejected: {result:?}"
+                    );
                 }
 
                 #[test]

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -4867,9 +4867,13 @@ where
     U: DataType,
     V: DataType,
 {
-    let periodic_offset = match source_cell {
-        Some(cell_key) => periodic_offset_for_cell_vertex(tds, cell_key, vertex_key)?,
-        None => None,
+    let periodic_offset = if topology_model.supports_periodic_orientation_offsets() {
+        match source_cell {
+            Some(cell_key) => periodic_offset_for_cell_vertex(tds, cell_key, vertex_key)?,
+            None => None,
+        }
+    } else {
+        None
     };
     lift_vertex_point(tds, topology_model, vertex_key, periodic_offset)
 }
@@ -4892,8 +4896,16 @@ where
         return vertex_point_with_optional_lift(tds, topology_model, vertex_key, None);
     };
 
-    if let Some(offset) = periodic_offset_for_cell_vertex(tds, target_cell_key, vertex_key)? {
-        return lift_vertex_point(tds, topology_model, vertex_key, Some(offset));
+    let target_offset = periodic_offset_for_cell_vertex(tds, target_cell_key, vertex_key)?;
+    if let Some(offset) = target_offset {
+        let periodic_offset = topology_model
+            .supports_periodic_orientation_offsets()
+            .then_some(offset);
+        return lift_vertex_point(tds, topology_model, vertex_key, periodic_offset);
+    }
+
+    if !topology_model.supports_periodic_orientation_offsets() {
+        return lift_vertex_point(tds, topology_model, vertex_key, None);
     }
 
     let target_cell = tds
@@ -7887,6 +7899,142 @@ mod tests {
         tds.insert_cell_with_mapping(cell).unwrap()
     }
 
+    fn insert_periodic_cell_with_offsets<const D: usize>(
+        tds: &mut Tds<f64, (), (), D>,
+        vertices: Vec<VertexKey>,
+        offsets: Vec<[i8; D]>,
+    ) -> CellKey {
+        let mut cell = Cell::new(vertices, None).unwrap();
+        cell.set_periodic_vertex_offsets(offsets);
+        tds.insert_cell_with_mapping(cell).unwrap()
+    }
+
+    fn insert_plain_cell<const D: usize>(
+        tds: &mut Tds<f64, (), (), D>,
+        vertices: Vec<VertexKey>,
+    ) -> CellKey {
+        tds.insert_cell_with_mapping(Cell::new(vertices, None).unwrap())
+            .unwrap()
+    }
+
+    fn periodic_helper_vertices<const D: usize>(
+        tds: &mut Tds<f64, (), (), D>,
+        count: usize,
+    ) -> Vec<VertexKey> {
+        (0..count)
+            .map(|index| {
+                let mut coords = [0.0; D];
+                coords[index % D] =
+                    0.05 * f64::from(u32::try_from(index + 1).expect("test index fits in u32"));
+                coords[(index + 1) % D] +=
+                    0.01 * f64::from(u32::try_from(index + 2).expect("test index fits in u32"));
+                tds.insert_vertex_with_mapping(vertex!(coords)).unwrap()
+            })
+            .collect()
+    }
+
+    macro_rules! gen_periodic_lift_helper_tests {
+        ($dim:literal) => {
+            pastey::paste! {
+                #[test]
+                fn [<test_periodic_lift_helpers_use_cell_offsets_ $dim d>]() {
+                    let mut tds: Tds<f64, (), (), $dim> = Tds::empty();
+                    let lifted_vertex = tds
+                        .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(0)))
+                        .unwrap();
+                    let mut cell_vertices = Vec::with_capacity($dim + 1);
+                    cell_vertices.push(lifted_vertex);
+                    cell_vertices.extend(periodic_helper_vertices::<$dim>(&mut tds, $dim));
+                    let mut offsets = vec![[0_i8; $dim]; cell_vertices.len()];
+                    offsets[0][0] = 1;
+                    let cell_key =
+                        insert_periodic_cell_with_offsets(&mut tds, cell_vertices.clone(), offsets);
+                    let topology_model = toroidal_periodic_model::<$dim>();
+
+                    let direct = vertex_point_with_optional_lift(
+                        &tds,
+                        &topology_model,
+                        lifted_vertex,
+                        Some(cell_key),
+                    )
+                    .unwrap();
+                    let mut expected = unit_vector::<$dim>(0);
+                    expected[0] += 1.0;
+                    assert_relative_eq!(direct.coords().as_slice(), expected.as_slice());
+
+                    let framed = vertex_point_lifted_into_cell(
+                        &tds,
+                        &topology_model,
+                        lifted_vertex,
+                        Some(cell_key),
+                        &[],
+                    )
+                    .unwrap();
+                    assert_relative_eq!(framed.coords().as_slice(), expected.as_slice());
+
+                    let points = vertices_to_points_with_optional_lift(
+                        &tds,
+                        &topology_model,
+                        &[lifted_vertex],
+                        Some(cell_key),
+                        &[cell_key],
+                    )
+                    .unwrap();
+                    assert_relative_eq!(points[0].coords().as_slice(), expected.as_slice());
+                    assert_eq!(matching_source_cell(&tds, &cell_vertices, &[cell_key]), Some(cell_key));
+                }
+
+                #[test]
+                fn [<test_periodic_lift_rejects_missing_source_offsets_ $dim d>]() {
+                    let mut tds: Tds<f64, (), (), $dim> = Tds::empty();
+                    let shared_vertex = tds
+                        .insert_vertex_with_mapping(vertex!([0.0; $dim]))
+                        .unwrap();
+                    let lifted_vertex = tds
+                        .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(0)))
+                        .unwrap();
+
+                    let mut target_vertices = Vec::with_capacity($dim + 1);
+                    target_vertices.push(shared_vertex);
+                    target_vertices.extend(periodic_helper_vertices::<$dim>(&mut tds, $dim));
+                    let target_offsets = vec![[0_i8; $dim]; target_vertices.len()];
+                    let target_cell =
+                        insert_periodic_cell_with_offsets(&mut tds, target_vertices, target_offsets);
+
+                    let mut source_vertices = Vec::with_capacity($dim + 1);
+                    source_vertices.push(shared_vertex);
+                    source_vertices.push(lifted_vertex);
+                    source_vertices.extend(periodic_helper_vertices::<$dim>(
+                        &mut tds,
+                        $dim - 1,
+                    ));
+                    let source_cell = insert_plain_cell(&mut tds, source_vertices);
+                    let topology_model = toroidal_periodic_model::<$dim>();
+
+                    let result = vertex_point_lifted_into_cell(
+                        &tds,
+                        &topology_model,
+                        lifted_vertex,
+                        Some(target_cell),
+                        &[source_cell],
+                    );
+                    assert!(matches!(result, Err(FlipError::InvalidFlipContext { .. })));
+                }
+
+                #[test]
+                fn [<test_removed_cell_frame_requires_source_cell_ $dim d>]() {
+                    let result = removed_cell_frame(&[]);
+                    assert!(matches!(result, Err(FlipError::InvalidFlipContext { .. })));
+                }
+            }
+        };
+    }
+
+    gen_periodic_lift_helper_tests!(2);
+    gen_periodic_lift_helper_tests!(3);
+    gen_periodic_lift_helper_tests!(4);
+    gen_periodic_lift_helper_tests!(5);
+
     fn periodic_inverse_k2_fixture<const D: usize>() -> (
         Tds<f64, (), (), D>,
         Vec<VertexKey>,
@@ -8074,6 +8222,41 @@ mod tests {
 
     gen_periodic_inverse_predicate_tests!(4);
     gen_periodic_inverse_predicate_tests!(5);
+
+    #[test]
+    fn test_non_periodic_lift_ignores_stored_periodic_offsets() {
+        let (tds, face_vertices, _opposite_a, _opposite_b, removed_cells) =
+            periodic_inverse_k2_fixture::<4>();
+        let lifted_vertex = face_vertices[0];
+        let source_cell = removed_cells
+            .iter()
+            .copied()
+            .find(|&cell_key| {
+                tds.get_cell(cell_key)
+                    .is_some_and(|cell| cell.contains_vertex(lifted_vertex))
+            })
+            .expect("fixture should contain a removed cell with the lifted vertex");
+        let topology_model = GlobalTopology::Euclidean.model();
+
+        let direct = vertex_point_with_optional_lift(
+            &tds,
+            &topology_model,
+            lifted_vertex,
+            Some(source_cell),
+        )
+        .unwrap();
+        assert_relative_eq!(direct.coords().as_slice(), unit_vector::<4>(0).as_slice());
+
+        let framed = vertex_point_lifted_into_cell(
+            &tds,
+            &topology_model,
+            lifted_vertex,
+            Some(source_cell),
+            &removed_cells,
+        )
+        .unwrap();
+        assert_relative_eq!(framed.coords().as_slice(), unit_vector::<4>(0).as_slice());
+    }
 
     #[test]
     fn test_periodic_inverse_k2_alignment_failure_is_error() {

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -40,14 +40,18 @@ use crate::core::facet::{AllFacetsIter, FacetHandle, facet_key_from_vertices};
 use crate::core::operations::TopologicalOperation;
 use crate::core::tds::{CellKey, Tds, VertexKey};
 use crate::core::traits::data_type::DataType;
-use crate::core::triangulation::TopologyGuarantee;
+use crate::core::triangulation::{TopologyGuarantee, Triangulation};
 use crate::core::util::stable_hash_u64_slice;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
 use crate::geometry::predicates::Orientation;
 use crate::geometry::robust_predicates::robust_orientation;
-use crate::geometry::traits::coordinate::CoordinateScalar;
+use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
+use crate::topology::traits::global_topology_model::{
+    GlobalTopologyModel, GlobalTopologyModelAdapter,
+};
+use crate::topology::traits::topological_space::GlobalTopology;
 use slotmap::Key;
 use std::collections::VecDeque;
 use std::fmt;
@@ -529,6 +533,7 @@ fn debug_ridge_context<T, U, V, const D: usize>(
 fn is_delaunay_violation_k3<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     context: &FlipContext<D, 3>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
@@ -541,8 +546,10 @@ where
     delaunay_violation_k3_for_ridge(
         tds,
         kernel,
+        topology_model,
         &context.removed_face_vertices,
         &context.inserted_face_vertices,
+        &context.removed_cells,
         config,
         diagnostics,
     )
@@ -1711,13 +1718,19 @@ where
 }
 
 #[allow(clippy::too_many_lines)]
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Local predicate evaluation threads topology, source cells, and diagnostics explicitly"
+)]
 /// Evaluate the k=2 facet flip predicate for a local Delaunay violation.
 fn delaunay_violation_k2_for_facet<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     facet_vertices: &[VertexKey],
     opposite_a: VertexKey,
     opposite_b: VertexKey,
+    source_cells: &[CellKey],
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
 ) -> Result<bool, FlipError>
@@ -1757,22 +1770,18 @@ where
     cell_vertices[0].sort_unstable_by_key(|v| v.data().as_ffi());
     cell_vertices[1].sort_unstable_by_key(|v| v.data().as_ffi());
 
-    let points_a = vertices_to_points(tds, &cell_vertices[0])?;
-    let points_b = vertices_to_points(tds, &cell_vertices[1])?;
+    let source_a = matching_source_cell(tds, &cell_vertices[0], source_cells);
+    let source_b = matching_source_cell(tds, &cell_vertices[1], source_cells);
+    let points_a =
+        vertices_to_points_with_optional_lift(tds, topology_model, &cell_vertices[0], source_a)?;
+    let points_b =
+        vertices_to_points_with_optional_lift(tds, topology_model, &cell_vertices[1], source_b)?;
 
-    let opposite_point_a = tds
-        .get_vertex_by_key(opposite_a)
-        .ok_or(FlipError::MissingVertex {
-            vertex_key: opposite_a,
-        })?
-        .point();
-    let opposite_point_b = tds
-        .get_vertex_by_key(opposite_b)
-        .ok_or(FlipError::MissingVertex {
-            vertex_key: opposite_b,
-        })?
-        .point();
-    let in_a = match kernel.in_sphere(&points_a, opposite_point_b) {
+    let opposite_point_a =
+        vertex_point_lifted_into_cell(tds, topology_model, opposite_a, source_b, source_cells)?;
+    let opposite_point_b =
+        vertex_point_lifted_into_cell(tds, topology_model, opposite_b, source_a, source_cells)?;
+    let in_a = match kernel.in_sphere(&points_a, &opposite_point_b) {
         Ok(value) => value,
         Err(e) => {
             diagnostics.record_predicate_failure();
@@ -1782,7 +1791,7 @@ where
         }
     };
 
-    let in_b = match kernel.in_sphere(&points_b, opposite_point_a) {
+    let in_b = match kernel.in_sphere(&points_b, &opposite_point_a) {
         Ok(value) => value,
         Err(e) => {
             diagnostics.record_predicate_failure();
@@ -1898,6 +1907,7 @@ where
 fn is_delaunay_violation_k2<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     context: &FlipContext<D, 2>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
@@ -1920,9 +1930,11 @@ where
     delaunay_violation_k2_for_facet(
         tds,
         kernel,
+        topology_model,
         &context.removed_face_vertices,
         opposite_a,
         opposite_b,
+        &context.removed_cells,
         config,
         diagnostics,
     )
@@ -2144,12 +2156,18 @@ where
         direction: FlipDirection::Inverse,
     })
 }
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Local predicate evaluation threads topology, source cells, and diagnostics explicitly"
+)]
 /// Evaluate the k=3 ridge flip predicate for a local Delaunay violation.
 fn delaunay_violation_k3_for_ridge<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     ridge_vertices: &[VertexKey],
     triangle_vertices: &[VertexKey],
+    source_cells: &[CellKey],
     _config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
 ) -> Result<bool, FlipError>
@@ -2189,15 +2207,17 @@ where
         // Sort by VertexKey for canonical SoS perturbation ordering
         cell_vertices.sort_unstable_by_key(|v| v.data().as_ffi());
 
-        let points = vertices_to_points(tds, &cell_vertices)?;
-        let missing_point = tds
-            .get_vertex_by_key(missing)
-            .ok_or(FlipError::MissingVertex {
-                vertex_key: missing,
-            })?
-            .point();
+        let source_cell = matching_source_cell(tds, &cell_vertices, source_cells);
+        let points = vertices_to_points_with_optional_lift(
+            tds,
+            topology_model,
+            &cell_vertices,
+            source_cell,
+        )?;
+        let missing_point =
+            vertex_point_lifted_into_cell(tds, topology_model, missing, source_cell, source_cells)?;
 
-        let in_sphere = match kernel.in_sphere(&points, missing_point) {
+        let in_sphere = match kernel.in_sphere(&points, &missing_point) {
             Ok(value) => value,
             Err(e) => {
                 diagnostics.record_predicate_failure();
@@ -2345,6 +2365,7 @@ where
     let mut queue: VecDeque<(FacetHandle, u64)> = VecDeque::new();
     let mut queued: FastHashSet<u64> = FastHashSet::default();
     let mut facet_handles: FastHashMap<u64, FacetHandle> = FastHashMap::default();
+    let topology_model = GlobalTopology::DEFAULT.model();
 
     if let Some(seeds) = seed_cells {
         for &cell_key in seeds {
@@ -2405,14 +2426,20 @@ where
             Err(e) => return Err(e.into()),
         };
 
-        let violates =
-            match is_delaunay_violation_k2(tds, kernel, &context, config, &mut diagnostics) {
-                Ok(violates) => violates,
-                Err(FlipError::PredicateFailure { .. }) => {
-                    continue;
-                }
-                Err(e) => return Err(e.into()),
-            };
+        let violates = match is_delaunay_violation_k2(
+            tds,
+            kernel,
+            &topology_model,
+            &context,
+            config,
+            &mut diagnostics,
+        ) {
+            Ok(violates) => violates,
+            Err(FlipError::PredicateFailure { .. }) => {
+                continue;
+            }
+            Err(e) => return Err(e.into()),
+        };
 
         if !violates {
             continue;
@@ -2757,7 +2784,70 @@ where
     U: DataType,
     V: DataType,
 {
-    verify_repair_postcondition(tds, kernel, None)
+    verify_delaunay_with_topology(tds, kernel, GlobalTopology::DEFAULT)
+}
+
+/// Verify the Delaunay property via local flip predicates for a full triangulation.
+///
+/// This is the preferred Level 4 validation entry point because it carries the
+/// triangulation's global topology alongside the TDS.  For periodic topologies
+/// (e.g. toroidal), insphere predicates are evaluated in lifted coordinates so
+/// that facets spanning periodic boundaries are not reported as false violations.
+///
+/// # Errors
+///
+/// Returns [`DelaunayRepairError::PostconditionFailed`] if any flip predicate detects
+/// a Delaunay violation, or another [`DelaunayRepairError`] if verification cannot
+/// evaluate the local predicates.
+///
+/// # Examples
+///
+/// ```
+/// use delaunay::prelude::triangulation::*;
+/// use delaunay::core::algorithms::flips::verify_delaunay_for_triangulation;
+///
+/// let vertices = vec![
+///     vertex!([0.0, 0.0, 0.0]),
+///     vertex!([1.0, 0.0, 0.0]),
+///     vertex!([0.0, 1.0, 0.0]),
+///     vertex!([0.0, 0.0, 1.0]),
+/// ];
+///
+/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+///
+/// // Topology-aware O(N) verification
+/// assert!(verify_delaunay_for_triangulation(dt.as_triangulation()).is_ok());
+/// ```
+pub fn verify_delaunay_for_triangulation<K, U, V, const D: usize>(
+    triangulation: &Triangulation<K, U, V, D>,
+) -> Result<(), DelaunayRepairError>
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    verify_delaunay_with_topology(
+        &triangulation.tds,
+        &triangulation.kernel,
+        triangulation.global_topology,
+    )
+}
+
+/// Verify the Delaunay property via local flip predicates under a global topology model.
+///
+/// For periodic topologies this evaluates predicates in lifted coordinates using the
+/// per-cell periodic vertex offsets stored on quotient cells.
+fn verify_delaunay_with_topology<K, U, V, const D: usize>(
+    tds: &Tds<K::Scalar, U, V, D>,
+    kernel: &K,
+    global_topology: GlobalTopology<D>,
+) -> Result<(), DelaunayRepairError>
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    verify_repair_postcondition_with_topology(tds, kernel, None, global_topology)
 }
 
 fn verify_repair_postcondition<K, U, V, const D: usize>(
@@ -2770,13 +2860,29 @@ where
     U: DataType,
     V: DataType,
 {
-    verify_repair_postcondition_locally(tds, kernel, seed_cells)
+    verify_repair_postcondition_with_topology(tds, kernel, seed_cells, GlobalTopology::DEFAULT)
+}
+
+fn verify_repair_postcondition_with_topology<K, U, V, const D: usize>(
+    tds: &Tds<K::Scalar, U, V, D>,
+    kernel: &K,
+    seed_cells: Option<&[CellKey]>,
+    global_topology: GlobalTopology<D>,
+) -> Result<(), DelaunayRepairError>
+where
+    K: Kernel<D>,
+    U: DataType,
+    V: DataType,
+{
+    let topology_model = global_topology.model();
+    verify_repair_postcondition_locally(tds, kernel, seed_cells, &topology_model)
 }
 
 fn verify_repair_postcondition_locally<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
     seed_cells: Option<&[CellKey]>,
+    topology_model: &GlobalTopologyModelAdapter<D>,
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
@@ -2811,6 +2917,7 @@ where
     verify_postcondition_k2_facets(
         tds,
         kernel,
+        topology_model,
         &mut queues.facet_queue,
         &config,
         &mut diagnostics,
@@ -2818,6 +2925,7 @@ where
     verify_postcondition_k3_ridges(
         tds,
         kernel,
+        topology_model,
         &mut queues.ridge_queue,
         &config,
         &mut diagnostics,
@@ -2825,6 +2933,7 @@ where
     verify_postcondition_inverse_k2_edges(
         tds,
         kernel,
+        topology_model,
         &mut queues.edge_queue,
         &config,
         &mut diagnostics,
@@ -2832,6 +2941,7 @@ where
     verify_postcondition_inverse_k3_triangles(
         tds,
         kernel,
+        topology_model,
         &mut queues.triangle_queue,
         &config,
         &mut diagnostics,
@@ -2858,6 +2968,7 @@ where
 fn verify_postcondition_k2_facets<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     queue: &mut VecDeque<(FacetHandle, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
@@ -2882,7 +2993,7 @@ where
             Err(e) => return Err(e.into()),
         };
 
-        match is_delaunay_violation_k2(tds, kernel, &context, config, diagnostics) {
+        match is_delaunay_violation_k2(tds, kernel, topology_model, &context, config, diagnostics) {
             Ok(true) => {
                 let flip_degenerate = match k2_flip_would_create_degenerate_cell(tds, &context) {
                     Ok(degenerate) => degenerate,
@@ -2952,6 +3063,7 @@ where
 fn verify_postcondition_k3_ridges<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     queue: &mut VecDeque<(RidgeHandle, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
@@ -2975,7 +3087,7 @@ where
             Err(e) => return Err(e.into()),
         };
 
-        match is_delaunay_violation_k3(tds, kernel, &context, config, diagnostics) {
+        match is_delaunay_violation_k3(tds, kernel, topology_model, &context, config, diagnostics) {
             Ok(true) => {
                 let flip_degenerate = match flip_would_create_degenerate_cell(
                     tds,
@@ -3028,6 +3140,7 @@ where
 fn verify_postcondition_inverse_k2_edges<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     queue: &mut VecDeque<(EdgeKey, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
@@ -3060,9 +3173,11 @@ where
         let violates = match delaunay_violation_k2_for_facet(
             tds,
             kernel,
+            topology_model,
             &context.inserted_face_vertices,
             opposite_a,
             opposite_b,
+            &context.removed_cells,
             config,
             diagnostics,
         ) {
@@ -3108,6 +3223,7 @@ where
 fn verify_postcondition_inverse_k3_triangles<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     queue: &mut VecDeque<(TriangleHandle, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
@@ -3134,8 +3250,10 @@ where
         let violates = match delaunay_violation_k3_for_ridge(
             tds,
             kernel,
+            topology_model,
             &context.inserted_face_vertices,
             &context.removed_face_vertices,
+            &context.removed_cells,
             config,
             diagnostics,
         ) {
@@ -3781,13 +3899,16 @@ where
         Err(e) => return Err(e.into()),
     };
 
-    let violates = match is_delaunay_violation_k3(tds, kernel, &context, config, diagnostics) {
-        Ok(violates) => violates,
-        Err(FlipError::PredicateFailure { .. }) => {
-            return Ok(true);
-        }
-        Err(e) => return Err(e.into()),
-    };
+    let topology_model = GlobalTopology::DEFAULT.model();
+    let violates =
+        match is_delaunay_violation_k3(tds, kernel, &topology_model, &context, config, diagnostics)
+        {
+            Ok(violates) => violates,
+            Err(FlipError::PredicateFailure { .. }) => {
+                return Ok(true);
+            }
+            Err(e) => return Err(e.into()),
+        };
 
     if !violates {
         return Ok(true);
@@ -3955,9 +4076,11 @@ where
     let violates = match delaunay_violation_k2_for_facet(
         tds,
         kernel,
+        &GlobalTopology::DEFAULT.model(),
         &context.inserted_face_vertices,
         opposite_a,
         opposite_b,
+        &context.removed_cells,
         config,
         diagnostics,
     ) {
@@ -4135,8 +4258,10 @@ where
     let violates = match delaunay_violation_k3_for_ridge(
         tds,
         kernel,
+        &GlobalTopology::DEFAULT.model(),
         &context.inserted_face_vertices,
         &context.removed_face_vertices,
+        &context.removed_cells,
         config,
         diagnostics,
     ) {
@@ -4309,13 +4434,16 @@ where
         Err(e) => return Err(e.into()),
     };
 
-    let violates = match is_delaunay_violation_k2(tds, kernel, &context, config, diagnostics) {
-        Ok(violates) => violates,
-        Err(FlipError::PredicateFailure { .. }) => {
-            return Ok(true);
-        }
-        Err(e) => return Err(e.into()),
-    };
+    let topology_model = GlobalTopology::DEFAULT.model();
+    let violates =
+        match is_delaunay_violation_k2(tds, kernel, &topology_model, &context, config, diagnostics)
+        {
+            Ok(violates) => violates,
+            Err(FlipError::PredicateFailure { .. }) => {
+                return Ok(true);
+            }
+            Err(e) => return Err(e.into()),
+        };
 
     if !violates {
         return Ok(true);
@@ -4583,6 +4711,240 @@ where
         points.push(*vertex.point());
     }
     Ok(points)
+}
+
+fn vertices_to_points_with_optional_lift<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    topology_model: &GlobalTopologyModelAdapter<D>,
+    vertices: &[VertexKey],
+    source_cell: Option<CellKey>,
+) -> Result<SmallBuffer<Point<T, D>, MAX_PRACTICAL_DIMENSION_SIZE>, FlipError>
+where
+    T: CoordinateScalar,
+    U: DataType,
+    V: DataType,
+{
+    let mut points: SmallBuffer<Point<T, D>, MAX_PRACTICAL_DIMENSION_SIZE> =
+        SmallBuffer::with_capacity(vertices.len());
+    for &vkey in vertices {
+        points.push(vertex_point_with_optional_lift(
+            tds,
+            topology_model,
+            vkey,
+            source_cell,
+        )?);
+    }
+    Ok(points)
+}
+
+fn vertex_point_with_optional_lift<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    topology_model: &GlobalTopologyModelAdapter<D>,
+    vertex_key: VertexKey,
+    source_cell: Option<CellKey>,
+) -> Result<Point<T, D>, FlipError>
+where
+    T: CoordinateScalar,
+    U: DataType,
+    V: DataType,
+{
+    let periodic_offset = match source_cell {
+        Some(cell_key) => periodic_offset_for_cell_vertex(tds, cell_key, vertex_key)?,
+        None => None,
+    };
+    lift_vertex_point(tds, topology_model, vertex_key, periodic_offset)
+}
+
+fn vertex_point_lifted_into_cell<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    topology_model: &GlobalTopologyModelAdapter<D>,
+    vertex_key: VertexKey,
+    target_cell: Option<CellKey>,
+    source_cells: &[CellKey],
+) -> Result<Point<T, D>, FlipError>
+where
+    T: CoordinateScalar,
+    U: DataType,
+    V: DataType,
+{
+    let Some(target_cell_key) = target_cell else {
+        return vertex_point_with_optional_lift(tds, topology_model, vertex_key, None);
+    };
+
+    if let Some(offset) = periodic_offset_for_cell_vertex(tds, target_cell_key, vertex_key)? {
+        return lift_vertex_point(tds, topology_model, vertex_key, Some(offset));
+    }
+
+    let target_cell = tds
+        .get_cell(target_cell_key)
+        .ok_or(FlipError::MissingCell {
+            cell_key: target_cell_key,
+        })?;
+    let Some(target_offsets) = target_cell.periodic_vertex_offsets() else {
+        return vertex_point_with_optional_lift(tds, topology_model, vertex_key, None);
+    };
+    validate_periodic_offset_len(target_cell_key, target_cell, target_offsets)?;
+
+    for &source_cell_key in source_cells {
+        let Some(source_cell) = tds.get_cell(source_cell_key) else {
+            continue;
+        };
+        if !source_cell.contains_vertex(vertex_key) {
+            continue;
+        }
+        let Some(source_offsets) = source_cell.periodic_vertex_offsets() else {
+            return vertex_point_with_optional_lift(tds, topology_model, vertex_key, None);
+        };
+        validate_periodic_offset_len(source_cell_key, source_cell, source_offsets)?;
+        let Some(source_vertex_index) = source_cell
+            .vertices()
+            .iter()
+            .position(|&vkey| vkey == vertex_key)
+        else {
+            continue;
+        };
+        if let Some((target_shared_index, source_shared_index)) =
+            shared_vertex_indices(target_cell, source_cell)
+        {
+            let target_offset = target_offsets[target_shared_index];
+            let source_offset = source_offsets[source_shared_index];
+            let source_vertex_offset = source_offsets[source_vertex_index];
+            let aligned_offset =
+                align_periodic_offset(source_vertex_offset, source_offset, target_offset)?;
+            return lift_vertex_point(tds, topology_model, vertex_key, Some(aligned_offset));
+        }
+    }
+
+    vertex_point_with_optional_lift(tds, topology_model, vertex_key, None)
+}
+
+fn lift_vertex_point<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    topology_model: &GlobalTopologyModelAdapter<D>,
+    vertex_key: VertexKey,
+    periodic_offset: Option<[i8; D]>,
+) -> Result<Point<T, D>, FlipError>
+where
+    T: CoordinateScalar,
+    U: DataType,
+    V: DataType,
+{
+    let vertex = tds
+        .get_vertex_by_key(vertex_key)
+        .ok_or(FlipError::MissingVertex { vertex_key })?;
+    let lifted_coords = topology_model
+        .lift_for_orientation(*vertex.point().coords(), periodic_offset)
+        .map_err(|error| FlipError::PredicateFailure {
+            message: format!(
+                "failed to lift vertex {vertex_key:?} for periodic predicate: {error}"
+            ),
+        })?;
+    Ok(Point::new(lifted_coords))
+}
+
+fn periodic_offset_for_cell_vertex<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    cell_key: CellKey,
+    vertex_key: VertexKey,
+) -> Result<Option<[i8; D]>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    let cell = tds
+        .get_cell(cell_key)
+        .ok_or(FlipError::MissingCell { cell_key })?;
+    let Some(offsets) = cell.periodic_vertex_offsets() else {
+        return Ok(None);
+    };
+    validate_periodic_offset_len(cell_key, cell, offsets)?;
+    Ok(cell
+        .vertices()
+        .iter()
+        .position(|&vkey| vkey == vertex_key)
+        .map(|index| offsets[index]))
+}
+
+fn validate_periodic_offset_len<T, U, V, const D: usize>(
+    cell_key: CellKey,
+    cell: &Cell<T, U, V, D>,
+    offsets: &[[i8; D]],
+) -> Result<(), FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    if offsets.len() == cell.number_of_vertices() {
+        return Ok(());
+    }
+    Err(FlipError::InvalidFlipContext {
+        message: format!(
+            "cell {cell_key:?} periodic offset count {} does not match vertex count {}",
+            offsets.len(),
+            cell.number_of_vertices()
+        ),
+    })
+}
+
+fn shared_vertex_indices<T, U, V, const D: usize>(
+    target_cell: &Cell<T, U, V, D>,
+    source_cell: &Cell<T, U, V, D>,
+) -> Option<(usize, usize)>
+where
+    U: DataType,
+    V: DataType,
+{
+    target_cell
+        .vertices()
+        .iter()
+        .enumerate()
+        .find_map(|(target_index, &target_vertex)| {
+            source_cell
+                .vertices()
+                .iter()
+                .position(|&source_vertex| source_vertex == target_vertex)
+                .map(|source_index| (target_index, source_index))
+        })
+}
+
+fn align_periodic_offset<const D: usize>(
+    source_vertex_offset: [i8; D],
+    source_reference_offset: [i8; D],
+    target_reference_offset: [i8; D],
+) -> Result<[i8; D], FlipError> {
+    let mut aligned = [0_i8; D];
+    for axis in 0..D {
+        let delta = target_reference_offset[axis]
+            .checked_sub(source_reference_offset[axis])
+            .ok_or_else(|| FlipError::InvalidFlipContext {
+                message: format!("periodic offset subtraction overflow on axis {axis}"),
+            })?;
+        aligned[axis] = source_vertex_offset[axis]
+            .checked_add(delta)
+            .ok_or_else(|| FlipError::InvalidFlipContext {
+                message: format!("periodic offset addition overflow on axis {axis}"),
+            })?;
+    }
+    Ok(aligned)
+}
+
+fn matching_source_cell<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    vertices: &[VertexKey],
+    source_cells: &[CellKey],
+) -> Option<CellKey>
+where
+    U: DataType,
+    V: DataType,
+{
+    source_cells.iter().copied().find(|&cell_key| {
+        tds.get_cell(cell_key).is_some_and(|cell| {
+            cell.number_of_vertices() == vertices.len()
+                && vertices
+                    .iter()
+                    .all(|&vertex_key| cell.contains_vertex(vertex_key))
+        })
+    })
 }
 
 #[derive(Debug, Default)]
@@ -7230,6 +7592,48 @@ mod tests {
 
         // Different variants are never equal.
         assert_ne!(post_test, topo_err);
+    }
+
+    #[test]
+    fn test_align_periodic_offset_identity() {
+        // Same reference offset in source and target → no change.
+        let result = align_periodic_offset([0, 1], [0, 0], [0, 0]).unwrap();
+        assert_eq!(result, [0, 1]);
+    }
+
+    #[test]
+    fn test_align_periodic_offset_shifts_by_delta() {
+        // Source vertex at [1, 0], source ref at [0, 0], target ref at [0, 1].
+        // delta = [0, 1], aligned = [1, 1].
+        let result = align_periodic_offset([1, 0], [0, 0], [0, 1]).unwrap();
+        assert_eq!(result, [1, 1]);
+    }
+
+    #[test]
+    fn test_align_periodic_offset_negative_delta() {
+        // delta = [-1, 0], aligned = [0, 1].
+        let result = align_periodic_offset([1, 1], [1, 0], [0, 0]).unwrap();
+        assert_eq!(result, [0, 1]);
+    }
+
+    #[test]
+    fn test_align_periodic_offset_higher_dimension() {
+        let result = align_periodic_offset([0, 0, 1, -1], [0, 0, 0, 0], [1, -1, 0, 1]).unwrap();
+        assert_eq!(result, [1, -1, 1, 0]);
+    }
+
+    #[test]
+    fn test_align_periodic_offset_subtraction_overflow() {
+        // i8::MIN - 1 overflows.
+        let result = align_periodic_offset::<1>([0], [1], [i8::MIN]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_align_periodic_offset_addition_overflow() {
+        // i8::MAX + 1 overflows.
+        let result = align_periodic_offset::<1>([i8::MAX], [0], [1]);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -2872,7 +2872,13 @@ where
     U: DataType,
     V: DataType,
 {
-    verify_repair_postcondition_with_topology(tds, kernel, None, global_topology)
+    verify_repair_postcondition_with_topology(
+        tds,
+        kernel,
+        None,
+        global_topology,
+        PostconditionMode::Strict,
+    )
 }
 
 /// Keeps legacy Euclidean repair checks on the same validation path as the
@@ -2887,7 +2893,19 @@ where
     U: DataType,
     V: DataType,
 {
-    verify_repair_postcondition_with_topology(tds, kernel, seed_cells, GlobalTopology::DEFAULT)
+    verify_repair_postcondition_with_topology(
+        tds,
+        kernel,
+        seed_cells,
+        GlobalTopology::DEFAULT,
+        PostconditionMode::Repair,
+    )
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum PostconditionMode {
+    Repair,
+    Strict,
 }
 
 /// Adapts the public topology enum into the model used for lifted predicate
@@ -2897,6 +2915,7 @@ fn verify_repair_postcondition_with_topology<K, U, V, const D: usize>(
     kernel: &K,
     seed_cells: Option<&[CellKey]>,
     global_topology: GlobalTopology<D>,
+    mode: PostconditionMode,
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
@@ -2904,7 +2923,7 @@ where
     V: DataType,
 {
     let topology_model = global_topology.model();
-    verify_repair_postcondition_locally(tds, kernel, seed_cells, &topology_model)
+    verify_repair_postcondition_locally(tds, kernel, seed_cells, &topology_model, mode)
 }
 
 /// Replays the repair queues without mutating the TDS so postconditions cover
@@ -2914,6 +2933,7 @@ fn verify_repair_postcondition_locally<K, U, V, const D: usize>(
     kernel: &K,
     seed_cells: Option<&[CellKey]>,
     topology_model: &GlobalTopologyModelAdapter<D>,
+    mode: PostconditionMode,
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
@@ -2968,6 +2988,7 @@ where
         &mut queues.edge_queue,
         &config,
         &mut diagnostics,
+        mode,
     )?;
     verify_postcondition_inverse_k3_triangles(
         tds,
@@ -2976,6 +2997,7 @@ where
         &mut queues.triangle_queue,
         &config,
         &mut diagnostics,
+        mode,
     )?;
 
     // After all flip predicates pass, verify that the repair did not disconnect the
@@ -3181,6 +3203,7 @@ fn verify_postcondition_inverse_k2_edges<K, U, V, const D: usize>(
     queue: &mut VecDeque<(EdgeKey, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
+    mode: PostconditionMode,
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
@@ -3233,14 +3256,12 @@ where
         };
 
         if !violates {
-            // For D≥4, flip-based inverse postcondition checks can produce false
+            // During repair, D≥4 inverse postcondition checks can produce false
             // positives in near-degenerate configurations (both forward and inverse
             // flip predicates simultaneously report a violation — a numerical
-            // artifact).  Ground-truth validation via `is_delaunay_property_only()`
-            // is performed at the bulk-construction layer (e.g.
-            // `build_with_shuffled_retries`), not here, because calling it per-edge
-            // would be O(cells × vertices) per iteration.
-            if D >= 4 {
+            // artifact).  Strict validation still reports these instead of
+            // suppressing applicable inverse flips.
+            if mode == PostconditionMode::Repair && D >= 4 {
                 continue;
             }
             if repair_trace_enabled() {
@@ -3268,6 +3289,7 @@ fn verify_postcondition_inverse_k3_triangles<K, U, V, const D: usize>(
     queue: &mut VecDeque<(TriangleHandle, u64)>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
+    mode: PostconditionMode,
 ) -> Result<(), DelaunayRepairError>
 where
     K: Kernel<D>,
@@ -3313,12 +3335,10 @@ where
         };
 
         if !violates {
-            // Symmetric guard to the inverse k=2 check above: for D≥4,
-            // flip-based inverse postcondition checks can produce false
-            // positives in near-degenerate configurations.  Ground-truth
-            // validation via `is_delaunay_property_only()` is performed at the
-            // bulk-construction layer, not here (see inverse k=2 comment).
-            if D >= 4 {
+            // Symmetric repair-mode guard to the inverse k=2 check above:
+            // D≥4 inverse checks can be noisy in near-degenerate repair states,
+            // while strict validation still reports applicable inverse flips.
+            if mode == PostconditionMode::Repair && D >= 4 {
                 continue;
             }
             if repair_trace_enabled() {
@@ -4896,16 +4916,13 @@ where
         return vertex_point_with_optional_lift(tds, topology_model, vertex_key, None);
     };
 
-    let target_offset = periodic_offset_for_cell_vertex(tds, target_cell_key, vertex_key)?;
-    if let Some(offset) = target_offset {
-        let periodic_offset = topology_model
-            .supports_periodic_orientation_offsets()
-            .then_some(offset);
-        return lift_vertex_point(tds, topology_model, vertex_key, periodic_offset);
-    }
-
     if !topology_model.supports_periodic_orientation_offsets() {
         return lift_vertex_point(tds, topology_model, vertex_key, None);
+    }
+
+    let target_offset = periodic_offset_for_cell_vertex(tds, target_cell_key, vertex_key)?;
+    if let Some(offset) = target_offset {
+        return lift_vertex_point(tds, topology_model, vertex_key, Some(offset));
     }
 
     let target_cell = tds

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -416,6 +416,8 @@ where
     })
 }
 
+/// Detects replacement simplices that already exist outside the flip cavity so
+/// a flip cannot silently duplicate a cell.
 fn find_cell_containing_simplex<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     simplex_vertices: &[VertexKey],
@@ -450,6 +452,8 @@ where
     None
 }
 
+/// Scans the whole TDS for ridge diagnostics when local neighbor links are the
+/// thing being investigated.
 fn cells_containing_vertices<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     vertices: &[VertexKey],
@@ -471,6 +475,8 @@ where
     cells
 }
 
+/// Emits a bounded ridge snapshot so repair failures can distinguish bad local
+/// handles from genuinely inconsistent global incidence.
 fn debug_ridge_context<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     ridge: RidgeHandle,
@@ -550,6 +556,7 @@ where
         &context.removed_face_vertices,
         &context.inserted_face_vertices,
         &context.removed_cells,
+        None,
         config,
         diagnostics,
     )
@@ -646,6 +653,8 @@ struct FlipCycleContext<'a> {
 }
 
 impl<'a> FlipCycleContext<'a> {
+    /// Bundles the flip data needed for diagnostics without cloning vertex
+    /// buffers on every repair step.
     const fn new(
         signature: u64,
         k_move: usize,
@@ -663,6 +672,8 @@ impl<'a> FlipCycleContext<'a> {
     }
 }
 
+/// Converts repeated flip signatures into typed non-convergence before the
+/// repair loop burns the full budget on a short oscillation.
 fn check_flip_cycle<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     context: FlipCycleContext<'_>,
@@ -1731,6 +1742,7 @@ fn delaunay_violation_k2_for_facet<K, U, V, const D: usize>(
     opposite_a: VertexKey,
     opposite_b: VertexKey,
     source_cells: &[CellKey],
+    frame_cell: Option<CellKey>,
     config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
 ) -> Result<bool, FlipError>
@@ -1770,12 +1782,22 @@ where
     cell_vertices[0].sort_unstable_by_key(|v| v.data().as_ffi());
     cell_vertices[1].sort_unstable_by_key(|v| v.data().as_ffi());
 
-    let source_a = matching_source_cell(tds, &cell_vertices[0], source_cells);
-    let source_b = matching_source_cell(tds, &cell_vertices[1], source_cells);
-    let points_a =
-        vertices_to_points_with_optional_lift(tds, topology_model, &cell_vertices[0], source_a)?;
-    let points_b =
-        vertices_to_points_with_optional_lift(tds, topology_model, &cell_vertices[1], source_b)?;
+    let source_a = matching_source_cell(tds, &cell_vertices[0], source_cells).or(frame_cell);
+    let source_b = matching_source_cell(tds, &cell_vertices[1], source_cells).or(frame_cell);
+    let points_a = vertices_to_points_with_optional_lift(
+        tds,
+        topology_model,
+        &cell_vertices[0],
+        source_a,
+        source_cells,
+    )?;
+    let points_b = vertices_to_points_with_optional_lift(
+        tds,
+        topology_model,
+        &cell_vertices[1],
+        source_b,
+        source_cells,
+    )?;
 
     let opposite_point_a =
         vertex_point_lifted_into_cell(tds, topology_model, opposite_a, source_b, source_cells)?;
@@ -1935,6 +1957,7 @@ where
         opposite_a,
         opposite_b,
         &context.removed_cells,
+        None,
         config,
         diagnostics,
     )
@@ -2168,6 +2191,7 @@ fn delaunay_violation_k3_for_ridge<K, U, V, const D: usize>(
     ridge_vertices: &[VertexKey],
     triangle_vertices: &[VertexKey],
     source_cells: &[CellKey],
+    frame_cell: Option<CellKey>,
     _config: &RepairAttemptConfig,
     diagnostics: &mut RepairDiagnostics,
 ) -> Result<bool, FlipError>
@@ -2207,12 +2231,13 @@ where
         // Sort by VertexKey for canonical SoS perturbation ordering
         cell_vertices.sort_unstable_by_key(|v| v.data().as_ffi());
 
-        let source_cell = matching_source_cell(tds, &cell_vertices, source_cells);
+        let source_cell = matching_source_cell(tds, &cell_vertices, source_cells).or(frame_cell);
         let points = vertices_to_points_with_optional_lift(
             tds,
             topology_model,
             &cell_vertices,
             source_cell,
+            source_cells,
         )?;
         let missing_point =
             vertex_point_lifted_into_cell(tds, topology_model, missing, source_cell, source_cells)?;
@@ -2850,6 +2875,8 @@ where
     verify_repair_postcondition_with_topology(tds, kernel, None, global_topology)
 }
 
+/// Keeps legacy Euclidean repair checks on the same validation path as the
+/// topology-aware verifier.
 fn verify_repair_postcondition<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -2863,6 +2890,8 @@ where
     verify_repair_postcondition_with_topology(tds, kernel, seed_cells, GlobalTopology::DEFAULT)
 }
 
+/// Adapts the public topology enum into the model used for lifted predicate
+/// evaluation.
 fn verify_repair_postcondition_with_topology<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -2878,6 +2907,8 @@ where
     verify_repair_postcondition_locally(tds, kernel, seed_cells, &topology_model)
 }
 
+/// Replays the repair queues without mutating the TDS so postconditions cover
+/// the same local predicates that drive repair.
 fn verify_repair_postcondition_locally<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -2965,6 +2996,8 @@ where
     Ok(())
 }
 
+/// Rechecks queued facets after repair so unresolved k=2 violations surface as
+/// postcondition failures instead of latent invalid triangulations.
 fn verify_postcondition_k2_facets<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -3060,6 +3093,8 @@ where
     Ok(())
 }
 
+/// Rechecks queued ridges after repair so higher-dimensional k=3 violations get
+/// the same explicit postcondition treatment as facets.
 fn verify_postcondition_k3_ridges<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -3137,6 +3172,8 @@ where
     Ok(())
 }
 
+/// Exercises inverse k=2 predicates after repair because an apparently valid
+/// facet pass can still leave an edge-collapse move applicable.
 fn verify_postcondition_inverse_k2_edges<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -3169,6 +3206,7 @@ where
         }
         let opposite_a = context.removed_face_vertices[0];
         let opposite_b = context.removed_face_vertices[1];
+        let frame_cell = removed_cell_frame(&context.removed_cells)?;
 
         let violates = match delaunay_violation_k2_for_facet(
             tds,
@@ -3178,6 +3216,7 @@ where
             opposite_a,
             opposite_b,
             &context.removed_cells,
+            Some(frame_cell),
             config,
             diagnostics,
         ) {
@@ -3220,6 +3259,8 @@ where
     Ok(())
 }
 
+/// Exercises inverse k=3 predicates after repair so triangle-collapse moves do
+/// not hide behind forward-only verification.
 fn verify_postcondition_inverse_k3_triangles<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -3247,6 +3288,7 @@ where
             Err(e) => return Err(e.into()),
         };
 
+        let frame_cell = removed_cell_frame(&context.removed_cells)?;
         let violates = match delaunay_violation_k3_for_ridge(
             tds,
             kernel,
@@ -3254,6 +3296,7 @@ where
             &context.inserted_face_vertices,
             &context.removed_face_vertices,
             &context.removed_cells,
+            Some(frame_cell),
             config,
             diagnostics,
         ) {
@@ -3323,6 +3366,8 @@ struct RepairDiagnostics {
 }
 
 impl RepairDiagnostics {
+    /// Records uncertain predicate sites with bounded samples so diagnostics stay
+    /// actionable on large repairs.
     fn record_ambiguous(&mut self, key: u64) {
         self.ambiguous_predicates += 1;
         if self.ambiguous_samples.len() >= AMBIGUOUS_SAMPLE_LIMIT {
@@ -3333,10 +3378,14 @@ impl RepairDiagnostics {
         }
     }
 
+    /// Counts predicate failures separately from ambiguity because failures abort
+    /// the current local check.
     const fn record_predicate_failure(&mut self) {
         self.predicate_failures = self.predicate_failures.saturating_add(1);
     }
 
+    /// Maintains a sliding signature window so cycle detection is bounded in
+    /// memory but still catches local oscillations.
     fn record_flip_signature(&mut self, signature: u64) {
         let count = self.flip_signature_counts.entry(signature).or_insert(0);
         *count = count.saturating_add(1);
@@ -3362,6 +3411,8 @@ impl RepairDiagnostics {
         }
     }
 
+    /// Preserves the signature that triggered a non-convergence abort even if it
+    /// was already sampled earlier.
     fn record_cycle_abort(&mut self, signature: u64) {
         self.cycle_detections = self.cycle_detections.saturating_add(1);
         if self.cycle_samples.len() < CYCLE_SAMPLE_LIMIT && !self.cycle_samples.contains(&signature)
@@ -3370,6 +3421,8 @@ impl RepairDiagnostics {
         }
     }
 
+    /// Captures one duplicate-simplex skip sample without formatting strings on
+    /// every skipped flip.
     fn record_inserted_simplex_skip(&mut self, sample: impl FnOnce() -> String) {
         self.inserted_simplex_skips = self.inserted_simplex_skips.saturating_add(1);
         if self.inserted_simplex_sample.is_none() {
@@ -3377,6 +3430,7 @@ impl RepairDiagnostics {
         }
     }
 
+    /// Captures one invalid-ridge sample lazily so common skip paths stay cheap.
     fn record_invalid_ridge_multiplicity_skip(&mut self, sample: impl FnOnce() -> String) {
         self.invalid_ridge_multiplicity_skips =
             self.invalid_ridge_multiplicity_skips.saturating_add(1);
@@ -3385,6 +3439,8 @@ impl RepairDiagnostics {
         }
     }
 
+    /// Captures one stale-cell sample lazily so slot-swap churn is visible when
+    /// repair diagnostics are inspected.
     fn record_missing_cell_skip(&mut self, sample: impl FnOnce() -> String) {
         self.missing_cell_skips = self.missing_cell_skips.saturating_add(1);
         if self.missing_cell_sample.is_none() {
@@ -3403,6 +3459,8 @@ struct RepairAttemptConfig {
     max_flips_override: Option<usize>,
 }
 
+/// Builds the public non-convergence error in one place so diagnostics, queue
+/// order, and attempt metadata stay consistent.
 fn non_convergent_error(
     max_flips: usize,
     stats: &DelaunayRepairStats,
@@ -3427,6 +3485,8 @@ fn non_convergent_error(
     }
 }
 
+/// Gates the expensive repair summary behind an environment variable while
+/// keeping all attempts logged in a uniform shape.
 fn emit_repair_debug_summary(
     label: &str,
     stats: &DelaunayRepairStats,
@@ -3459,6 +3519,8 @@ fn emit_repair_debug_summary(
     );
 }
 
+/// Shares FIFO/LIFO behavior across repair queues so alternate attempts only
+/// differ by scheduling policy.
 fn pop_queue<T>(queue: &mut VecDeque<T>, order: RepairQueueOrder) -> Option<T> {
     match order {
         RepairQueueOrder::Fifo => queue.pop_front(),
@@ -3466,6 +3528,8 @@ fn pop_queue<T>(queue: &mut VecDeque<T>, order: RepairQueueOrder) -> Option<T> {
     }
 }
 
+/// Hashes a predicate site canonically so ambiguous-predicate samples are stable
+/// across vertex ordering in a simplex.
 fn predicate_key_from_vertices(simplex_vertices: &[VertexKey], test_vertex: VertexKey) -> u64 {
     let mut sorted: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE> =
         simplex_vertices.iter().copied().collect();
@@ -3479,6 +3543,7 @@ fn predicate_key_from_vertices(simplex_vertices: &[VertexKey], test_vertex: Vert
     hasher.finish()
 }
 
+/// Canonicalizes a flip attempt into a compact key for cycle detection.
 fn flip_signature(
     k_move: usize,
     direction: FlipDirection,
@@ -3518,6 +3583,8 @@ struct LastAppliedFlip {
 }
 
 impl LastAppliedFlip {
+    /// Sorts faces so immediate-reversal detection is independent of local cell
+    /// vertex order.
     fn new(k_move: usize, removed: &[VertexKey], inserted: &[VertexKey]) -> Self {
         let mut removed_face_vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE> =
             removed.iter().copied().collect();
@@ -3535,6 +3602,8 @@ impl LastAppliedFlip {
     }
 }
 
+/// Catches two-step flip oscillations before they inflate repair diagnostics or
+/// consume the global flip budget.
 fn would_immediately_reverse_last_flip<const D: usize>(
     last: Option<&LastAppliedFlip>,
     k_move: usize,
@@ -3554,11 +3623,15 @@ fn would_immediately_reverse_last_flip<const D: usize>(
         && current.inserted_face_vertices == last_flip.removed_face_vertices
 }
 
+/// Keeps verbose repair tracing opt-in because the hot repair loop calls this
+/// frequently.
 #[inline]
 fn repair_trace_enabled() -> bool {
     std::env::var_os("DELAUNAY_REPAIR_TRACE").is_some()
 }
 
+/// Treats full repair tracing as enabling ridge snapshots so one debug switch
+/// gives enough topology context.
 #[inline]
 fn repair_ridge_debug_enabled() -> bool {
     std::env::var_os("DELAUNAY_REPAIR_DEBUG_RIDGE").is_some() || repair_trace_enabled()
@@ -3567,6 +3640,8 @@ fn repair_ridge_debug_enabled() -> bool {
 const RIDGE_DEBUG_LIMIT_DEFAULT: usize = 64;
 static RIDGE_DEBUG_EMITTED: AtomicUsize = AtomicUsize::new(0);
 
+/// Rate-limits ridge snapshots to keep pathological repair runs from flooding
+/// logs.
 fn ridge_debug_limit() -> usize {
     std::env::var("DELAUNAY_REPAIR_DEBUG_RIDGE_LIMIT")
         .ok()
@@ -3574,6 +3649,8 @@ fn ridge_debug_limit() -> usize {
         .unwrap_or(RIDGE_DEBUG_LIMIT_DEFAULT)
 }
 
+/// Applies the ridge debug limit atomically so concurrent tests still share a
+/// bounded diagnostic budget.
 fn should_emit_ridge_debug() -> bool {
     let limit = ridge_debug_limit();
     if limit == 0 {
@@ -3587,6 +3664,9 @@ fn should_emit_ridge_debug() -> bool {
     }
     current < limit
 }
+
+/// Computes a dimension-sensitive flip budget so non-convergent repair fails
+/// predictably instead of running unbounded.
 fn default_max_flips<const D: usize>(cell_count: usize) -> usize {
     // Flip budget strategy by dimension and build mode:
     //
@@ -3633,6 +3713,8 @@ struct RepairQueues {
 }
 
 impl RepairQueues {
+    /// Initializes all repair worklists together so queue state cannot be
+    /// partially seeded.
     fn new() -> Self {
         Self {
             facet_queue: VecDeque::new(),
@@ -3648,6 +3730,8 @@ impl RepairQueues {
         }
     }
 
+    /// Reports aggregate queued work for diagnostics that compare scheduling
+    /// strategies.
     fn total_len(&self) -> usize {
         self.facet_queue.len()
             + self.ridge_queue.len()
@@ -3655,6 +3739,8 @@ impl RepairQueues {
             + self.triangle_queue.len()
     }
 
+    /// Gives the repair loop one invariant-preserving exit check across all
+    /// dimension-specific queues.
     fn has_work(&self) -> bool {
         !self.facet_queue.is_empty()
             || !self.ridge_queue.is_empty()
@@ -3663,6 +3749,8 @@ impl RepairQueues {
     }
 }
 
+/// Seeds exactly the queues supported by the current dimension so repair and
+/// verification inspect the same local neighborhoods.
 #[allow(
     clippy::too_many_lines,
     reason = "Seeding logic mirrors runtime queues; keep as single flow for diagnostics"
@@ -3784,6 +3872,8 @@ where
     Ok(())
 }
 
+/// Requeues the local neighborhood created by a flip so the repair loop follows
+/// newly exposed violations instead of rescanning the whole triangulation.
 fn enqueue_new_cells_for_repair<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     new_cells: &[CellKey],
@@ -3831,6 +3921,8 @@ where
     Ok(())
 }
 
+/// Processes one queued ridge because k=3 moves are only meaningful in D>=3 and
+/// need their own adjacency validation.
 #[expect(
     clippy::too_many_arguments,
     reason = "Repair step threads queues, diagnostics, and config explicitly"
@@ -4013,6 +4105,8 @@ where
     Ok(true)
 }
 
+/// Processes one queued edge for inverse k=2 moves so higher-dimensional repair
+/// can collapse locally Delaunay edge stars.
 #[expect(
     clippy::too_many_arguments,
     reason = "Repair step threads queues, diagnostics, and config explicitly"
@@ -4072,6 +4166,7 @@ where
     }
     let opposite_a = context.removed_face_vertices[0];
     let opposite_b = context.removed_face_vertices[1];
+    let frame_cell = removed_cell_frame(&context.removed_cells)?;
 
     let violates = match delaunay_violation_k2_for_facet(
         tds,
@@ -4081,6 +4176,7 @@ where
         opposite_a,
         opposite_b,
         &context.removed_cells,
+        Some(frame_cell),
         config,
         diagnostics,
     ) {
@@ -4198,6 +4294,8 @@ where
     Ok(true)
 }
 
+/// Processes one queued triangle for inverse k=3 moves, which only appear once
+/// D is high enough for a triangle star to be replaced.
 #[expect(
     clippy::too_many_arguments,
     reason = "Repair step threads queues, diagnostics, and config explicitly"
@@ -4255,6 +4353,7 @@ where
         Err(e) => return Err(e.into()),
     };
 
+    let frame_cell = removed_cell_frame(&context.removed_cells)?;
     let violates = match delaunay_violation_k3_for_ridge(
         tds,
         kernel,
@@ -4262,6 +4361,7 @@ where
         &context.inserted_face_vertices,
         &context.removed_face_vertices,
         &context.removed_cells,
+        Some(frame_cell),
         config,
         diagnostics,
     ) {
@@ -4375,6 +4475,8 @@ where
     Ok(true)
 }
 
+/// Processes one queued facet because k=2 facet flips are the primary local
+/// repair move across supported dimensions.
 #[expect(
     clippy::too_many_arguments,
     reason = "Repair step threads queues, diagnostics, and config explicitly"
@@ -4558,6 +4660,8 @@ where
     Ok(true)
 }
 
+/// Extracts facet vertices by omitted slot so facet hashing matches the cell's
+/// current vertex ordering.
 fn facet_vertices_from_cell<T, U, V, const D: usize>(
     cell: &Cell<T, U, V, D>,
     facet_index: usize,
@@ -4577,6 +4681,8 @@ where
     vertices
 }
 
+/// Extracts ridge vertices by omitted slots so ridge handles remain compact but
+/// can still be converted into stable vertex sets.
 fn ridge_vertices_from_cell<T, U, V, const D: usize>(
     cell: &Cell<T, U, V, D>,
     omit_a: usize,
@@ -4597,6 +4703,8 @@ where
     vertices
 }
 
+/// Finds the two vertices opposite a ridge in one cell while validating that the
+/// requested ridge is actually incident to that cell.
 fn cell_extras_for_ridge<T, U, V, const D: usize>(
     cell_key: CellKey,
     cell: &Cell<T, U, V, D>,
@@ -4621,6 +4729,7 @@ where
     Ok(extras)
 }
 
+/// Identifies the one opposite vertex needed to complete a k=3 cavity cycle.
 fn missing_opposite_for_cell(
     extras: &[VertexKey; 2],
     opposites: &[VertexKey; 3],
@@ -4631,6 +4740,8 @@ fn missing_opposite_for_cell(
         .find(|v| *v != extras[0] && *v != extras[1])
 }
 
+/// Walks the neighbor graph around a ridge so k=3 context construction uses the
+/// local star rather than a global incidence scan.
 fn collect_cells_around_ridge<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     start_cell: CellKey,
@@ -4693,6 +4804,8 @@ where
     Ok(cells)
 }
 
+/// Converts vertex keys to Euclidean points for predicates that do not need a
+/// periodic frame.
 fn vertices_to_points<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     vertices: &[VertexKey],
@@ -4713,11 +4826,14 @@ where
     Ok(points)
 }
 
+/// Builds predicate points in one periodic frame so quotient-cell coordinates
+/// compare as lifted representatives.
 fn vertices_to_points_with_optional_lift<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     topology_model: &GlobalTopologyModelAdapter<D>,
     vertices: &[VertexKey],
     source_cell: Option<CellKey>,
+    source_cells: &[CellKey],
 ) -> Result<SmallBuffer<Point<T, D>, MAX_PRACTICAL_DIMENSION_SIZE>, FlipError>
 where
     T: CoordinateScalar,
@@ -4727,16 +4843,19 @@ where
     let mut points: SmallBuffer<Point<T, D>, MAX_PRACTICAL_DIMENSION_SIZE> =
         SmallBuffer::with_capacity(vertices.len());
     for &vkey in vertices {
-        points.push(vertex_point_with_optional_lift(
+        points.push(vertex_point_lifted_into_cell(
             tds,
             topology_model,
             vkey,
             source_cell,
+            source_cells,
         )?);
     }
     Ok(points)
 }
 
+/// Applies a cell-local periodic offset when the vertex is already present in
+/// the selected source cell.
 fn vertex_point_with_optional_lift<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     topology_model: &GlobalTopologyModelAdapter<D>,
@@ -4755,6 +4874,8 @@ where
     lift_vertex_point(tds, topology_model, vertex_key, periodic_offset)
 }
 
+/// Lifts a vertex into a target cell's frame, aligning from neighboring source
+/// cells instead of falling back to bare periodic coordinates.
 fn vertex_point_lifted_into_cell<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     topology_model: &GlobalTopologyModelAdapter<D>,
@@ -4793,7 +4914,11 @@ where
             continue;
         }
         let Some(source_offsets) = source_cell.periodic_vertex_offsets() else {
-            return vertex_point_with_optional_lift(tds, topology_model, vertex_key, None);
+            return Err(FlipError::InvalidFlipContext {
+                message: format!(
+                    "cannot align periodic vertex {vertex_key:?} from cell {source_cell_key:?} into frame {target_cell_key:?}: source cell has no periodic offsets"
+                ),
+            });
         };
         validate_periodic_offset_len(source_cell_key, source_cell, source_offsets)?;
         let Some(source_vertex_index) = source_cell
@@ -4815,9 +4940,15 @@ where
         }
     }
 
-    vertex_point_with_optional_lift(tds, topology_model, vertex_key, None)
+    Err(FlipError::InvalidFlipContext {
+        message: format!(
+            "cannot align periodic vertex {vertex_key:?} into frame {target_cell_key:?}"
+        ),
+    })
 }
 
+/// Centralizes topology-model lifting so missing vertices and non-liftable
+/// offsets become typed flip errors.
 fn lift_vertex_point<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     topology_model: &GlobalTopologyModelAdapter<D>,
@@ -4842,6 +4973,8 @@ where
     Ok(Point::new(lifted_coords))
 }
 
+/// Looks up the offset paired with a vertex slot, preserving the invariant that
+/// periodic offsets are indexed exactly like cell vertices.
 fn periodic_offset_for_cell_vertex<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     cell_key: CellKey,
@@ -4865,6 +4998,8 @@ where
         .map(|index| offsets[index]))
 }
 
+/// Rejects malformed quotient cells before offset indexing can desynchronize
+/// vertices from their lifted representatives.
 fn validate_periodic_offset_len<T, U, V, const D: usize>(
     cell_key: CellKey,
     cell: &Cell<T, U, V, D>,
@@ -4886,6 +5021,8 @@ where
     })
 }
 
+/// Finds a common vertex to act as the reference point for aligning two
+/// periodic cell frames.
 fn shared_vertex_indices<T, U, V, const D: usize>(
     target_cell: &Cell<T, U, V, D>,
     source_cell: &Cell<T, U, V, D>,
@@ -4907,6 +5044,9 @@ where
         })
 }
 
+/// Aligns a periodic vertex offset from a source cell's frame into a target
+/// cell's frame so cross-cell insphere predicates see consistent lifted
+/// coordinates.
 fn align_periodic_offset<const D: usize>(
     source_vertex_offset: [i8; D],
     source_reference_offset: [i8; D],
@@ -4928,6 +5068,8 @@ fn align_periodic_offset<const D: usize>(
     Ok(aligned)
 }
 
+/// Reuses an existing removed cell as the predicate frame when the candidate
+/// simplex exactly matches that cell.
 fn matching_source_cell<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     vertices: &[VertexKey],
@@ -4945,6 +5087,17 @@ where
                     .all(|&vertex_key| cell.contains_vertex(vertex_key))
         })
     })
+}
+
+/// Selects a concrete removed-cell frame for inverse predicates, where no
+/// forward replacement simplex may match exactly.
+fn removed_cell_frame(source_cells: &[CellKey]) -> Result<CellKey, FlipError> {
+    source_cells
+        .first()
+        .copied()
+        .ok_or_else(|| FlipError::InvalidFlipContext {
+            message: "inverse flip predicate requires at least one removed cell frame".to_string(),
+        })
 }
 
 #[derive(Debug, Default)]
@@ -4972,6 +5125,8 @@ struct CandidateFacetInfo {
     last_cell: Option<CellKey>,
 }
 
+/// Sorts stable slotmap key values before hashing so signatures are independent
+/// of local cell vertex order.
 fn sorted_vertex_key_values(
     vertices: &[VertexKey],
 ) -> SmallBuffer<u64, MAX_PRACTICAL_DIMENSION_SIZE> {
@@ -4981,11 +5136,14 @@ fn sorted_vertex_key_values(
     key_values
 }
 
+/// Hashes a complete cell vertex set for duplicate-cell detection during flips.
 fn cell_signature(vertices: &[VertexKey]) -> u64 {
     let key_values = sorted_vertex_key_values(vertices);
     stable_hash_u64_slice(&key_values)
 }
 
+/// Builds the small topology index needed to reject duplicate cells and
+/// non-manifold internal facets without repeated global scans.
 fn build_flip_topology_index<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     new_cell_vertices: &[SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>],
@@ -5126,6 +5284,8 @@ where
     }
 }
 
+/// Checks candidate cells against the topology index before mutation so a flip
+/// cannot introduce two cells with the same vertex set.
 fn flip_would_duplicate_cell_any<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     vertices: &[VertexKey],
@@ -5172,6 +5332,8 @@ where
     true
 }
 
+/// Checks candidate internal facets against existing incidence so a flip cannot
+/// create facet multiplicity greater than two.
 fn flip_would_create_nonmanifold_facets_any(
     vertices: &[VertexKey],
     topology: &FlipTopologyIndex,
@@ -5223,6 +5385,8 @@ fn flip_would_create_nonmanifold_facets_any(
     false
 }
 
+/// Queues all interior facets of a cell because k=2 repair is driven by shared
+/// facet predicates.
 fn enqueue_cell_facets<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     cell_key: CellKey,
@@ -5253,6 +5417,8 @@ where
     Ok(())
 }
 
+/// Enqueues a facet by stable vertex hash so stale handles can be resolved after
+/// slot swaps.
 fn enqueue_facet<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     handle: FacetHandle,
@@ -5292,6 +5458,7 @@ fn enqueue_facet<T, U, V, const D: usize>(
     }
 }
 
+/// Queues cell edges only in dimensions where inverse k=2 repair is admissible.
 fn enqueue_cell_edges<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     cell_key: CellKey,
@@ -5321,6 +5488,7 @@ fn enqueue_cell_edges<T, U, V, const D: usize>(
     }
 }
 
+/// Deduplicates inverse k=2 edge work by vertex-set hash across incident cells.
 fn enqueue_edge(
     edge: EdgeKey,
     queue: &mut VecDeque<(EdgeKey, u64)>,
@@ -5334,6 +5502,8 @@ fn enqueue_edge(
     }
 }
 
+/// Queues cell triangles only in dimensions where inverse k=3 repair is
+/// admissible.
 fn enqueue_cell_triangles<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     cell_key: CellKey,
@@ -5365,6 +5535,8 @@ fn enqueue_cell_triangles<T, U, V, const D: usize>(
     }
 }
 
+/// Deduplicates inverse k=3 triangle work by vertex-set hash across incident
+/// cells.
 fn enqueue_triangle(
     triangle: TriangleHandle,
     queue: &mut VecDeque<(TriangleHandle, u64)>,
@@ -5379,6 +5551,8 @@ fn enqueue_triangle(
     }
 }
 
+/// Queues all ridges of a cell because k=3 repair needs codimension-two local
+/// stars.
 fn enqueue_cell_ridges<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     cell_key: CellKey,
@@ -5425,6 +5599,8 @@ where
     Ok(())
 }
 
+/// Enqueues a ridge by stable vertex hash so post-flip slot swaps do not strand
+/// stale ridge handles.
 fn enqueue_ridge<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
     handle: RidgeHandle,
@@ -5471,8 +5647,10 @@ mod tests {
     use crate::core::algorithms::incremental_insertion::repair_neighbor_pointers;
     use crate::core::collections::Uuid;
     use crate::geometry::kernel::{AdaptiveKernel, FastKernel};
+    use crate::topology::traits::topological_space::ToroidalConstructionMode;
     use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
+    use approx::assert_relative_eq;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -7594,46 +7772,353 @@ mod tests {
         assert_ne!(post_test, topo_err);
     }
 
-    #[test]
-    fn test_align_periodic_offset_identity() {
-        // Same reference offset in source and target → no change.
-        let result = align_periodic_offset([0, 1], [0, 0], [0, 0]).unwrap();
-        assert_eq!(result, [0, 1]);
+    macro_rules! gen_align_periodic_offset_tests {
+        ($dim:literal) => {
+            pastey::paste! {
+                #[test]
+                fn [<test_align_periodic_offset_identity_ $dim d>]() {
+                    // Same reference offset in source and target -> no change.
+                    let mut source_vertex_offset = [0_i8; $dim];
+                    source_vertex_offset[$dim - 1] = 1;
+                    let result = align_periodic_offset(
+                        source_vertex_offset,
+                        [0_i8; $dim],
+                        [0_i8; $dim],
+                    )
+                    .unwrap();
+                    assert_eq!(result, source_vertex_offset);
+                }
+
+                #[test]
+                fn [<test_align_periodic_offset_shifts_by_delta_ $dim d>]() {
+                    // delta = target reference - source reference.
+                    let mut source_vertex_offset = [0_i8; $dim];
+                    source_vertex_offset[0] = 1;
+                    let mut target_reference_offset = [0_i8; $dim];
+                    target_reference_offset[$dim - 1] = 1;
+                    let mut expected = source_vertex_offset;
+                    expected[$dim - 1] = expected[$dim - 1].saturating_add(1);
+
+                    let result = align_periodic_offset(
+                        source_vertex_offset,
+                        [0_i8; $dim],
+                        target_reference_offset,
+                    )
+                    .unwrap();
+                    assert_eq!(result, expected);
+                }
+
+                #[test]
+                fn [<test_align_periodic_offset_negative_delta_ $dim d>]() {
+                    let source_vertex_offset = [1_i8; $dim];
+                    let mut source_reference_offset = [0_i8; $dim];
+                    source_reference_offset[0] = 1;
+                    let mut expected = source_vertex_offset;
+                    expected[0] = 0;
+
+                    let result = align_periodic_offset(
+                        source_vertex_offset,
+                        source_reference_offset,
+                        [0_i8; $dim],
+                    )
+                    .unwrap();
+                    assert_eq!(result, expected);
+                }
+
+                #[test]
+                fn [<test_align_periodic_offset_subtraction_overflow_ $dim d>]() {
+                    // i8::MIN - 1 overflows.
+                    let mut source_reference_offset = [0_i8; $dim];
+                    source_reference_offset[0] = 1;
+                    let mut target_reference_offset = [0_i8; $dim];
+                    target_reference_offset[0] = i8::MIN;
+
+                    let result = align_periodic_offset(
+                        [0_i8; $dim],
+                        source_reference_offset,
+                        target_reference_offset,
+                    );
+                    assert!(result.is_err());
+                }
+
+                #[test]
+                fn [<test_align_periodic_offset_addition_overflow_ $dim d>]() {
+                    // i8::MAX + 1 overflows.
+                    let mut source_vertex_offset = [0_i8; $dim];
+                    source_vertex_offset[0] = i8::MAX;
+                    let mut target_reference_offset = [0_i8; $dim];
+                    target_reference_offset[0] = 1;
+
+                    let result = align_periodic_offset(
+                        source_vertex_offset,
+                        [0_i8; $dim],
+                        target_reference_offset,
+                    );
+                    assert!(result.is_err());
+                }
+            }
+        };
     }
 
-    #[test]
-    fn test_align_periodic_offset_shifts_by_delta() {
-        // Source vertex at [1, 0], source ref at [0, 0], target ref at [0, 1].
-        // delta = [0, 1], aligned = [1, 1].
-        let result = align_periodic_offset([1, 0], [0, 0], [0, 1]).unwrap();
-        assert_eq!(result, [1, 1]);
+    gen_align_periodic_offset_tests!(2);
+    gen_align_periodic_offset_tests!(3);
+    gen_align_periodic_offset_tests!(4);
+    gen_align_periodic_offset_tests!(5);
+
+    fn toroidal_periodic_model<const D: usize>() -> GlobalTopologyModelAdapter<D> {
+        GlobalTopology::Toroidal {
+            domain: [1.0; D],
+            mode: ToroidalConstructionMode::PeriodicImagePoint,
+        }
+        .model()
     }
 
-    #[test]
-    fn test_align_periodic_offset_negative_delta() {
-        // delta = [-1, 0], aligned = [0, 1].
-        let result = align_periodic_offset([1, 1], [1, 0], [0, 0]).unwrap();
-        assert_eq!(result, [0, 1]);
+    fn insert_periodic_cell_with_lifted_vertex<const D: usize>(
+        tds: &mut Tds<f64, (), (), D>,
+        vertices: Vec<VertexKey>,
+        lifted_vertex: VertexKey,
+    ) -> CellKey {
+        let mut offsets = vec![[0_i8; D]; vertices.len()];
+        if let Some(index) = vertices.iter().position(|&vkey| vkey == lifted_vertex) {
+            offsets[index][0] = 1;
+        }
+        let mut cell = Cell::new(vertices, None).unwrap();
+        cell.set_periodic_vertex_offsets(offsets);
+        tds.insert_cell_with_mapping(cell).unwrap()
     }
 
-    #[test]
-    fn test_align_periodic_offset_higher_dimension() {
-        let result = align_periodic_offset([0, 0, 1, -1], [0, 0, 0, 0], [1, -1, 0, 1]).unwrap();
-        assert_eq!(result, [1, -1, 1, 0]);
+    fn periodic_inverse_k2_fixture<const D: usize>() -> (
+        Tds<f64, (), (), D>,
+        Vec<VertexKey>,
+        VertexKey,
+        VertexKey,
+        CellKeyBuffer,
+    ) {
+        let mut tds: Tds<f64, (), (), D> = Tds::empty();
+        let mut face_vertices = Vec::with_capacity(D);
+        for axis in 0..D {
+            face_vertices.push(
+                tds.insert_vertex_with_mapping(vertex!(unit_vector::<D>(axis)))
+                    .unwrap(),
+            );
+        }
+        let opposite_a = tds.insert_vertex_with_mapping(vertex!([0.0; D])).unwrap();
+        let opposite_b = tds.insert_vertex_with_mapping(vertex!([0.25; D])).unwrap();
+
+        let lifted_vertex = face_vertices[0];
+        let mut removed_cells = CellKeyBuffer::new();
+        for skip in 0..D {
+            let mut vertices = Vec::with_capacity(D + 1);
+            vertices.push(opposite_a);
+            vertices.push(opposite_b);
+            for (index, &vertex) in face_vertices.iter().enumerate() {
+                if index != skip {
+                    vertices.push(vertex);
+                }
+            }
+            removed_cells.push(insert_periodic_cell_with_lifted_vertex(
+                &mut tds,
+                vertices,
+                lifted_vertex,
+            ));
+        }
+
+        (tds, face_vertices, opposite_a, opposite_b, removed_cells)
     }
 
-    #[test]
-    fn test_align_periodic_offset_subtraction_overflow() {
-        // i8::MIN - 1 overflows.
-        let result = align_periodic_offset::<1>([0], [1], [i8::MIN]);
-        assert!(result.is_err());
+    fn periodic_inverse_k3_fixture<const D: usize>() -> (
+        Tds<f64, (), (), D>,
+        Vec<VertexKey>,
+        Vec<VertexKey>,
+        CellKeyBuffer,
+    ) {
+        let mut tds: Tds<f64, (), (), D> = Tds::empty();
+        let mut ridge_vertices = Vec::with_capacity(D - 1);
+        for axis in 0..(D - 1) {
+            ridge_vertices.push(
+                tds.insert_vertex_with_mapping(vertex!(unit_vector::<D>(axis)))
+                    .unwrap(),
+            );
+        }
+        let a = tds.insert_vertex_with_mapping(vertex!([0.0; D])).unwrap();
+        let b = tds
+            .insert_vertex_with_mapping(vertex!(unit_vector::<D>(D - 1)))
+            .unwrap();
+        let c = tds
+            .insert_vertex_with_mapping(vertex!(skewed_point::<D>()))
+            .unwrap();
+        let triangle_vertices = vec![a, b, c];
+
+        let lifted_vertex = ridge_vertices[0];
+        let mut removed_cells = CellKeyBuffer::new();
+        for skip in 0..(D - 1) {
+            let mut vertices = Vec::with_capacity(D + 1);
+            vertices.extend_from_slice(&triangle_vertices);
+            for (index, &vertex) in ridge_vertices.iter().enumerate() {
+                if index != skip {
+                    vertices.push(vertex);
+                }
+            }
+            removed_cells.push(insert_periodic_cell_with_lifted_vertex(
+                &mut tds,
+                vertices,
+                lifted_vertex,
+            ));
+        }
+
+        (tds, ridge_vertices, triangle_vertices, removed_cells)
     }
 
+    macro_rules! gen_periodic_inverse_predicate_tests {
+        ($dim:literal) => {
+            pastey::paste! {
+                #[test]
+                fn [<test_periodic_inverse_k2_uses_removed_cell_frame_ $dim d>]() {
+                    let (tds, face_vertices, opposite_a, opposite_b, removed_cells) =
+                        periodic_inverse_k2_fixture::<$dim>();
+                    let mut target_cell_vertices = face_vertices.clone();
+                    target_cell_vertices.push(opposite_a);
+                    target_cell_vertices.sort_unstable_by_key(|v| v.data().as_ffi());
+                    assert!(
+                        matching_source_cell(&tds, &target_cell_vertices, &removed_cells)
+                            .is_none(),
+                        "inverse k=2 target cell should require explicit frame alignment",
+                    );
+
+                    let topology_model = toroidal_periodic_model::<$dim>();
+                    let frame_cell = removed_cell_frame(&removed_cells).unwrap();
+                    let lifted = vertex_point_lifted_into_cell(
+                        &tds,
+                        &topology_model,
+                        face_vertices[0],
+                        Some(frame_cell),
+                        &removed_cells,
+                    )
+                    .unwrap();
+                    let mut expected = unit_vector::<$dim>(0);
+                    expected[0] += 1.0;
+                    assert_relative_eq!(lifted.coords().as_slice(), expected.as_slice());
+
+                    let kernel = AdaptiveKernel::<f64>::new();
+                    let config = RepairAttemptConfig {
+                        attempt: 0,
+                        queue_order: RepairQueueOrder::Fifo,
+                        max_flips_override: None,
+                    };
+                    let mut diagnostics = RepairDiagnostics::default();
+                    let result = delaunay_violation_k2_for_facet(
+                        &tds,
+                        &kernel,
+                        &topology_model,
+                        &face_vertices,
+                        opposite_a,
+                        opposite_b,
+                        &removed_cells,
+                        Some(frame_cell),
+                        &config,
+                        &mut diagnostics,
+                    );
+                    assert!(result.is_ok(), "inverse k=2 predicate should align periodic frame: {result:?}");
+                }
+
+                #[test]
+                fn [<test_periodic_inverse_k3_uses_removed_cell_frame_ $dim d>]() {
+                    let (tds, ridge_vertices, triangle_vertices, removed_cells) =
+                        periodic_inverse_k3_fixture::<$dim>();
+                    let mut target_cell_vertices = ridge_vertices.clone();
+                    target_cell_vertices.extend_from_slice(&triangle_vertices[1..]);
+                    target_cell_vertices.sort_unstable_by_key(|v| v.data().as_ffi());
+                    assert!(
+                        matching_source_cell(&tds, &target_cell_vertices, &removed_cells)
+                            .is_none(),
+                        "inverse k=3 target cell should require explicit frame alignment",
+                    );
+
+                    let topology_model = toroidal_periodic_model::<$dim>();
+                    let frame_cell = removed_cell_frame(&removed_cells).unwrap();
+                    let lifted = vertex_point_lifted_into_cell(
+                        &tds,
+                        &topology_model,
+                        ridge_vertices[0],
+                        Some(frame_cell),
+                        &removed_cells,
+                    )
+                    .unwrap();
+                    let mut expected = unit_vector::<$dim>(0);
+                    expected[0] += 1.0;
+                    assert_relative_eq!(lifted.coords().as_slice(), expected.as_slice());
+
+                    let kernel = AdaptiveKernel::<f64>::new();
+                    let config = RepairAttemptConfig {
+                        attempt: 0,
+                        queue_order: RepairQueueOrder::Fifo,
+                        max_flips_override: None,
+                    };
+                    let mut diagnostics = RepairDiagnostics::default();
+                    let result = delaunay_violation_k3_for_ridge(
+                        &tds,
+                        &kernel,
+                        &topology_model,
+                        &ridge_vertices,
+                        &triangle_vertices,
+                        &removed_cells,
+                        Some(frame_cell),
+                        &config,
+                        &mut diagnostics,
+                    );
+                    assert!(result.is_ok(), "inverse k=3 predicate should align periodic frame: {result:?}");
+                }
+            }
+        };
+    }
+
+    gen_periodic_inverse_predicate_tests!(4);
+    gen_periodic_inverse_predicate_tests!(5);
+
     #[test]
-    fn test_align_periodic_offset_addition_overflow() {
-        // i8::MAX + 1 overflows.
-        let result = align_periodic_offset::<1>([i8::MAX], [0], [1]);
-        assert!(result.is_err());
+    fn test_periodic_inverse_k2_alignment_failure_is_error() {
+        let (tds, face_vertices, opposite_a, opposite_b, removed_cells) =
+            periodic_inverse_k2_fixture::<4>();
+        let topology_model = toroidal_periodic_model::<4>();
+        let frame_cell = removed_cell_frame(&removed_cells).unwrap();
+        let truncated_removed_cells: CellKeyBuffer = std::iter::once(frame_cell).collect();
+        let lift_result = vertex_point_lifted_into_cell(
+            &tds,
+            &topology_model,
+            face_vertices[0],
+            Some(frame_cell),
+            &truncated_removed_cells,
+        );
+        assert!(matches!(
+            lift_result,
+            Err(FlipError::InvalidFlipContext { .. })
+        ));
+
+        let kernel = AdaptiveKernel::<f64>::new();
+        let config = RepairAttemptConfig {
+            attempt: 0,
+            queue_order: RepairQueueOrder::Fifo,
+            max_flips_override: None,
+        };
+        let mut diagnostics = RepairDiagnostics::default();
+
+        let result = delaunay_violation_k2_for_facet(
+            &tds,
+            &kernel,
+            &topology_model,
+            &face_vertices,
+            opposite_a,
+            opposite_b,
+            &truncated_removed_cells,
+            Some(frame_cell),
+            &config,
+            &mut diagnostics,
+        );
+
+        assert!(
+            result.is_err(),
+            "periodic inverse predicate should not fall back to bare coordinates"
+        );
     }
 
     #[test]

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -4258,11 +4258,13 @@ where
                 // insertion schedule that keeps the triangulation near-Delaunay (local repairs on
                 // each insertion) so we do not get stuck in a non-regular configuration that flip
                 // repair cannot escape.
-                let topology = self.tri.topology_guarantee();
+                let topology_guarantee = self.tri.topology_guarantee();
+                let global_topology = self.tri.global_topology();
                 let mut candidate = Self::with_empty_kernel_and_topology_guarantee(
                     self.tri.kernel.clone(),
-                    topology,
+                    topology_guarantee,
                 );
+                candidate.set_global_topology(global_topology);
 
                 // During rebuild, force local repair after every insertion. We'll restore the caller's
                 // policies after we have a repaired candidate.
@@ -5987,6 +5989,7 @@ mod tests {
     use crate::geometry::kernel::{AdaptiveKernel, FastKernel, RobustKernel};
     use crate::geometry::traits::coordinate::Coordinate;
     use crate::topology::characteristics::euler::TopologyClassification;
+    use crate::topology::traits::topological_space::ToroidalConstructionMode;
     use crate::triangulation::flips::BistellarFlips;
     use crate::vertex;
     use rand::{RngExt, SeedableRng};
@@ -6853,6 +6856,36 @@ mod tests {
         // Original vertex_key may be stale after heuristic rebuild; that is
         // expected. The important invariant is that the UUID lookup works.
         let _ = vertex_key;
+    }
+
+    #[test]
+    fn test_heuristic_rebuild_preserves_global_topology() {
+        init_tracing();
+        let vertices: Vec<Vertex<f64, (), 2>> = vec![
+            vertex!([0.0, 0.0]),
+            vertex!([1.0, 0.0]),
+            vertex!([0.0, 1.0]),
+            vertex!([1.0, 1.0]),
+        ];
+        let mut dt: DelaunayTriangulation<_, (), (), 2> =
+            DelaunayTriangulation::new(&vertices).unwrap();
+        let global_topology = GlobalTopology::Toroidal {
+            domain: [1.0, 1.0],
+            mode: ToroidalConstructionMode::PeriodicImagePoint,
+        };
+        dt.set_global_topology(global_topology);
+
+        let _guard = ForceHeuristicRebuildGuard::enable();
+        let outcome = dt
+            .repair_delaunay_with_flips_advanced(DelaunayRepairHeuristicConfig::default())
+            .unwrap();
+
+        assert!(
+            outcome.used_heuristic(),
+            "Expected forced heuristic rebuild to be used"
+        );
+        assert_eq!(dt.global_topology(), global_topology);
+        assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
     }
 
     /// Slow search helper to find a natural stale-key repro case.

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -9,6 +9,7 @@ use crate::core::adjacency::{AdjacencyIndex, AdjacencyIndexBuildError};
 use crate::core::algorithms::flips::{
     DelaunayRepairError, DelaunayRepairStats, FlipError, apply_bistellar_flip_k1_inverse,
     repair_delaunay_local_single_pass, repair_delaunay_with_flips_k2_k3,
+    verify_delaunay_for_triangulation,
 };
 use crate::core::algorithms::incremental_insertion::InsertionError;
 use crate::core::cell::{Cell, CellValidationError};
@@ -5406,10 +5407,7 @@ where
     /// assert!(dt.is_delaunay_via_flips().is_ok());
     /// ```
     pub fn is_delaunay_via_flips(&self) -> Result<(), DelaunayRepairError> {
-        crate::core::algorithms::flips::verify_delaunay_via_flip_predicates(
-            &self.tri.tds,
-            &self.tri.kernel,
-        )
+        verify_delaunay_for_triangulation(&self.tri)
     }
 
     /// Performs cumulative validation for Levels 1–4.

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -74,6 +74,8 @@ struct HeuristicRebuildRecursionGuard {
 }
 
 impl HeuristicRebuildRecursionGuard {
+    /// Tracks nested heuristic rebuilds so fallback construction cannot recurse
+    /// indefinitely through repair hooks.
     fn enter() -> Self {
         let prior_depth = HEURISTIC_REBUILD_DEPTH.with(|depth| {
             let prior = depth.get();
@@ -562,6 +564,8 @@ pub struct DelaunayTriangulationConstructionErrorWithStatistics {
 }
 
 impl ConstructionStatistics {
+    /// Aggregates attempt counters shared by inserted, skipped, and duplicate
+    /// insertion outcomes.
     #[inline]
     fn record_common(&mut self, stats: &InsertionStatistics) {
         self.total_attempts = self.total_attempts.saturating_add(stats.attempts);
@@ -630,14 +634,20 @@ where
     T: CoordinateScalar,
     U: DataType,
 {
+    /// Borrows the preprocessed vertex order when one exists, avoiding a clone
+    /// for policies that leave the input unchanged.
     fn primary_slice<'a>(&'a self, input: &'a [Vertex<T, U, D>]) -> &'a [Vertex<T, U, D>] {
         self.primary.as_deref().unwrap_or(input)
     }
 
+    /// Exposes the original order as a retry fallback for balanced-simplex
+    /// preprocessing.
     fn fallback_slice(&self) -> Option<&[Vertex<T, U, D>]> {
         self.fallback.as_deref()
     }
 
+    /// Carries the dedup grid size forward so incremental insertion can reuse a
+    /// compatible spatial index.
     const fn grid_cell_size(&self) -> Option<T> {
         self.grid_cell_size
     }
@@ -646,6 +656,7 @@ where
 type PreprocessVerticesResult<T, U, const D: usize> =
     Result<PreprocessVertices<T, U, D>, DelaunayTriangulationConstructionError>;
 
+/// Hashes coordinates as a deterministic tiebreaker for partial vertex ordering.
 fn vertex_coordinate_hash<T, U, const D: usize>(vertex: &Vertex<T, U, D>) -> u64
 where
     T: CoordinateScalar,
@@ -656,6 +667,8 @@ where
     hasher.finish()
 }
 
+/// Produces a stable construction order when Hilbert ordering is unavailable or
+/// unsuitable.
 fn order_vertices_lexicographic<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
 ) -> Vec<Vertex<T, U, D>>
@@ -685,6 +698,8 @@ where
 const BATCH_DEDUP_BUCKET_INLINE_CAPACITY: usize = 8;
 const BATCH_DEDUP_MAX_DIMENSION: usize = 5;
 
+/// Centralizes insertion-order dispatch so preprocessing applies dedup and
+/// ordering in a consistent sequence.
 fn order_vertices_by_strategy<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
     insertion_order: InsertionOrderStrategy,
@@ -699,10 +714,14 @@ where
     }
 }
 
+/// Provides a scalar-aware tolerance for dedup paths that need a nonzero grid
+/// size even under exact duplicate policy.
 fn default_duplicate_tolerance<T: CoordinateScalar>() -> T {
     <T as NumCast>::from(1e-10_f64).unwrap_or_else(T::default_tolerance)
 }
 
+/// Verifies the hash grid can represent every input coordinate before choosing
+/// the O(n) duplicate path.
 fn hash_grid_usable_for_vertices<T, U, const D: usize>(
     grid: &HashGridIndex<T, D, usize>,
     vertices: &[Vertex<T, U, D>],
@@ -719,6 +738,8 @@ where
         .all(|v| grid.can_key_coords(v.point().coords()))
 }
 
+/// Keeps exact dedup deterministic when the hash grid cannot safely key the
+/// input coordinates.
 fn dedup_vertices_exact_sorted<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
 ) -> Vec<Vertex<T, U, D>>
@@ -743,6 +764,8 @@ where
     unique
 }
 
+/// Uses the spatial grid for exact duplicate removal while falling back to the
+/// sorted path if coordinate keying is unavailable.
 fn dedup_vertices_exact_hash_grid<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
     grid: &mut HashGridIndex<T, D, usize>,
@@ -786,6 +809,8 @@ where
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 struct QuantizedKey<const D: usize>([i64; D]);
 
+/// Quantizes coordinates for epsilon buckets only when finite values can be
+/// represented without losing the bucket invariant.
 fn quantize_coords<T: CoordinateScalar, const D: usize>(
     coords: &[T; D],
     inv_cell: f64,
@@ -807,6 +832,8 @@ fn quantize_coords<T: CoordinateScalar, const D: usize>(
     Some(key)
 }
 
+/// Visits adjacent epsilon buckets recursively so near-duplicate checks cover
+/// boundary-straddling points.
 fn visit_quantized_neighbors<const D: usize, F>(
     axis: usize,
     base: &[i64; D],
@@ -832,6 +859,8 @@ where
     true
 }
 
+/// Provides the correctness fallback for epsilon dedup when bucket or grid
+/// assumptions fail.
 fn dedup_vertices_epsilon_n2<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
     epsilon: T,
@@ -857,6 +886,8 @@ where
     unique
 }
 
+/// Uses bounded quantized buckets for epsilon dedup in practical dimensions
+/// while preserving an exact fallback for unsupported cases.
 fn dedup_vertices_epsilon_quantized<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
     epsilon: T,
@@ -925,6 +956,8 @@ where
     unique
 }
 
+/// Prefers the reusable hash grid for epsilon dedup when its coordinate model is
+/// valid for every input vertex.
 fn dedup_vertices_epsilon_hash_grid<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
     epsilon: T,
@@ -972,6 +1005,8 @@ where
     unique
 }
 
+/// Chooses a well-spread initial simplex to reduce early degeneracy in
+/// incremental construction.
 fn select_balanced_simplex_indices<T, U, const D: usize>(
     vertices: &[Vertex<T, U, D>],
 ) -> Option<Vec<usize>>
@@ -1072,6 +1107,8 @@ where
     }
 }
 
+/// Places the selected simplex first while preserving every remaining input
+/// vertex exactly once.
 fn reorder_vertices_for_simplex<T, U, const D: usize>(
     vertices: &[Vertex<T, U, D>],
     simplex_indices: &[usize],
@@ -1104,6 +1141,8 @@ where
     Some(reordered)
 }
 
+/// Computes the largest per-axis Hilbert precision that still fits in the
+/// u128-backed index.
 fn hilbert_bits_per_coord<const D: usize>() -> Option<u32> {
     if D == 0 {
         return None;
@@ -1126,6 +1165,8 @@ fn hilbert_bits_per_coord<const D: usize>() -> Option<u32> {
 /// Sort key for Hilbert ordering: `(hilbert_index, quantized_coords, vertex, input_index)`.
 type HilbertSortKey<T, U, const D: usize> = (u128, [u32; D], Vertex<T, U, D>, usize);
 
+/// Orders vertices along a Hilbert curve to improve insertion locality while
+/// retaining deterministic lexicographic fallbacks.
 fn order_vertices_hilbert<T, U, const D: usize>(
     vertices: Vec<Vertex<T, U, D>>,
     dedup_quantized: bool,
@@ -2044,6 +2085,8 @@ where
         result
     }
 
+    /// Applies deduplication, insertion ordering, and initial-simplex selection
+    /// before any topology is created.
     fn preprocess_vertices_for_construction(
         vertices: &[Vertex<K::Scalar, U, D>],
         dedup_policy: DedupPolicy,
@@ -2162,6 +2205,8 @@ where
         )
     }
 
+    /// Retries batch construction with deterministic shuffles so retryable
+    /// degeneracies can be escaped reproducibly.
     #[allow(clippy::too_many_lines)]
     fn build_with_shuffled_retries(
         kernel: &K,
@@ -2293,6 +2338,8 @@ where
         .into())
     }
 
+    /// Mirrors shuffled retry construction while preserving per-attempt
+    /// statistics for callers that need skip and retry diagnostics.
     #[allow(clippy::too_many_lines)]
     #[expect(
         clippy::result_large_err,
@@ -2453,10 +2500,13 @@ where
         })
     }
 
+    /// Avoids retry work when construction has no incremental phase to reorder.
     const fn should_retry_construction(vertices: &[Vertex<K::Scalar, U, D>]) -> bool {
         D >= 2 && vertices.len() > D + 1
     }
 
+    /// Derives an input-order-independent seed so retries are reproducible for
+    /// the same vertex set.
     fn construction_shuffle_seed(vertices: &[Vertex<K::Scalar, U, D>]) -> u64 {
         let mut vertex_hashes = Vec::with_capacity(vertices.len());
         for vertex in vertices {
@@ -2468,11 +2518,15 @@ where
         stable_hash_u64_slice(&vertex_hashes)
     }
 
+    /// Keeps construction retry shuffling deterministic for diagnostics and
+    /// tests.
     fn shuffle_vertices(vertices: &mut [Vertex<K::Scalar, U, D>], seed: u64) {
         let mut rng = StdRng::seed_from_u64(seed);
         vertices.shuffle(&mut rng);
     }
 
+    /// Runs batch construction without statistics while preserving the same
+    /// final validation path as the statistics variant.
     fn build_with_kernel_inner(
         kernel: K,
         vertices: &[Vertex<K::Scalar, U, D>],
@@ -2531,6 +2585,8 @@ where
         Ok(dt)
     }
 
+    /// Runs batch construction with aggregate statistics without changing the
+    /// construction algorithm itself.
     #[expect(
         clippy::result_large_err,
         reason = "Internal helper propagates public by-value construction-statistics error type"
@@ -2603,6 +2659,8 @@ where
         Ok((dt, stats))
     }
 
+    /// Implements the seeded batch-construction core so retry and statistics
+    /// entry points share perturbation behavior.
     #[expect(
         clippy::result_large_err,
         reason = "Internal helper propagates public by-value construction-statistics error type"
@@ -2726,6 +2784,8 @@ where
         Ok((dt, stats))
     }
 
+    /// Implements the non-statistics seeded construction core for callers that
+    /// only need the triangulation.
     fn build_with_kernel_inner_seeded(
         kernel: K,
         vertices: &[Vertex<K::Scalar, U, D>],
@@ -2853,6 +2913,8 @@ where
         .into())
     }
 
+    /// Inserts the non-simplex vertices under a fixed perturbation seed so bulk
+    /// construction retries are reproducible.
     #[allow(clippy::too_many_lines)]
     fn insert_remaining_vertices_seeded(
         &mut self,
@@ -3200,6 +3262,8 @@ where
         Ok(())
     }
 
+    /// Restores runtime policies and performs the final repair/orientation
+    /// checks that were deferred during batch insertion.
     fn finalize_bulk_construction(
         &mut self,
         original_validation_policy: ValidationPolicy,
@@ -3366,6 +3430,8 @@ where
         }
     }
 
+    /// Classifies insertion-layer failures as input degeneracy or internal
+    /// inconsistency for construction callers.
     fn map_insertion_error(error: InsertionError) -> TriangulationConstructionError {
         match error {
             // Preserve underlying construction errors (e.g. duplicate UUID).
@@ -3924,7 +3990,8 @@ where
         self.repair_delaunay_with_flips_capped(None)
     }
 
-    /// Internal helper: runs flip-based repair with an optional per-attempt flip cap.
+    /// Runs flip-based repair with an optional per-attempt cap so public repair
+    /// and heuristic harnesses share one mutation path.
     fn repair_delaunay_with_flips_capped(
         &mut self,
         max_flips: Option<usize>,
@@ -3965,6 +4032,8 @@ where
             })
     }
 
+    /// Replays repair with an exact-predicate kernel before escalating to
+    /// heuristic rebuild.
     fn repair_delaunay_with_flips_robust(
         &mut self,
         seed_cells: Option<&[CellKey]>,
@@ -3976,6 +4045,8 @@ where
         repair_delaunay_with_flips_k2_k3(tds, kernel, seed_cells, topology, max_flips)
     }
 
+    /// Applies the repair policy only when the dimension and topology can
+    /// support bistellar flips.
     fn should_run_delaunay_repair_for(
         &self,
         topology: TopologyGuarantee,
@@ -3998,6 +4069,8 @@ where
             RepairDecision::Proceed
         )
     }
+
+    /// Enables test-only repair fallback paths without exposing a public knob.
     #[allow(clippy::missing_const_for_fn)]
     fn force_heuristic_rebuild_enabled() -> bool {
         #[cfg(test)]
@@ -4129,6 +4202,8 @@ where
         }
     }
 
+    /// Rebuilds from the current vertex set with varied deterministic seeds when
+    /// flip repair cannot converge directly.
     #[allow(clippy::too_many_lines)]
     fn rebuild_with_heuristic(
         &self,
@@ -4308,6 +4383,8 @@ where
         })
     }
 
+    /// Preserves vertex UUIDs and data so heuristic rebuilds remain an internal
+    /// repair strategy, not a user-visible remapping.
     fn collect_vertices_for_rebuild(&self) -> Vec<Vertex<K::Scalar, U, D>> {
         self.tri
             .tds
@@ -4316,6 +4393,8 @@ where
             .collect()
     }
 
+    /// Derives rebuild seeds from the vertex set so fallback behavior is
+    /// reproducible regardless of slotmap iteration accidents.
     fn heuristic_rebuild_base_seed(&self) -> u64 {
         let mut vertex_hashes = Vec::with_capacity(self.tri.tds.number_of_vertices());
         for (_, vertex) in self.tri.tds.vertices() {
@@ -4784,6 +4863,8 @@ where
     U: DataType,
     V: DataType,
 {
+    /// Lazily seeds the spatial index from existing vertices so incremental
+    /// insertion can start from deserialized or manually constructed TDS state.
     fn ensure_spatial_index_seeded(&mut self) {
         if self.spatial_index.is_some() {
             return;
@@ -5061,6 +5142,8 @@ where
         }
     }
 
+    /// Keeps the default insertion path on the same repair helper as capped
+    /// debug and heuristic paths.
     fn maybe_repair_after_insertion(
         &mut self,
         vertex_key: VertexKey,
@@ -5181,6 +5264,8 @@ where
         Ok(())
     }
 
+    /// Runs policy-controlled global validation after insertion so expensive
+    /// Delaunay checks stay opt-in for incremental workflows.
     fn maybe_check_after_insertion(&self) -> Result<(), InsertionError> {
         if self.tri.tds.number_of_cells() == 0 {
             return Ok(());
@@ -5760,6 +5845,8 @@ pub struct DelaunayRepairHeuristicConfig {
 }
 
 impl DelaunayRepairHeuristicConfig {
+    /// Fills omitted seeds from a stable base so heuristic rebuilds are
+    /// repeatable even when callers only configure one axis of randomness.
     fn resolve_seeds(self, base_seed: u64) -> DelaunayRepairHeuristicSeeds {
         // Derive deterministic defaults when the caller does not provide explicit seeds.
         const SHUFFLE_SALT: u64 = 0x9E37_79B9_7F4A_7C15;

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -3,6 +3,8 @@
 //! These tests exercise the public API from the outside, using only items exposed
 //! through `delaunay::prelude::triangulation` and `delaunay::triangulation::builder`.
 
+#![forbid(unsafe_code)]
+
 use std::collections::HashMap;
 use std::f64::consts::TAU;
 

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -356,8 +356,8 @@ fn test_builder_toroidal_periodic_chi_zero_2d() {
 /// `GlobalTopology::Toroidal` Euler override AND the lifted-vertex-identity
 /// logic in `validate_ridge_links` / `validate_vertex_links`.
 ///
-/// Level 4 (Delaunay property) is not checked because the quotient mesh
-/// may contain local violations that are valid under periodic identification.
+/// Level 4 (Delaunay property) is exercised separately by
+/// `test_builder_toroidal_periodic_level4_validate_2d`.
 #[test]
 fn test_builder_toroidal_periodic_full_validate_2d() {
     let vertices = vec![
@@ -385,6 +385,33 @@ fn test_builder_toroidal_periodic_full_validate_2d() {
     assert!(
         result.is_ok(),
         "PLManifold Levels 1-3 validate() should pass for toroidal_periodic: {:?}",
+        result.err()
+    );
+}
+
+/// `toroidal_periodic` full Level 1–4 validation uses periodic lifted
+/// coordinates for local Delaunay flip predicates.
+#[test]
+fn test_builder_toroidal_periodic_level4_validate_2d() {
+    let vertices = vec![
+        vertex!([0.1_f64, 0.2]),
+        vertex!([0.4, 0.7]),
+        vertex!([0.7, 0.3]),
+        vertex!([0.2, 0.9]),
+        vertex!([0.8, 0.6]),
+        vertex!([0.5, 0.1]),
+        vertex!([0.3, 0.5]),
+    ];
+    let kernel = RobustKernel::new();
+    let dt = DelaunayTriangulationBuilder::new(&vertices)
+        .toroidal_periodic([1.0_f64, 1.0])
+        .build_with_kernel::<_, ()>(&kernel)
+        .expect("periodic 2D build should succeed");
+
+    let result = dt.validate();
+    assert!(
+        result.is_ok(),
+        "Level 1-4 validate() should pass for toroidal_periodic: {:?}",
         result.err()
     );
 }

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -356,6 +356,10 @@ fn build_toroidal_periodic_triangulation<const D: usize>()
         dt.global_topology().is_toroidal(),
         "global_topology should be Toroidal"
     );
+    assert!(
+        dt.global_topology().is_periodic(),
+        "global_topology should use periodic image-point construction"
+    );
     dt
 }
 
@@ -414,6 +418,38 @@ macro_rules! gen_toroidal_periodic_validation_test {
 }
 
 gen_toroidal_periodic_validation_test!(2, levels_1_to_4, true);
+#[test]
+fn test_builder_periodic_topology_level4_smoke_3d() {
+    let vertices = vec![
+        vertex!([0.2_f64, 0.3, 0.4]),
+        vertex!([0.8, 0.1, 0.2]),
+        vertex!([0.5, 0.7, 0.6]),
+        vertex!([0.1, 0.9, 0.3]),
+        vertex!([0.6, 0.4, 0.8]),
+    ];
+    let kernel = RobustKernel::new();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+        .build_with_kernel::<_, ()>(&kernel)
+        .expect("compact 3D build should succeed");
+
+    assert_eq!(dt.number_of_vertices(), vertices.len());
+    assert!(
+        dt.as_triangulation().validate().is_ok(),
+        "PLManifold Levels 1-3 validate() should pass for compact 3D"
+    );
+    dt.set_global_topology(GlobalTopology::Toroidal {
+        domain: [1.0_f64; 3],
+        mode: ToroidalConstructionMode::PeriodicImagePoint,
+    });
+    assert!(
+        dt.global_topology().is_periodic(),
+        "global_topology should use periodic image-point construction"
+    );
+    assert!(
+        dt.is_delaunay_via_flips().is_ok(),
+        "Level 4 flip validation should pass under periodic 3D topology"
+    );
+}
 gen_toroidal_periodic_validation_test!(
     3,
     levels_1_to_4,

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -8,6 +8,7 @@
 use std::collections::HashMap;
 use std::f64::consts::TAU;
 
+use delaunay::core::algorithms::flips::DelaunayRepairError;
 use delaunay::core::triangulation::TopologyGuarantee;
 use delaunay::core::vertex::{Vertex, VertexBuilder};
 use delaunay::geometry::kernel::RobustKernel;
@@ -419,6 +420,7 @@ macro_rules! gen_toroidal_periodic_validation_test {
 
 gen_toroidal_periodic_validation_test!(2, levels_1_to_4, true);
 #[test]
+#[ignore = "Slow (>60s): periodic 3D Level 4 scans image-point quotient cells"]
 fn test_builder_periodic_topology_level4_smoke_3d() {
     let vertices = vec![
         vertex!([0.2_f64, 0.3, 0.4]),
@@ -426,29 +428,46 @@ fn test_builder_periodic_topology_level4_smoke_3d() {
         vertex!([0.5, 0.7, 0.6]),
         vertex!([0.1, 0.9, 0.3]),
         vertex!([0.6, 0.4, 0.8]),
+        vertex!([0.3, 0.5, 0.9]),
+        vertex!([0.9, 0.2, 0.6]),
     ];
     let kernel = RobustKernel::new();
-    let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+    let dt = DelaunayTriangulationBuilder::new(&vertices)
+        .toroidal_periodic([1.0_f64; 3])
         .build_with_kernel::<_, ()>(&kernel)
-        .expect("compact 3D build should succeed");
+        .expect("compact periodic 3D build should succeed");
 
     assert_eq!(dt.number_of_vertices(), vertices.len());
     assert!(
-        dt.as_triangulation().validate().is_ok(),
-        "PLManifold Levels 1-3 validate() should pass for compact 3D"
+        dt.tds().is_valid().is_ok(),
+        "TDS structural validity should pass for compact periodic 3D"
     );
-    dt.set_global_topology(GlobalTopology::Toroidal {
-        domain: [1.0_f64; 3],
-        mode: ToroidalConstructionMode::PeriodicImagePoint,
-    });
     assert!(
         dt.global_topology().is_periodic(),
         "global_topology should use periodic image-point construction"
     );
     assert!(
-        dt.is_delaunay_via_flips().is_ok(),
-        "Level 4 flip validation should pass under periodic 3D topology"
+        dt.cells().all(|(_, cell)| {
+            cell.periodic_vertex_offsets()
+                .is_some_and(|offsets| offsets.len() == cell.number_of_vertices())
+        }),
+        "periodic image-point construction should populate per-cell periodic offsets"
     );
+    // The compact 3D quotient is a smoke fixture for lifted predicate evaluation,
+    // not a full periodic-Delaunay quality fixture. A local violation is a valid
+    // Level 4 result; malformed periodic-offset plumbing is not.
+    match dt.is_delaunay_via_flips() {
+        Ok(()) => {}
+        Err(DelaunayRepairError::PostconditionFailed { message }) => {
+            assert!(
+                !message.contains("predicate failed in strict mode")
+                    && !message.contains("periodic offset")
+                    && !message.contains("cannot align periodic vertex"),
+                "periodic Level 4 should evaluate lifted predicates with populated offsets: {message}"
+            );
+        }
+        Err(err) => panic!("periodic Level 4 validation returned an unexpected error: {err:?}"),
+    }
 }
 gen_toroidal_periodic_validation_test!(
     3,

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -316,29 +316,58 @@ fn test_builder_toroidal_robust_kernel_3d() {
 // Periodic (image-point method) path
 // =============================================================================
 
+fn toroidal_periodic_vertices<const D: usize>() -> Vec<Vertex<f64, (), D>> {
+    assert!((2..=5).contains(&D));
+
+    let multipliers = [
+        0.618_033_988_749_894_8,
+        0.414_213_562_373_095_03,
+        0.732_050_807_568_877_2,
+        0.236_067_977_499_789_8,
+        0.324_717_957_244_746,
+    ];
+    (0..(2 * D + 3))
+        .map(|index| {
+            let mut coords = [0.0_f64; D];
+            let index_f64 = f64::from(u32::try_from(index).expect("test index fits in u32"));
+            for axis in 0..D {
+                let axis_f64 = f64::from(u32::try_from(axis).expect("test axis fits in u32"));
+                let stride = 0.037_f64.mul_add(axis_f64 + 1.0, multipliers[axis]);
+                let phase = (index_f64 + 1.0) * stride;
+                coords[axis] = 0.9_f64.mul_add(phase.fract(), 0.05);
+            }
+            vertex!(coords)
+        })
+        .collect()
+}
+
+fn build_toroidal_periodic_triangulation<const D: usize>()
+-> DelaunayTriangulation<RobustKernel<f64>, (), (), D> {
+    let vertices = toroidal_periodic_vertices::<D>();
+    let expected_vertices = vertices.len();
+    let kernel = RobustKernel::new();
+    let dt = DelaunayTriangulationBuilder::new(&vertices)
+        .toroidal_periodic([1.0_f64; D])
+        .build_with_kernel::<_, ()>(&kernel)
+        .expect("periodic build should succeed");
+
+    assert_eq!(dt.number_of_vertices(), expected_vertices);
+    assert!(
+        dt.global_topology().is_toroidal(),
+        "global_topology should be Toroidal"
+    );
+    dt
+}
+
 /// `toroidal_periodic` builds a valid 2D periodic triangulation with χ = 0.
 ///
 /// Verifies TDS structural validity and χ = 0 directly.
-/// See `test_builder_toroidal_periodic_full_validate_2d` for the full
-/// `PLManifold` `validate()` path.
+/// See the macro-generated toroidal periodic validation tests for the full
+/// `PLManifold` and Level 4 `validate()` paths.
 #[test]
 fn test_builder_toroidal_periodic_chi_zero_2d() {
-    let vertices = vec![
-        vertex!([0.1_f64, 0.2]),
-        vertex!([0.4, 0.7]),
-        vertex!([0.7, 0.3]),
-        vertex!([0.2, 0.9]),
-        vertex!([0.8, 0.6]),
-        vertex!([0.5, 0.1]),
-        vertex!([0.3, 0.5]),
-    ];
-    let kernel = RobustKernel::new();
-    let dt = DelaunayTriangulationBuilder::new(&vertices)
-        .toroidal_periodic([1.0_f64, 1.0])
-        .build_with_kernel::<_, ()>(&kernel)
-        .expect("periodic 2D build should succeed");
+    let dt = build_toroidal_periodic_triangulation::<2>();
 
-    assert_eq!(dt.number_of_vertices(), 7);
     assert!(
         dt.tds().is_valid().is_ok(),
         "TDS structural validity should pass for periodic triangulation"
@@ -351,72 +380,58 @@ fn test_builder_toroidal_periodic_chi_zero_2d() {
     );
 }
 
-/// `toroidal_periodic` 2D with full `PLManifold` Levels 1–3 validation.
-///
-/// Periodic-aware ridge and vertex link validation correctly handles reused
-/// vertex keys via lifted vertex identity.  This exercises the
-/// `GlobalTopology::Toroidal` Euler override AND the lifted-vertex-identity
-/// logic in `validate_ridge_links` / `validate_vertex_links`.
-///
-/// Level 4 (Delaunay property) is exercised separately by
-/// `test_builder_toroidal_periodic_level4_validate_2d`.
-#[test]
-fn test_builder_toroidal_periodic_full_validate_2d() {
-    let vertices = vec![
-        vertex!([0.1_f64, 0.2]),
-        vertex!([0.4, 0.7]),
-        vertex!([0.7, 0.3]),
-        vertex!([0.2, 0.9]),
-        vertex!([0.8, 0.6]),
-        vertex!([0.5, 0.1]),
-        vertex!([0.3, 0.5]),
-    ];
-    let kernel = RobustKernel::new();
-    let dt = DelaunayTriangulationBuilder::new(&vertices)
-        .toroidal_periodic([1.0_f64, 1.0])
-        .build_with_kernel::<_, ()>(&kernel)
-        .expect("periodic 2D build should succeed");
+macro_rules! gen_toroidal_periodic_validation_test {
+    ($dim:literal, $label:ident, $run_level4:expr $(, #[$attr:meta])?) => {
+        pastey::paste! {
+            /// `toroidal_periodic` validation for this dimension.
+            ///
+            /// Periodic-aware ridge and vertex link validation correctly handles reused
+            /// vertex keys via lifted vertex identity. When `$run_level4` is true, this
+            /// also exercises Level 4 periodic lifted Delaunay predicates.
+            #[test]
+            $(#[$attr])?
+            fn [<test_builder_toroidal_periodic_validate_ $label _ $dim d>]() {
+                let dt = build_toroidal_periodic_triangulation::<$dim>();
 
-    assert_eq!(dt.number_of_vertices(), 7);
-    assert!(
-        dt.global_topology().is_toroidal(),
-        "global_topology should be Toroidal"
-    );
-    // Levels 1–3 (TDS structure + topology including PLManifold ridge/vertex links).
-    let result = dt.as_triangulation().validate();
-    assert!(
-        result.is_ok(),
-        "PLManifold Levels 1-3 validate() should pass for toroidal_periodic: {:?}",
-        result.err()
-    );
+                let topology_result = dt.as_triangulation().validate();
+                assert!(
+                    topology_result.is_ok(),
+                    "PLManifold Levels 1-3 validate() should pass for toroidal_periodic: {:?}",
+                    topology_result.err()
+                );
+
+                if $run_level4 {
+                    let level4_result = dt.validate();
+                    assert!(
+                        level4_result.is_ok(),
+                        "Level 1-4 validate() should pass for toroidal_periodic: {:?}",
+                        level4_result.err()
+                    );
+                }
+            }
+        }
+    };
 }
 
-/// `toroidal_periodic` full Level 1–4 validation uses periodic lifted
-/// coordinates for local Delaunay flip predicates.
-#[test]
-fn test_builder_toroidal_periodic_level4_validate_2d() {
-    let vertices = vec![
-        vertex!([0.1_f64, 0.2]),
-        vertex!([0.4, 0.7]),
-        vertex!([0.7, 0.3]),
-        vertex!([0.2, 0.9]),
-        vertex!([0.8, 0.6]),
-        vertex!([0.5, 0.1]),
-        vertex!([0.3, 0.5]),
-    ];
-    let kernel = RobustKernel::new();
-    let dt = DelaunayTriangulationBuilder::new(&vertices)
-        .toroidal_periodic([1.0_f64, 1.0])
-        .build_with_kernel::<_, ()>(&kernel)
-        .expect("periodic 2D build should succeed");
-
-    let result = dt.validate();
-    assert!(
-        result.is_ok(),
-        "Level 1-4 validate() should pass for toroidal_periodic: {:?}",
-        result.err()
-    );
-}
+gen_toroidal_periodic_validation_test!(2, levels_1_to_4, true);
+gen_toroidal_periodic_validation_test!(
+    3,
+    levels_1_to_4,
+    true,
+    #[ignore = "Slow (>60s): periodic 3D expands to 3^D image points; run with --ignored"]
+);
+gen_toroidal_periodic_validation_test!(
+    4,
+    levels_1_to_3,
+    false,
+    #[ignore = "Slow: periodic 4D expands to 3^D image points; run with --ignored"]
+);
+gen_toroidal_periodic_validation_test!(
+    5,
+    levels_1_to_3,
+    false,
+    #[ignore = "Slow: periodic 5D expands to 3^D image points; run with --ignored"]
+);
 
 /// Explicit 7-vertex torus (Heawood triangulation) with `GlobalTopology::Toroidal`
 /// builds successfully under `PLManifold` guarantee.


### PR DESCRIPTION
…ngulations (#315)

- Thread GlobalTopologyModelAdapter through all flip-predicate evaluation functions (k=2 facets, k=3 ridges, and their inverses) so insphere predicates use lifted coordinates for periodic topologies.
- Add verify_delaunay_for_triangulation() as the preferred topology-aware Level 4 entry point; is_delaunay_via_flips() now delegates to it.
- Add periodic lifting helpers: vertices_to_points_with_optional_lift, vertex_point_lifted_into_cell, align_periodic_offset, and supporting functions for offset lookup, validation, and cross-cell alignment.
- Repair paths continue to use GlobalTopology::DEFAULT (non-periodic), which is correct since flip repair runs during construction.
- Add integration test reproducing the issue: toroidal_periodic 2D triangulation now passes dt.validate() (Levels 1–4).
- Add doctest for verify_delaunay_for_triangulation.
- Add unit tests for align_periodic_offset (identity, delta shifts, higher-dimension, overflow).

Closes #315