### PR TITLE
fix: harden Python benchmark parsing

### DIFF
--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -84,3 +84,14 @@ Put reusable typed test helpers near the top of the test module or in
 `scripts/tests/conftest.py` when they are shared. Prefer one helper that returns
 the real structured type over repeating partially configured mocks throughout a
 file.
+
+## Parser and File-Format Contracts
+
+When a script both writes and parses a text format, add a focused round-trip
+test that writes representative records and parses them back. The test should
+cover stable identifiers, optional sections, units, and numeric forms such as
+scientific notation when those values can be emitted by production code.
+
+For parser refactors, keep malformed-input regression tests for behavior that
+callers depend on, such as skipping incomplete sections or failing loudly on
+invalid numerical data.

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -223,7 +223,7 @@ def _load_ci_performance_manifest_ids(criterion_dir: Path) -> set[str] | None:
     return manifest_ids or None
 
 
-def _is_valid_criterion_estimate(mean_ns: float, low_ns: float, high_ns: float) -> bool:
+def is_valid_criterion_estimate(mean_ns: float, low_ns: float, high_ns: float) -> bool:
     """Return whether Criterion estimate values are finite and ordered."""
     return all(math.isfinite(value) for value in (mean_ns, low_ns, high_ns)) and mean_ns > 0 and 0 <= low_ns <= mean_ns <= high_ns
 
@@ -1041,12 +1041,18 @@ class PerformanceSummaryGenerator:
             with estimates_path.open("r", encoding="utf-8") as f:
                 data = json.load(f)
 
+            if not isinstance(data, dict):
+                return None
             mean_data = data.get("mean", {})
+            if not isinstance(mean_data, dict):
+                return None
             mean_ns = float(mean_data["point_estimate"])
             confidence_interval = mean_data.get("confidence_interval", {})
+            if not isinstance(confidence_interval, dict):
+                return None
             low_ns = float(confidence_interval.get("lower_bound", mean_ns))
             high_ns = float(confidence_interval.get("upper_bound", mean_ns))
-            if not _is_valid_criterion_estimate(mean_ns, low_ns, high_ns):
+            if not is_valid_criterion_estimate(mean_ns, low_ns, high_ns):
                 return None
             return mean_ns, low_ns, high_ns
         except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
@@ -1683,7 +1689,7 @@ class CriterionParser:
             low_ns = float(data["mean"]["confidence_interval"]["lower_bound"])
             high_ns = float(data["mean"]["confidence_interval"]["upper_bound"])
 
-            if not _is_valid_criterion_estimate(mean_ns, low_ns, high_ns):
+            if not is_valid_criterion_estimate(mean_ns, low_ns, high_ns):
                 return None
 
             # Convert nanoseconds to microseconds

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -223,6 +223,11 @@ def _load_ci_performance_manifest_ids(criterion_dir: Path) -> set[str] | None:
     return manifest_ids or None
 
 
+def _is_valid_criterion_estimate(mean_ns: float, low_ns: float, high_ns: float) -> bool:
+    """Return whether Criterion estimate values are finite and ordered."""
+    return all(math.isfinite(value) for value in (mean_ns, low_ns, high_ns)) and mean_ns > 0 and 0 <= low_ns <= mean_ns <= high_ns
+
+
 def _collect_ci_suite_estimates(criterion_dir: Path) -> list[tuple[tuple[str, ...], Path]]:
     """Collect deduplicated ci_performance_suite estimates, preferring new over base."""
     manifest_ids = _load_ci_performance_manifest_ids(criterion_dir)
@@ -1041,7 +1046,7 @@ class PerformanceSummaryGenerator:
             confidence_interval = mean_data.get("confidence_interval", {})
             low_ns = float(confidence_interval.get("lower_bound", mean_ns))
             high_ns = float(confidence_interval.get("upper_bound", mean_ns))
-            if mean_ns <= 0:
+            if not _is_valid_criterion_estimate(mean_ns, low_ns, high_ns):
                 return None
             return mean_ns, low_ns, high_ns
         except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
@@ -1674,11 +1679,11 @@ class CriterionParser:
                 data = json.load(f)
 
             # Extract timing data (nanoseconds from Criterion)
-            mean_ns = data["mean"]["point_estimate"]
-            low_ns = data["mean"]["confidence_interval"]["lower_bound"]
-            high_ns = data["mean"]["confidence_interval"]["upper_bound"]
+            mean_ns = float(data["mean"]["point_estimate"])
+            low_ns = float(data["mean"]["confidence_interval"]["lower_bound"])
+            high_ns = float(data["mean"]["confidence_interval"]["upper_bound"])
 
-            if mean_ns <= 0:
+            if not _is_valid_criterion_estimate(mean_ns, low_ns, high_ns):
                 return None
 
             # Convert nanoseconds to microseconds
@@ -1702,7 +1707,7 @@ class CriterionParser:
 
             return benchmark
 
-        except (FileNotFoundError, json.JSONDecodeError, KeyError, ZeroDivisionError, ValueError):
+        except (FileNotFoundError, json.JSONDecodeError, KeyError, TypeError, ZeroDivisionError, ValueError):
             return None
 
     @staticmethod
@@ -2093,70 +2098,14 @@ class PerformanceComparator:
     def _parse_baseline_file(self, baseline_content: str) -> dict[str, BenchmarkData]:
         """Parse baseline file content into benchmark data."""
         results = {}
-        lines = baseline_content.split("\n")
-        i = 0
-
-        while i < len(lines):
-            line = lines[i].strip()
-
-            # Look for benchmark sections
-            match = re.match(r"=== (?:(\d+) Points|Unsized Workload) \((\d+)D\) ===", line)
-            if match:
-                points = int(match.group(1)) if match.group(1) is not None else None
-                dimension = f"{match.group(2)}D"
-                benchmark_id = ""
-                next_line_index = i + 1
-
-                if next_line_index < len(lines):
-                    id_match = re.match(r"Benchmark ID:\s*(.+)", lines[next_line_index].strip())
-                    if id_match:
-                        benchmark_id = id_match.group(1).strip()
-                        next_line_index += 1
-
-                # Parse time line
-                if next_line_index < len(lines):
-                    time_line = lines[next_line_index].strip()
-                    time_match = re.match(r"Time: \[([0-9.]+), ([0-9.]+), ([0-9.]+)\] (.+)", time_line)
-                    if time_match:
-                        time_low = float(time_match.group(1))
-                        time_mean = float(time_match.group(2))
-                        time_high = float(time_match.group(3))
-                        time_unit = time_match.group(4)
-
-                        # Parse throughput line if present
-                        throughput_low = throughput_mean = throughput_high = None
-                        throughput_unit = None
-
-                        if next_line_index + 1 < len(lines):
-                            thrpt_line = lines[next_line_index + 1].strip()
-                            thrpt_match = re.match(r"Throughput: \[([0-9.]+), ([0-9.]+), ([0-9.]+)\] (.+)", thrpt_line)
-                            if thrpt_match:
-                                throughput_low = float(thrpt_match.group(1))
-                                throughput_mean = float(thrpt_match.group(2))
-                                throughput_high = float(thrpt_match.group(3))
-                                throughput_unit = thrpt_match.group(4)
-
-                        benchmark = BenchmarkData(points, dimension, benchmark_id=benchmark_id).with_timing(time_low, time_mean, time_high, time_unit)
-                        if throughput_mean is not None and throughput_low is not None and throughput_high is not None and throughput_unit is not None:
-                            benchmark.with_throughput(
-                                throughput_low,
-                                throughput_mean,
-                                throughput_high,
-                                throughput_unit,
-                            )
-                        else:
-                            logger.debug(
-                                "Missing throughput data for %s: low=%s mean=%s high=%s unit=%s",
-                                benchmark.comparison_key,
-                                throughput_low,
-                                throughput_mean,
-                                throughput_high,
-                                throughput_unit,
-                            )
-                        results[benchmark.comparison_key] = benchmark
-
-            i += 1
-
+        for benchmark in extract_benchmark_data(baseline_content):
+            if not benchmark.time_unit:
+                logger.debug("Skipping baseline benchmark without timing data: %s", benchmark)
+                continue
+            try:
+                results[benchmark.comparison_key] = benchmark
+            except ValueError:
+                logger.debug("Skipping baseline benchmark without stable comparison key: %s", benchmark)
         return results
 
     def parse_baseline_file(self, baseline_content: str) -> dict[str, BenchmarkData]:

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -879,10 +879,21 @@ class PerformanceSummaryGenerator:
         if estimates_file.exists():
             try:
                 with estimates_file.open(encoding="utf-8") as f:
-                    estimates = json.load(f)
+                    data = json.load(f)
 
-                # Extract mean time in nanoseconds
-                mean_ns = estimates["mean"]["point_estimate"]
+                if not isinstance(data, dict):
+                    return None
+                mean_data = data.get("mean", {})
+                if not isinstance(mean_data, dict):
+                    return None
+                mean_ns = float(mean_data["point_estimate"])
+                confidence_interval = mean_data.get("confidence_interval", {})
+                if not isinstance(confidence_interval, dict):
+                    return None
+                low_ns = float(confidence_interval.get("lower_bound", mean_ns))
+                high_ns = float(confidence_interval.get("upper_bound", mean_ns))
+                if not is_valid_criterion_estimate(mean_ns, low_ns, high_ns):
+                    return None
                 return CircumspherePerformanceData(method=method_name, time_ns=mean_ns)
 
             except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError) as e:

--- a/scripts/compare_storage_backends.py
+++ b/scripts/compare_storage_backends.py
@@ -37,10 +37,10 @@ from json import loads
 from pathlib import Path
 
 try:
-    from benchmark_utils import TRUSTED_BENCH_PROFILE  # type: ignore[import-not-found]
+    from benchmark_utils import TRUSTED_BENCH_PROFILE, is_valid_criterion_estimate  # type: ignore[import-not-found]
     from subprocess_utils import ExecutableNotFoundError, find_project_root, run_cargo_command  # type: ignore[import-not-found]
 except ModuleNotFoundError:
-    from scripts.benchmark_utils import TRUSTED_BENCH_PROFILE  # type: ignore[no-redef,import-not-found]
+    from scripts.benchmark_utils import TRUSTED_BENCH_PROFILE, is_valid_criterion_estimate  # type: ignore[no-redef,import-not-found]
     from scripts.subprocess_utils import ExecutableNotFoundError, find_project_root, run_cargo_command  # type: ignore[no-redef,import-not-found]
 
 logger = logging.getLogger(__name__)
@@ -268,9 +268,7 @@ class StorageBackendComparator:
                         name = "/".join(path.relative_to(criterion_path).parts[:-2])
                         lower_bound = float(data["mean"]["confidence_interval"]["lower_bound"])
                         upper_bound = float(data["mean"]["confidence_interval"]["upper_bound"])
-                        if not (math.isfinite(estimate) and math.isfinite(lower_bound) and math.isfinite(upper_bound)):
-                            continue
-                        if estimate <= 0 or not (0 <= lower_bound <= estimate <= upper_bound):
+                        if not is_valid_criterion_estimate(estimate, lower_bound, upper_bound):
                             continue
 
                         benchmarks_list.append(

--- a/scripts/compare_storage_backends.py
+++ b/scripts/compare_storage_backends.py
@@ -27,6 +27,7 @@ Usage:
 
 import argparse
 import logging
+import math
 import re
 import shutil
 import subprocess
@@ -44,15 +45,36 @@ except ModuleNotFoundError:
 
 logger = logging.getLogger(__name__)
 
+_DURATION_UNIT_TO_NS = {
+    "ns": 1.0,
+    "µs": 1_000.0,
+    "μs": 1_000.0,
+    "us": 1_000.0,
+    "ms": 1_000_000.0,
+    "s": 1_000_000_000.0,
+}
+
 _RECOVERABLE_COMPARISON_ERRORS: tuple[type[BaseException], ...] = (
     ExecutableNotFoundError,
     OSError,
     RuntimeError,
-    TypeError,
     ValueError,
-    KeyError,
     subprocess.SubprocessError,
 )
+
+
+def _duration_to_ns(value: str | float, unit: object) -> float | None:
+    """Convert a positive finite duration to nanoseconds."""
+    if not isinstance(unit, str):
+        return None
+    try:
+        duration = float(value)
+    except (TypeError, ValueError):
+        return None
+    scale = _DURATION_UNIT_TO_NS.get(unit)
+    if scale is None or duration <= 0 or not math.isfinite(duration):
+        return None
+    return duration * scale
 
 
 class StorageBackendComparator:
@@ -241,11 +263,15 @@ class StorageBackendComparator:
                 for path in criterion_path.rglob("new/estimates.json"):
                     try:
                         data = loads(path.read_text(encoding="utf-8"))
-                        estimate = data["mean"]["point_estimate"]
-                        # Infer name from parent directory
-                        name = path.parent.parent.name
+                        estimate = float(data["mean"]["point_estimate"])
+                        # Preserve the full Criterion benchmark ID, excluding new/estimates.json.
+                        name = "/".join(path.relative_to(criterion_path).parts[:-2])
                         lower_bound = float(data["mean"]["confidence_interval"]["lower_bound"])
                         upper_bound = float(data["mean"]["confidence_interval"]["upper_bound"])
+                        if not (math.isfinite(estimate) and math.isfinite(lower_bound) and math.isfinite(upper_bound)):
+                            continue
+                        if estimate <= 0 or not (0 <= lower_bound <= estimate <= upper_bound):
+                            continue
 
                         benchmarks_list.append(
                             {
@@ -304,8 +330,17 @@ class StorageBackendComparator:
             if slotmap_bench and denseslotmap_bench:
                 slotmap_time = slotmap_bench["estimate"]
                 denseslotmap_time = denseslotmap_bench["estimate"]
-                unit = slotmap_bench["unit"]
-                diff_pct = ((denseslotmap_time - slotmap_time) / slotmap_time) * 100
+                slotmap_unit = slotmap_bench["unit"]
+                denseslotmap_unit = denseslotmap_bench["unit"]
+                slotmap_time_ns = _duration_to_ns(slotmap_time, slotmap_unit)
+                denseslotmap_time_ns = _duration_to_ns(denseslotmap_time, denseslotmap_unit)
+                if slotmap_time_ns is None or denseslotmap_time_ns is None:
+                    lines.append(
+                        f"| {name} | {slotmap_time:.2f} {slotmap_unit} | {denseslotmap_time:.2f} {denseslotmap_unit} | N/A | invalid timing data |",
+                    )
+                    continue
+
+                diff_pct = ((denseslotmap_time_ns - slotmap_time_ns) / slotmap_time_ns) * 100
                 diffs.append(diff_pct)
 
                 # Determine winner (green=faster, yellow=same)
@@ -316,7 +351,12 @@ class StorageBackendComparator:
                 else:
                     winner, emoji = "✅ SlotMap", "🟢"
 
-                lines.append(f"| {name} | {slotmap_time:.2f} {unit} | {denseslotmap_time:.2f} {unit} | {diff_pct:+.1f}% {emoji} | {winner} |")
+                lines.append(
+                    (
+                        f"| {name} | {slotmap_time:.2f} {slotmap_unit} | "
+                        f"{denseslotmap_time:.2f} {denseslotmap_unit} | {diff_pct:+.1f}% {emoji} | {winner} |"
+                    ),
+                )
             elif slotmap_bench:
                 lines.append(f"| {name} | {slotmap_bench['estimate']:.2f} {slotmap_bench['unit']} | N/A | - | - |")
             elif denseslotmap_bench:

--- a/scripts/hardware_utils.py
+++ b/scripts/hardware_utils.py
@@ -166,9 +166,16 @@ class HardwareInfo:
         Returns:
             CPU core count or "Unknown"
         """
-        if not shutil.which("lscpu"):
-            return self._get_linux_cpu_cores_from_proc()
-        return self._get_linux_cpu_cores_from_lscpu()
+        if shutil.which("lscpu"):
+            try:
+                cpu_cores = self._get_linux_cpu_cores_from_lscpu()
+            except (OSError, RuntimeError, subprocess.SubprocessError, TypeError, ValueError, IndexError):
+                logger.debug("Failed to parse Linux CPU cores from lscpu", exc_info=True)
+            else:
+                if cpu_cores != "Unknown":
+                    return cpu_cores
+
+        return self._get_linux_cpu_cores_from_proc()
 
     def _get_linux_cpu_threads(self) -> str:
         """

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -249,6 +249,26 @@ class TestCriterionParser:
         finally:
             estimates_path.unlink()
 
+    @pytest.mark.parametrize(
+        "estimates_data",
+        [
+            [],
+            {"mean": []},
+            {"mean": {"point_estimate": 100000.0, "confidence_interval": []}},
+        ],
+    )
+    def test_summary_estimate_loader_rejects_structurally_invalid_mean_data(self, estimates_data) -> None:
+        """Test performance summary loader rejects structurally malformed Criterion estimates."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(estimates_data, f)
+            f.flush()
+            estimates_path = Path(f.name)
+
+        try:
+            assert PerformanceSummaryGenerator._load_criterion_estimate(estimates_path) is None
+        finally:
+            estimates_path.unlink()
+
     def test_parse_estimates_json_very_fast_benchmark_division_by_zero_protection(self) -> None:
         """Test division by zero protection for very fast benchmarks with near-zero confidence intervals."""
         estimates_data = {

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -2303,6 +2303,53 @@ class TestPerformanceSummaryGenerator:
             assert isinstance(generator.current_version, str)
             assert isinstance(generator.current_date, str)
 
+    def test_parse_single_method_result_accepts_valid_estimate(self, tmp_path) -> None:
+        """Test circumsphere method parsing accepts finite ordered Criterion estimates."""
+        criterion_path = tmp_path / "target" / "criterion" / "basic_2d_insphere"
+        estimates_dir = criterion_path / "base"
+        estimates_dir.mkdir(parents=True)
+        (estimates_dir / "estimates.json").write_text(
+            json.dumps(
+                {
+                    "mean": {
+                        "point_estimate": 100000.0,
+                        "confidence_interval": {
+                            "lower_bound": 90000.0,
+                            "upper_bound": 110000.0,
+                        },
+                    },
+                },
+            ),
+            encoding="utf-8",
+        )
+        generator = PerformanceSummaryGenerator(tmp_path)
+
+        result = generator._parse_single_method_result(criterion_path, "insphere")
+
+        assert result is not None
+        assert result.method == "insphere"
+        assert result.time_ns == pytest.approx(100000.0)
+
+    @pytest.mark.parametrize(
+        "estimates_data",
+        [
+            [],
+            {"mean": []},
+            {"mean": {"point_estimate": 100000.0, "confidence_interval": []}},
+            {"mean": {"point_estimate": float("nan"), "confidence_interval": {"lower_bound": 90000.0, "upper_bound": 110000.0}}},
+            {"mean": {"point_estimate": 100000.0, "confidence_interval": {"lower_bound": 110000.0, "upper_bound": 120000.0}}},
+        ],
+    )
+    def test_parse_single_method_result_rejects_invalid_estimates(self, tmp_path, estimates_data) -> None:
+        """Test circumsphere method parsing rejects malformed or invalid Criterion estimates."""
+        criterion_path = tmp_path / "target" / "criterion" / "basic_2d_insphere"
+        estimates_dir = criterion_path / "base"
+        estimates_dir.mkdir(parents=True)
+        (estimates_dir / "estimates.json").write_text(json.dumps(estimates_data), encoding="utf-8")
+        generator = PerformanceSummaryGenerator(tmp_path)
+
+        assert generator._parse_single_method_result(criterion_path, "insphere") is None
+
     def test_generate_summary_parser_defaults_to_trusted_profile(self) -> None:
         """Test that fresh summary benchmarks default to the trusted Cargo profile."""
         parser = create_argument_parser()

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -210,6 +210,45 @@ class TestCriterionParser:
         finally:
             estimates_path.unlink()
 
+    @pytest.mark.parametrize(
+        "estimates_data",
+        [
+            {"mean": {"point_estimate": float("nan"), "confidence_interval": {"lower_bound": 100000.0, "upper_bound": 120000.0}}},
+            {"mean": {"point_estimate": float("inf"), "confidence_interval": {"lower_bound": 100000.0, "upper_bound": 120000.0}}},
+            {"mean": {"point_estimate": 110000.0, "confidence_interval": {"lower_bound": 120000.0, "upper_bound": 130000.0}}},
+        ],
+    )
+    def test_parse_estimates_json_rejects_invalid_estimates(self, estimates_data) -> None:
+        """Test parsing rejects non-finite or unordered Criterion estimates."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(estimates_data, f)
+            f.flush()
+            estimates_path = Path(f.name)
+
+        try:
+            result = CriterionParser.parse_estimates_json(estimates_path, 1000, "2D")
+            assert result is None
+        finally:
+            estimates_path.unlink()
+
+    def test_summary_estimate_loader_rejects_nonfinite_values(self) -> None:
+        """Test performance summary loader rejects non-finite Criterion estimates."""
+        estimates_data = {
+            "mean": {
+                "point_estimate": float("nan"),
+                "confidence_interval": {"lower_bound": 100000.0, "upper_bound": 120000.0},
+            },
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(estimates_data, f)
+            f.flush()
+            estimates_path = Path(f.name)
+
+        try:
+            assert PerformanceSummaryGenerator._load_criterion_estimate(estimates_path) is None
+        finally:
+            estimates_path.unlink()
+
     def test_parse_estimates_json_very_fast_benchmark_division_by_zero_protection(self) -> None:
         """Test division by zero protection for very fast benchmarks with near-zero confidence intervals."""
         estimates_data = {
@@ -463,6 +502,41 @@ Throughput: [2.381, 2.5, 2.632] Kelem/s
         assert results["boundary_facets/boundary_facets_3d/50"].time_mean == 10.0
         assert results["validation/validate_3d/50"].time_mean == 20.0
 
+    def test_parse_baseline_file_with_scientific_notation(self, comparator) -> None:
+        """Test baseline parsing accepts the full float domain written by Python."""
+        baseline_content = """Date: 2023-06-15 10:30:00 PDT
+Git commit: abc123def456
+
+=== 1000 Points (2D) ===
+Time: [1.0e-6, 1.1e-6, 1.2e-6] µs
+Throughput: [8.333e3, 9.091e3, 1.0e4] Kelem/s
+"""
+
+        results = comparator._parse_baseline_file(baseline_content)
+
+        benchmark = results["1000_2D"]
+        assert benchmark.time_low == pytest.approx(1.0e-6)
+        assert benchmark.time_mean == pytest.approx(1.1e-6)
+        assert benchmark.time_high == pytest.approx(1.2e-6)
+        assert benchmark.throughput_mean == pytest.approx(9.091e3)
+
+    def test_parse_baseline_file_skips_sections_without_timing(self, comparator) -> None:
+        """Test malformed baseline sections without timing data are not compared."""
+        baseline_content = """Date: 2023-06-15 10:30:00 PDT
+Git commit: abc123def456
+
+=== 1000 Points (2D) ===
+Benchmark ID: malformed/no_timing
+
+=== 2000 Points (2D) ===
+Time: [190.0, 200.0, 210.0] µs
+Throughput: [9.524, 10.0, 10.526] Kelem/s
+"""
+
+        results = comparator._parse_baseline_file(baseline_content)
+
+        assert set(results) == {"2000_2D"}
+
     def test_parse_baseline_file_with_unsized_benchmark_id(self, comparator) -> None:
         """Test parsing expanded CI benchmarks without numeric input sizes."""
         baseline_content = """Date: 2023-06-15 10:30:00 PDT
@@ -559,7 +633,7 @@ Time: [0.8, 0.95, 1.1] µs
 
         result = output.getvalue()
         assert "15.0%" in result
-        assert "⚠️  REGRESSION" in result
+        assert "REGRESSION" in result
 
     def test_write_time_comparison_with_improvement(self, comparator) -> None:
         """Test time comparison writing with significant improvement."""
@@ -951,6 +1025,37 @@ class TestBaselineGenerator:
             assert f"Cargo profile: {TRUSTED_BENCH_PROFILE}" in content
             assert "Criterion sample size: 10" in content
 
+    @patch("benchmark_utils.get_git_commit_hash", return_value="abc123")
+    def test_written_baseline_round_trips_through_parser(self, mock_git, tmp_path) -> None:
+        """Test the baseline writer/parser contract for representative records."""
+        benchmark_results = [
+            BenchmarkData(1000, "2D").with_timing(1.0e-6, 1.1e-6, 1.2e-6, "µs").with_throughput(8.333e3, 9.091e3, 1.0e4, "Kelem/s"),
+            BenchmarkData(None, "4D", benchmark_id="bistellar_flips_4d/k2_roundtrip").with_timing(0.8, 0.95, 1.1, "µs"),
+        ]
+        output_file = tmp_path / "baseline.txt"
+        generator = BaselineGenerator(tmp_path)
+
+        with patch.object(generator.hardware, "format_hardware_info", return_value="Hardware Information:\n"):
+            generator._write_baseline_file(benchmark_results, output_file, dev_mode=True)
+
+        parsed = PerformanceComparator(tmp_path)._parse_baseline_file(output_file.read_text(encoding="utf-8"))
+
+        assert set(parsed) == {"1000_2D", "bistellar_flips_4d/k2_roundtrip"}
+        for expected in benchmark_results:
+            actual = parsed[expected.comparison_key]
+            assert actual.points == expected.points
+            assert actual.dimension == expected.dimension
+            assert actual.benchmark_id == expected.benchmark_id
+            assert actual.time_low == pytest.approx(expected.time_low)
+            assert actual.time_mean == pytest.approx(expected.time_mean)
+            assert actual.time_high == pytest.approx(expected.time_high)
+            assert actual.time_unit == expected.time_unit
+            assert actual.throughput_low == expected.throughput_low
+            assert actual.throughput_mean == expected.throughput_mean
+            assert actual.throughput_high == expected.throughput_high
+            assert actual.throughput_unit == expected.throughput_unit
+        mock_git.assert_called_once()
+
 
 class TestIntegrationScenarios:
     """Integration test scenarios for real-world use cases."""
@@ -1314,7 +1419,7 @@ Time: [220.0, 250.0, 280.0] µs
 
             # Check that summary was printed
             captured = capsys.readouterr()
-            assert "📊 Baseline summary:" in captured.out
+            assert "Baseline summary:" in captured.out
             assert "Total benchmarks: 3" in captured.out
             assert "Date: 2023-12-15 14:30:00 UTC" in captured.out
         finally:
@@ -1533,7 +1638,7 @@ Time: [95.0, 100.0, 105.0] µs
 
                     # Check warning message was printed to stderr
                     captured = capsys.readouterr()
-                    assert "⚠️ Failed to read baseline summary: Read permission denied" in captured.err
+                    assert "Failed to read baseline summary: Read permission denied" in captured.err
                     assert "=== Baseline Information (from artifact) ===" in captured.out
 
             finally:
@@ -1727,15 +1832,15 @@ Hardware Information:
         BenchmarkRegressionHelper.display_skip_message("same_commit", "abc1234")
 
         captured = capsys.readouterr()
-        assert "🔍 Current commit matches baseline (abc1234)" in captured.out
+        assert "Current commit matches baseline (abc1234)" in captured.out
 
     def test_display_no_baseline_message(self, capsys) -> None:
         """Test displaying no baseline message."""
         BenchmarkRegressionHelper.display_no_baseline_message()
 
         captured = capsys.readouterr()
-        assert "⚠️ No performance baseline available" in captured.out
-        assert "💡 To enable performance regression testing:" in captured.out
+        assert "No performance baseline available" in captured.out
+        assert "To enable performance regression testing:" in captured.out
 
     def test_run_regression_test_success(self, capsys) -> None:
         """Test successful regression test run."""
@@ -1754,7 +1859,7 @@ Hardware Information:
                 mock_comparator.compare_with_baseline.assert_called_once_with(baseline_file, dev_mode=False, bench_timeout=1800)
 
                 captured = capsys.readouterr()
-                assert "🚀 Running performance regression test" in captured.out
+                assert "Running performance regression test" in captured.out
 
     def test_run_regression_test_dev_mode(self, capsys) -> None:
         """Test regression test run with dev mode enabled."""
@@ -1807,7 +1912,7 @@ Hardware Information:
                 mock_comparator.compare_with_baseline.assert_called_once_with(baseline_file, dev_mode=False, bench_timeout=3600)
 
                 captured = capsys.readouterr()
-                assert "🚀 Running performance regression test" in captured.out
+                assert "Running performance regression test" in captured.out
 
     def test_display_results_file_exists(self, capsys) -> None:
         """Test displaying results when file exists."""
@@ -1829,7 +1934,7 @@ Hardware Information:
         BenchmarkRegressionHelper.display_results(missing_file)
 
         captured = capsys.readouterr()
-        assert "⚠️ No comparison results file found" in captured.out
+        assert "No comparison results file found" in captured.out
 
     def test_generate_summary_with_regression(self, temp_chdir, capsys) -> None:
         """Test generating summary when regression is detected."""
@@ -1852,9 +1957,10 @@ Hardware Information:
                 BenchmarkRegressionHelper.generate_summary()
 
                 captured = capsys.readouterr()
-                assert "📊 Performance Regression Testing Summary" in captured.out
+                assert "Performance Regression Testing Summary" in captured.out
                 assert "Baseline source: artifact" in captured.out
-                assert "Result: ⚠️ Performance regressions detected" in captured.out
+                assert "Result:" in captured.out
+                assert "Performance regressions detected" in captured.out
 
     def test_generate_summary_skip_same_commit(self, capsys) -> None:
         """Test generating summary when benchmarks skipped due to same commit."""
@@ -1870,7 +1976,8 @@ Hardware Information:
             BenchmarkRegressionHelper.generate_summary()
 
             captured = capsys.readouterr()
-            assert "Result: ⏭️ Benchmarks skipped (same commit as baseline)" in captured.out
+            assert "Result:" in captured.out
+            assert "Benchmarks skipped (same commit as baseline)" in captured.out
 
     def test_generate_summary_no_baseline(self, capsys) -> None:
         """Test generating summary when no baseline available."""
@@ -1883,7 +1990,8 @@ Hardware Information:
             BenchmarkRegressionHelper.generate_summary()
 
             captured = capsys.readouterr()
-            assert "Result: ⏭️ Benchmarks skipped (no baseline available)" in captured.out
+            assert "Result:" in captured.out
+            assert "Benchmarks skipped (no baseline available)" in captured.out
 
     def test_generate_summary_sets_regression_environment_variable(self, temp_chdir, capsys) -> None:
         """Test that generate_summary sets BENCHMARK_REGRESSION_DETECTED environment variable when regressions are found."""
@@ -1961,13 +2069,14 @@ Hardware Information:
                 BenchmarkRegressionHelper.generate_summary()
 
                 captured = capsys.readouterr()
-                assert "📊 Performance Regression Testing Summary" in captured.out
+                assert "Performance Regression Testing Summary" in captured.out
                 assert "Baseline source: artifact" in captured.out
                 # Should detect error and report failure, not "no regressions"
-                assert "Result: ❌ Benchmark comparison failed" in captured.out
+                assert "Result:" in captured.out
+                assert "Benchmark comparison failed" in captured.out
                 assert "(see benches/compare_results.txt for details)" in captured.out
                 # Should NOT say "no regressions" when there was an error
-                assert "✅ No significant performance regressions" not in captured.out
+                assert "No significant performance regressions" not in captured.out
 
 
 class TestProjectRootHandling:
@@ -2312,9 +2421,9 @@ Throughput: [8333.3, 9090.9, 10000.0] Kelem/s
     def test_parse_comparison_results_with_regression(self) -> None:
         """Test parsing comparison results that show regression."""
         comparison_content = """Performance Comparison Results
-⚠️  REGRESSION: Time increased by 15.2% (slower performance)
-✅ OK: Time change +2.1% within acceptable range
-✅ IMPROVEMENT: Time decreased by 8.5% (faster performance)
+REGRESSION: Time increased by 15.2% (slower performance)
+OK: Time change +2.1% within acceptable range
+IMPROVEMENT: Time decreased by 8.5% (faster performance)
 """
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -2328,16 +2437,16 @@ Throughput: [8333.3, 9090.9, 10000.0] Kelem/s
             lines = generator._parse_comparison_results()
 
             markdown_content = "\n".join(lines)
-            assert "### ⚠️ Performance Regression Detected" in markdown_content
+            assert "Performance Regression Detected" in markdown_content
             assert "REGRESSION: Time increased by 15.2%" in markdown_content
             assert "IMPROVEMENT: Time decreased by 8.5%" in markdown_content
 
     def test_parse_comparison_results_no_regression(self) -> None:
         """Test parsing comparison results with no regression."""
         comparison_content = """Performance Comparison Results
-✅ OK: Time change +2.1% within acceptable range
-✅ IMPROVEMENT: Time decreased by 3.2% (faster performance)
-✅ OK: Time change -1.8% within acceptable range
+OK: Time change +2.1% within acceptable range
+IMPROVEMENT: Time decreased by 3.2% (faster performance)
+OK: Time change -1.8% within acceptable range
 """
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/scripts/tests/test_compare_storage_backends.py
+++ b/scripts/tests/test_compare_storage_backends.py
@@ -112,11 +112,36 @@ class TestStorageBackendComparator:
         assert len(results["benchmarks"]) == 1
 
         bench = results["benchmarks"][0]
-        assert bench["name"] == "1000v"
+        assert bench["name"] == "construction/2D/1000v"
         assert bench["estimate"] == 150000000.0
         assert bench["unit"] == "ns"
         assert bench["lower"] == 145000000.0
         assert bench["upper"] == 155000000.0
+
+    def test_parse_criterion_output_json_preserves_full_ids(self, comparator, sample_criterion_json) -> None:
+        """Test JSON parsing keeps full Criterion IDs when leaf names collide."""
+        for group in ("construction", "validation"):
+            estimates_file = comparator.criterion_dir / group / "2D" / "1000v" / "new" / "estimates.json"
+            estimates_file.parent.mkdir(parents=True)
+            estimates_file.write_text(json.dumps(sample_criterion_json), encoding="utf-8")
+
+        results = comparator._parse_criterion_output("")
+
+        names = {bench["name"] for bench in results["benchmarks"]}
+        assert names == {"construction/2D/1000v", "validation/2D/1000v"}
+
+    def test_parse_criterion_output_json_rejects_nonfinite_estimates(self, comparator) -> None:
+        """Test non-finite Criterion JSON timings are skipped."""
+        estimates_file = comparator.criterion_dir / "construction" / "2D" / "1000v" / "new" / "estimates.json"
+        estimates_file.parent.mkdir(parents=True)
+        estimates_file.write_text(
+            json.dumps({"mean": {"point_estimate": float("nan"), "confidence_interval": {"lower_bound": 1.0, "upper_bound": 2.0}}}),
+            encoding="utf-8",
+        )
+
+        results = comparator._parse_criterion_output("")
+
+        assert results["benchmarks"] == []
 
     def test_parse_criterion_output_regex_fallback(self, comparator, sample_criterion_stdout) -> None:
         """Test parsing Criterion output using regex fallback when JSON unavailable."""
@@ -144,6 +169,17 @@ class TestStorageBackendComparator:
         assert bench3["name"] == "queries/neighbors/1000v"
         assert bench3["estimate"] == 9.012
         assert bench3["unit"] == "ms"
+
+    def test_parse_criterion_output_malformed_json_uses_regex_fallback(self, comparator, sample_criterion_stdout) -> None:
+        """Test malformed Criterion JSON is handled locally before regex fallback."""
+        estimates_file = comparator.criterion_dir / "construction" / "2D" / "1000v" / "new" / "estimates.json"
+        estimates_file.parent.mkdir(parents=True)
+        estimates_file.write_text(json.dumps({"unexpected": "shape"}), encoding="utf-8")
+
+        results = comparator._parse_criterion_output(sample_criterion_stdout)
+
+        assert len(results["benchmarks"]) == 3
+        assert results["benchmarks"][0]["name"] == "construction/2D/1000v"
 
     def test_parse_criterion_output_empty(self, comparator) -> None:
         """Test parsing empty Criterion output."""
@@ -202,6 +238,36 @@ class TestStorageBackendComparator:
 
         assert len(lines) == 1
         assert "~Same" in lines[0]
+
+    def test_build_comparison_table_normalizes_mixed_units(self, comparator) -> None:
+        """Test backend comparison normalizes units before calculating differences."""
+        slotmap_by_name = {
+            "test": {"estimate": 1_000_000.0, "unit": "ns"},
+        }
+        denseslotmap_by_name = {
+            "test": {"estimate": 0.95, "unit": "ms"},
+        }
+
+        lines, diffs = comparator._build_comparison_table(slotmap_by_name, denseslotmap_by_name, ["test"])
+
+        assert diffs == pytest.approx([-5.0])
+        assert "1000000.00 ns" in lines[0]
+        assert "0.95 ms" in lines[0]
+        assert "-5.0%" in lines[0]
+
+    def test_build_comparison_table_rejects_invalid_timing_data(self, comparator) -> None:
+        """Test invalid timing data is not used for percentage differences."""
+        slotmap_by_name = {
+            "test": {"estimate": 100.0, "unit": "ms"},
+        }
+        denseslotmap_by_name = {
+            "test": {"estimate": float("inf"), "unit": "ms"},
+        }
+
+        lines, diffs = comparator._build_comparison_table(slotmap_by_name, denseslotmap_by_name, ["test"])
+
+        assert diffs == []
+        assert "invalid timing data" in lines[0]
 
     def test_build_comparison_table_missing_data(self, comparator) -> None:
         """Test comparison table with missing data for one backend."""
@@ -319,6 +385,16 @@ class TestStorageBackendComparator:
         # Check error message was printed
         captured = capsys.readouterr()
         assert "Benchmark failed" in captured.err
+
+    @patch.object(StorageBackendComparator, "_parse_criterion_output")
+    @patch("compare_storage_backends.run_cargo_command")
+    def test_run_benchmark_type_error_propagates(self, mock_run_cargo, mock_parse_output, comparator, completed_ok) -> None:
+        """Test programming errors are not downgraded to benchmark failures."""
+        mock_run_cargo.return_value = completed_ok
+        mock_parse_output.side_effect = TypeError("programming error")
+
+        with pytest.raises(TypeError, match="programming error"):
+            comparator._run_benchmark("test_bench", use_dense_slotmap=False, dev_mode=False)
 
     @patch("compare_storage_backends.run_cargo_command")
     def test_run_comparison_success(self, mock_run_cargo, comparator, tmp_path) -> None:

--- a/scripts/tests/test_compare_storage_backends.py
+++ b/scripts/tests/test_compare_storage_backends.py
@@ -143,6 +143,18 @@ class TestStorageBackendComparator:
 
         assert results["benchmarks"] == []
 
+    @patch("compare_storage_backends.is_valid_criterion_estimate", return_value=False)
+    def test_parse_criterion_output_json_uses_shared_estimate_validator(self, mock_validator, comparator, sample_criterion_json) -> None:
+        """Test JSON parsing delegates Criterion estimate validation to the shared helper."""
+        estimates_file = comparator.criterion_dir / "construction" / "2D" / "1000v" / "new" / "estimates.json"
+        estimates_file.parent.mkdir(parents=True)
+        estimates_file.write_text(json.dumps(sample_criterion_json), encoding="utf-8")
+
+        results = comparator._parse_criterion_output("")
+
+        assert results["benchmarks"] == []
+        mock_validator.assert_called_once_with(150000000.0, 145000000.0, 155000000.0)
+
     def test_parse_criterion_output_regex_fallback(self, comparator, sample_criterion_stdout) -> None:
         """Test parsing Criterion output using regex fallback when JSON unavailable."""
         results = comparator._parse_criterion_output(sample_criterion_stdout)

--- a/scripts/tests/test_hardware_utils.py
+++ b/scripts/tests/test_hardware_utils.py
@@ -128,6 +128,32 @@ Thread(s) per core:  2"""
         assert cpu_cores == "Unknown"  # Can't determine cores without lscpu
         assert cpu_threads == "2"  # Count of processors
 
+    @patch("hardware_utils.shutil.which")
+    @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_proc")
+    @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_lscpu")
+    def test_get_linux_cpu_cores_falls_back_when_lscpu_unknown(self, mock_lscpu_cores, mock_proc_cores, mock_which, hardware) -> None:
+        """Test Linux CPU core fallback when lscpu output is unusable."""
+        mock_which.side_effect = lambda cmd: cmd == "lscpu"
+        mock_lscpu_cores.return_value = "Unknown"
+        mock_proc_cores.return_value = "6"
+
+        assert hardware._get_linux_cpu_cores() == "6"
+        mock_lscpu_cores.assert_called_once_with()
+        mock_proc_cores.assert_called_once_with()
+
+    @patch("hardware_utils.shutil.which")
+    @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_proc")
+    @patch.object(HardwareInfo, "_get_linux_cpu_cores_from_lscpu")
+    def test_get_linux_cpu_cores_falls_back_when_lscpu_raises(self, mock_lscpu_cores, mock_proc_cores, mock_which, hardware) -> None:
+        """Test Linux CPU core fallback when lscpu parsing raises."""
+        mock_which.side_effect = lambda cmd: cmd == "lscpu"
+        mock_lscpu_cores.side_effect = RuntimeError("bad lscpu output")
+        mock_proc_cores.return_value = "6"
+
+        assert hardware._get_linux_cpu_cores() == "6"
+        mock_lscpu_cores.assert_called_once_with()
+        mock_proc_cores.assert_called_once_with()
+
     @patch("hardware_utils.platform.system")
     @patch("hardware_utils.shutil.which")
     @patch.object(HardwareInfo, "_run_command")


### PR DESCRIPTION
- Reject non-finite and unordered Criterion timing estimates before using them in summaries, baselines, or backend comparisons.
- Preserve full Criterion benchmark IDs and normalize timing units when comparing storage backend results.
- Reuse the shared baseline parser while preserving malformed-section skip behavior and supporting scientific notation.
- Fall back from unusable lscpu output to /proc CPU core detection on Linux.
- Add regression and round-trip tests for parser behavior, benchmark IDs, unit normalization, and Linux CPU fallback.
- Document Python parser/file-format round-trip test expectations.