### PR TITLE
ci: switch coverage reporting to cargo-llvm-cov

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,65 @@
+name: Bug report
+description: Report a reproducible problem in delaunay.
+title: "fix: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug.
+
+        For security vulnerabilities, do not open a public issue. Use the private reporting instructions in SECURITY.md.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong?
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproducer
+    attributes:
+      label: Minimal reproducer
+      description: Provide the smallest Rust example, input point set, or test case that triggers the problem.
+      render: rust
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include panic messages, validation errors, or incorrect output.
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      value: |
+        - delaunay version:
+        - rustc version:
+        - OS:
+        - Feature flags:
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues and did not find a duplicate.
+          required: true
+        - label: This is not a security vulnerability.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/acgetchell/delaunay/security/advisories/new
+    about: Please report security vulnerabilities privately.

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -21,7 +21,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     env:
-      TARPAULIN_VERSION: "0.32.8"
+      CARGO_LLVM_COV_VERSION: "0.8.5"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -34,18 +34,27 @@ jobs:
           cache: true
           # toolchain, components, etc. are specified in rust-toolchain.toml
 
-      - name: Cache tarpaulin
+      - name: Install LLVM coverage tools
+        run: rustup component add llvm-tools-preview
+
+      - name: Cache cargo-llvm-cov
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         with:
-          path: ~/.cargo/bin/cargo-tarpaulin
-          key: tarpaulin-${{ runner.os }}-${{ env.TARPAULIN_VERSION }}
+          path: ~/.cargo/bin/cargo-llvm-cov
+          key: cargo-llvm-cov-${{ runner.os }}-${{ env.CARGO_LLVM_COV_VERSION }}
           restore-keys: |
-            tarpaulin-${{ runner.os }}-
+            cargo-llvm-cov-${{ runner.os }}-
 
-      - name: Install tarpaulin
+      - name: Install cargo-llvm-cov
         run: |
-          if ! command -v cargo-tarpaulin &> /dev/null; then
-            cargo install cargo-tarpaulin --locked --version "${TARPAULIN_VERSION}"
+          installed_version=""
+          if command -v cargo-llvm-cov &> /dev/null; then
+            installed_version="$(cargo llvm-cov --version)"
+            installed_version="${installed_version#cargo-llvm-cov }"
+          fi
+
+          if [ "${installed_version}" != "${CARGO_LLVM_COV_VERSION}" ]; then
+            cargo install cargo-llvm-cov --locked --version "${CARGO_LLVM_COV_VERSION}"
           fi
 
       - name: Install just
@@ -60,13 +69,11 @@ jobs:
 
       - name: Run tests with nextest (for JUnit XML)
         run: |
-          # Note: We run tests twice in this workflow (nextest + tarpaulin).
+          # Note: We run tests twice in this workflow (nextest + cargo-llvm-cov).
           # This is intentional and necessary because:
           # 1. nextest: Fast parallel execution → high-quality JUnit XML for test analytics
-          # 2. tarpaulin: Instrumented execution → accurate code coverage metrics
+          # 2. cargo-llvm-cov: LLVM-instrumented execution → accurate code coverage metrics
           # Trade-off: ~1-2 extra minutes of CI time for significantly better data quality.
-          # Using tarpaulin's experimental JUnit output would save time but produces
-          # less reliable test analytics data.
 
           echo "::group::Running tests with nextest"
           # Generate JUnit XML for Codecov Test Analytics
@@ -113,8 +120,8 @@ jobs:
           find . -name "*cobertura*" -type f -ls 2>/dev/null || echo "No cobertura files found"
 
           if [ ! -f coverage/cobertura.xml ]; then
-            echo "::error::coverage/cobertura.xml not found. Tarpaulin failed to generate XML output."
-            echo "::error::Check tarpaulin logs above for errors."
+            echo "::error::coverage/cobertura.xml not found. cargo-llvm-cov failed to generate XML output."
+            echo "::error::Check cargo-llvm-cov logs above for errors."
             exit 2
           else
             coverage_bytes=$(wc -c < coverage/cobertura.xml)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,8 +17,8 @@ Users are expected to upgrade to the most recent version to receive security upd
 
 If you discover a security vulnerability, please report it **privately**.
 
-- Preferred: GitHub Security Advisory (Security tab → “Report a vulnerability”)
-- Alternative: Contact the maintainer via GitHub
+- Preferred: [GitHub private vulnerability report](https://github.com/acgetchell/delaunay/security/advisories/new)
+- Alternative: Email the maintainer at [adam@adamgetchell.org](mailto:adam@adamgetchell.org)
 
 Do **not** open a public issue for security vulnerabilities.
 
@@ -34,8 +34,9 @@ Do **not** open a public issue for security vulnerabilities.
 
 ## Disclosure Process
 
-- Reports will be acknowledged within a reasonable timeframe (typically a few days)
-- The issue will be triaged and severity assessed
+- Reports will be acknowledged as soon as maintainer availability allows
+- The issue will be triaged and severity assessed on a best-effort basis
+- For accepted reports, status updates will be provided when there is meaningful progress or a material change in assessment
 - If accepted:
   - A fix will be prepared and released
   - A GitHub Security Advisory will be published
@@ -53,7 +54,7 @@ This crate uses `#![forbid(unsafe_code)]`, reducing memory safety risks. However
 
 - Panics or crashes triggered by malformed or adversarial inputs
 - Denial-of-service (CPU or memory exhaustion)
-- Incorrect geometric or topological results under adversarial conditions
+- Incorrect geometric or topological results that affect security, integrity, or availability when processing untrusted input
 - Serialization/deserialization issues (e.g., malformed JSON inputs)
 
 Out of scope:
@@ -74,10 +75,20 @@ Out of scope:
 
 ## RustSec
 
-Security vulnerabilities may be disclosed via the RustSec Advisory Database:
-https://github.com/RustSec/advisory-db
+Security vulnerabilities may be disclosed via the
+[RustSec Advisory Database](https://github.com/RustSec/advisory-db).
 
 This enables detection via `cargo audit`.
+
+---
+
+## Safe Harbor
+
+Good-faith security research is welcome. Please avoid privacy violations,
+data destruction, persistence, service disruption, and public disclosure before
+a fix or mitigation is available. Reports that follow coordinated disclosure
+and make a reasonable effort to avoid harm will be treated as helpful
+contributions.
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -6,18 +6,28 @@
 # Use bash with strict error handling for all recipes
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
-# Common tarpaulin arguments for all coverage runs
-# Note: -t 300 sets per-test timeout to 5 minutes (needed for slow CI environments)
-# Excludes: storage_backend_compatibility (all tests ignored - Phase 4 evaluation tests)
-_coverage_base_args := '''--exclude-files 'benches/*' --exclude-files 'examples/*' \
+cargo_llvm_cov_version := "0.8.5"
+
+# Common cargo-llvm-cov arguments for all coverage runs.
+# Excludes benches/examples from reports while allowing integration tests to
+# exercise library code.
+_coverage_base_args := '''--ignore-filename-regex '(^|/)(benches|examples)/' \
   --workspace --lib --tests \
-  --exclude storage_backend_compatibility \
-  -t 300 --verbose --implicit-test-threads'''
+  --verbose'''
 
 _ensure-actionlint:
     #!/usr/bin/env bash
     set -euo pipefail
     command -v actionlint >/dev/null || { echo "❌ 'actionlint' not found. See 'just setup' or https://github.com/rhysd/actionlint"; exit 1; }
+
+_ensure-cargo-llvm-cov:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if ! command -v cargo-llvm-cov >/dev/null; then
+        echo "❌ 'cargo-llvm-cov' not found. See 'just setup-tools' or install:"
+        echo "   cargo install --locked cargo-llvm-cov --version {{cargo_llvm_cov_version}}"
+        exit 1
+    fi
 
 # Internal helpers: ensure external tooling is installed
 _ensure-git-cliff:
@@ -181,7 +191,7 @@ ci-slow: ci test-slow
 # Clean build artifacts
 clean:
     cargo clean
-    rm -rf target/tarpaulin
+    rm -rf target/llvm-cov
     rm -rf coverage_report
     rm -rf coverage
 
@@ -206,13 +216,15 @@ compare-storage-large: _ensure-uv
     BENCH_LARGE_SCALE=1 uv run compare-storage-backends --bench large_scale_performance
 
 # Coverage analysis for local development (HTML output)
-coverage:
-    cargo tarpaulin {{_coverage_base_args}} --out Html --output-dir target/tarpaulin
-    @echo "📊 Coverage report generated: target/tarpaulin/tarpaulin-report.html"
+coverage: _ensure-cargo-llvm-cov
+    mkdir -p target/llvm-cov
+    cargo llvm-cov {{_coverage_base_args}} --html --output-dir target/llvm-cov
+    @echo "📊 Coverage report generated: target/llvm-cov/html/index.html"
 
 # Coverage analysis for CI (XML output for codecov/codacy)
-coverage-ci:
-    cargo tarpaulin {{_coverage_base_args}} --out Xml --output-dir coverage -- --skip prop_
+coverage-ci: _ensure-cargo-llvm-cov
+    mkdir -p coverage
+    cargo llvm-cov {{_coverage_base_args}} --cobertura --output-path coverage/cobertura.xml -- --skip prop_
 
 debug-large-scale-3d n="10000":
     DELAUNAY_BULK_PROGRESS_EVERY=100 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_3D={{n}} cargo test --release --test large_scale_debug debug_large_scale_3d -- --ignored --exact --nocapture
@@ -472,7 +484,7 @@ python-sync: _ensure-uv
     uv sync --group dev
 
 python-typecheck: _ensure-uv
-    uv run ty check scripts/
+    uv run ty check scripts/ --error all
 
 # Repository-owned Semgrep rules. Currently opt-in because the Rust rules are
 # staged but disabled while legacy diagnostics are cleaned up.
@@ -572,15 +584,18 @@ setup-tools:
         echo "  ✓ git-cliff"
     fi
 
-    if ! have cargo-tarpaulin; then
-        if [[ "$os" == "Linux" ]]; then
-            echo "  ⏳ Installing cargo-tarpaulin (cargo)..."
-            cargo install --locked cargo-tarpaulin
-        else
-            echo "  ⚠️  Skipping cargo-tarpaulin install on $os (coverage is typically Linux-only)"
-        fi
+    if ! rustup component list --installed | grep -q '^llvm-tools'; then
+        echo "  ⏳ Installing llvm-tools-preview (rustup)..."
+        rustup component add llvm-tools-preview
     else
-        echo "  ✓ cargo-tarpaulin"
+        echo "  ✓ llvm-tools-preview"
+    fi
+
+    if ! have cargo-llvm-cov; then
+        echo "  ⏳ Installing cargo-llvm-cov {{cargo_llvm_cov_version}} (cargo)..."
+        cargo install --locked cargo-llvm-cov --version {{cargo_llvm_cov_version}}
+    else
+        echo "  ✓ cargo-llvm-cov"
     fi
 
     echo ""
@@ -588,9 +603,7 @@ setup-tools:
     missing=0
 
     cmds=(uv jq taplo yamllint shfmt shellcheck actionlint git-cliff node npx typos)
-    if [[ "$os" == "Linux" ]]; then
-        cmds+=(cargo-tarpaulin)
-    fi
+    cmds+=(cargo-llvm-cov)
 
     for cmd in "${cmds[@]}"; do
         if have "$cmd"; then

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ select = [
     "N",
     "UP",
     "YTT",
+    "ASYNC",
     "S",
     "BLE",
     "FBT",
@@ -79,13 +80,19 @@ select = [
     "COM",
     "C4",
     "DTZ",
+    "FA",
     "T10",
     "EM",
     "EXE",
+    "FIX",
+    "FLY",
+    "FURB",
     "ISC",
     "ICN",
+    "LOG",
     "G",
     "INP",
+    "PERF",
     "PIE",
     "T20",
     "PYI",
@@ -95,7 +102,10 @@ select = [
     "RET",
     "SLF",
     "SIM",
+    "SLOT",
+    "TC",
     "TID",
+    "TD",
     "TCH",
     "ARG",
     "PTH",
@@ -106,6 +116,14 @@ select = [
     "TRY",
     "NPY",
     "RUF",
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
 ]
 fixable = [ "ALL" ]
 unfixable = [  ]
@@ -140,7 +158,9 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"**/tests/test_*.py" = [ "S101", "SLF001" ] # Allow assert statements and private member access in test files
+# Test names and class groupings already document behavior; avoid requiring
+# docstrings for each pytest case while still checking production scripts.
+"**/tests/test_*.py" = [ "S101", "SLF001", "D101", "D102", "D103" ]
 
 # Import sorting and organization configuration
 [tool.ruff.lint.isort]

--- a/scripts/archive_changelog.py
+++ b/scripts/archive_changelog.py
@@ -271,8 +271,7 @@ def build_root(
         # Build the Archives section.
         archive_lines = ["## Archives\n"]
         archive_lines.append("Older releases are archived by minor series:\n")
-        for minor in archived_minors:
-            archive_lines.append(f"- [{minor}.x]({archive_dir_rel}/{minor}.md)")
+        archive_lines.extend(f"- [{minor}.x]({archive_dir_rel}/{minor}.md)" for minor in archived_minors)
         archive_lines.append("")
         parts.append("\n".join(archive_lines))
 

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -269,7 +269,7 @@ class PerformanceSummaryGenerator:
             if commit_hash and commit_hash != "unknown":
                 lines.append(f"**Git Commit**: {commit_hash}")
         except Exception as e:
-            logging.debug("Could not get git commit hash: %s", e)
+            logger.debug("Could not get git commit hash: %s", e)
 
         # Add hardware information
         try:
@@ -284,7 +284,7 @@ class PerformanceSummaryGenerator:
                 ],
             )
         except Exception as e:
-            logging.debug("Could not get hardware info: %s", e)
+            logger.debug("Could not get hardware info: %s", e)
             lines.append("**Hardware**: Unknown")
 
         lines.extend(
@@ -442,7 +442,7 @@ class PerformanceSummaryGenerator:
                                 accuracy_data[key] = f"{float(match.group(1)):.1f}%"
                     break
 
-            return accuracy_data if accuracy_data else None
+            return accuracy_data or None
 
         except Exception:
             return None
@@ -886,11 +886,8 @@ class PerformanceSummaryGenerator:
                 content = f.read()
 
             # Extract metadata from baseline
-            metadata_lines = []
             first_lines = content.split("\n")[:20]
-            for line in first_lines:
-                if line.startswith(("Generated at:", "Date:", "Git commit:", "Hardware:")):
-                    metadata_lines.append(line)
+            metadata_lines = [line for line in first_lines if line.startswith(("Generated at:", "Date:", "Git commit:", "Hardware:"))]
             if not any(line.startswith("Hardware:") for line in metadata_lines) and "Hardware Information:" in content:
                 hw = HardwareComparator.parse_baseline_hardware(content)
                 cpu = hw.get("CPU", "")
@@ -906,8 +903,7 @@ class PerformanceSummaryGenerator:
                         "",
                     ],
                 )
-                for meta_line in metadata_lines:
-                    lines.append(f"- **{meta_line}**")
+                lines.extend(f"- **{meta_line}**" for meta_line in metadata_lines)
                 lines.append("")
 
             # Extract and format benchmark data
@@ -948,9 +944,7 @@ class PerformanceSummaryGenerator:
 
                 # Extract and include specific regression details from content
                 content_lines = content.split("\n")
-                for line in content_lines:
-                    if "REGRESSION:" in line or "IMPROVEMENT:" in line:
-                        lines.append(f"- {line.strip()}")
+                lines.extend(f"- {line.strip()}" for line in content_lines if "REGRESSION:" in line or "IMPROVEMENT:" in line)
 
                 if any("REGRESSION:" in line or "IMPROVEMENT:" in line for line in content_lines):
                     lines.append("")
@@ -1453,6 +1447,7 @@ class BaselineGenerator:
     """Generate performance baselines from benchmark data."""
 
     def __init__(self, project_root: Path, tag: str | None = None):
+        """Initialize baseline generation for a project root and optional tag."""
         self.project_root = project_root
         self.hardware = HardwareInfo()
         self.tag = tag
@@ -1516,7 +1511,7 @@ class BaselineGenerator:
         except subprocess.TimeoutExpired as e:
             print(f"❌ Benchmark execution timed out after {bench_timeout} seconds", file=sys.stderr)
             print("   Consider increasing --bench-timeout or using --dev mode for faster benchmarks", file=sys.stderr)
-            logging.debug("TimeoutExpired: %s", e)
+            logger.debug("TimeoutExpired: %s", e)
             return False
         except subprocess.CalledProcessError as e:
             # Print captured stderr/stdout from cargo bench failure
@@ -1529,10 +1524,10 @@ class BaselineGenerator:
                 print("\n=== cargo bench stdout ===", file=sys.stderr)
                 print(e.stdout, file=sys.stderr)
                 print("=== end stdout ===\n", file=sys.stderr)
-            logging.exception("Error in generate_baseline")
+            logger.exception("Error in generate_baseline")
             return False
         except Exception:
-            logging.exception("Error in generate_baseline")
+            logger.exception("Error in generate_baseline")
             return False
 
     def _write_baseline_file(self, benchmark_results: list[BenchmarkData], output_file: Path, *, dev_mode: bool = False) -> None:
@@ -1574,6 +1569,7 @@ class PerformanceComparator:
     """Compare current performance against baseline."""
 
     def __init__(self, project_root: Path):
+        """Initialize comparison state for benchmark results under a project root."""
         self.project_root = project_root
         self.hardware = HardwareInfo()
         self.regression_threshold = DEFAULT_REGRESSION_THRESHOLD  # default threshold for proactive regression detection in CI
@@ -1654,7 +1650,7 @@ class PerformanceComparator:
         except subprocess.TimeoutExpired as e:
             print(f"❌ Benchmark execution timed out after {bench_timeout} seconds", file=sys.stderr)
             print("   Consider increasing --bench-timeout or using --dev mode for faster benchmarks", file=sys.stderr)
-            logging.debug("TimeoutExpired: %s", e)
+            logger.debug("TimeoutExpired: %s", e)
             self._write_error_file(output_file, "Benchmark execution timeout", f"{e} (timeout after {bench_timeout} seconds)")
             return False, False
         except subprocess.CalledProcessError as e:
@@ -1669,11 +1665,11 @@ class PerformanceComparator:
                 print(e.stdout, file=sys.stderr)
                 print("=== end stdout ===\n", file=sys.stderr)
             self._write_error_file(output_file, "Benchmark execution error", str(e))
-            logging.exception("Error in compare_with_baseline")
+            logger.exception("Error in compare_with_baseline")
             return False, False
         except Exception as e:
             self._write_error_file(output_file, "Benchmark execution error", str(e))
-            logging.exception("Error in compare_with_baseline")
+            logger.exception("Error in compare_with_baseline")
             return False, False
 
     def _parse_baseline_file(self, baseline_content: str) -> dict[str, BenchmarkData]:
@@ -2077,7 +2073,7 @@ class PerformanceComparator:
                 f.write("This error prevented the benchmark comparison from completing successfully.\n")
                 f.write("Please check the CI logs for more information.\n")
         except Exception:
-            logging.exception("Failed to write error file")
+            logger.exception("Failed to write error file")
 
 
 class WorkflowHelper:
@@ -2363,7 +2359,7 @@ class BenchmarkRegressionHelper:
                     return (1, version, p.name)
                 except Exception as e:
                     # Invalid version format, treat as non-semver
-                    logging.debug("Invalid version format in %s: %s", p.name, e)
+                    logger.debug("Invalid version format in %s: %s", p.name, e)
             # Fallback: put non-matching names last (priority 0, sorts after valid versions when reversed)
             return (0, p.name, "")
 
@@ -2392,7 +2388,7 @@ class BenchmarkRegressionHelper:
                         if re.match(r"^[0-9A-Fa-f]{7,40}$", potential_sha):
                             return potential_sha
         except (OSError, ValueError) as e:
-            logging.debug("Could not extract commit from %s: %s", baseline_file.name, e)
+            logger.debug("Could not extract commit from %s: %s", baseline_file.name, e)
         return None
 
     @staticmethod
@@ -2409,7 +2405,7 @@ class BenchmarkRegressionHelper:
             if isinstance(potential_sha, str) and re.match(r"^[0-9A-Fa-f]{7,40}$", potential_sha):
                 return potential_sha
         except (OSError, json.JSONDecodeError, KeyError) as e:
-            logging.debug("Could not extract commit from metadata.json: %s", e)
+            logger.debug("Could not extract commit from metadata.json: %s", e)
         return None
 
     @staticmethod
@@ -2522,7 +2518,7 @@ class BenchmarkRegressionHelper:
         print("⚠️ No performance baseline available for comparison.")
         print("   - No baseline artifacts found in recent workflow runs")
         print("   - Performance regression testing requires a baseline")
-        print("")
+        print()
         print("💡 To enable performance regression testing:")
         print("   1. Create a release tag (e.g., v0.4.3), or")
         print("   2. Manually trigger the 'Generate Performance Baseline' workflow")
@@ -2674,8 +2670,7 @@ def _default_baseline_cache_dir(project_root: Path, tag_name: str) -> Path:
 def _parse_github_owner_repo(remote_url: str) -> tuple[str, str] | None:
     """Parse a GitHub owner/repo from a git remote URL."""
     url = remote_url.strip()
-    if url.endswith(".git"):
-        url = url[: -len(".git")]
+    url = url.removesuffix(".git")
 
     # https://github.com/OWNER/REPO
     if url.startswith(("https://", "http://")):
@@ -2809,6 +2804,8 @@ def render_baseline_comparison(project_root: Path, old_baseline: Path, new_basel
 
 @dataclass(frozen=True)
 class BaselineFetchOptions:
+    """Options controlling how missing performance baselines are fetched."""
+
     regenerate_missing: bool = False
     workflow_ref: str = "main"
     wait_seconds: int = 3600
@@ -2819,6 +2816,7 @@ class GitHubBaselineFetcher:
     """Fetch tag baselines from GitHub Actions artifacts using the GitHub CLI."""
 
     def __init__(self, project_root: Path, *, repo: str | None = None, remote: str = "origin") -> None:
+        """Initialize artifact fetching for a project repository."""
         self.project_root = project_root
         self.repo = _resolve_github_repo(project_root, repo=repo, remote=remote)
 

--- a/scripts/compare_storage_backends.py
+++ b/scripts/compare_storage_backends.py
@@ -119,7 +119,7 @@ class StorageBackendComparator:
 
         except Exception as e:
             print(f"❌ Comparison failed: {e}", file=sys.stderr)
-            logging.exception("Comparison failed")
+            logger.exception("Comparison failed")
             return False
 
     def _run_benchmark(self, benchmark_name: str, use_dense_slotmap: bool, dev_mode: bool, extra_args: list[str] | None = None) -> dict | None:
@@ -200,7 +200,7 @@ class StorageBackendComparator:
             return results
 
         except Exception:
-            logging.exception("Benchmark execution failed")
+            logger.exception("Benchmark execution failed")
             return None
 
     def _parse_criterion_output(self, output: str) -> dict:
@@ -512,7 +512,7 @@ def main():
 
     except Exception as e:
         print(f"❌ Error: {e}", file=sys.stderr)
-        logging.exception("Fatal error")
+        logger.exception("Fatal error")
         sys.exit(1)
 
 

--- a/scripts/hardware_utils.py
+++ b/scripts/hardware_utils.py
@@ -38,6 +38,7 @@ class HardwareInfo:
     """Cross-platform hardware information detection."""
 
     def __init__(self):
+        """Initialize cached platform identifiers for hardware probes."""
         self.os_type = platform.system()
         self.machine = platform.machine()
 

--- a/scripts/postprocess_changelog.py
+++ b/scripts/postprocess_changelog.py
@@ -71,6 +71,10 @@ _INDENTED_ATX_HEADING_RE = re.compile(r"^(?P<indent>\s+)#{1,6}\s+(?P<title>.*?)(
 # generated commits. Treat them as prose headings inside the parent entry.
 _SQUASH_HEADING_RE = re.compile(r"^(?P<indent>\s*)-\s+(?P<prefix>[A-Za-z]+(?:\([^)]+\))?!?):\s+(?P<title>.+?)\s*$")
 
+# This label set is intentionally broad, including release labels such as
+# "added", "fixed", "changed", "removed", and "deprecated". Rewriting is
+# only allowed when _is_isolated_body_heading accepts the line; do not relax
+# that guard because tests rely on it to preserve handcrafted sub-bullets.
 _SQUASH_HEADING_LABELS: dict[str, str] = {
     "feat": "Added",
     "fix": "Fixed",
@@ -484,7 +488,7 @@ def postprocess(path: Path) -> None:
 
         if line.startswith("- ") and _COMMIT_LINK_RE.search(line):
             current_entry_summary = _plain_summary(line)
-        elif line.startswith("### "):
+        elif line.startswith(("### ", "## ", "# ")):
             current_entry_summary = None
 
         is_isolated_body_heading = _is_isolated_body_heading(lines, idx)

--- a/scripts/tests/test_postprocess_changelog.py
+++ b/scripts/tests/test_postprocess_changelog.py
@@ -484,6 +484,26 @@ class TestSquashHeadingNormalization:
         assert "**Fixed: Close the 4D bulk repair retry collapse**" in result
         assert "  - Thread cavity-touched cells through insertion." in result
 
+    def test_full_pipeline_resets_parent_summary_at_version_heading(self, tmp_path: Path) -> None:
+        """Version headings reset duplicate-squash tracking between releases."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(
+            "# Changelog\n\n"
+            "## [1.0.0]\n\n"
+            "### Added\n\n"
+            f"- Repeatable summary {_commit()}\n\n"
+            "## [0.9.0]\n\n"
+            "- fixed: repeatable summary\n\n"
+            "  - Preserve this historical squash-body heading.\n",
+            encoding="utf-8",
+        )
+
+        postprocess(f)
+
+        result = f.read_text(encoding="utf-8")
+        assert "**Fixed: Repeatable summary**" in result
+        assert "  - Preserve this historical squash-body heading." in result
+
     def test_full_pipeline_preserves_non_isolated_conventional_bullets(self, tmp_path: Path) -> None:
         f = tmp_path / "CHANGELOG.md"
         f.write_text(

--- a/tests/COVERAGE.md
+++ b/tests/COVERAGE.md
@@ -1,125 +1,58 @@
-# Test Coverage Report
+# Coverage
 
-Generated on 2026-03-24 using `cargo tarpaulin --lib` (v0.7.3, lib unit tests only; doctests excluded due to tarpaulin MSRV mismatch)
+This repository uses `cargo-llvm-cov` for local and CI coverage. Coverage runs
+use Rust's LLVM source-based instrumentation and keep the coverage command in
+the `justfile` so local runs and CI stay aligned.
 
-## Overall Coverage: 68.48% (9,393/13,716 lines covered)
+## Local HTML
 
-## Files by Coverage (Sorted by Coverage Percentage)
+Generate the local developer report with:
 
-### Full Coverage (100%)
+```bash
+just coverage
+```
 
-| File | Lines Covered | Total Lines |
-|------|---------------|-------------|
-| `src/core/adjacency.rs` | 24/24 | 24 |
-| `src/core/boundary.rs` | 14/14 | 14 |
-| `src/core/collections/helpers.rs` | 10/10 | 10 |
-| `src/core/edge.rs` | 12/12 | 12 |
-| `src/core/util/canonical_points.rs` | 17/17 | 17 |
-| `src/core/util/facet_keys.rs` | 56/56 | 56 |
-| `src/core/util/hashing.rs` | 12/12 | 12 |
-| `src/core/util/uuid.rs` | 9/9 | 9 |
-| `src/topology/spaces/euclidean.rs` | 9/9 | 9 |
-| `src/topology/spaces/spherical.rs` | 9/9 | 9 |
-| `src/topology/spaces/toroidal.rs` | 22/22 | 22 |
+The HTML report is written to:
 
-### High Coverage (≥70%)
+```text
+target/llvm-cov/html/index.html
+```
 
-| File | Coverage | Lines Covered | Total Lines |
-|------|----------|---------------|-------------|
-| `src/core/vertex.rs` | 96.19% | 101/105 | 105 |
-| `src/core/util/deduplication.rs` | 95.12% | 39/41 | 41 |
-| `src/core/util/facet_utils.rs` | 93.94% | 31/33 | 33 |
-| `src/topology/traits/global_topology_model.rs` | 93.37% | 169/181 | 181 |
-| `src/core/cell.rs` | 92.86% | 221/238 | 238 |
-| `src/core/util/jaccard.rs` | 92.68% | 76/82 | 82 |
-| `src/geometry/traits/coordinate.rs` | 92.31% | 24/26 | 26 |
-| `src/geometry/sos.rs` | 91.67% | 121/132 | 132 |
-| `src/core/facet.rs` | 91.20% | 114/125 | 125 |
-| `src/geometry/point.rs` | 88.66% | 86/97 | 97 |
-| `src/topology/manifold.rs` | 87.39% | 513/587 | 587 |
-| `src/geometry/util/norms.rs` | 86.67% | 26/30 | 30 |
-| `src/core/collections/spatial_hash_grid.rs` | 85.29% | 58/68 | 68 |
-| `src/topology/characteristics/validation.rs` | 84.62% | 22/26 | 26 |
-| `src/geometry/util/point_generation.rs` | 83.33% | 145/174 | 174 |
-| `src/core/tds.rs` | 81.34% | 1,077/1,324 | 1,324 |
-| `src/geometry/algorithms/convex_hull.rs` | 80.29% | 224/279 | 279 |
-| `src/geometry/util/circumsphere.rs` | 79.69% | 51/64 | 64 |
-| `src/core/operations.rs` | 76.32% | 29/38 | 38 |
-| `src/topology/characteristics/euler.rs` | 76.47% | 143/187 | 187 |
-| `src/geometry/util/conversions.rs` | 71.93% | 41/57 | 57 |
-| `src/core/util/hilbert.rs` | 71.35% | 122/171 | 171 |
-| `src/core/triangulation.rs` | 69.94% | 1,197/1,710 | 1,710 |
+## CI XML
 
-### Medium Coverage (40–69%)
+Generate the CI-compatible Cobertura report with:
 
-| File | Coverage | Lines Covered | Total Lines |
-|------|----------|---------------|-------------|
-| `src/triangulation/delaunay.rs` | 66.56% | 1,192/1,791 | 1,791 |
-| `src/geometry/robust_predicates.rs` | 66.36% | 73/110 | 110 |
-| `src/core/algorithms/flips.rs` | 66.33% | 1,440/2,171 | 2,171 |
-| `src/geometry/quality.rs` | 65.88% | 56/85 | 85 |
-| `src/geometry/util/measures.rs` | 64.92% | 161/248 | 248 |
-| `src/core/traits/facet_cache.rs` | 62.50% | 35/56 | 56 |
-| `src/geometry/matrix.rs` | 61.54% | 8/13 | 13 |
-| `src/core/algorithms/locate.rs` | 60.43% | 252/417 | 417 |
-| `src/triangulation/builder.rs` | 55.89% | 441/789 | 789 |
-| `src/geometry/kernel.rs` | 55.45% | 61/110 | 110 |
-| `src/geometry/predicates.rs` | 54.84% | 102/186 | 186 |
-| `src/core/algorithms/incremental_insertion.rs` | 54.19% | 569/1,050 | 1,050 |
-| `src/core/util/delaunay_validation.rs` | 47.62% | 90/189 | 189 |
-| `src/geometry/util/triangulation_generation.rs` | 47.65% | 81/170 | 170 |
+```bash
+just coverage-ci
+```
 
-### Low Coverage (<40%) — Priority for Improvement
+The XML report is written to:
 
-| File | Coverage | Lines Covered | Total Lines | Notes |
-|------|----------|---------------|-------------|-------|
-| `src/core/util/measurement.rs` | 33.33% | 2/6 | 6 | Feature-gated (`count-allocations`) |
-| `src/lib.rs` | 28.57% | 2/7 | 7 | Re-exports only |
-| `src/triangulation/flips.rs` | 12.50% | 4/32 | 32 | Public trait; delegates to `core::algorithms::flips` |
-| `src/topology/traits/topological_space.rs` | 0.00% | 0/20 | 20 | Type definitions, minimal executable code |
+```text
+coverage/cobertura.xml
+```
 
-## Coverage by Module
+The Codecov workflow installs Rust's `llvm-tools-preview` component, installs
+`cargo-llvm-cov`, caches the installed cargo binary by version, runs
+`just coverage-ci`, verifies `coverage/cobertura.xml`, uploads that file to
+Codecov and Codacy, and archives the full `coverage/` directory.
 
-### Core Module: 69.09% (6,960/10,072 lines)
+## Coverage Surface
 
-- **Data structures** (`cell`, `vertex`, `facet`, `edge`, `boundary`): 91–100%
-- **TDS** (`tds`): 81%
-- **Triangulation layer** (`triangulation`): 70%
-- **Delaunay layer** (`triangulation::delaunay`): 67%
-- **Algorithms** (`flips`, `incremental_insertion`, `locate`): 54–66%
-- **Builder**: 56%
-- **Utilities** (`canonical_points`, `facet_keys`, `hashing`, `uuid`): 95–100%
-- **Collections** (`spatial_hash_grid`, `helpers`): 85–100%
+Both local and CI coverage use:
 
-### Geometry Module: 69.89% (1,346/1,926 lines)
+```bash
+cargo llvm-cov --workspace --lib --tests
+```
 
-- **Point/Coordinate**: 89–92%
-- **SoS** (`sos`): 92%
-- **Convex hull**: 80%
-- **Predicates** (`predicates`, `robust_predicates`): 55–66%
-- **Kernel**: 55%
-- **Quality metrics**: 66%
-- **Utilities** (`circumsphere`, `conversions`, `norms`): 72–87%
+The common arguments also ignore `benches/` and `examples/` source paths in
+reports. Integration tests still run and exercise library code, but coverage
+metrics focus on the library implementation rather than benchmark, example, or
+test harness source.
 
-### Topology Module: 85.22% (887/1,041 lines)
+`just coverage-ci` passes `-- --skip prop_` to keep CI behavior aligned with the
+previous coverage path: property tests are skipped for coverage uploads, while
+regular library and integration tests still contribute coverage.
 
-- **Manifold**: 87%
-- **Euler characteristic**: 76%
-- **Validation**: 85%
-- **Spaces** (euclidean, spherical, toroidal): 100%
-- **Topology model trait**: 93%
-
-### Triangulation Public API: 12.50% (4/32 lines)
-
-- `src/triangulation/flips.rs`: public flip trait (mostly delegates to `core::algorithms::flips`)
-
-## Notes
-
-- Coverage is from `cargo tarpaulin --lib` (unit tests only). Integration tests
-  (`tests/`) and property tests (`proptest_*.rs`) exercise significant additional
-  code paths not reflected here.
-- Benchmark files (`benches/`) are excluded (0% is expected).
-- `src/core/util/measurement.rs` is feature-gated (`count-allocations`) and
-  intentionally low.
-- `src/topology/traits/topological_space.rs` contains public type definitions
-  with minimal executable code.
+Doc-test coverage remains intentionally disabled because `cargo-llvm-cov` marks
+that path as unstable.


### PR DESCRIPTION
- Replace tarpaulin coverage commands with cargo-llvm-cov for local HTML and CI Cobertura reports.
- Update Codecov workflow setup, caching, validation, and coverage documentation for the new toolchain.
- Add GitHub issue templates and clarify private vulnerability reporting guidance.
- Tighten Python lint/typecheck settings and clean up benchmark/changelog utility diagnostics.
- Add changelog post-processing coverage for version-heading reset behavior.

Closes #343