### PR TITLE
ci: quiet Codacy code scanning noise

### DIFF
--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -46,7 +46,9 @@ jobs:
       fail-fast: false
       matrix:
         tool:
-          - markdownlint
+          # Upload only repository-owned rules to GitHub Code Scanning.
+          # Advisory quality engines stay in local/Codacy checks so they do
+          # not create empty Security/Quality tool configurations.
           - opengrep
     steps:
       # Checkout the repository to the GitHub Actions runner
@@ -56,8 +58,11 @@ jobs:
       - name: Set Codacy paths
         run: |
           set -euo pipefail
-          echo "CODACY_WORKDIR=$RUNNER_TEMP/codacy-src" >> "$GITHUB_ENV"
-          echo "CODACY_SARIF=$RUNNER_TEMP/results-${{ matrix.tool }}.sarif" >> "$GITHUB_ENV"
+          {
+            echo "CODACY_WORKDIR=$RUNNER_TEMP/codacy-src"
+            echo "CODACY_SARIF=$RUNNER_TEMP/results-${{ matrix.tool }}.sarif"
+            echo "CODACY_HAS_UPLOADABLE_SARIF=false"
+          } >> "$GITHUB_ENV"
 
       - name: Prepare workspace copy without .git
         run: |
@@ -126,7 +131,14 @@ jobs:
               return normalized.strip("-") or "unknown"
 
           seen_categories: dict[str, int] = {}
+          uploadable_count = 0
           for index, run in enumerate(runs, start=1):
+              rules = run.get("tool", {}).get("driver", {}).get("rules")
+              results = run.get("results")
+              if not rules and not results:
+                  print(f"Skipping empty SARIF run {index} with no rules or results")
+                  continue
+
               run_copy = copy.deepcopy(run)
               tool = run_copy.get("tool", {}).get("driver", {}).get("name")
               base_category = f"codacy-{slug(str(tool or f'run-{index}'))}"
@@ -148,12 +160,18 @@ jobs:
               out_file = out_dir / f"{index:02d}-{category}.sarif"
               out_file.write_text(json.dumps(split_sarif, indent=2), encoding="utf-8")
               print(f"Wrote {out_file} with category {category}")
+              uploadable_count += 1
 
           with Path(os.environ["GITHUB_ENV"]).open("a", encoding="utf-8") as env_file:
               env_file.write(f"CODACY_SPLIT_SARIF_DIR={out_dir}\n")
+              env_file.write(f"CODACY_HAS_UPLOADABLE_SARIF={'true' if uploadable_count else 'false'}\n")
+
+          if uploadable_count == 0:
+              print("No non-empty Codacy SARIF runs to upload")
           PY
 
       - name: Upload split SARIF files
+        if: env.CODACY_HAS_UPLOADABLE_SARIF == 'true'
         uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
         with:
           sarif_file: ${{ env.CODACY_SPLIT_SARIF_DIR }}

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -119,8 +119,10 @@ jobs:
               raise SystemExit(f"Codacy produced invalid SARIF JSON: {exc}") from exc
 
           runs = sarif.get("runs")
-          if not isinstance(runs, list) or not runs:
-              sys.exit("Codacy SARIF did not contain any runs to upload")
+          if not isinstance(runs, list):
+              sys.exit("Codacy SARIF did not contain a runs array")
+          if not runs:
+              print("Codacy SARIF did not contain any runs to upload")
 
           out_dir.mkdir(parents=True, exist_ok=True)
           for stale in out_dir.glob("*.sarif"):
@@ -175,4 +177,5 @@ jobs:
         uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
         with:
           sarif_file: ${{ env.CODACY_SPLIT_SARIF_DIR }}
+          category: codacy-${{ matrix.tool }}
           wait-for-processing: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -283,6 +283,12 @@ degenerate input, and tests under `tests/proptest_sos.rs` enforce that.
 - New functionality is additive: use `crate::prelude::*` (or the focused
   `prelude::triangulation`, `prelude::query`, etc.) for ergonomic
   re‑exports; never silently rename or remove a public item.
+- Focused preludes are an exception to preserving accidental breadth: keep
+  them narrow, orthogonal, and purpose-specific, bundling only related,
+  non-overlapping functionality. Prefer fixing an over-broad or ambiguous
+  focused prelude over maintaining backwards compatibility for unrelated
+  re-exports. The root `crate::prelude::*` remains the kitchen-sink import for
+  new users, quick experiments, and exploratory tests.
 - Pre‑1.0 semver: `0.x.Y` is a patch‑level additive bump, `0.X.y` is a
   minor bump that may include breaking changes.  Conventional‑commit
   types (`feat`, `fix`, `refactor`, …) mirror this convention.
@@ -300,7 +306,7 @@ degenerate input, and tests under `tests/proptest_sos.rs` enforce that.
   necessity, not by accident.
 - Feature flags isolate optional dependency weight.  Default builds stay
   dep‑minimal.  Known flags: `dense-slotmap` (default),
-  `count-allocations`, `bench`, `bench-logging`, `test-debug`,
+  `count-allocations`, `bench`, `bench-logging`, `diagnostics`,
   `slow-tests`.
 
 ### Idiomatic Rust as a proxy for mathematical clarity
@@ -328,11 +334,11 @@ degenerate input, and tests under `tests/proptest_sos.rs` enforce that.
 - Never log inside hot benchmark loops or Criterion-measured closures.
   Emit setup/summary diagnostics outside the measured path instead.
 - Gate non-essential test/benchmark diagnostics behind feature flags.
-  In this repository use `test-debug` for test diagnostics and
+  In this repository use `diagnostics` for test diagnostics and
   `bench-logging` for benchmark diagnostics, e.g.:
 
   ```rust
-  #[cfg(feature = "test-debug")]
+  #[cfg(feature = "diagnostics")]
   tracing::debug!("test diagnostic");
 
   #[cfg(feature = "bench-logging")]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,116 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Merged Pull Requests
+
+- Enable repo Semgrep rules for issue #338 [#354](https://github.com/acgetchell/delaunay/pull/354)
+- Type repair diagnostics and harden invariants [#332](https://github.com/acgetchell/delaunay/pull/332) [#352](https://github.com/acgetchell/delaunay/pull/352)
+- Harden Python benchmark parsing [#351](https://github.com/acgetchell/delaunay/pull/351)
+- Expand profiling benchmarks around public API workflows [#349](https://github.com/acgetchell/delaunay/pull/349)
+- Bump taiki-e/install-action from 2.75.18 to 2.75.22 [#348](https://github.com/acgetchell/delaunay/pull/348)
+
+### Changed
+
+- Type repair diagnostics and harden invariants [#332](https://github.com/acgetchell/delaunay/pull/332) [#352](https://github.com/acgetchell/delaunay/pull/352)
+  [`a244053`](https://github.com/acgetchell/delaunay/commit/a2440531ae7ee1407e7436379a82fe092f02e7dd)
+
+- Replace stringified flip-repair skip samples with typed diagnostic context.
+  - Make vertex removal transactional across post-removal repair and orientation canonicalization.
+  - Deprecate DelaunayTriangulation::as_triangulation_mut ahead of removal in v0.8.0.
+  - Use scale-aware degeneracy checks for low-dimensional simplex and facet measures.
+  - Add regression and property coverage for rollback behavior, typed diagnostics, and scaled valid measures.
+  - Tolerate throughput formatting precision in benchmark baseline round-trip tests.
+
+### Fixed
+
+- Harden Python benchmark parsing [#351](https://github.com/acgetchell/delaunay/pull/351)
+  [`fea5898`](https://github.com/acgetchell/delaunay/commit/fea58987a2fb84e47603be9f0d1960aaa7e0f5f0)
+
+  - Reject non-finite and unordered Criterion timing estimates before using them in summaries, baselines, or backend comparisons.
+  - Preserve full Criterion benchmark IDs and normalize timing units when comparing storage backend results.
+  - Reuse the shared baseline parser while preserving malformed-section skip behavior and supporting scientific notation.
+  - Fall back from unusable lscpu output to /proc CPU core detection on Linux.
+  - Add regression and round-trip tests for parser behavior, benchmark IDs, unit normalization, and Linux CPU fallback.
+  - Document Python parser/file-format round-trip test expectations.
+
+  **Fixed: Harden Criterion estimate parsing and validation**
+
+  Consolidates estimate validation into a single public helper,
+  `is_valid_criterion_estimate`, now used by `PerformanceSummaryGenerator`
+  and `StorageBackendComparator`. Adds explicit type checks to
+  `PerformanceSummaryGenerator` to reject structurally malformed JSON
+  data, improving parsing robustness.
+
+### Maintenance
+
+- Bump taiki-e/install-action from 2.75.18 to 2.75.22 [#348](https://github.com/acgetchell/delaunay/pull/348)
+  [`31ec720`](https://github.com/acgetchell/delaunay/commit/31ec720a8638103b9acd7ea58c35b2baa5f571b9)
+
+Bumps [taiki-e/install-action](https://github.com/taiki-e/install-action) from 2.75.18 to 2.75.22.
+
+- [Release notes](https://github.com/taiki-e/install-action/releases)
+- [Changelog](https://github.com/taiki-e/install-action/blob/main/CHANGELOG.md)
+- [Commits](https://github.com/taiki-e/install-action/compare/055f5df8c3f65ea01cd41e9dc855becd88953486...cf525cb33f51aca27cd6fa02034117ab963ff9f1)
+
+  ---
+  updated-dependencies:
+
+- dependency-name: taiki-e/install-action
+    dependency-version: 2.75.22
+    dependency-type: direct:production
+    update-type: version-update:semver-patch
+  ...
+
+- Enable repo Semgrep rules for issue #338 [#354](https://github.com/acgetchell/delaunay/pull/354)
+  [`9d51d30`](https://github.com/acgetchell/delaunay/commit/9d51d3038ae3f3316102ecaf39429bdfb73ff1cc)
+
+  - Enable project-owned Semgrep rules in local checks, CodeRabbit, and Codacy/OpenGrep scanning.
+  - Harden Semgrep execution with strict mode, a higher timeout, and fixture coverage for hot-path hash collection rules.
+  - Replace flagged diagnostics and silent numeric fallbacks with explicit tracing, expectations, and typed Hilbert quantization errors.
+  - Centralize Delaunay triangulation cache invalidation through the existing repair-cache helper.
+
+  **Maintenance: Enable repository Semgrep rules**
+
+  - Rename the Semgrep config to semgrep.yaml and wire it into local checks, CodeRabbit, and Codacy/OpenGrep.
+  - Add strict Semgrep execution plus fixture coverage for hot-path hash collections and targeted panic bypasses.
+  - Make Hilbert errors non-exhaustive and document quantization-scale conversion failures on APIs that can return them.
+  - Replace fragile VertexBuilder expect paths with infallible Vertex point constructors.
+
+  **Maintenance: Expand repository Semgrep rules**
+
+  - Add project-specific Semgrep checks for Rust dynamic errors, lint suppression reasons, Python subprocess mocks, and typed script helpers.
+  - Add focused Semgrep fixtures for hot-path hash collections, Rust project rules, and Python test conventions.
+  - Wire the expanded Semgrep fixture suite into `just check`.
+  - Replace stale Clippy `allow` suppressions with documented `expect` attributes and remove dynamic error trait-object usage from tests.
+
+  **Maintenance: Refresh quality tooling and diagnostics**
+
+  - Pin GitHub workflow tool versions and update action SHAs for cache, artifact upload, install-action, and SARIF upload.
+  - Exclude Semgrep fixtures from Codacy analysis so intentional rule-test violations do not surface as production issues.
+  - Add a cargo-machete backed just unused-deps recipe for checking unused direct dependencies.
+  - Gate convex hull test diagnostics behind test-debug tracing instead of unconditional stdout output.
+  - Add Hilbert ordering and zero-dimensional sort coverage for Codecov patch gaps.
+
+  **Fixed: Harden Hilbert ordering errors and prelude checks [#338](https://github.com/acgetchell/delaunay/pull/338)**
+
+  - Return typed Hilbert errors for non-finite quantization inputs and failed u32 coordinate conversions instead of silently collapsing values.
+  - Preserve item order when Hilbert sort key construction fails, and add regression coverage for the new error paths.
+  - Add the focused ordering prelude and update doctests, examples, benchmarks, and integration tests to use orthogonal prelude imports.
+  - Add a Semgrep rule and fixture coverage for examples and benchmarks that bypass focused preludes.
+  - Verify pinned shfmt binaries in CI with explicit SHA256 values instead of downloading a missing upstream checksum file.
+
+### Performance
+
+- Expand profiling benchmarks around public API workflows [#349](https://github.com/acgetchell/delaunay/pull/349)
+  [`0acbf65`](https://github.com/acgetchell/delaunay/commit/0acbf651b57c287aecc10bd51eea55fdbcbe2442)
+
+- Run profiling comparisons with the checked-out crate toolchain by default
+  - Add local `just profile` support for comparing code refs and compiler versions
+  - Expand `ci_performance_suite` beyond construction to cover hulls, boundary traversal, validation, and bistellar flips
+  - Emit a versioned API benchmark manifest so benchmark logs show which public workflows were measured
+
 ## [0.7.6] - 2026-04-25
 
 ### ⚠️ Breaking Changes
@@ -14,6 +124,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Merged Pull Requests
 
+- Release v0.7.6 [#347](https://github.com/acgetchell/delaunay/pull/347)
 - Preserve fallback rebuild cell data [#305](https://github.com/acgetchell/delaunay/pull/305) [#346](https://github.com/acgetchell/delaunay/pull/346)
 - Switch coverage reporting to cargo-llvm-cov [#345](https://github.com/acgetchell/delaunay/pull/345)
 - Clarify research scope and changelog hygiene [#344](https://github.com/acgetchell/delaunay/pull/344)
@@ -502,6 +613,13 @@ Bumps [actions/setup-node](https://github.com/actions/setup-node) from 6.3.0 to 
   - Add GitHub issue templates and clarify private vulnerability reporting guidance.
   - Tighten Python lint/typecheck settings and clean up benchmark/changelog utility diagnostics.
   - Add changelog post-processing coverage for version-heading reset behavior.
+- Release v0.7.6 [#347](https://github.com/acgetchell/delaunay/pull/347)
+  [`6e437fb`](https://github.com/acgetchell/delaunay/commit/6e437fb5869f7ada49d6760114c4d25f15eb9b29)
+
+- Bump version to v0.7.6
+  - Update changelog with latest changes
+  - Update documentation for release
+  - Add performance results for v0.7.6
 
 ## [0.7.5] - 2026-04-10
 
@@ -2866,6 +2984,7 @@ Older releases are archived by minor series:
 - [0.3.x](docs/archive/changelog/0.3.md)
 - [0.2.x](docs/archive/changelog/0.2.md)
 
+[unreleased]: https://github.com/acgetchell/delaunay/compare/v0.7.6..HEAD
 [0.7.6]: https://github.com/acgetchell/delaunay/compare/v0.7.5..v0.7.6
 [0.7.5]: https://github.com/acgetchell/delaunay/compare/v0.7.4..v0.7.5
 [0.7.4]: https://github.com/acgetchell/delaunay/compare/v0.7.3..v0.7.4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -408,7 +408,7 @@ just bench-dev        # Reduced-sample perf-profile comparison (~1-2 min)
 - `just test-release` - All tests in release mode
 - `just test-slow` - Run slow/stress tests with --features slow-tests
 - `just test-slow-release` - Slow tests in release mode (faster)
-- `just test-debug` - Debug tools with output
+- `just test-diagnostics` - Diagnostics tools with output
 - `just debug-large-scale-*` - Active large-scale debug harnesses retained
   while issues #307 and #204 are being fixed
 - `just test-allocation` - Memory allocation profiling

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ default = [ "dense-slotmap" ]
 count-allocations = [ "allocation-counter" ]
 bench = [  ] # Enable benchmark-style tests and performance analysis
 bench-logging = [  ] # Enable extra benchmark logging for CI diagnostics
-test-debug = [  ] # Enable verbose debug output in tests for development
+diagnostics = [  ] # Enable opt-in diagnostic helpers and verbose test diagnostics
 dense-slotmap = [  ] # Use DenseSlotMap-backed internal storage (default)
 slow-tests = [
 ] # Enable slow-running integration tests (100+ vertices, multiple dimensions)

--- a/README.md
+++ b/README.md
@@ -88,6 +88,26 @@ Add the library to your crate:
 cargo add delaunay
 ```
 
+Choose the smallest prelude that matches the task:
+
+| Task | Import |
+|---|---|
+| Build, configure, insert, or remove vertices | `use delaunay::prelude::triangulation::*` |
+| Read-only traversal, adjacency, convex hulls, and comparison helpers | `use delaunay::prelude::query::*` |
+| Points, kernels, predicates, and geometric measures | `use delaunay::prelude::geometry::*` |
+| Random points or triangulations for examples, tests, and benchmarks | `use delaunay::prelude::generators::*` |
+| Bistellar flips / Edit API | `use delaunay::prelude::triangulation::flips::*` |
+| Delaunay repair diagnostics and policies | `use delaunay::prelude::triangulation::repair::*` |
+| Delaunayize workflow | `use delaunay::prelude::triangulation::delaunayize::*` |
+| Hilbert ordering and quantization utilities | `use delaunay::prelude::ordering::*` |
+| Low-level TDS cells, facets, keys, and validation reports | `use delaunay::prelude::tds::*` |
+| Collection aliases and small buffers | `use delaunay::prelude::collections::*` |
+| Topology validation and Euler characteristic helpers | `use delaunay::prelude::topology::validation::*` |
+| Topological spaces and topology traits | `use delaunay::prelude::topology::spaces::*` |
+
+`use delaunay::prelude::*` remains available for quick experiments, but examples
+and benchmarks in this repository prefer focused preludes so imports document intent.
+
 ```rust
 use delaunay::prelude::triangulation::*;
 

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -88,7 +88,6 @@ use `DelaunayTriangulationBuilder`:
 
 ```rust
 use delaunay::prelude::triangulation::*;
-use delaunay::core::triangulation::{TopologyGuarantee, ValidationPolicy};
 
 // Toroidal (periodic) triangulation in 2D
 let vertices = vec![

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -310,14 +310,14 @@ delaunay/
 
 ```bash
 # Run debug tests with interactive output (just command)
-just test-debug
+just test-diagnostics
 
 # Or run specific test functions with verbose output (direct cargo)
-cargo test --test circumsphere_debug_tools test_2d_circumsphere_debug -- --nocapture
-cargo test --test circumsphere_debug_tools test_3d_circumsphere_debug -- --nocapture
-cargo test --test circumsphere_debug_tools test_all_debug -- --nocapture
+cargo test --test circumsphere_debug_tools --features diagnostics test_2d_circumsphere_debug -- --nocapture
+cargo test --test circumsphere_debug_tools --features diagnostics test_3d_circumsphere_debug -- --nocapture
+cargo test --test circumsphere_debug_tools --features diagnostics test_all_debug -- --nocapture
 # Or run all debug tests at once
-cargo test --test circumsphere_debug_tools -- --nocapture
+cargo test --test circumsphere_debug_tools --features diagnostics -- --nocapture
 ```
 
 **Note**: Memory allocation profiling is available through the `count-allocations` feature:
@@ -552,7 +552,7 @@ just test-python   # Python tests only (pytest)
 just test-release  # All tests in release mode
 just test-slow     # Run slow/stress tests with --features slow-tests
 just test-slow-release # Slow tests in release mode (faster)
-just test-debug    # Run debug tools with output
+just test-diagnostics # Run diagnostics tools with output
 just test-allocation  # Run allocation profiling tests
 ```
 

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -61,7 +61,7 @@ This matters for large-scale investigations that need to run under
 | `DELAUNAY_DEBUG_CONFLICT` | presence | `locate.rs` | Per-cell insphere classification during BFS, including BFS boundary cells |
 | `DELAUNAY_DEBUG_CONFLICT_PROGRESS` | presence | `locate.rs` | Periodic progress during large BFS traversals |
 | `DELAUNAY_DEBUG_CONFLICT_PROGRESS_EVERY` | **value** (integer) | `locate.rs` | Interval for progress logging (default: dimension-dependent) |
-| `DELAUNAY_DEBUG_CONFLICT_VERIFY` | presence | `triangulation.rs` | Brute-force verification of BFS conflict-region completeness with reachability analysis |
+| `DELAUNAY_DEBUG_CONFLICT_VERIFY` | presence | `triangulation.rs` | `[diagnostics]` Brute-force BFS conflict-region completeness check |
 | `DELAUNAY_DEBUG_RIDGE_FAN_ONCE` | presence | `locate.rs` | `[release]` One-shot dump of first detected ridge fan (ridge verts, boundary facets, extras). |
 
 ## Cavity & Hull

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -547,11 +547,17 @@ pub mod core {
 
 ## Prelude Design
 
-Focused preludes should remain **small and purpose-specific**.
+Focused preludes should remain **small, orthogonal, and purpose-specific**.
 
 A focused prelude should import only the items needed for a specific task.
-Prefer these focused preludes in doctests, integration tests, examples, and
-benchmarks because they make intent visible at the import site.
+Bundle only related, non-overlapping functionality in a focused prelude; do
+not use one focused prelude as a compatibility bucket for adjacent workflows.
+If a focused prelude has grown too broad or ambiguous, prefer fixing the
+taxonomy over preserving backwards compatibility for unrelated re-exports.
+Create a new focused prelude when a distinct workflow needs one.
+
+Prefer focused preludes in doctests, integration tests, examples, and benchmarks
+because they make intent visible at the import site.
 
 Examples:
 
@@ -563,6 +569,7 @@ delaunay::prelude::triangulation::delaunayize
 delaunay::prelude::query
 delaunay::prelude::geometry
 delaunay::prelude::generators
+delaunay::prelude::diagnostics
 delaunay::prelude::ordering
 delaunay::prelude::collections
 delaunay::prelude::tds
@@ -570,10 +577,10 @@ delaunay::prelude::topology::validation
 delaunay::prelude::topology::spaces
 ```
 
-The root `delaunay::prelude::*` is intentionally available as a convenience for
-new users and quick experiments. Avoid using it in committed examples,
-benchmarks, and doctests when a focused prelude communicates the workflow more
-clearly.
+The root `delaunay::prelude::*` is intentionally available as the
+kitchen-sink prelude for new users, quick experiments, and exploratory tests.
+Avoid using it in committed examples, benchmarks, and doctests when a focused
+prelude communicates the workflow more clearly.
 
 ---
 
@@ -802,11 +809,11 @@ if std::env::var_os("DELAUNAY_DEBUG_FOO").is_some() {
   Emit diagnostics before or after the measured path so measurements stay
   meaningful.
 - Gate non-essential test and benchmark diagnostics behind feature flags.
-  In this repository, use `test-debug` for test diagnostics and
+  In this repository, use `diagnostics` for test diagnostics and
   `bench-logging` for benchmark diagnostics:
 
 ```rust
-#[cfg(feature = "test-debug")]
+#[cfg(feature = "diagnostics")]
 tracing::debug!("test diagnostic");
 
 #[cfg(feature = "bench-logging")]

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -547,17 +547,33 @@ pub mod core {
 
 ## Prelude Design
 
-Preludes should remain **small and purpose‑specific**.
+Focused preludes should remain **small and purpose-specific**.
 
-A prelude should import only the items needed for a specific task.
+A focused prelude should import only the items needed for a specific task.
+Prefer these focused preludes in doctests, integration tests, examples, and
+benchmarks because they make intent visible at the import site.
 
-Example:
+Examples:
 
 ```text
 delaunay::prelude::triangulation
+delaunay::prelude::triangulation::flips
+delaunay::prelude::triangulation::repair
+delaunay::prelude::triangulation::delaunayize
+delaunay::prelude::query
+delaunay::prelude::geometry
+delaunay::prelude::generators
+delaunay::prelude::ordering
+delaunay::prelude::collections
+delaunay::prelude::tds
+delaunay::prelude::topology::validation
+delaunay::prelude::topology::spaces
 ```
 
-Avoid giant catch‑all preludes.
+The root `delaunay::prelude::*` is intentionally available as a convenience for
+new users and quick experiments. Avoid using it in committed examples,
+benchmarks, and doctests when a focused prelude communicates the workflow more
+clearly.
 
 ---
 

--- a/docs/numerical_robustness_guide.md
+++ b/docs/numerical_robustness_guide.md
@@ -80,7 +80,7 @@ The convenience constructors (`DelaunayTriangulation::new()`, `::empty()`, etc.)
 `AdaptiveKernel`. To opt into a different kernel, use the explicit-kernel constructors:
 
 ```rust
-use delaunay::geometry::kernel::RobustKernel;
+use delaunay::prelude::geometry::RobustKernel;
 use delaunay::prelude::triangulation::*;
 
 let kernel = RobustKernel::<f64>::new();

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -137,7 +137,7 @@ If repair fails to converge within the flip budget, you get
 detections, etc.).
 
 ```rust
-use delaunay::core::algorithms::flips::DelaunayRepairError;
+use delaunay::prelude::triangulation::repair::DelaunayRepairError;
 use delaunay::prelude::triangulation::*;
 
 let vertices = vec![

--- a/examples/memory_analysis.rs
+++ b/examples/memory_analysis.rs
@@ -3,6 +3,7 @@
 //! This example demonstrates basic memory usage analysis for Delaunay triangulations
 //! using the existing allocation counter infrastructure from the tests.
 
+use delaunay::prelude::generators::generate_random_triangulation;
 use delaunay::prelude::query::*;
 use std::any::Any;
 use std::backtrace::Backtrace;

--- a/examples/zero_allocation_iterator_demo.rs
+++ b/examples/zero_allocation_iterator_demo.rs
@@ -5,7 +5,7 @@
 //! zero-allocation `vertex_uuid_iter()` method compared to the traditional
 //! `vertex_uuids()` method that allocates a Vec.
 
-use delaunay::prelude::query::*;
+use delaunay::prelude::generators::generate_random_triangulation;
 use std::hint::black_box;
 use std::time::Instant;
 

--- a/justfile
+++ b/justfile
@@ -283,7 +283,7 @@ help-workflows:
     @echo "  just examples          # Run all examples"
     @echo ""
     @echo "Active large-scale debugging:"
-    @echo "  just test-debug            # Run debug tools with output"
+    @echo "  just test-diagnostics      # Run diagnostics tools with output"
     @echo "  just debug-large-scale-4d [n] # Issue #340: 4D large-scale runtime (default n=3000)"
     @echo "  just debug-large-scale-3d [n] # Issue #341: 3D scalability (default n=10000)"
     @echo "  just debug-large-scale-5d [n] # Issue #342: 5D feasibility (default n=1000)"
@@ -832,8 +832,8 @@ test-all: test-unit test-integration test-python
 test-allocation:
     cargo test --test allocation_api --features count-allocations -- --nocapture
 
-test-debug:
-    cargo test --test circumsphere_debug_tools -- --nocapture
+test-diagnostics:
+    cargo test --test circumsphere_debug_tools --features diagnostics -- --nocapture
 
 # test-integration: runs all integration tests (includes proptests) in release mode.
 # Release mode is required because exact-predicate arithmetic in debug mode makes

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -386,7 +386,7 @@ rules:
         - "/tests/semgrep/src/project_rules/**/*.rs"
     patterns:
       - pattern-regex: '^\s*//[/!]\s*(?:#\s*)?use\s+delaunay::(core|geometry|triangulation|topology)::'
-      - pattern-not-regex: '^\s*//[/!]\s+use\s+delaunay::prelude::'
+      - pattern-not-regex: '^\s*//[/!]\s*(?:#\s*)?use\s+delaunay::prelude::'
 
   - id: delaunay.python.no-broad-exception
     languages:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -367,6 +367,27 @@ rules:
       - pattern-regex: '^\s*use\s+delaunay::(core|geometry|triangulation|topology)::'
       - pattern-not-regex: '^\s*use\s+delaunay::prelude::'
 
+  - id: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
+    languages:
+      - rust
+    severity: WARNING
+    message: >-
+      Use focused delaunay::prelude imports in public triangulation doctests
+      instead of deep crate module paths.
+    metadata:
+      category: maintainability
+      tracking_issue: "https://github.com/acgetchell/delaunay/issues/355"
+      rationale: >-
+        Public doctests should model the small, orthogonal prelude import
+        surfaces that users can copy into their own code.
+    paths:
+      include:
+        - "/src/triangulation/**/*.rs"
+        - "/tests/semgrep/src/project_rules/**/*.rs"
+    patterns:
+      - pattern-regex: '^\s*//[/!]\s+use\s+delaunay::(core|geometry|triangulation|topology)::'
+      - pattern-not-regex: '^\s*//[/!]\s+use\s+delaunay::prelude::'
+
   - id: delaunay.python.no-broad-exception
     languages:
       - python

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -382,10 +382,10 @@ rules:
         surfaces that users can copy into their own code.
     paths:
       include:
-        - "/src/triangulation/**/*.rs"
+        - "/src/**/*.rs"
         - "/tests/semgrep/src/project_rules/**/*.rs"
     patterns:
-      - pattern-regex: '^\s*//[/!]\s+use\s+delaunay::(core|geometry|triangulation|topology)::'
+      - pattern-regex: '^\s*//[/!]\s*(?:#\s*)?use\s+delaunay::(core|geometry|triangulation|topology)::'
       - pattern-not-regex: '^\s*//[/!]\s+use\s+delaunay::prelude::'
 
   - id: delaunay.python.no-broad-exception

--- a/src/core/adjacency.rs
+++ b/src/core/adjacency.rs
@@ -23,8 +23,8 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::adjacency::AdjacencyIndexBuildError;
-/// use delaunay::core::tds::{CellKey, VertexKey};
+/// use delaunay::prelude::query::AdjacencyIndexBuildError;
+/// use delaunay::prelude::tds::{CellKey, VertexKey};
 /// use slotmap::KeyData;
 ///
 /// let cell_key = CellKey::from(KeyData::from_ffi(1));

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -70,7 +70,7 @@ type RemovedCellVertexSnapshot = SmallBuffer<VertexKeyList, MAX_PRACTICAL_DIMENS
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::BistellarFlipKind;
+/// use delaunay::prelude::triangulation::flips::BistellarFlipKind;
 ///
 /// let kind = BistellarFlipKind::k2(3);
 /// let inverse = kind.inverse();
@@ -1322,7 +1322,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::FlipDirection;
+/// use delaunay::prelude::triangulation::flips::FlipDirection;
 ///
 /// assert_eq!(FlipDirection::Forward.inverse(), FlipDirection::Inverse);
 /// ```
@@ -1551,7 +1551,7 @@ impl BistellarFlipKind {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::{BistellarMove, ConstK};
+/// use delaunay::prelude::triangulation::flips::{BistellarMove, ConstK};
 ///
 /// fn move_k<const D: usize, M: BistellarMove<D>>() -> usize {
 ///     M::K
@@ -1567,7 +1567,7 @@ pub struct ConstK<const K: usize>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::{BistellarMove, ConstK};
+/// use delaunay::prelude::triangulation::flips::{BistellarMove, ConstK};
 ///
 /// fn move_k<const D: usize, M: BistellarMove<D>>() -> usize {
 ///     M::K
@@ -1589,7 +1589,7 @@ impl<const D: usize, const K: usize> BistellarMove<D> for ConstK<K> {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::FlipError;
+/// use delaunay::prelude::triangulation::flips::FlipError;
 ///
 /// let err = FlipError::UnsupportedDimension { dimension: 1 };
 /// assert!(matches!(err, FlipError::UnsupportedDimension { .. }));
@@ -1783,9 +1783,9 @@ pub enum FlipError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::{BistellarFlipKind, FlipDirection, FlipInfo};
-/// use delaunay::core::collections::{CellKeyBuffer, SmallBuffer, MAX_PRACTICAL_DIMENSION_SIZE};
-/// use delaunay::core::tds::{CellKey, VertexKey};
+/// use delaunay::prelude::triangulation::flips::{BistellarFlipKind, FlipDirection, FlipInfo};
+/// use delaunay::prelude::collections::{CellKeyBuffer, SmallBuffer, MAX_PRACTICAL_DIMENSION_SIZE};
+/// use delaunay::prelude::tds::{CellKey, VertexKey};
 /// use slotmap::KeyData;
 ///
 /// let mut removed_cells = CellKeyBuffer::new();
@@ -1863,8 +1863,8 @@ pub(crate) struct FlipContextDyn<const D: usize> {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::TriangleHandle;
-/// use delaunay::core::tds::VertexKey;
+/// use delaunay::prelude::triangulation::flips::TriangleHandle;
+/// use delaunay::prelude::tds::VertexKey;
 /// use slotmap::KeyData;
 ///
 /// let a = VertexKey::from(KeyData::from_ffi(1));
@@ -1888,8 +1888,8 @@ impl TriangleHandle {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::algorithms::flips::TriangleHandle;
-    /// use delaunay::core::tds::VertexKey;
+    /// use delaunay::prelude::triangulation::flips::TriangleHandle;
+    /// use delaunay::prelude::tds::VertexKey;
     /// use slotmap::KeyData;
     ///
     /// let a = VertexKey::from(KeyData::from_ffi(10));
@@ -1921,8 +1921,8 @@ impl TriangleHandle {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::flips::RidgeHandle;
-/// use delaunay::core::tds::CellKey;
+/// use delaunay::prelude::triangulation::flips::RidgeHandle;
+/// use delaunay::prelude::tds::CellKey;
 /// use slotmap::KeyData;
 ///
 /// let cell_key = CellKey::from(KeyData::from_ffi(7));
@@ -3664,7 +3664,7 @@ where
 /// ```
 /// use delaunay::prelude::triangulation::*;
 /// use delaunay::prelude::triangulation::repair::verify_delaunay_via_flip_predicates;
-/// use delaunay::geometry::kernel::AdaptiveKernel;
+/// use delaunay::prelude::geometry::AdaptiveKernel;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -52,7 +52,7 @@ pub use crate::core::operations::{InsertionOutcome, InsertionResult, InsertionSt
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::incremental_insertion::HullExtensionReason;
+/// use delaunay::prelude::triangulation::insertion::HullExtensionReason;
 ///
 /// let reason = HullExtensionReason::NoVisibleFacets;
 /// assert!(matches!(reason, HullExtensionReason::NoVisibleFacets));
@@ -108,7 +108,7 @@ impl std::fmt::Display for HullExtensionReason {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::incremental_insertion::InsertionError;
+/// use delaunay::prelude::triangulation::insertion::InsertionError;
 ///
 /// let err = InsertionError::DuplicateCoordinates {
 ///     coordinates: "[0.0, 0.0, 0.0]".to_string(),
@@ -246,7 +246,7 @@ impl InsertionError {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::algorithms::incremental_insertion::{HullExtensionReason, InsertionError};
+    /// use delaunay::prelude::triangulation::insertion::{HullExtensionReason, InsertionError};
     ///
     /// let retryable = InsertionError::NonManifoldTopology {
     ///     facet_hash: 1,
@@ -397,8 +397,8 @@ impl InsertionError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::incremental_insertion::fill_cavity;
-/// use delaunay::core::facet::FacetHandle;
+/// use delaunay::prelude::triangulation::insertion::fill_cavity;
+/// use delaunay::prelude::tds::FacetHandle;
 /// use delaunay::prelude::query::*;
 ///
 /// let vertices = vec![
@@ -705,9 +705,9 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::incremental_insertion::wire_cavity_neighbors;
-/// use delaunay::core::collections::CellKeyBuffer;
-/// use delaunay::core::tds::Tds;
+/// use delaunay::prelude::triangulation::insertion::wire_cavity_neighbors;
+/// use delaunay::prelude::collections::CellKeyBuffer;
+/// use delaunay::prelude::tds::Tds;
 ///
 /// let mut tds: Tds<f64, (), (), 3> = Tds::empty();
 /// let new_cells = CellKeyBuffer::new();
@@ -1506,12 +1506,12 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::incremental_insertion::extend_hull;
-/// use delaunay::core::tds::Tds;
-/// use delaunay::core::tds::VertexKey;
-/// use delaunay::geometry::kernel::FastKernel;
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::triangulation::insertion::extend_hull;
+/// use delaunay::prelude::tds::Tds;
+/// use delaunay::prelude::tds::VertexKey;
+/// use delaunay::prelude::geometry::FastKernel;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 /// use slotmap::Key;
 ///
 /// let mut tds: Tds<f64, (), (), 3> = Tds::empty();

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -1255,7 +1255,7 @@ where
 /// Activated by setting `DELAUNAY_DEBUG_CONFLICT_VERIFY=1`.
 ///
 /// Returns the number of missed cells (0 means the BFS result is complete).
-#[cfg(debug_assertions)]
+#[cfg(any(test, feature = "test-debug"))]
 pub fn verify_conflict_region_completeness<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,
@@ -3061,8 +3061,8 @@ mod tests {
     // =============================================================================
     // VERIFY CONFLICT REGION COMPLETENESS TESTS
     // =============================================================================
-    // The function under test is #[cfg(debug_assertions)], so these tests are
-    // also gated to avoid compilation errors in release/bench builds.
+    // The production diagnostic is feature-gated; keep the unit coverage in
+    // debug builds to avoid adding cost to release/bench test runs.
 
     #[cfg(debug_assertions)]
     /// Macro to test `verify_conflict_region_completeness` across dimensions.

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -1255,7 +1255,7 @@ where
 /// Activated by setting `DELAUNAY_DEBUG_CONFLICT_VERIFY=1`.
 ///
 /// Returns the number of missed cells (0 means the BFS result is complete).
-#[cfg(any(test, feature = "test-debug"))]
+#[cfg(any(test, feature = "diagnostics"))]
 pub fn verify_conflict_region_completeness<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
     kernel: &K,

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -69,8 +69,8 @@ fn ridge_fan_dump_enabled() -> bool {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::LocateResult;
-/// use delaunay::core::tds::VertexKey;
+/// use delaunay::prelude::query::LocateResult;
+/// use delaunay::prelude::tds::VertexKey;
 /// use slotmap::KeyData;
 ///
 /// let vertex = VertexKey::from(KeyData::from_ffi(2));
@@ -96,7 +96,7 @@ pub enum LocateResult {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::LocateError;
+/// use delaunay::prelude::query::LocateError;
 ///
 /// let err = LocateError::EmptyTriangulation;
 /// assert!(matches!(err, LocateError::EmptyTriangulation));
@@ -128,8 +128,8 @@ pub enum LocateError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::ConflictError;
-/// use delaunay::core::tds::CellKey;
+/// use delaunay::prelude::query::ConflictError;
+/// use delaunay::prelude::tds::CellKey;
 /// use slotmap::KeyData;
 ///
 /// let cell_key = CellKey::from(KeyData::from_ffi(5));
@@ -295,7 +295,7 @@ pub enum ConflictError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::{ConflictError, InternalInconsistencySite};
+/// use delaunay::prelude::query::{ConflictError, InternalInconsistencySite};
 ///
 /// let site = InternalInconsistencySite::RidgeFanExtraFacetOutOfBounds {
 ///     index: 7,
@@ -585,7 +585,7 @@ fn collect_ridge_fan_extra_cells(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::LocateFallbackReason;
+/// use delaunay::prelude::query::LocateFallbackReason;
 ///
 /// let reason = LocateFallbackReason::StepLimit;
 /// assert_eq!(reason, LocateFallbackReason::StepLimit);
@@ -603,7 +603,7 @@ pub enum LocateFallbackReason {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::{LocateFallback, LocateFallbackReason};
+/// use delaunay::prelude::query::{LocateFallback, LocateFallbackReason};
 ///
 /// let fallback = LocateFallback {
 ///     reason: LocateFallbackReason::CycleDetected,
@@ -627,8 +627,8 @@ pub struct LocateFallback {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::LocateStats;
-/// use delaunay::core::tds::CellKey;
+/// use delaunay::prelude::query::LocateStats;
+/// use delaunay::prelude::tds::CellKey;
 /// use slotmap::KeyData;
 ///
 /// let stats = LocateStats {
@@ -725,7 +725,7 @@ impl LocateStats {
 /// Using a hint cell for faster location:
 ///
 /// ```rust
-/// use delaunay::geometry::kernel::RobustKernel;
+/// use delaunay::prelude::geometry::RobustKernel;
 /// use delaunay::prelude::algorithms::*;
 /// use delaunay::prelude::query::*;
 ///
@@ -1029,11 +1029,11 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::{locate, find_conflict_region, LocateResult};
+/// use delaunay::prelude::query::{locate, find_conflict_region, LocateResult};
 /// use delaunay::prelude::DelaunayTriangulation;
-/// use delaunay::geometry::kernel::FastKernel;
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::FastKernel;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 /// use delaunay::vertex;
 ///
 /// // Create a 4D simplex (5 vertices forming a 4-simplex)
@@ -1398,9 +1398,9 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::extract_cavity_boundary;
-/// use delaunay::core::collections::CellKeyBuffer;
-/// use delaunay::core::tds::Tds;
+/// use delaunay::prelude::query::extract_cavity_boundary;
+/// use delaunay::prelude::collections::CellKeyBuffer;
+/// use delaunay::prelude::tds::Tds;
 ///
 /// let tds: Tds<f64, (), (), 3> = Tds::empty();
 /// let boundary = extract_cavity_boundary(&tds, &CellKeyBuffer::new()).unwrap();
@@ -1409,11 +1409,11 @@ where
 ///
 ///
 /// ```rust
-/// use delaunay::core::algorithms::locate::{locate, find_conflict_region, extract_cavity_boundary, LocateResult};
+/// use delaunay::prelude::query::{locate, find_conflict_region, extract_cavity_boundary, LocateResult};
 /// use delaunay::prelude::DelaunayTriangulation;
-/// use delaunay::geometry::kernel::FastKernel;
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::FastKernel;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 /// use delaunay::vertex;
 ///
 /// // Create a 4D simplex

--- a/src/core/algorithms/pl_manifold_repair.rs
+++ b/src/core/algorithms/pl_manifold_repair.rs
@@ -78,7 +78,7 @@ impl Default for PlManifoldRepairConfig {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunayize::PlManifoldRepairStats;
+/// use delaunay::prelude::triangulation::delaunayize::PlManifoldRepairStats;
 ///
 /// let stats = PlManifoldRepairStats::<f64, (), (), 3>::default();
 /// assert_eq!(stats.iterations, 0);
@@ -152,7 +152,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunayize::PlManifoldRepairError;
+/// use delaunay::prelude::triangulation::delaunayize::PlManifoldRepairError;
 ///
 /// let err = PlManifoldRepairError::BudgetExhausted {
 ///     iterations: 64,

--- a/src/core/cell.rs
+++ b/src/core/cell.rs
@@ -75,7 +75,7 @@ use uuid::Uuid;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::cell::CellValidationError;
+/// use delaunay::prelude::tds::CellValidationError;
 ///
 /// let err = CellValidationError::DuplicateVertices;
 /// assert!(matches!(err, CellValidationError::DuplicateVertices));
@@ -179,7 +179,7 @@ impl From<crate::geometry::matrix::StackMatrixDispatchError> for CellValidationE
 ///
 /// Since cells now store keys, you need a `&Tds` reference to access vertex data:
 /// ```rust
-/// use delaunay::core::collections::Uuid;
+/// use delaunay::prelude::collections::Uuid;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// // Create a triangulation with some vertices
@@ -585,7 +585,7 @@ where
     ///
     /// This method returns keys (not full vertex objects). Use the TDS to resolve keys:
     /// ```rust
-    /// use delaunay::core::collections::Uuid;
+    /// use delaunay::prelude::collections::Uuid;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -822,7 +822,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use delaunay::core::collections::Uuid;
+    /// use delaunay::prelude::collections::Uuid;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -847,6 +847,7 @@ where
     ///
     /// ```
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
@@ -1033,6 +1034,7 @@ where
     ///
     /// ```
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 1.0]),
@@ -1069,7 +1071,7 @@ where
     ///
     /// ```
     /// use delaunay::prelude::triangulation::*;
-    /// use delaunay::core::cell::Cell;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// // Create two separate triangulations
     /// let vertices1 = vec![
@@ -1103,7 +1105,7 @@ where
     /// ```
     ///
     /// ```
-    /// use delaunay::core::cell::Cell;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// // Empty collection produces empty FastHashMap
     /// let empty_map = Cell::<f64, (), (), 3>::into_hashmap([]);
@@ -1150,6 +1152,7 @@ where
     ///
     /// ```
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 1.0]),
@@ -1296,6 +1299,7 @@ where
     ///
     /// ```
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -1473,6 +1477,7 @@ where
     ///
     /// ```
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -1498,6 +1503,7 @@ where
     ///
     /// ```
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::Cell;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),

--- a/src/core/collections/aliases.rs
+++ b/src/core/collections/aliases.rs
@@ -27,7 +27,7 @@ use slotmap::DenseSlotMap;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::FacetIndex;
+/// use delaunay::prelude::collections::FacetIndex;
 ///
 /// // 3D triangulation: facets 0, 1, 2, 3 (fits comfortably in u8)
 /// let facet: FacetIndex = 2;
@@ -94,7 +94,7 @@ pub type StorageMap<K, V> = DenseSlotMap<K, V>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::FastHashMap;
+/// use delaunay::prelude::collections::FastHashMap;
 ///
 /// let mut map: FastHashMap<u64, usize> = FastHashMap::default();
 /// map.insert(123, 456);
@@ -120,7 +120,7 @@ pub type FastBuildHasher = FxBuildHasher;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::{Entry, FastHashMap};
+/// use delaunay::prelude::collections::{Entry, FastHashMap};
 ///
 /// let mut map: FastHashMap<String, String> = FastHashMap::default();
 /// match map.entry("key".to_string()) {
@@ -150,7 +150,7 @@ pub use std::collections::hash_map::Entry;
 ///
 /// External API usage (UUID-based for compatibility):
 /// ```rust
-/// use delaunay::core::collections::FastHashSet;
+/// use delaunay::prelude::collections::FastHashSet;
 /// use uuid::Uuid;
 ///
 /// let mut set: FastHashSet<Uuid> = FastHashSet::default();
@@ -159,8 +159,8 @@ pub use std::collections::hash_map::Entry;
 ///
 /// **Phase 1**: Internal operations (key-based for performance):
 /// ```rust
-/// use delaunay::core::collections::{CellKeySet, FastHashSet};
-/// use delaunay::core::tds::CellKey;
+/// use delaunay::prelude::collections::{CellKeySet, FastHashSet};
+/// use delaunay::prelude::tds::CellKey;
 ///
 /// // For internal algorithms, prefer direct key-based collections
 /// let mut internal_set: CellKeySet = CellKeySet::default();
@@ -189,7 +189,7 @@ pub type FastHashSet<T> = FxHashSet<T>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::SmallBuffer;
+/// use delaunay::prelude::collections::SmallBuffer;
 ///
 /// // Stack-allocated for ≤8 elements, heap for more
 /// let mut buffer: SmallBuffer<i32, 8> = SmallBuffer::new();

--- a/src/core/collections/buffers.rs
+++ b/src/core/collections/buffers.rs
@@ -67,7 +67,7 @@ pub type CellKeyBuffer = SmallBuffer<CellKey, CLEANUP_OPERATION_BUFFER_SIZE>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::BadCellBuffer;
+/// use delaunay::prelude::collections::BadCellBuffer;
 ///
 /// // Accumulate bad cells during insertion
 /// let mut bad_cells: BadCellBuffer = BadCellBuffer::new();
@@ -129,7 +129,7 @@ pub type CavityBoundaryBuffer = SmallBuffer<FacetHandle, 64>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::FacetSharingCellsBuffer;
+/// use delaunay::prelude::collections::FacetSharingCellsBuffer;
 ///
 /// let mut sharing_cells: FacetSharingCellsBuffer = FacetSharingCellsBuffer::new();
 /// assert!(sharing_cells.is_empty());
@@ -180,8 +180,8 @@ pub type VertexKeyBuffer = SimplexVertexBuffer<VertexKey>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::NeighborBuffer;
-/// use delaunay::core::tds::CellKey;
+/// use delaunay::prelude::collections::NeighborBuffer;
+/// use delaunay::prelude::tds::CellKey;
 ///
 /// let mut neighbors: NeighborBuffer<Option<CellKey>> = NeighborBuffer::new();
 /// assert!(neighbors.is_empty());

--- a/src/core/collections/helpers.rs
+++ b/src/core/collections/helpers.rs
@@ -16,7 +16,7 @@ use super::{FastBuildHasher, FastHashMap, FastHashSet, SmallBuffer};
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::fast_hash_map_with_capacity;
+/// use delaunay::prelude::collections::fast_hash_map_with_capacity;
 ///
 /// let map = fast_hash_map_with_capacity::<u64, usize>(1000);
 /// // Can insert up to ~750 items without rehashing (load factor ~0.75)
@@ -40,7 +40,7 @@ pub fn fast_hash_map_with_capacity<K, V>(capacity: usize) -> FastHashMap<K, V> {
 ///
 /// External API usage (UUID-based):
 /// ```rust
-/// use delaunay::core::collections::fast_hash_set_with_capacity;
+/// use delaunay::prelude::collections::fast_hash_set_with_capacity;
 /// use uuid::Uuid;
 ///
 /// let set = fast_hash_set_with_capacity::<Uuid>(500);
@@ -49,8 +49,8 @@ pub fn fast_hash_map_with_capacity<K, V>(capacity: usize) -> FastHashMap<K, V> {
 ///
 /// **Phase 1**: Internal operations (key-based for better performance):
 /// ```rust
-/// use delaunay::core::collections::fast_hash_set_with_capacity;
-/// use delaunay::core::tds::CellKey;
+/// use delaunay::prelude::collections::fast_hash_set_with_capacity;
+/// use delaunay::prelude::tds::CellKey;
 ///
 /// let set = fast_hash_set_with_capacity::<CellKey>(500);
 /// // Can insert up to ~375 CellKeys without rehashing, avoids UUID→Key lookups
@@ -76,7 +76,7 @@ pub fn fast_hash_set_with_capacity<T>(capacity: usize) -> FastHashSet<T> {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::SmallBuffer;
+/// use delaunay::prelude::collections::SmallBuffer;
 ///
 /// // Use concrete types directly (preferred)
 /// let mut small_buf: SmallBuffer<i32, 8> = SmallBuffer::with_capacity(5);
@@ -95,7 +95,7 @@ pub fn small_buffer_with_capacity_8<T>(capacity: usize) -> SmallBuffer<T, 8> {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::small_buffer_with_capacity_2;
+/// use delaunay::prelude::collections::small_buffer_with_capacity_2;
 ///
 /// let mut buf = small_buffer_with_capacity_2::<i32>(2);
 /// buf.push(1);
@@ -115,7 +115,7 @@ pub fn small_buffer_with_capacity_2<T>(capacity: usize) -> SmallBuffer<T, 2> {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::small_buffer_with_capacity_16;
+/// use delaunay::prelude::collections::small_buffer_with_capacity_16;
 ///
 /// let mut buf = small_buffer_with_capacity_16::<i32>(4);
 /// buf.extend([1, 2, 3, 4]);

--- a/src/core/collections/key_maps.rs
+++ b/src/core/collections/key_maps.rs
@@ -118,7 +118,7 @@ pub type UuidToCellKeyMap = FastHashMap<Uuid, CellKey>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::CellKeySet;
+/// use delaunay::prelude::collections::CellKeySet;
 ///
 /// let cell_set: CellKeySet = CellKeySet::default();
 /// assert!(cell_set.is_empty());
@@ -146,7 +146,7 @@ pub type CellKeySet = FastHashSet<CellKey>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::VertexKeySet;
+/// use delaunay::prelude::collections::VertexKeySet;
 ///
 /// let vertex_set: VertexKeySet = VertexKeySet::default();
 /// assert!(vertex_set.is_empty());
@@ -175,7 +175,7 @@ pub type VertexKeySet = FastHashSet<VertexKey>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::KeyBasedCellMap;
+/// use delaunay::prelude::collections::KeyBasedCellMap;
 ///
 /// let cell_map: KeyBasedCellMap<f64> = KeyBasedCellMap::default();
 /// assert!(cell_map.is_empty());
@@ -204,7 +204,7 @@ pub type KeyBasedCellMap<V> = FastHashMap<CellKey, V>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::KeyBasedVertexMap;
+/// use delaunay::prelude::collections::KeyBasedVertexMap;
 ///
 /// let vertex_map: KeyBasedVertexMap<i32> = KeyBasedVertexMap::default();
 /// assert!(vertex_map.is_empty());

--- a/src/core/collections/triangulation_maps.rs
+++ b/src/core/collections/triangulation_maps.rs
@@ -23,7 +23,7 @@ use crate::core::tds::{CellKey, VertexKey};
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::FacetToCellsMap;
+/// use delaunay::prelude::collections::FacetToCellsMap;
 ///
 /// let facet_map: FacetToCellsMap = FacetToCellsMap::default();
 /// assert!(facet_map.is_empty());
@@ -45,7 +45,7 @@ pub type FacetToCellsMap = FastHashMap<u64, SmallBuffer<FacetHandle, 2>>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::FacetIssuesMap;
+/// use delaunay::prelude::collections::FacetIssuesMap;
 ///
 /// let issues: FacetIssuesMap = FacetIssuesMap::default();
 /// assert!(issues.is_empty());
@@ -69,7 +69,7 @@ pub type FacetIssuesMap = FastHashMap<u64, SmallBuffer<(CellKey, FacetIndex), 4>
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::CellNeighborsMap;
+/// use delaunay::prelude::collections::CellNeighborsMap;
 ///
 /// let neighbors: CellNeighborsMap = CellNeighborsMap::default();
 /// assert!(neighbors.is_empty());
@@ -91,7 +91,7 @@ pub type CellNeighborsMap = FastHashMap<CellKey, NeighborBuffer<Option<CellKey>>
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::VertexToCellsMap;
+/// use delaunay::prelude::collections::VertexToCellsMap;
 ///
 /// let vertex_cells: VertexToCellsMap = VertexToCellsMap::default();
 /// assert!(vertex_cells.is_empty());
@@ -112,7 +112,7 @@ pub type VertexToCellsMap =
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::CellVerticesMap;
+/// use delaunay::prelude::collections::CellVerticesMap;
 ///
 /// let cell_vertices: CellVerticesMap = CellVerticesMap::default();
 /// assert!(cell_vertices.is_empty());
@@ -132,7 +132,7 @@ pub type CellVerticesMap = FastHashMap<CellKey, FastHashSet<VertexKey>>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::CellVertexKeysMap;
+/// use delaunay::prelude::collections::CellVertexKeysMap;
 ///
 /// let cell_vertex_keys: CellVertexKeysMap = CellVertexKeysMap::default();
 /// assert!(cell_vertex_keys.is_empty());
@@ -168,7 +168,7 @@ pub type FacetVertexMap = FastHashMap<u64, VertexUuidSet>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::collections::CellToVertexUuidsMap;
+/// use delaunay::prelude::collections::CellToVertexUuidsMap;
 ///
 /// let mapping: CellToVertexUuidsMap = CellToVertexUuidsMap::default();
 /// assert!(mapping.is_empty());

--- a/src/core/edge.rs
+++ b/src/core/edge.rs
@@ -24,8 +24,8 @@ use slotmap::Key;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::edge::EdgeKey;
-/// use delaunay::core::tds::VertexKey;
+/// use delaunay::prelude::tds::EdgeKey;
+/// use delaunay::prelude::tds::VertexKey;
 /// use slotmap::KeyData;
 ///
 /// let a = VertexKey::from(KeyData::from_ffi(1));

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -1446,8 +1446,8 @@ mod tests {
                         let facet2 = FacetView::new(dt.tds(), cell_key, 0).unwrap();
                         let facet3 = FacetView::new(dt.tds(), cell_key, 1).unwrap();
 
-                        assert_eq!(facet1, facet2, "Same facet should be equal");
-                        assert_ne!(facet1, facet3, "Different facets should not be equal");
+                        assert!(facet1 == facet2, "Same facet should be equal");
+                        assert!(facet1 != facet3, "Different facets should not be equal");
                     }
 
                     #[test]

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -35,6 +35,7 @@
 //!
 //! ```rust
 //! use delaunay::prelude::triangulation::*;
+//! use delaunay::prelude::tds::FacetView;
 //!
 //! // Create vertices for a tetrahedron
 //! let vertices = vec![
@@ -78,7 +79,7 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::facet::FacetError;
+/// use delaunay::prelude::tds::FacetError;
 ///
 /// let err = FacetError::FacetNotFoundInTriangulation;
 /// assert!(matches!(err, FacetError::FacetNotFoundInTriangulation));
@@ -219,6 +220,7 @@ pub enum FacetError {
 ///
 /// ```rust
 /// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::{FacetHandle, FacetView};
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -253,6 +255,7 @@ impl FacetHandle {
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetHandle;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
@@ -280,6 +283,7 @@ impl FacetHandle {
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetHandle;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
@@ -303,6 +307,7 @@ impl FacetHandle {
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetHandle;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
@@ -352,8 +357,8 @@ impl FacetHandle {
 /// # Examples
 ///
 /// ```rust,no_run
-/// use delaunay::core::facet::FacetView;
-/// use delaunay::core::tds::{Tds, CellKey};
+/// use delaunay::prelude::tds::FacetView;
+/// use delaunay::prelude::tds::{Tds, CellKey};
 ///
 /// // This is a conceptual example showing FacetView usage
 /// // In practice, tds and cell_key would come from your triangulation
@@ -436,6 +441,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetView;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -498,6 +504,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetView;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -551,6 +558,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetView;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -602,6 +610,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetView;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -640,6 +649,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
+    /// use delaunay::prelude::tds::FacetView;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -757,7 +767,7 @@ where
 ///
 /// ```rust
 /// use delaunay::prelude::triangulation::*;
-/// use delaunay::core::facet::all_facets_for_cell;
+/// use delaunay::prelude::tds::all_facets_for_cell;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -805,7 +815,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::facet::AllFacetsIter;
+/// use delaunay::prelude::tds::AllFacetsIter;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -844,7 +854,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::facet::AllFacetsIter;
+    /// use delaunay::prelude::tds::AllFacetsIter;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -936,7 +946,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::facet::BoundaryFacetsIter;
+/// use delaunay::prelude::tds::BoundaryFacetsIter;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -968,7 +978,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::facet::BoundaryFacetsIter;
+    /// use delaunay::prelude::tds::BoundaryFacetsIter;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -1051,8 +1061,8 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::facet::facet_key_from_vertices;
-/// use delaunay::core::tds::VertexKey;
+/// use delaunay::prelude::tds::facet_key_from_vertices;
+/// use delaunay::prelude::tds::VertexKey;
 /// use slotmap::Key;
 ///
 /// // Create some vertex keys (normally these would come from a TDS)

--- a/src/core/operations.rs
+++ b/src/core/operations.rs
@@ -22,8 +22,8 @@ use crate::triangulation::delaunay::{DelaunayCheckPolicy, DelaunayRepairPolicy};
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::operations::TopologicalOperation;
-/// use delaunay::core::triangulation::TopologyGuarantee;
+/// use delaunay::prelude::triangulation::operations::TopologicalOperation;
+/// use delaunay::prelude::triangulation::TopologyGuarantee;
 ///
 /// let op = TopologicalOperation::FacetFlip;
 /// assert!(op.is_admissible_under(TopologyGuarantee::Pseudomanifold));
@@ -45,8 +45,8 @@ pub enum TopologicalOperation {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::operations::{RepairDecision, RepairSkipReason, TopologicalOperation};
-/// use delaunay::core::triangulation::TopologyGuarantee;
+/// use delaunay::prelude::triangulation::operations::{RepairDecision, RepairSkipReason, TopologicalOperation};
+/// use delaunay::prelude::triangulation::TopologyGuarantee;
 ///
 /// let decision = RepairDecision::Skip {
 ///     reason: RepairSkipReason::Inadmissible {
@@ -73,7 +73,7 @@ pub enum RepairDecision {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::operations::RepairSkipReason;
+/// use delaunay::prelude::triangulation::operations::RepairSkipReason;
 ///
 /// let reason = RepairSkipReason::PolicyDisabled;
 /// assert!(matches!(reason, RepairSkipReason::PolicyDisabled));
@@ -159,7 +159,7 @@ impl TopologicalOperation {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::operations::InsertionResult;
+/// use delaunay::prelude::triangulation::operations::InsertionResult;
 ///
 /// let result = InsertionResult::default();
 /// assert_eq!(result, InsertionResult::Inserted);
@@ -180,7 +180,7 @@ pub enum InsertionResult {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::operations::{InsertionResult, InsertionStatistics};
+/// use delaunay::prelude::triangulation::operations::{InsertionResult, InsertionStatistics};
 ///
 /// let stats = InsertionStatistics {
 ///     attempts: 2,
@@ -277,8 +277,8 @@ impl DelaunayInsertionState {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::algorithms::incremental_insertion::InsertionError;
-/// use delaunay::core::operations::InsertionOutcome;
+/// use delaunay::prelude::triangulation::insertion::InsertionError;
+/// use delaunay::prelude::triangulation::operations::InsertionOutcome;
 ///
 /// let outcome = InsertionOutcome::Skipped {
 ///     error: InsertionError::DuplicateCoordinates {
@@ -316,7 +316,7 @@ pub enum InsertionOutcome {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::operations::SuspicionFlags;
+/// use delaunay::prelude::triangulation::operations::SuspicionFlags;
 ///
 /// let flags = SuspicionFlags {
 ///     perturbation_used: true,

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -270,7 +270,7 @@ use uuid::Uuid;
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::TriangulationConstructionState;
 ///
 /// let state = TriangulationConstructionState::Incomplete(2);
 /// assert!(matches!(state, TriangulationConstructionState::Incomplete(2)));
@@ -305,7 +305,7 @@ impl Default for TriangulationConstructionState {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::{EntityKind, TdsConstructionError};
 /// use uuid::Uuid;
 ///
 /// let err = TdsConstructionError::DuplicateUuid {
@@ -335,7 +335,7 @@ pub enum TdsConstructionError {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::EntityKind;
 ///
 /// let kind = EntityKind::Cell;
 /// assert_eq!(kind, EntityKind::Cell);
@@ -358,7 +358,7 @@ pub enum EntityKind {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::GeometricError;
 ///
 /// let err = GeometricError::DegenerateOrientation {
 ///     message: "det=0".to_string(),
@@ -612,7 +612,7 @@ pub enum TdsError {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::{TdsError, TdsMutationError};
 ///
 /// let err = TdsError::InvalidNeighbors {
 ///     message: "bad neighbors".to_string(),
@@ -656,7 +656,7 @@ impl From<TdsMutationError> for TdsError {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::InvariantKind;
 ///
 /// let kind = InvariantKind::Topology;
 /// assert_eq!(kind, InvariantKind::Topology);
@@ -701,7 +701,7 @@ pub enum InvariantKind {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::{InvariantError, TdsError};
 ///
 /// let err = InvariantError::Tds(TdsError::InvalidNeighbors {
 ///     message: "bad neighbors".to_string(),
@@ -733,7 +733,7 @@ pub enum InvariantError {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::triangulation::*;
+/// use delaunay::prelude::tds::{InvariantError, InvariantKind, InvariantViolation, TdsError};
 ///
 /// let violation = InvariantViolation {
 ///     kind: InvariantKind::Topology,
@@ -762,7 +762,7 @@ pub struct InvariantViolation {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::tds::TriangulationValidationReport;
+/// use delaunay::prelude::tds::TriangulationValidationReport;
 ///
 /// let report = TriangulationValidationReport { violations: Vec::new() };
 /// assert!(report.is_empty());
@@ -1408,7 +1408,7 @@ where
     /// Count vertices in an empty triangulation:
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
+    /// use delaunay::prelude::tds::Tds;
     ///
     /// let tds = Tds::<f64, (), (), 3>::empty();
     /// assert_eq!(tds.number_of_vertices(), 0);
@@ -1463,9 +1463,9 @@ where
     /// Dimension of an empty triangulation:
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::tds::Tds;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     ///
     /// let tds = Tds::<f64, (), (), 3>::empty();
     /// assert_eq!(tds.dim(), -1); // Empty triangulation
@@ -1581,7 +1581,7 @@ where
     /// Empty triangulation has no cells:
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
+    /// use delaunay::prelude::tds::Tds;
     ///
     /// let tds = Tds::<f64, (), (), 3>::empty();
     /// assert_eq!(tds.number_of_cells(), 0); // No cells for empty input
@@ -1689,7 +1689,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
+    /// use delaunay::prelude::tds::Tds;
     ///
     /// let tds: Tds<f64, (), (), 2> = Tds::empty();
     /// assert_eq!(tds.generation(), 0);
@@ -1989,7 +1989,7 @@ where
     /// Returns `None` for non-existent UUID:
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
+    /// use delaunay::prelude::tds::Tds;
     /// use uuid::Uuid;
     ///
     /// let tds: Tds<f64, (), (), 3> = Tds::empty();
@@ -2049,7 +2049,7 @@ where
     /// Returns `None` for non-existent UUID:
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
+    /// use delaunay::prelude::tds::Tds;
     /// use uuid::Uuid;
     ///
     /// let tds: Tds<f64, (), (), 3> = Tds::empty();
@@ -3441,8 +3441,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
-    /// use delaunay::core::tds::TriangulationConstructionState;
+    /// use delaunay::prelude::tds::Tds;
+    /// use delaunay::prelude::tds::TriangulationConstructionState;
     ///
     /// let tds: Tds<f64, (), (), 3> = Tds::empty();
     /// assert_eq!(tds.number_of_vertices(), 0);
@@ -3728,7 +3728,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::core::tds::Tds;
+    /// use delaunay::prelude::tds::Tds;
     ///
     /// let mut tds: Tds<f64, (), (), 2> = Tds::empty();
     /// let removed = tds.remove_duplicate_cells().unwrap();

--- a/src/core/traits/data_type.rs
+++ b/src/core/traits/data_type.rs
@@ -27,7 +27,7 @@ use std::{fmt::Debug, hash::Hash};
 /// # Usage
 ///
 /// ```rust
-/// use delaunay::core::DataType;
+/// use delaunay::prelude::triangulation::DataType;
 ///
 /// fn process_data<T: DataType>(data: T) {
 ///     // T has all the necessary bounds for use as vertex/cell data

--- a/src/core/traits/facet_cache.rs
+++ b/src/core/traits/facet_cache.rs
@@ -33,10 +33,10 @@ use std::sync::{
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::traits::facet_cache::FacetCacheProvider;
-/// use delaunay::core::tds::Tds;
-/// use delaunay::geometry::traits::coordinate::CoordinateScalar;
-/// use delaunay::core::traits::data_type::DataType;
+/// use delaunay::prelude::tds::FacetCacheProvider;
+/// use delaunay::prelude::tds::Tds;
+/// use delaunay::prelude::geometry::CoordinateScalar;
+/// use delaunay::prelude::triangulation::DataType;
 /// use std::sync::Arc;
 /// use std::sync::atomic::{AtomicU64, Ordering};
 /// use serde::de::DeserializeOwned;

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -114,7 +114,7 @@ use crate::core::algorithms::incremental_insertion::{
 };
 #[cfg(debug_assertions)]
 use crate::core::algorithms::locate::locate_with_stats;
-#[cfg(feature = "test-debug")]
+#[cfg(feature = "diagnostics")]
 use crate::core::algorithms::locate::verify_conflict_region_completeness;
 use crate::core::algorithms::locate::{
     ConflictError, LocateResult, extract_cavity_boundary, find_conflict_region, locate,
@@ -1264,9 +1264,10 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::geometry::FastKernel;
     /// use delaunay::prelude::triangulation::Triangulation;
     ///
-    /// let count = Triangulation::<delaunay::geometry::kernel::FastKernel<f64>, (), (), 3>
+    /// let count = Triangulation::<FastKernel<f64>, (), (), 3>
     ///     ::topology_safety_net_star_split_fallback_successes();
     /// assert!(count >= 0);
     /// ```
@@ -1284,9 +1285,10 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::geometry::FastKernel;
     /// use delaunay::prelude::triangulation::{DuplicateDetectionMetrics, Triangulation};
     ///
-    /// let metrics = Triangulation::<delaunay::geometry::kernel::FastKernel<f64>, (), (), 3>
+    /// let metrics = Triangulation::<FastKernel<f64>, (), (), 3>
     ///     ::duplicate_detection_metrics();
     /// let _ = metrics; // None unless DELAUNAY_DUPLICATE_METRICS is set
     /// ```
@@ -5165,7 +5167,7 @@ where
                 // a star-split of that cell to keep the simplicial complex connected.
                 let computed = find_conflict_region(&self.tds, &self.kernel, &point, start_cell)?;
 
-                #[cfg(feature = "test-debug")]
+                #[cfg(feature = "diagnostics")]
                 if std::env::var_os("DELAUNAY_DEBUG_CONFLICT_VERIFY").is_some() {
                     let missed = verify_conflict_region_completeness(
                         &self.tds,

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -112,12 +112,14 @@ use crate::core::algorithms::incremental_insertion::{
     HullExtensionReason, InsertionError, extend_hull, external_facets_for_boundary, fill_cavity,
     repair_neighbor_pointers, wire_cavity_neighbors,
 };
+#[cfg(debug_assertions)]
+use crate::core::algorithms::locate::locate_with_stats;
+#[cfg(feature = "test-debug")]
+use crate::core::algorithms::locate::verify_conflict_region_completeness;
 use crate::core::algorithms::locate::{
     ConflictError, LocateResult, extract_cavity_boundary, find_conflict_region, locate,
     locate_by_scan,
 };
-#[cfg(debug_assertions)]
-use crate::core::algorithms::locate::{locate_with_stats, verify_conflict_region_completeness};
 use crate::core::cell::{Cell, CellValidationError};
 use crate::core::collections::spatial_hash_grid::HashGridIndex;
 use crate::core::collections::{
@@ -5163,7 +5165,7 @@ where
                 // a star-split of that cell to keep the simplicial complex connected.
                 let computed = find_conflict_region(&self.tds, &self.kernel, &point, start_cell)?;
 
-                #[cfg(debug_assertions)]
+                #[cfg(feature = "test-debug")]
                 if std::env::var_os("DELAUNAY_DEBUG_CONFLICT_VERIFY").is_some() {
                     let missed = verify_conflict_region_completeness(
                         &self.tds,

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -491,8 +491,8 @@ pub(crate) fn insertion_error_to_invariant_error(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::triangulation::{Triangulation, TriangulationConstructionError};
-/// use delaunay::geometry::kernel::FastKernel;
+/// use delaunay::prelude::triangulation::{Triangulation, TriangulationConstructionError};
+/// use delaunay::prelude::geometry::FastKernel;
 /// use delaunay::vertex;
 ///
 /// let vertices = vec![
@@ -563,7 +563,7 @@ pub enum TriangulationConstructionError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::tds::InvariantError;
+/// use delaunay::prelude::tds::InvariantError;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -794,8 +794,8 @@ pub(crate) struct DetailedInsertionResult {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::operations::SuspicionFlags;
-/// use delaunay::core::triangulation::ValidationPolicy;
+/// use delaunay::prelude::triangulation::operations::SuspicionFlags;
+/// use delaunay::prelude::triangulation::ValidationPolicy;
 ///
 /// let policy = ValidationPolicy::OnSuspicion;
 /// let suspicion = SuspicionFlags { perturbation_used: true, ..SuspicionFlags::default() };
@@ -942,7 +942,7 @@ impl TopologyGuarantee {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::{TopologyGuarantee, ValidationPolicy};
+    /// use delaunay::prelude::triangulation::{TopologyGuarantee, ValidationPolicy};
     ///
     /// assert_eq!(
     ///     TopologyGuarantee::PLManifoldStrict.default_validation_policy(),
@@ -987,8 +987,8 @@ impl TopologyGuarantee {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::triangulation::Triangulation;
-/// use delaunay::geometry::kernel::FastKernel;
+/// use delaunay::prelude::triangulation::Triangulation;
+/// use delaunay::prelude::geometry::FastKernel;
 ///
 /// let tri: Triangulation<FastKernel<f64>, (), (), 3> =
 ///     Triangulation::new_empty(FastKernel::new());
@@ -1141,8 +1141,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::{Triangulation, ValidationPolicy};
-    /// use delaunay::geometry::kernel::FastKernel;
+    /// use delaunay::prelude::triangulation::{Triangulation, ValidationPolicy};
+    /// use delaunay::prelude::geometry::FastKernel;
     ///
     /// let tri: Triangulation<FastKernel<f64>, (), (), 2> =
     ///     Triangulation::new_empty(FastKernel::new());
@@ -1166,8 +1166,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::{Triangulation, ValidationPolicy};
-    /// use delaunay::geometry::kernel::FastKernel;
+    /// use delaunay::prelude::triangulation::{Triangulation, ValidationPolicy};
+    /// use delaunay::prelude::geometry::FastKernel;
     ///
     /// let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
     ///     Triangulation::new_empty(FastKernel::new());
@@ -1213,8 +1213,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::{TopologyGuarantee, Triangulation};
-    /// use delaunay::geometry::kernel::FastKernel;
+    /// use delaunay::prelude::triangulation::{TopologyGuarantee, Triangulation};
+    /// use delaunay::prelude::geometry::FastKernel;
     ///
     /// let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
     ///     Triangulation::new_empty(FastKernel::new());
@@ -1262,7 +1262,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::Triangulation;
+    /// use delaunay::prelude::triangulation::Triangulation;
     ///
     /// let count = Triangulation::<delaunay::geometry::kernel::FastKernel<f64>, (), (), 3>
     ///     ::topology_safety_net_star_split_fallback_successes();
@@ -1282,7 +1282,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::{DuplicateDetectionMetrics, Triangulation};
+    /// use delaunay::prelude::triangulation::{DuplicateDetectionMetrics, Triangulation};
     ///
     /// let metrics = Triangulation::<delaunay::geometry::kernel::FastKernel<f64>, (), (), 3>
     ///     ::duplicate_detection_metrics();
@@ -6014,7 +6014,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::collections::FacetIssuesMap;
+    /// use delaunay::prelude::collections::FacetIssuesMap;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// // Start with a valid 2D simplex.

--- a/src/core/util/deduplication.rs
+++ b/src/core/util/deduplication.rs
@@ -44,10 +44,10 @@ pub enum DeduplicationError {
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::util::dedup_vertices_exact;
-/// use delaunay::core::vertex::Vertex;
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::triangulation::dedup_vertices_exact;
+/// use delaunay::prelude::triangulation::Vertex;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let v1: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([0.0, 0.0])])
 ///     .into_iter().next().unwrap();
@@ -113,10 +113,10 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::util::dedup_vertices_epsilon;
-/// use delaunay::core::vertex::Vertex;
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::triangulation::dedup_vertices_epsilon;
+/// use delaunay::prelude::triangulation::Vertex;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let v1: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([0.0, 0.0])])
 ///     .into_iter().next().unwrap();
@@ -225,10 +225,10 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::util::filter_vertices_excluding;
-/// use delaunay::core::vertex::Vertex;
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::triangulation::filter_vertices_excluding;
+/// use delaunay::prelude::triangulation::Vertex;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let v1: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([0.0, 0.0])])
 ///     .into_iter().next().unwrap();

--- a/src/core/util/delaunay_validation.rs
+++ b/src/core/util/delaunay_validation.rs
@@ -18,8 +18,8 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::tds::CellKey;
-/// use delaunay::core::util::DelaunayValidationError;
+/// use delaunay::prelude::tds::CellKey;
+/// use delaunay::prelude::triangulation::repair::DelaunayValidationError;
 /// use slotmap::KeyData;
 ///
 /// let cell_key = CellKey::from(KeyData::from_ffi(1));
@@ -277,7 +277,7 @@ where
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::core::util::find_delaunay_violations;
+/// use delaunay::prelude::triangulation::repair::find_delaunay_violations;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -373,8 +373,8 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::tds::Tds;
-/// use delaunay::core::util::debug_print_first_delaunay_violation;
+/// use delaunay::prelude::tds::Tds;
+/// use delaunay::prelude::triangulation::repair::debug_print_first_delaunay_violation;
 ///
 /// let tds: Tds<f64, (), (), 3> = Tds::empty();
 /// debug_print_first_delaunay_violation(&tds, None);

--- a/src/core/util/delaunay_validation.rs
+++ b/src/core/util/delaunay_validation.rs
@@ -379,7 +379,7 @@ where
 /// let tds: Tds<f64, (), (), 3> = Tds::empty();
 /// debug_print_first_delaunay_violation(&tds, None);
 /// ```
-#[cfg(any(test, debug_assertions))]
+#[cfg(any(test, feature = "test-debug"))]
 #[expect(
     clippy::too_many_lines,
     reason = "Debug-only helper with intentionally verbose logging"
@@ -599,7 +599,7 @@ mod tests {
 
         // Smoke test for the debug helper: it should not panic and should print a
         // summary indicating that no violations were found.
-        #[cfg(any(test, debug_assertions))]
+        #[cfg(any(test, feature = "test-debug"))]
         debug_print_first_delaunay_violation(tds, None);
     }
 
@@ -768,7 +768,7 @@ mod tests {
         init_tracing();
         let (tds, _, _) = build_non_delaunay_quad_2d();
 
-        #[cfg(any(test, debug_assertions))]
+        #[cfg(any(test, feature = "test-debug"))]
         debug_print_first_delaunay_violation(&tds, None);
     }
 

--- a/src/core/util/delaunay_validation.rs
+++ b/src/core/util/delaunay_validation.rs
@@ -374,12 +374,12 @@ where
 ///
 /// ```rust
 /// use delaunay::prelude::tds::Tds;
-/// use delaunay::prelude::triangulation::repair::debug_print_first_delaunay_violation;
+/// use delaunay::prelude::diagnostics::debug_print_first_delaunay_violation;
 ///
 /// let tds: Tds<f64, (), (), 3> = Tds::empty();
 /// debug_print_first_delaunay_violation(&tds, None);
 /// ```
-#[cfg(any(test, feature = "test-debug"))]
+#[cfg(any(test, feature = "diagnostics"))]
 #[expect(
     clippy::too_many_lines,
     reason = "Debug-only helper with intentionally verbose logging"
@@ -599,7 +599,7 @@ mod tests {
 
         // Smoke test for the debug helper: it should not panic and should print a
         // summary indicating that no violations were found.
-        #[cfg(any(test, feature = "test-debug"))]
+        #[cfg(any(test, feature = "diagnostics"))]
         debug_print_first_delaunay_violation(tds, None);
     }
 
@@ -768,7 +768,7 @@ mod tests {
         init_tracing();
         let (tds, _, _) = build_non_delaunay_quad_2d();
 
-        #[cfg(any(test, feature = "test-debug"))]
+        #[cfg(any(test, feature = "diagnostics"))]
         debug_print_first_delaunay_violation(&tds, None);
     }
 

--- a/src/core/util/facet_keys.rs
+++ b/src/core/util/facet_keys.rs
@@ -34,7 +34,7 @@ use thiserror::Error;
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::core::util::checked_facet_key_from_vertex_keys;
+/// use delaunay::prelude::tds::checked_facet_key_from_vertex_keys;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -205,8 +205,8 @@ pub(crate) fn periodic_facet_key_from_lifted_vertices<const D: usize>(
 /// # Examples
 ///
 /// ```rust,no_run
-/// use delaunay::core::util::verify_facet_index_consistency;
-/// use delaunay::core::tds::Tds;
+/// use delaunay::prelude::tds::verify_facet_index_consistency;
+/// use delaunay::prelude::tds::Tds;
 ///
 /// fn validate_neighbor_consistency(
 ///     tds: &Tds<f64, (), (), 3>,
@@ -296,7 +296,7 @@ pub fn verify_facet_index_consistency<const D: usize>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::util::usize_to_u8;
+/// use delaunay::prelude::tds::usize_to_u8;
 ///
 /// // Successful conversion
 /// assert_eq!(usize_to_u8(0, 4), Ok(0));

--- a/src/core/util/facet_utils.rs
+++ b/src/core/util/facet_utils.rs
@@ -35,9 +35,9 @@ use crate::geometry::traits::coordinate::CoordinateScalar;
 /// # Examples
 ///
 /// ```rust,no_run
-/// use delaunay::core::facet::{FacetView, FacetError};
-/// use delaunay::core::util::facet_views_are_adjacent;
-/// use delaunay::core::tds::Tds;
+/// use delaunay::prelude::tds::{FacetView, FacetError};
+/// use delaunay::prelude::tds::facet_views_are_adjacent;
+/// use delaunay::prelude::tds::Tds;
 ///
 /// // This is a conceptual example - in practice you would get these from a real TDS
 /// fn example(tds: &Tds<f64, (), (), 3>) -> Result<bool, FacetError> {
@@ -105,9 +105,9 @@ where
 /// # Examples
 ///
 /// ```rust,no_run
-/// use delaunay::core::facet::FacetView;
-/// use delaunay::core::util::facet_view_to_vertices;
-/// use delaunay::core::tds::Tds;
+/// use delaunay::prelude::tds::FacetView;
+/// use delaunay::prelude::tds::facet_view_to_vertices;
+/// use delaunay::prelude::tds::Tds;
 ///
 /// fn extract_vertices_example(
 ///     tds: &Tds<f64, (), (), 3>,
@@ -157,8 +157,8 @@ where
 /// This function is made public for testing purposes.
 ///
 /// ```
-/// use delaunay::core::util::generate_combinations;
-/// use delaunay::core::vertex::Vertex;
+/// use delaunay::prelude::tds::generate_combinations;
+/// use delaunay::prelude::triangulation::Vertex;
 /// use delaunay::vertex;
 ///
 /// let vertices: Vec<Vertex<f64, (), 1>> = vec![

--- a/src/core/util/hashing.rs
+++ b/src/core/util/hashing.rs
@@ -26,7 +26,7 @@
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::util::stable_hash_u64_slice;
+/// use delaunay::prelude::tds::stable_hash_u64_slice;
 /// let values = vec![1u64, 2u64, 3u64];
 /// let hash1 = stable_hash_u64_slice(&values);
 ///

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::util::JaccardComputationError;
+/// use delaunay::prelude::query::JaccardComputationError;
 ///
 /// let err = JaccardComputationError::SetSizeTooLarge {
 ///     intersection: 1,
@@ -78,7 +78,7 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashSet;
-/// use delaunay::core::util::jaccard_index;
+/// use delaunay::prelude::query::jaccard_index;
 ///
 /// // Identical sets => similarity 1.0
 /// let a: HashSet<_> = [1, 2, 3].into_iter().collect();
@@ -143,7 +143,7 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashSet;
-/// use delaunay::core::util::{jaccard_index, jaccard_distance};
+/// use delaunay::prelude::query::{jaccard_distance, jaccard_index};
 ///
 /// let a: HashSet<_> = [1, 2, 3].into_iter().collect();
 /// let b: HashSet<_> = [3, 4].into_iter().collect();
@@ -193,7 +193,7 @@ where
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::core::util::extract_vertex_coordinate_set;
+/// use delaunay::prelude::query::extract_vertex_coordinate_set;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -250,7 +250,7 @@ const fn canonical_edge(u: u128, v: u128) -> (u128, u128) {
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::core::util::extract_edge_set;
+/// use delaunay::prelude::query::extract_edge_set;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -322,7 +322,7 @@ where
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::core::util::extract_facet_identifier_set;
+/// use delaunay::prelude::query::extract_facet_identifier_set;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -387,9 +387,9 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::util::extract_hull_facet_set;
-/// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-/// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+/// use delaunay::prelude::query::extract_hull_facet_set;
+/// use delaunay::prelude::triangulation::DelaunayTriangulation;
+/// use delaunay::prelude::query::ConvexHull;
 /// use delaunay::vertex;
 ///
 /// let vertices: Vec<_> = vec![
@@ -456,7 +456,7 @@ where
 ///
 /// ```
 /// use std::collections::HashSet;
-/// use delaunay::core::util::format_jaccard_report;
+/// use delaunay::prelude::query::format_jaccard_report;
 ///
 /// let a: HashSet<i32> = [1, 2, 3, 4].into_iter().collect();
 /// let b: HashSet<i32> = [3, 4, 5, 6].into_iter().collect();

--- a/src/core/util/measurement.rs
+++ b/src/core/util/measurement.rs
@@ -28,7 +28,7 @@
 ///
 /// ```rust,ignore
 /// // With count-allocations feature enabled
-/// use delaunay::core::util::measure_with_result;
+/// use delaunay::prelude::tds::measure_with_result;
 ///
 /// let (result, alloc_info) = measure_with_result(|| {
 ///     // Some memory-allocating operation
@@ -57,7 +57,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::util::measure_with_result;
+/// use delaunay::prelude::tds::measure_with_result;
 ///
 /// let (value, alloc) = measure_with_result(|| 7u64);
 /// assert_eq!(value, 7);

--- a/src/core/util/uuid.rs
+++ b/src/core/util/uuid.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::util::UuidValidationError;
+/// use delaunay::prelude::tds::UuidValidationError;
 ///
 /// let err = UuidValidationError::NilUuid;
 /// assert!(matches!(err, UuidValidationError::NilUuid));
@@ -51,8 +51,8 @@ pub enum UuidValidationError {
 /// # Examples
 ///
 /// ```
-/// use delaunay::core::collections::Uuid;
-/// use delaunay::core::util::{make_uuid, validate_uuid};
+/// use delaunay::prelude::collections::Uuid;
+/// use delaunay::prelude::tds::{make_uuid, validate_uuid};
 ///
 /// // Valid UUID (version 4)
 /// let valid_uuid = make_uuid();
@@ -87,7 +87,7 @@ pub const fn validate_uuid(uuid: &Uuid) -> Result<(), UuidValidationError> {
 /// # Example
 ///
 /// ```
-/// use delaunay::core::util::make_uuid;
+/// use delaunay::prelude::tds::make_uuid;
 /// let uuid = make_uuid();
 /// assert_eq!(uuid.get_version_num(), 4);
 /// ```

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -562,8 +562,10 @@ where
 
     /// Creates a vertex directly from a point with a fresh UUID and no user data.
     ///
-    /// This constructor is infallible because [`Point`] already owns validated
-    /// coordinates for the vertex dimension.
+    /// This constructor is infallible because it stores the supplied [`Point`]
+    /// without performing additional validation. Callers that require finite or
+    /// otherwise validated coordinates must enforce that before constructing
+    /// the vertex.
     ///
     /// # Examples
     ///
@@ -590,8 +592,10 @@ where
 
     /// Creates a vertex directly from a point and user data with a fresh UUID.
     ///
-    /// This constructor is infallible because [`Point`] already owns validated
-    /// coordinates for the vertex dimension and `data` is stored as provided.
+    /// This constructor is infallible because it stores the supplied [`Point`]
+    /// and user data without performing additional validation. Callers that
+    /// require finite or otherwise validated coordinates must enforce that
+    /// before constructing the vertex.
     ///
     /// # Examples
     ///

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -18,7 +18,7 @@
 //! # Examples
 //!
 //! ```rust
-//! use delaunay::core::vertex::Vertex;
+//! use delaunay::prelude::triangulation::Vertex;
 //! use delaunay::vertex;
 //!
 //! // Create a simple vertex
@@ -62,8 +62,8 @@ use uuid::Uuid;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::util::UuidValidationError;
-/// use delaunay::core::vertex::VertexValidationError;
+/// use delaunay::prelude::tds::UuidValidationError;
+/// use delaunay::prelude::triangulation::VertexValidationError;
 ///
 /// let err = VertexValidationError::InvalidUuid {
 ///     source: UuidValidationError::NilUuid,
@@ -93,7 +93,7 @@ pub enum VertexValidationError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::vertex::VertexBuilderError;
+/// use delaunay::prelude::triangulation::VertexBuilderError;
 ///
 /// let err = VertexBuilderError::MissingPoint;
 /// assert_eq!(err.to_string(), "Missing required field: `point`");
@@ -124,9 +124,9 @@ pub enum VertexBuilderError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::core::vertex::{Vertex, VertexBuilder};
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::triangulation::{Vertex, VertexBuilder};
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// // Build a vertex with just a point
 /// let v: Vertex<f64, (), 3> = VertexBuilder::default()
@@ -225,7 +225,7 @@ where
 ///
 /// ```rust
 /// use delaunay::vertex;
-/// use delaunay::core::vertex::Vertex;
+/// use delaunay::prelude::triangulation::Vertex;
 ///
 /// // Create a vertex without data
 /// let v1: Vertex<f64, (), 3> = vertex!([1.0, 2.0, 3.0]);
@@ -291,7 +291,7 @@ pub use crate::vertex;
 /// Vertices are typically created using the builder pattern for convenience:
 ///
 /// ```rust
-/// use delaunay::core::vertex::Vertex;
+/// use delaunay::prelude::triangulation::Vertex;
 /// use delaunay::vertex;
 ///
 /// let vertex: Vertex<f64, i32, 3> = vertex!([1.0, 2.0, 3.0], 42);
@@ -337,9 +337,9 @@ where
     /// # Example
     ///
     /// ```
-    /// use delaunay::core::vertex::Vertex;
+    /// use delaunay::prelude::triangulation::Vertex;
     /// use delaunay::vertex;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::Coordinate;
     ///
     /// let vertex: Vertex<f64, (), 3> = vertex!([1.0, 2.0, 3.0]);
     /// let retrieved_point = vertex.point();
@@ -356,7 +356,7 @@ where
     ///
     /// ```
     /// use delaunay::vertex;
-    /// use delaunay::core::vertex::Vertex;
+    /// use delaunay::prelude::triangulation::Vertex;
     ///
     /// let v: Vertex<f64, i32, 2> = vertex!([1.0, 2.0], 42);
     /// assert_eq!(v.data(), Some(&42));
@@ -534,8 +534,8 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::core::vertex::Vertex;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::triangulation::Vertex;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// use approx::assert_relative_eq;
     ///
     /// let empty_vertex: Vertex<f64, (), 3> = Vertex::empty();
@@ -636,9 +636,9 @@ where
     /// # Example
     ///
     /// ```
-    /// use delaunay::core::vertex::Vertex;
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::triangulation::Vertex;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// let points = [Point::new([1.0, 2.0, 3.0])];
     /// let vertices: Vec<Vertex<f64, (), 3>> = Vertex::from_points(&points);
     /// assert_eq!(vertices.len(), 1);
@@ -666,7 +666,7 @@ where
     ///
     /// ```
     /// use std::collections::HashMap;
-    /// use delaunay::core::vertex::Vertex;
+    /// use delaunay::prelude::triangulation::Vertex;
     /// use delaunay::vertex;
     ///
     /// let v1: Vertex<f64, (), 2> = vertex!([1.0, 2.0]);
@@ -730,7 +730,7 @@ where
     /// # Example
     ///
     /// ```
-    /// use delaunay::core::vertex::{Vertex, VertexValidationError};
+    /// use delaunay::prelude::triangulation::{Vertex, VertexValidationError};
     /// use delaunay::vertex;
     /// use uuid::Uuid;
     ///

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -1612,14 +1612,14 @@ mod tests {
     use std::sync::atomic::Ordering;
     use std::thread;
 
-    #[cfg(feature = "test-debug")]
+    #[cfg(feature = "diagnostics")]
     macro_rules! test_debug {
         ($($arg:tt)*) => {{
             tracing::debug!($($arg)*);
         }};
     }
 
-    #[cfg(not(feature = "test-debug"))]
+    #[cfg(not(feature = "diagnostics"))]
     macro_rules! test_debug {
         ($($arg:tt)*) => {{
             let _ = core::format_args!($($arg)*);

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -71,7 +71,7 @@ use num_traits::NumCast;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::algorithms::convex_hull::ConvexHullValidationError;
+/// use delaunay::prelude::query::ConvexHullValidationError;
 ///
 /// let err = ConvexHullValidationError::StaleHull {
 ///     hull_generation: 1,
@@ -116,7 +116,7 @@ pub enum ConvexHullValidationError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::algorithms::convex_hull::ConvexHullConstructionError;
+/// use delaunay::prelude::query::ConvexHullConstructionError;
 ///
 /// let err = ConvexHullConstructionError::InvalidTriangulation {
 ///     message: "empty".to_string(),
@@ -237,8 +237,8 @@ pub enum ConvexHullConstructionError {
 /// Use `is_valid_for_triangulation()` to check if a hull is still valid for a given TDS:
 ///
 /// ```rust
-/// # use delaunay::triangulation::delaunay::DelaunayTriangulation;
-/// # use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+/// # use delaunay::prelude::triangulation::DelaunayTriangulation;
+/// # use delaunay::prelude::query::ConvexHull;
 /// # use delaunay::vertex;
 /// # let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vec![
 /// #     vertex!([0.0, 0.0, 0.0]),
@@ -264,8 +264,8 @@ pub enum ConvexHullConstructionError {
 /// ## Example: Correct Usage Pattern
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-/// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+/// use delaunay::prelude::triangulation::DelaunayTriangulation;
+/// use delaunay::prelude::query::ConvexHull;
 /// use delaunay::vertex;
 ///
 /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vec![
@@ -365,8 +365,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -400,8 +400,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -430,8 +430,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -451,7 +451,7 @@ where
     ///
     /// // Check that all facets have the expected number of vertices
     /// // Note: facets() returns FacetHandle structs - need to create FacetView to access vertices
-    /// use delaunay::core::facet::FacetView;
+    /// use delaunay::prelude::tds::FacetView;
     /// for facet_handle in hull.facets() {
     ///     if let Ok(facet_view) = FacetView::new(&dt.tds(), facet_handle.cell_key(), facet_handle.facet_index()) {
     ///         assert_eq!(facet_view.vertices().unwrap().count(), 3); // 3D facets have 3 vertices
@@ -467,8 +467,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // Empty hull
@@ -499,8 +499,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // Create different dimensional hulls
@@ -550,8 +550,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vec![
@@ -629,8 +629,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -691,8 +691,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // 3D example
@@ -817,10 +817,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -1205,10 +1205,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -1281,10 +1281,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -1403,10 +1403,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// use delaunay::vertex;
     ///
     /// // Create a 3D tetrahedron
@@ -1449,8 +1449,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+    /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
     /// // Create a valid 3D tetrahedron

--- a/src/geometry/kernel.rs
+++ b/src/geometry/kernel.rs
@@ -42,9 +42,9 @@ use core::marker::PhantomData;
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::kernel::{FastKernel, Kernel};
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::{FastKernel, Kernel};
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let kernel = FastKernel::<f64>::new();
 ///
@@ -97,9 +97,9 @@ pub trait Kernel<const D: usize>: Clone + Default {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::kernel::{FastKernel, Kernel};
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::{FastKernel, Kernel};
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     ///
     /// let kernel = FastKernel::<f64>::new();
     ///
@@ -148,9 +148,9 @@ pub trait Kernel<const D: usize>: Clone + Default {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::kernel::{FastKernel, Kernel};
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::{FastKernel, Kernel};
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     ///
     /// let kernel = FastKernel::<f64>::new();
     ///
@@ -214,7 +214,7 @@ pub trait Kernel<const D: usize>: Clone + Default {
 /// [`FastKernel`] does not implement `ExactPredicates`, so this fails:
 ///
 /// ```compile_fail
-/// use delaunay::geometry::kernel::{ExactPredicates, FastKernel};
+/// use delaunay::prelude::geometry::{ExactPredicates, FastKernel};
 /// fn requires_exact<T: ExactPredicates>() {}
 /// requires_exact::<FastKernel<f64>>(); // ERROR: FastKernel doesn't implement ExactPredicates
 /// ```
@@ -252,9 +252,9 @@ impl<T: CoordinateScalar> ExactPredicates for AdaptiveKernel<T> {}
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::kernel::{FastKernel, Kernel};
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::{FastKernel, Kernel};
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// // Create a fast kernel for f64 coordinates
 /// let kernel = FastKernel::<f64>::new();
@@ -286,7 +286,7 @@ impl<T: CoordinateScalar> FastKernel<T> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::kernel::FastKernel;
+    /// use delaunay::prelude::geometry::FastKernel;
     ///
     /// let kernel = FastKernel::<f64>::new();
     /// ```
@@ -363,9 +363,9 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::kernel::{RobustKernel, Kernel};
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::{RobustKernel, Kernel};
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let kernel = RobustKernel::<f64>::new();
 ///
@@ -394,7 +394,7 @@ impl<T: CoordinateScalar> RobustKernel<T> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
     ///
     /// let kernel = RobustKernel::<f64>::new();
     /// ```
@@ -474,9 +474,9 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::kernel::{AdaptiveKernel, Kernel};
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::{AdaptiveKernel, Kernel};
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let kernel = AdaptiveKernel::<f64>::new();
 ///
@@ -500,7 +500,7 @@ impl<T: CoordinateScalar> AdaptiveKernel<T> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::kernel::AdaptiveKernel;
+    /// use delaunay::prelude::geometry::AdaptiveKernel;
     ///
     /// let kernel = AdaptiveKernel::<f64>::new();
     /// ```

--- a/src/geometry/matrix.rs
+++ b/src/geometry/matrix.rs
@@ -25,7 +25,7 @@ pub type Matrix<const D: usize> = LaMatrix<D>;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::matrix::MatrixError;
+/// use delaunay::prelude::geometry::MatrixError;
 ///
 /// let err = MatrixError::SingularMatrix;
 /// assert!(matches!(err, MatrixError::SingularMatrix));
@@ -138,7 +138,7 @@ pub(crate) fn matrix_set<const D: usize>(m: &mut Matrix<D>, r: usize, c: usize, 
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::matrix::{determinant, Matrix};
+/// use delaunay::prelude::geometry::{determinant, Matrix};
 ///
 /// let m = Matrix::<2>::zero();
 /// assert_eq!(determinant(&m), 0.0);

--- a/src/geometry/point.rs
+++ b/src/geometry/point.rs
@@ -61,8 +61,8 @@ use std::marker::PhantomData;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let p = Point::new([1.0, 2.0]);
 /// assert_eq!(p.coords(), &[1.0, 2.0]);
@@ -92,8 +92,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     ///
     /// let point = Point::new([1.0, 2.0, 3.0]);
     /// let coords = point.coords();
@@ -402,8 +402,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// let point = Point::new([1.0, 2.0]);
     /// let coords: [f64; 2] = point.into();
     /// assert_eq!(coords, [1.0, 2.0]);
@@ -421,8 +421,8 @@ where
     /// # Example
     ///
     /// ```rust
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::Point;
+    /// use delaunay::prelude::geometry::Coordinate;
     /// let point = Point::new([3.0, 4.0]);
     /// let coords: [f64; 2] = (&point).into();
     /// assert_eq!(coords, [3.0, 4.0]);

--- a/src/geometry/predicates.rs
+++ b/src/geometry/predicates.rs
@@ -153,7 +153,7 @@ pub(crate) fn orientation_from_matrix<const N: usize>(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::predicates::InSphere;
+/// use delaunay::prelude::geometry::InSphere;
 ///
 /// let status = InSphere::INSIDE;
 /// assert_eq!(status.to_string(), "INSIDE");
@@ -183,7 +183,7 @@ impl std::fmt::Display for InSphere {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::predicates::Orientation;
+/// use delaunay::prelude::geometry::Orientation;
 ///
 /// let orientation = Orientation::POSITIVE;
 /// assert_eq!(orientation.to_string(), "POSITIVE");
@@ -252,10 +252,10 @@ impl std::fmt::Display for Orientation {
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::Orientation;
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::predicates::simplex_orientation;
+/// use delaunay::prelude::geometry::Orientation;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::simplex_orientation;
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
@@ -354,9 +354,9 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::predicates::{insphere_distance, InSphere};
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::{insphere_distance, InSphere};
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
@@ -501,10 +501,10 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::predicates::insphere;
-/// use delaunay::geometry::InSphere;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::insphere;
+/// use delaunay::prelude::geometry::InSphere;
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
@@ -712,9 +712,9 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::predicates::insphere_lifted;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::insphere_lifted;
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -54,7 +54,7 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::quality::QualityError;
+/// use delaunay::prelude::geometry::QualityError;
 ///
 /// let err = QualityError::NumericalError {
 ///     message: "overflow".to_string(),
@@ -215,7 +215,7 @@ where
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::geometry::quality::radius_ratio;
+/// use delaunay::prelude::geometry::radius_ratio;
 ///
 /// // Create a 2D equilateral triangle
 /// let vertices = vec![
@@ -312,7 +312,7 @@ where
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::geometry::quality::normalized_volume;
+/// use delaunay::prelude::geometry::normalized_volume;
 ///
 /// // Create a 2D triangle
 /// let vertices = vec![

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -26,7 +26,7 @@ static STRICT_INSPHERE_CONSISTENCY: LazyLock<bool> =
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::robust_predicates::ConsistencyResult;
+/// use delaunay::prelude::geometry::ConsistencyResult;
 ///
 /// let result = ConsistencyResult::Consistent;
 /// assert!(result.is_consistent());
@@ -116,10 +116,10 @@ pub enum InsphereConsistencyError {
 ///
 /// Example (3D):
 /// ```rust
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::robust_predicates::robust_insphere;
-/// use delaunay::geometry::predicates::InSphere;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::robust_insphere;
+/// use delaunay::prelude::geometry::InSphere;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let tetra = vec![
 ///     Point::new([0.0, 0.0, 0.0]),
@@ -344,10 +344,10 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::predicates::Orientation;
-/// use delaunay::geometry::robust_predicates::robust_orientation;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Orientation;
+/// use delaunay::prelude::geometry::robust_orientation;
+/// use delaunay::prelude::geometry::Coordinate;
 ///
 /// let tri = vec![
 ///     Point::new([0.0, 0.0]),

--- a/src/geometry/traits/coordinate.rs
+++ b/src/geometry/traits/coordinate.rs
@@ -36,8 +36,8 @@
 //! # Usage Examples
 //!
 //! ```rust
-//! use delaunay::geometry::traits::coordinate::*;
-//! use delaunay::geometry::point::Point;
+//! use delaunay::prelude::geometry::*;
+//! use delaunay::prelude::geometry::Point;
 //!
 //! // Create coordinates using Point (which implements Coordinate)
 //! let coord: Point<f64, 3> = Coordinate::new([1.0, 2.0, 3.0]);
@@ -77,7 +77,7 @@ use std::{
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::traits::coordinate::CoordinateConversionError;
+/// use delaunay::prelude::geometry::CoordinateConversionError;
 ///
 /// let err = CoordinateConversionError::ConversionFailed {
 ///     coordinate_index: 0,
@@ -157,7 +157,7 @@ impl From<crate::geometry::matrix::StackMatrixDispatchError> for CoordinateConve
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::geometry::traits::coordinate::CoordinateValidationError;
+/// use delaunay::prelude::geometry::CoordinateValidationError;
 ///
 /// let err = CoordinateValidationError::InvalidCoordinate {
 ///     coordinate_index: 1,
@@ -207,7 +207,7 @@ pub const DEFAULT_TOLERANCE_F64: f64 = 1e-15;
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::traits::coordinate::FiniteCheck;
+/// use delaunay::prelude::geometry::FiniteCheck;
 ///
 /// let valid_value = 3.14f64;
 /// assert!(valid_value.is_finite_generic());
@@ -233,7 +233,7 @@ pub trait FiniteCheck {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::traits::coordinate::FiniteCheck;
+    /// use delaunay::prelude::geometry::FiniteCheck;
     ///
     /// // Valid finite values
     /// assert!(1.0f64.is_finite_generic());
@@ -278,7 +278,7 @@ impl_finite_check!(float: f32, f64);
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::traits::coordinate::OrderedEq;
+/// use delaunay::prelude::geometry::OrderedEq;
 ///
 /// // Normal values work as expected
 /// assert!(1.0f64.ordered_eq(&1.0f64));
@@ -312,7 +312,7 @@ pub trait OrderedEq {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::traits::coordinate::OrderedEq;
+    /// use delaunay::prelude::geometry::OrderedEq;
     ///
     /// // Standard comparisons
     /// assert!(1.0f64.ordered_eq(&1.0f64));
@@ -354,7 +354,7 @@ impl_ordered_eq!(float: f32, f64);
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::traits::coordinate::OrderedCmp;
+/// use delaunay::prelude::geometry::OrderedCmp;
 /// use std::cmp::Ordering;
 ///
 /// // Normal values work as expected
@@ -394,7 +394,7 @@ pub trait OrderedCmp {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::traits::coordinate::OrderedCmp;
+    /// use delaunay::prelude::geometry::OrderedCmp;
     /// use std::cmp::Ordering;
     ///
     /// // Standard comparisons
@@ -436,7 +436,7 @@ impl_ordered_cmp!(float: f32, f64);
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::traits::coordinate::HashCoordinate;
+/// use delaunay::prelude::geometry::HashCoordinate;
 /// use std::collections::hash_map::DefaultHasher;
 /// use std::hash::Hasher;
 ///
@@ -464,7 +464,7 @@ pub trait HashCoordinate {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::traits::coordinate::HashCoordinate;
+    /// use delaunay::prelude::geometry::HashCoordinate;
     /// use std::collections::hash_map::DefaultHasher;
     /// use std::hash::Hasher;
     ///
@@ -534,7 +534,7 @@ impl_hash_coordinate!(float: f32, f64);
 /// # Usage
 ///
 /// ```rust
-/// use delaunay::geometry::traits::coordinate::CoordinateScalar;
+/// use delaunay::prelude::geometry::CoordinateScalar;
 ///
 /// fn process_coordinate<T: CoordinateScalar>(value: T) {
 ///     // T has all the necessary bounds for coordinate operations,
@@ -572,7 +572,7 @@ pub trait CoordinateScalar:
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::traits::coordinate::CoordinateScalar;
+    /// use delaunay::prelude::geometry::CoordinateScalar;
     ///
     /// // Get appropriate tolerance for f32
     /// let tolerance_f32 = f32::default_tolerance();
@@ -589,7 +589,7 @@ pub trait CoordinateScalar:
     /// appropriate tolerance values for the specific type being used:
     ///
     /// ```
-    /// use delaunay::geometry::traits::coordinate::CoordinateScalar;
+    /// use delaunay::prelude::geometry::CoordinateScalar;
     ///
     /// fn compare_with_tolerance<T: CoordinateScalar>(a: T, b: T) -> bool {
     ///     (a - b).abs() < T::default_tolerance()
@@ -612,7 +612,7 @@ pub trait CoordinateScalar:
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::traits::coordinate::CoordinateScalar;
+    /// use delaunay::prelude::geometry::CoordinateScalar;
     ///
     /// // f32 has 24 mantissa bits
     /// assert_eq!(f32::mantissa_digits(), 24);
@@ -671,7 +671,7 @@ impl CoordinateScalar for f64 {
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::{point::Point, traits::coordinate::Coordinate};
+/// use delaunay::prelude::geometry::{Coordinate, Point};
 ///
 /// // Create coordinates using Point (which implements Coordinate)
 /// let coord1: Point<f64, 3> = Coordinate::new([1.0, 2.0, 3.0]);
@@ -696,7 +696,7 @@ impl CoordinateScalar for f64 {
 ///
 /// ```
 /// // Example of how future implementations could work:
-/// use delaunay::geometry::{point::Point, traits::coordinate::Coordinate};
+/// use delaunay::prelude::geometry::{Coordinate, Point};
 /// use std::collections::HashMap;
 ///
 /// // Current Point implementation uses arrays
@@ -731,7 +731,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::{point::Point, traits::coordinate::Coordinate};
+    /// use delaunay::prelude::geometry::{Coordinate, Point};
     ///
     /// let coord: Point<f64, 3> = Coordinate::new([1.0, 2.0, 3.0]);
     /// assert_eq!(coord.dim(), 3);
@@ -773,7 +773,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::{point::Point, traits::coordinate::Coordinate};
+    /// use delaunay::prelude::geometry::{Coordinate, Point};
     ///
     /// let coord: Point<f64, 3> = Coordinate::new([1.0, 2.0, 3.0]);
     /// assert_eq!(coord.get(0), Some(1.0));
@@ -791,7 +791,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::{point::Point, traits::coordinate::Coordinate};
+    /// use delaunay::prelude::geometry::{Coordinate, Point};
     ///
     /// let origin: Point<f64, 3> = Coordinate::origin();
     /// assert_eq!(origin.to_array(), [0.0, 0.0, 0.0]);
@@ -820,7 +820,7 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::geometry::{point::Point, traits::coordinate::Coordinate};
+    /// use delaunay::prelude::geometry::{Coordinate, Point};
     ///
     /// let valid: Point<f64, 3> = Coordinate::new([1.0, 2.0, 3.0]);
     /// assert!(valid.validate().is_ok());

--- a/src/geometry/util/circumsphere.rs
+++ b/src/geometry/util/circumsphere.rs
@@ -70,9 +70,9 @@ pub use super::CircumcenterError;
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::util::circumcenter;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::circumcenter;
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
@@ -209,9 +209,9 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::util::circumradius;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::circumradius;
 /// use approx::assert_relative_eq;
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
@@ -254,9 +254,9 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::util::{circumcenter, circumradius_with_center};
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::{circumcenter, circumradius_with_center};
 /// use approx::assert_relative_eq;
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);

--- a/src/geometry/util/conversions.rs
+++ b/src/geometry/util/conversions.rs
@@ -109,7 +109,7 @@ pub(in crate::geometry::util) fn safe_cast_from_f64<T: CoordinateScalar>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::safe_coords_to_f64;
+/// use delaunay::prelude::geometry::safe_coords_to_f64;
 ///
 /// // Convert f32 coordinates to f64
 /// let coords_f32 = [1.5f32, 2.5f32, 3.5f32];
@@ -151,7 +151,7 @@ pub fn safe_coords_to_f64<T: CoordinateScalar, const D: usize>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::safe_coords_from_f64;
+/// use delaunay::prelude::geometry::safe_coords_from_f64;
 ///
 /// // Convert f64 coordinates to f32
 /// let coords_f64 = [1.5f64, 2.5f64, 3.5f64];
@@ -195,7 +195,7 @@ pub fn safe_coords_from_f64<T: CoordinateScalar, const D: usize>(
 /// # Example
 ///
 /// ```
-/// use delaunay::geometry::util::safe_scalar_to_f64;
+/// use delaunay::prelude::geometry::safe_scalar_to_f64;
 ///
 /// let value_f32 = 42.5f32;
 /// let value_f64 = safe_scalar_to_f64(value_f32).unwrap();
@@ -224,7 +224,7 @@ pub fn safe_scalar_to_f64<T: CoordinateScalar>(value: T) -> Result<f64, Coordina
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::safe_scalar_from_f64;
+/// use delaunay::prelude::geometry::safe_scalar_from_f64;
 ///
 /// // Convert f64 to f32
 /// let value_f64 = 123.456f64;
@@ -266,7 +266,7 @@ pub fn safe_scalar_from_f64<T: CoordinateScalar>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::safe_usize_to_scalar;
+/// use delaunay::prelude::geometry::safe_usize_to_scalar;
 ///
 /// // Normal case - small usize values
 /// let result: Result<f64, _> = safe_usize_to_scalar(42_usize);

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -72,9 +72,9 @@ fn is_zero_or_roundoff<T: CoordinateScalar>(value: T, scale: T) -> Result<bool, 
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::util::simplex_volume;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::simplex_volume;
 /// use approx::assert_relative_eq;
 ///
 /// // 2D: Triangle area
@@ -350,9 +350,9 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::util::inradius;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::inradius;
 /// use approx::assert_relative_eq;
 ///
 /// // 2D: Equilateral triangle with side length 1
@@ -461,9 +461,9 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::point::Point;
-/// use delaunay::geometry::traits::coordinate::Coordinate;
-/// use delaunay::geometry::util::facet_measure;
+/// use delaunay::prelude::geometry::Point;
+/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::facet_measure;
 /// use approx::assert_relative_eq;
 ///
 /// // 2D: Line segment length (1D facet in 2D space)
@@ -695,7 +695,7 @@ where
 ///
 /// ```
 /// use delaunay::prelude::query::*;
-/// use delaunay::geometry::util::surface_measure;
+/// use delaunay::prelude::geometry::surface_measure;
 ///
 /// // Create a triangulation and calculate surface measure of boundary facets
 /// let vertices = vec![

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -1102,7 +1102,7 @@ mod tests {
         ];
         let area_3d = facet_measure(&triangle_3d).unwrap();
         assert_relative_eq!(area_3d, 0.5, epsilon = 1e-10);
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         tracing::debug!("3D triangle area: {area_3d} (expected: 0.5)");
 
         // Test 1b: Nearly singular triangle should not error due to tiny negative det
@@ -1118,7 +1118,7 @@ mod tests {
         // Test 2: Same triangle but use direct Gram matrix calculation
         let area_3d_gram = facet_measure_gram_matrix::<f64, 3>(&triangle_3d).unwrap();
         assert_relative_eq!(area_3d_gram, 0.5, epsilon = 1e-10);
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         tracing::debug!("3D triangle area (Gram): {area_3d_gram} (expected: 0.5)");
 
         // Test 3: Unit tetrahedron in 4D - should be 1/6 ≈ 0.167
@@ -1130,7 +1130,7 @@ mod tests {
         ];
         let volume_4d = facet_measure(&tetrahedron_4d).unwrap();
         assert_relative_eq!(volume_4d, 1.0 / 6.0, epsilon = 1e-10);
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         tracing::debug!(
             "4D tetrahedron volume: {} (expected: {})",
             volume_4d,
@@ -1140,7 +1140,7 @@ mod tests {
         // Test 4: Manual calculation for the 4D tetrahedron
         let volume_4d_gram = facet_measure_gram_matrix::<f64, 4>(&tetrahedron_4d).unwrap();
         assert_relative_eq!(volume_4d_gram, 1.0 / 6.0, epsilon = 1e-10);
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         tracing::debug!(
             "4D tetrahedron volume (Gram): {} (expected: {})",
             volume_4d_gram,

--- a/src/geometry/util/norms.rs
+++ b/src/geometry/util/norms.rs
@@ -49,7 +49,7 @@ pub(in crate::geometry::util) fn scaled_hypot_2d<T: CoordinateScalar>(x: T, y: T
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::squared_norm;
+/// use delaunay::prelude::geometry::squared_norm;
 ///
 /// // 2D vector
 /// let coords_2d = [3.0, 4.0];
@@ -98,7 +98,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::hypot;
+/// use delaunay::prelude::geometry::hypot;
 ///
 /// // 2D case - uses std::f64::hypot internally
 /// let distance_2d = hypot(&[3.0, 4.0]);

--- a/src/geometry/util/point_generation.rs
+++ b/src/geometry/util/point_generation.rs
@@ -85,7 +85,7 @@ fn format_bytes(bytes: usize) -> String {
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::scaled_bounds_by_point_count;
+/// use delaunay::prelude::generators::scaled_bounds_by_point_count;
 ///
 /// // 100 points -> side length 100, i.e. [-50, 50]
 /// let bounds = scaled_bounds_by_point_count::<f64>(100).unwrap();
@@ -133,7 +133,7 @@ pub fn scaled_bounds_by_point_count<T: CoordinateScalar>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::generate_random_points;
+/// use delaunay::prelude::generators::generate_random_points;
 ///
 /// // Generate 100 random 2D points with coordinates in [-10.0, 10.0]
 /// let points_2d = generate_random_points::<f64, 2>(100, (-10.0, 10.0)).unwrap();
@@ -205,7 +205,7 @@ pub fn generate_random_points<T: CoordinateScalar + SampleUniform, const D: usiz
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::generate_random_points_seeded;
+/// use delaunay::prelude::generators::generate_random_points_seeded;
 ///
 /// // Generate reproducible random points
 /// let points1 = generate_random_points_seeded::<f64, 3>(100, (-5.0, 5.0), 42).unwrap();
@@ -280,7 +280,7 @@ pub fn generate_random_points_seeded<T: CoordinateScalar + SampleUniform, const 
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::generate_random_points_periodic;
+/// use delaunay::prelude::generators::generate_random_points_periodic;
 ///
 /// // Generate 100 random 2D points in [0,1) × [0,2)
 /// let points = generate_random_points_periodic::<f64, 2>(100, [1.0, 2.0], 42).unwrap();
@@ -382,7 +382,7 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::generate_random_points_in_ball;
+/// use delaunay::prelude::generators::generate_random_points_in_ball;
 ///
 /// // Generate 100 random 4D points in a radius-10 ball.
 /// let points = generate_random_points_in_ball::<f64, 4>(100, 10.0).unwrap();
@@ -413,7 +413,7 @@ pub fn generate_random_points_in_ball<T: CoordinateScalar + SampleUniform, const
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::generate_random_points_in_ball_seeded;
+/// use delaunay::prelude::generators::generate_random_points_in_ball_seeded;
 ///
 /// let points1 = generate_random_points_in_ball_seeded::<f64, 4>(10, 1.0, 42).unwrap();
 /// let points2 = generate_random_points_in_ball_seeded::<f64, 4>(10, 1.0, 42).unwrap();
@@ -466,7 +466,7 @@ pub fn generate_random_points_in_ball_seeded<
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::generate_grid_points;
+/// use delaunay::prelude::generators::generate_grid_points;
 ///
 /// // Generate 2D grid: 4x4 = 16 points with unit spacing
 /// let grid_2d = generate_grid_points::<f64, 2>(4, 1.0, [0.0, 0.0]).unwrap();
@@ -585,7 +585,7 @@ pub fn generate_grid_points<T: CoordinateScalar, const D: usize>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::geometry::util::generate_poisson_points;
+/// use delaunay::prelude::generators::generate_poisson_points;
 ///
 /// // Generate ~100 2D points with minimum distance 0.1 in unit square
 /// let poisson_2d = generate_poisson_points::<f64, 2>(100, (0.0, 1.0), 0.1, 42).unwrap();

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -218,7 +218,7 @@ where
 /// # Examples
 ///
 /// ```no_run
-/// use delaunay::geometry::util::generate_random_triangulation;
+/// use delaunay::prelude::generators::generate_random_triangulation;
 ///
 /// // Generate a 2D triangulation with 50 points, no seed (random each time)
 /// let triangulation_2d = generate_random_triangulation::<f64, (), (), 2>(
@@ -330,8 +330,8 @@ where
 /// # Examples
 ///
 /// ```no_run
-/// use delaunay::geometry::util::generate_random_triangulation_with_topology_guarantee;
-/// use delaunay::core::triangulation::TopologyGuarantee;
+/// use delaunay::prelude::generators::generate_random_triangulation_with_topology_guarantee;
+/// use delaunay::prelude::triangulation::TopologyGuarantee;
 ///
 /// let dt = generate_random_triangulation_with_topology_guarantee::<f64, (), (), 3>(
 ///     20,
@@ -465,9 +465,9 @@ where
 /// # Examples
 ///
 /// ```no_run
-/// use delaunay::geometry::util::RandomTriangulationBuilder;
-/// use delaunay::core::InsertionOrderStrategy;
-/// use delaunay::core::triangulation::TopologyGuarantee;
+/// use delaunay::prelude::generators::RandomTriangulationBuilder;
+/// use delaunay::prelude::generators::InsertionOrderStrategy;
+/// use delaunay::prelude::triangulation::TopologyGuarantee;
 ///
 /// // Override the default `Hilbert` ordering with `Input` ordering.
 /// let dt = RandomTriangulationBuilder::new(20, (-3.0, 3.0))
@@ -512,7 +512,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use delaunay::geometry::util::RandomTriangulationBuilder;
+    /// use delaunay::prelude::generators::RandomTriangulationBuilder;
     ///
     /// let builder = RandomTriangulationBuilder::new(10, (-1.0, 1.0)).seed(42);
     /// let _ = builder;
@@ -549,8 +549,8 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use delaunay::geometry::util::RandomTriangulationBuilder;
-    /// use delaunay::core::InsertionOrderStrategy;
+    /// use delaunay::prelude::generators::RandomTriangulationBuilder;
+    /// use delaunay::prelude::generators::InsertionOrderStrategy;
     ///
     /// // Override the default `Hilbert` ordering with `Input` ordering.
     /// let dt = RandomTriangulationBuilder::new(20, (-3.0, 3.0))
@@ -593,7 +593,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use delaunay::geometry::util::RandomTriangulationBuilder;
+    /// use delaunay::prelude::generators::RandomTriangulationBuilder;
     ///
     /// let dt = RandomTriangulationBuilder::new(12, (-2.0, 2.0))
     ///     .seed(7)
@@ -627,7 +627,7 @@ where
     /// # Examples
     ///
     /// ```no_run
-    /// use delaunay::geometry::util::RandomTriangulationBuilder;
+    /// use delaunay::prelude::generators::RandomTriangulationBuilder;
     ///
     /// let dt = RandomTriangulationBuilder::new(12, (-2.0, 2.0))
     ///     .seed(7)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -948,8 +948,6 @@ pub mod prelude {
             pub use crate::core::triangulation::{
                 TopologyGuarantee, Triangulation, ValidationPolicy,
             };
-            #[cfg(any(test, feature = "test-debug"))]
-            pub use crate::core::util::debug_print_first_delaunay_violation;
             pub use crate::core::util::{DelaunayValidationError, find_delaunay_violations};
             pub use crate::triangulation::delaunay::{
                 DelaunayCheckPolicy, DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds,
@@ -1017,13 +1015,22 @@ pub mod prelude {
 
     /// Focused exports for core algorithms.
     pub mod algorithms {
-        #[cfg(feature = "test-debug")]
-        pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
         pub use crate::core::algorithms::locate::{
             ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
             LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
             find_conflict_region, locate, locate_with_stats,
         };
+    }
+
+    /// Focused exports for opt-in diagnostic helpers.
+    ///
+    /// These helpers are compiled only with the `diagnostics` feature because
+    /// they are intended for explicit debugging and verification workflows, not
+    /// the default public API surface.
+    #[cfg(feature = "diagnostics")]
+    pub mod diagnostics {
+        pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
+        pub use crate::core::util::debug_print_first_delaunay_violation;
     }
 
     /// Convenience re-exports for common **read-only** workflows (topology traversal, adjacency,
@@ -1048,8 +1055,6 @@ pub mod prelude {
         pub use crate::triangulation::delaunay::DelaunayTriangulation;
 
         // Locate and conflict-region queries
-        #[cfg(feature = "test-debug")]
-        pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
         pub use crate::core::algorithms::locate::{
             ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
             LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,7 +487,7 @@ pub mod core {
     }
 
     // Re-export the `core` modules.
-    pub use crate::triangulation::builder::DelaunayTriangulationBuilder;
+    pub use crate::triangulation::builder::*;
     pub use crate::triangulation::delaunay::*;
     pub use adjacency::*;
     pub use cell::*;
@@ -902,7 +902,7 @@ pub mod prelude {
             triangulation::*,
             vertex::*,
         };
-        pub use crate::triangulation::builder::DelaunayTriangulationBuilder;
+        pub use crate::triangulation::builder::*;
         pub use crate::triangulation::delaunay::*;
 
         pub use crate::core::algorithms::incremental_insertion::InsertionError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@
 //! | Delaunay repair and flip-based Level 4 validation | `use delaunay::prelude::triangulation::repair::*` |
 //! | Delaunayize workflow (repair + flip) | `use delaunay::prelude::triangulation::delaunayize::*` |
 //! | Topology validation, Euler characteristic | `use delaunay::prelude::topology::validation::*` |
+//! | Topological spaces and topology traits | `use delaunay::prelude::topology::spaces::*` |
+//! | Low-level TDS cells, facets, keys | `use delaunay::prelude::tds::*` |
 //! | Collection types (`FastHashMap`, etc.) | `use delaunay::prelude::collections::*` |
 //! | Everything (kitchen sink) | `use delaunay::prelude::*` |
 //!
@@ -393,7 +395,7 @@ pub mod core {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::collections::{FastHashMap, FacetToCellsMap, SmallBuffer};
+    /// use delaunay::prelude::collections::{FastHashMap, FacetToCellsMap, SmallBuffer};
     ///
     /// // Use optimized HashMap for temporary mappings
     /// let mut temp_map: FastHashMap<u64, usize> = FastHashMap::default();
@@ -413,7 +415,7 @@ pub mod core {
     /// This module provides optimized maps/sets keyed by those identifiers:
     ///
     /// ```rust
-    /// use delaunay::core::collections::{CellKeySet, KeyBasedCellMap, VertexKeySet};
+    /// use delaunay::prelude::collections::{CellKeySet, KeyBasedCellMap, VertexKeySet};
     ///
     /// let mut internal_cells: CellKeySet = CellKeySet::default();
     /// let mut internal_vertices: VertexKeySet = VertexKeySet::default();
@@ -540,7 +542,7 @@ pub mod geometry {
         /// # Examples
         ///
         /// ```rust
-        /// use delaunay::geometry::util::ValueConversionError;
+        /// use delaunay::prelude::geometry::ValueConversionError;
         ///
         /// let err = ValueConversionError::ConversionFailed {
         ///     value: "1.0".to_string(),
@@ -571,7 +573,7 @@ pub mod geometry {
         /// # Examples
         ///
         /// ```rust
-        /// use delaunay::geometry::util::RandomPointGenerationError;
+        /// use delaunay::prelude::generators::RandomPointGenerationError;
         ///
         /// let err = RandomPointGenerationError::InvalidRange {
         ///     min: "1.0".to_string(),
@@ -614,7 +616,7 @@ pub mod geometry {
         /// # Examples
         ///
         /// ```rust
-        /// use delaunay::geometry::util::CircumcenterError;
+        /// use delaunay::prelude::geometry::CircumcenterError;
         ///
         /// let err = CircumcenterError::EmptyPointSet;
         /// assert!(matches!(err, CircumcenterError::EmptyPointSet));
@@ -685,7 +687,7 @@ pub mod geometry {
         /// # Examples
         ///
         /// ```rust
-        /// use delaunay::geometry::util::{CircumcenterError, SurfaceMeasureError};
+        /// use delaunay::prelude::geometry::{CircumcenterError, SurfaceMeasureError};
         ///
         /// let err = SurfaceMeasureError::GeometryError(CircumcenterError::EmptyPointSet);
         /// assert!(matches!(err, SurfaceMeasureError::GeometryError(_)));
@@ -776,7 +778,7 @@ pub mod triangulation {
 ///
 /// ```rust
 /// use delaunay::prelude::triangulation::*;
-/// use delaunay::topology::characteristics::validation;
+/// use delaunay::prelude::topology::validation;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -890,38 +892,50 @@ pub mod prelude {
         robust_predicates::*, traits::coordinate::*, util::*,
     };
 
-    /// Focused exports for triangulation construction and inspection.
+    /// Focused exports for triangulation construction and mutation.
     pub mod triangulation {
-        pub use crate::core::{
-            adjacency::*,
-            cell::*,
-            edge::*,
-            facet::*,
-            tds::*,
-            traits::{boundary_analysis::*, data_type::*},
-            triangulation::*,
-            vertex::*,
+        pub use crate::core::operations::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
+        pub use crate::core::traits::data_type::DataType;
+        pub use crate::core::triangulation::{
+            DuplicateDetectionMetrics, TopologyGuarantee, Triangulation,
+            TriangulationConstructionError, TriangulationValidationError, ValidationPolicy,
         };
+        pub use crate::core::util::{
+            dedup_vertices_epsilon, dedup_vertices_exact, filter_vertices_excluding,
+        };
+        pub use crate::core::vertex::{
+            Vertex, VertexBuilder, VertexBuilderError, VertexValidationError,
+        };
+        pub use crate::topology::traits::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
         pub use crate::triangulation::builder::*;
         pub use crate::triangulation::delaunay::*;
 
-        pub use crate::core::algorithms::incremental_insertion::InsertionError;
-        pub use crate::core::operations::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
-
-        // Diagnostic types for scientific analysis of construction and repair
-        pub use crate::core::algorithms::flips::{
-            DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats, RepairQueueOrder,
-        };
-        pub use crate::topology::traits::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
-
         /// Bistellar (Pachner) flips for explicit triangulation editing.
         pub mod flips {
+            pub use crate::core::algorithms::flips::*;
+            pub use crate::core::collections::{
+                CellKeyBuffer, MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer,
+            };
+            pub use crate::core::tds::{CellKey, VertexKey};
             pub use crate::core::triangulation::{TopologyGuarantee, Triangulation};
             pub use crate::triangulation::delaunay::DelaunayTriangulation;
             pub use crate::triangulation::flips::*;
 
             // Convenience macro (commonly used in docs/examples).
             pub use crate::vertex;
+        }
+
+        /// Incremental insertion building blocks and diagnostics.
+        pub mod insertion {
+            pub use crate::core::algorithms::incremental_insertion::*;
+            pub use crate::core::collections::CellKeyBuffer;
+            pub use crate::core::facet::FacetHandle;
+            pub use crate::core::tds::{CellKey, Tds, VertexKey};
+        }
+
+        /// Topological operation telemetry and repair decisions.
+        pub mod operations {
+            pub use crate::core::operations::*;
         }
 
         /// Flip-based Delaunay repair, diagnostics, and Level 4 validation.
@@ -931,7 +945,12 @@ pub mod prelude {
                 RepairQueueOrder, verify_delaunay_for_triangulation,
                 verify_delaunay_via_flip_predicates,
             };
-            pub use crate::core::triangulation::{TopologyGuarantee, Triangulation};
+            pub use crate::core::triangulation::{
+                TopologyGuarantee, Triangulation, ValidationPolicy,
+            };
+            #[cfg(any(test, debug_assertions))]
+            pub use crate::core::util::debug_print_first_delaunay_violation;
+            pub use crate::core::util::{DelaunayValidationError, find_delaunay_violations};
             pub use crate::triangulation::delaunay::{
                 DelaunayCheckPolicy, DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds,
                 DelaunayRepairOutcome, DelaunayRepairPolicy, DelaunayTriangulation,
@@ -947,6 +966,9 @@ pub mod prelude {
         /// import brings in [`DelaunayTriangulation`], [`vertex!`], and all
         /// delaunayize-specific types.
         pub mod delaunayize {
+            pub use crate::core::algorithms::pl_manifold_repair::{
+                PlManifoldRepairError, PlManifoldRepairStats,
+            };
             pub use crate::triangulation::delaunay::DelaunayTriangulation;
             pub use crate::triangulation::delaunayize::*;
 
@@ -954,32 +976,53 @@ pub mod prelude {
             pub use crate::vertex;
         }
 
+        pub use crate::core::algorithms::incremental_insertion::InsertionError;
         // Convenience macro (commonly used in docs/tests/examples).
         pub use crate::vertex;
     }
 
     /// Focused exports for collection types used throughout the crate.
     pub mod collections {
+        pub use crate::core::collections::*;
+    }
+
+    /// Focused exports for low-level topology data structures.
+    pub mod tds {
+        pub use crate::core::adjacency::*;
+        pub use crate::core::cell::*;
         pub use crate::core::collections::{
-            CellNeighborsMap, CellSecondaryMap, FacetToCellsMap, FastHashMap, FastHashSet,
-            SmallBuffer, VertexSecondaryMap, VertexToCellsMap, fast_hash_map_with_capacity,
-            fast_hash_set_with_capacity,
+            CellKeyBuffer, FacetIndex, FastHashMap, FastHashSet, NeighborBuffer, SmallBuffer, Uuid,
         };
+        pub use crate::core::edge::*;
+        pub use crate::core::facet::*;
+        pub use crate::core::tds::*;
+        pub use crate::core::traits::facet_cache::*;
+        pub use crate::core::util::{
+            UuidValidationError, checked_facet_key_from_vertex_keys, facet_view_to_vertices,
+            facet_views_are_adjacent, format_jaccard_report, generate_combinations,
+            jaccard_distance, jaccard_index, make_uuid, measure_with_result, stable_hash_u64_slice,
+            usize_to_u8, validate_uuid, verify_facet_index_consistency,
+        };
+        pub use crate::core::vertex::*;
     }
 
     /// Focused exports for geometry types, predicates, and helpers.
     pub mod geometry {
         pub use crate::geometry::{
-            algorithms::*, kernel::*, matrix::*, point::*, predicates::*, quality::*,
-            robust_predicates::*, traits::coordinate::*, util::*,
+            kernel::*, matrix::*, point::*, predicates::*, quality::*, robust_predicates::*,
+            traits::coordinate::*, util::circumsphere::*, util::conversions::*, util::measures::*,
+            util::norms::*,
         };
     }
 
     /// Focused exports for core algorithms.
     pub mod algorithms {
+        #[cfg(debug_assertions)]
+        pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
         pub use crate::core::algorithms::locate::{
             ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
-            LocateFallbackReason, LocateResult, LocateStats, locate, locate_with_stats,
+            LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
+            find_conflict_region, locate, locate_with_stats,
         };
     }
 
@@ -1004,6 +1047,15 @@ pub mod prelude {
         pub use crate::core::triangulation::Triangulation;
         pub use crate::triangulation::delaunay::DelaunayTriangulation;
 
+        // Locate and conflict-region queries
+        #[cfg(debug_assertions)]
+        pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
+        pub use crate::core::algorithms::locate::{
+            ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
+            LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
+            find_conflict_region, locate, locate_with_stats,
+        };
+
         // Common input/output types (kept intentionally small)
         pub use crate::core::facet::FacetView;
         pub use crate::core::traits::boundary_analysis::BoundaryAnalysis;
@@ -1019,12 +1071,14 @@ pub mod prelude {
         pub use crate::geometry::{insphere, insphere_distance, insphere_lifted};
 
         // Read-only algorithms
-        pub use crate::geometry::algorithms::convex_hull::ConvexHull;
-
-        // Convenience generators kept for compatibility with existing docs/tests/examples/benches.
-        // Prefer prelude::generators for new code that only needs fixture data.
-        pub use crate::geometry::util::{
-            generate_random_points_seeded, generate_random_triangulation,
+        pub use crate::assert_jaccard_gte;
+        pub use crate::core::util::{
+            JaccardComputationError, extract_edge_set, extract_facet_identifier_set,
+            extract_hull_facet_set, extract_vertex_coordinate_set, format_jaccard_report,
+            jaccard_distance, jaccard_index,
+        };
+        pub use crate::geometry::algorithms::convex_hull::{
+            ConvexHull, ConvexHullConstructionError, ConvexHullValidationError,
         };
 
         // Instrumentation helpers (no-op unless features enable extra tracking)
@@ -1052,13 +1106,15 @@ pub mod prelude {
     /// assert_eq!(points.len(), 4);
     /// ```
     pub mod generators {
+        pub use crate::core::triangulation::TopologyGuarantee;
         pub use crate::geometry::util::{
-            RandomPointGenerationError, generate_grid_points, generate_poisson_points,
-            generate_random_points, generate_random_points_in_ball,
+            RandomPointGenerationError, RandomTriangulationBuilder, generate_grid_points,
+            generate_poisson_points, generate_random_points, generate_random_points_in_ball,
             generate_random_points_in_ball_seeded, generate_random_points_periodic,
             generate_random_points_seeded, generate_random_triangulation,
-            generate_random_triangulation_with_topology_guarantee,
+            generate_random_triangulation_with_topology_guarantee, scaled_bounds_by_point_count,
         };
+        pub use crate::triangulation::delaunay::InsertionOrderStrategy;
     }
 
     /// Focused exports for Hilbert ordering and quantization utilities.
@@ -1090,12 +1146,22 @@ pub mod prelude {
         /// Topology validation utilities.
         pub mod validation {
             pub use crate::topology::TopologyGuarantee;
-            pub use crate::topology::characteristics::*;
+            pub use crate::topology::characteristics::{euler, validation};
+            pub use crate::topology::characteristics::{euler::*, validation::*};
             pub use crate::topology::manifold::{
                 ManifoldError, validate_closed_boundary, validate_facet_degree,
-                validate_ridge_links, validate_vertex_links,
+                validate_ridge_links, validate_ridge_links_for_cells, validate_vertex_links,
             };
             pub use crate::topology::traits::*;
+        }
+
+        /// Topological space models and traits.
+        pub mod spaces {
+            pub use crate::topology::spaces::*;
+            pub use crate::topology::traits::{
+                GlobalTopology, TopologicalSpace, TopologyError, TopologyKind,
+                ToroidalConstructionMode,
+            };
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -948,7 +948,7 @@ pub mod prelude {
             pub use crate::core::triangulation::{
                 TopologyGuarantee, Triangulation, ValidationPolicy,
             };
-            #[cfg(any(test, debug_assertions))]
+            #[cfg(any(test, feature = "test-debug"))]
             pub use crate::core::util::debug_print_first_delaunay_violation;
             pub use crate::core::util::{DelaunayValidationError, find_delaunay_violations};
             pub use crate::triangulation::delaunay::{
@@ -1017,7 +1017,7 @@ pub mod prelude {
 
     /// Focused exports for core algorithms.
     pub mod algorithms {
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "test-debug")]
         pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
         pub use crate::core::algorithms::locate::{
             ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
@@ -1048,7 +1048,7 @@ pub mod prelude {
         pub use crate::triangulation::delaunay::DelaunayTriangulation;
 
         // Locate and conflict-region queries
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "test-debug")]
         pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
         pub use crate::core::algorithms::locate::{
             ConflictError, InternalInconsistencySite, LocateError, LocateFallback,

--- a/src/topology/characteristics/euler.rs
+++ b/src/topology/characteristics/euler.rs
@@ -7,7 +7,7 @@
 //!
 //! ```rust
 //! use delaunay::prelude::query::*;
-//! use delaunay::topology::characteristics::euler;
+//! use delaunay::prelude::topology::validation::euler;
 //!
 //! let vertices = vec![
 //!     vertex!([0.0, 0.0, 0.0]),
@@ -51,7 +51,7 @@ use crate::topology::traits::topological_space::TopologyError;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::characteristics::euler::FVector;
+/// use delaunay::prelude::topology::validation::FVector;
 ///
 /// // 2D triangle: 3 vertices, 3 edges, 1 face
 /// let counts = FVector {
@@ -77,7 +77,7 @@ impl FVector {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::characteristics::euler::FVector;
+    /// use delaunay::prelude::topology::validation::FVector;
     ///
     /// let counts = FVector {
     ///     by_dim: vec![4, 6, 4, 1],  // 3D tetrahedron
@@ -100,7 +100,7 @@ impl FVector {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::characteristics::euler::FVector;
+    /// use delaunay::prelude::topology::validation::FVector;
     ///
     /// let counts_3d = FVector {
     ///     by_dim: vec![4, 6, 4, 1],
@@ -134,7 +134,7 @@ impl FVector {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::characteristics::euler::TopologyClassification;
+/// use delaunay::prelude::topology::validation::TopologyClassification;
 ///
 /// let ball = TopologyClassification::Ball(3);
 /// assert_eq!(format!("{:?}", ball), "Ball(3)");
@@ -191,7 +191,7 @@ pub enum TopologyClassification {
 ///
 /// ```rust
 /// use delaunay::prelude::query::*;
-/// use delaunay::topology::characteristics::euler;
+/// use delaunay::prelude::topology::validation::euler;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
@@ -380,7 +380,7 @@ fn insert_simplices_of_size(
 ///
 /// ```rust
 /// use delaunay::prelude::query::*;
-/// use delaunay::topology::characteristics::euler;
+/// use delaunay::prelude::topology::validation::euler;
 ///
 /// // 3D tetrahedron - boundary is S² (sphere)
 /// let vertices = vec![
@@ -504,7 +504,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::characteristics::euler::{FVector, euler_characteristic};
+/// use delaunay::prelude::topology::validation::{FVector, euler_characteristic};
 ///
 /// // 2D triangle: V=3, E=3, F=1 → χ = 3-3+1 = 1
 /// let counts = FVector {
@@ -662,7 +662,7 @@ pub(crate) fn triangulated_surface_boundary_component_count(
 ///
 /// ```rust
 /// use delaunay::prelude::query::*;
-/// use delaunay::topology::characteristics::euler::{classify_triangulation, TopologyClassification};
+/// use delaunay::prelude::topology::validation::{classify_triangulation, TopologyClassification};
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -727,7 +727,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::characteristics::euler::{TopologyClassification, expected_chi_for};
+/// use delaunay::prelude::topology::validation::{TopologyClassification, expected_chi_for};
 ///
 /// assert_eq!(expected_chi_for(&TopologyClassification::Empty), Some(0));
 /// assert_eq!(expected_chi_for(&TopologyClassification::Ball(3)), Some(1));

--- a/src/topology/characteristics/validation.rs
+++ b/src/topology/characteristics/validation.rs
@@ -24,7 +24,7 @@ use crate::topology::{
 ///
 /// ```rust
 /// use delaunay::prelude::query::*;
-/// use delaunay::topology::characteristics::validation;
+/// use delaunay::prelude::topology::validation;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -65,7 +65,7 @@ impl TopologyCheckResult {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::characteristics::{euler::*, validation::TopologyCheckResult};
+    /// use delaunay::prelude::topology::validation::{euler::*, TopologyCheckResult};
     ///
     /// let valid_result = TopologyCheckResult {
     ///     chi: 1,
@@ -109,7 +109,7 @@ impl TopologyCheckResult {
 ///
 /// ```rust
 /// use delaunay::prelude::query::*;
-/// use delaunay::topology::characteristics::validation;
+/// use delaunay::prelude::topology::validation;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -168,7 +168,7 @@ fn periodic_ridge_key(lifted_vertices: &[VertexKey]) -> u64 {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::manifold::ManifoldError;
+/// use delaunay::prelude::topology::validation::ManifoldError;
 ///
 /// let err = ManifoldError::BoundaryRidgeMultiplicity {
 ///     ridge_key: 1,
@@ -267,7 +267,7 @@ pub enum ManifoldError {
 /// ```rust
 /// use delaunay::prelude::geometry::*;
 /// use delaunay::prelude::triangulation::*;
-/// use delaunay::topology::manifold::validate_facet_degree;
+/// use delaunay::prelude::topology::validation::validate_facet_degree;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -320,7 +320,7 @@ pub fn validate_facet_degree(facet_to_cells: &FacetToCellsMap) -> Result<(), Man
 /// ```rust
 /// use delaunay::prelude::geometry::*;
 /// use delaunay::prelude::triangulation::*;
-/// use delaunay::topology::manifold::validate_closed_boundary;
+/// use delaunay::prelude::topology::validation::validate_closed_boundary;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -1030,7 +1030,7 @@ where
 /// ```rust
 /// use delaunay::prelude::geometry::*;
 /// use delaunay::prelude::triangulation::*;
-/// use delaunay::topology::manifold::validate_ridge_links;
+/// use delaunay::prelude::topology::validation::validate_ridge_links;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -1109,8 +1109,8 @@ where
 /// ```rust
 /// use delaunay::prelude::geometry::*;
 /// use delaunay::prelude::triangulation::*;
-/// use delaunay::topology::manifold::validate_ridge_links_for_cells;
-/// use delaunay::core::collections::CellKeyBuffer;
+/// use delaunay::prelude::topology::validation::validate_ridge_links_for_cells;
+/// use delaunay::prelude::collections::CellKeyBuffer;
 ///
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -1200,7 +1200,7 @@ where
 /// ```rust
 /// use delaunay::prelude::geometry::*;
 /// use delaunay::prelude::triangulation::*;
-/// use delaunay::topology::manifold::{
+/// use delaunay::prelude::topology::validation::{
 ///     validate_closed_boundary, validate_facet_degree, validate_vertex_links,
 /// };
 ///

--- a/src/topology/spaces/euclidean.rs
+++ b/src/topology/spaces/euclidean.rs
@@ -18,8 +18,8 @@ use crate::topology::traits::topological_space::{TopologicalSpace, TopologyKind}
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::spaces::EuclideanSpace;
-/// use delaunay::topology::traits::topological_space::TopologicalSpace;
+/// use delaunay::prelude::topology::spaces::EuclideanSpace;
+/// use delaunay::prelude::topology::spaces::TopologicalSpace;
 ///
 /// let space = EuclideanSpace::<3>::new();
 /// assert!(space.allows_boundary());

--- a/src/topology/spaces/spherical.rs
+++ b/src/topology/spaces/spherical.rs
@@ -18,8 +18,8 @@ use crate::topology::traits::topological_space::{TopologicalSpace, TopologyKind}
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::spaces::SphericalSpace;
-/// use delaunay::topology::traits::topological_space::TopologicalSpace;
+/// use delaunay::prelude::topology::spaces::SphericalSpace;
+/// use delaunay::prelude::topology::spaces::TopologicalSpace;
 ///
 /// let space = SphericalSpace::<2>::new();
 /// assert!(!space.allows_boundary());

--- a/src/topology/spaces/toroidal.rs
+++ b/src/topology/spaces/toroidal.rs
@@ -21,7 +21,7 @@ use num_traits::NumCast;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::spaces::ToroidalSpace;
+/// use delaunay::prelude::topology::spaces::ToroidalSpace;
 ///
 /// let space = ToroidalSpace::<2>::new([1.0, 2.0]);
 /// assert_eq!(space.domain, [1.0, 2.0]);
@@ -48,7 +48,7 @@ impl<const D: usize> ToroidalSpace<D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::spaces::ToroidalSpace;
+    /// use delaunay::prelude::topology::spaces::ToroidalSpace;
     ///
     /// let space = ToroidalSpace::<3>::unit();
     /// assert_eq!(space.domain, [1.0, 1.0, 1.0]);
@@ -73,7 +73,7 @@ impl<const D: usize> ToroidalSpace<D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::spaces::ToroidalSpace;
+    /// use delaunay::prelude::topology::spaces::ToroidalSpace;
     ///
     /// let space = ToroidalSpace::<2>::new([1.0, 2.0]);
     ///

--- a/src/topology/traits/topological_space.rs
+++ b/src/topology/traits/topological_space.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::traits::topological_space::TopologyError;
+/// use delaunay::prelude::topology::spaces::TopologyError;
 ///
 /// let error = TopologyError::Counting("Failed to enumerate edges".to_string());
 /// assert_eq!(error.to_string(), "Failed to count simplices: Failed to enumerate edges");
@@ -64,7 +64,7 @@ pub enum TopologyError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::traits::topological_space::TopologyKind;
+/// use delaunay::prelude::topology::spaces::TopologyKind;
 ///
 /// let kind = TopologyKind::Euclidean;
 /// assert_eq!(format!("{:?}", kind), "Euclidean");
@@ -172,7 +172,7 @@ impl<const D: usize> GlobalTopology<D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::traits::topological_space::GlobalTopology;
+    /// use delaunay::prelude::topology::spaces::GlobalTopology;
     ///
     /// let topo = GlobalTopology::<3>::Euclidean;
     /// assert!(topo.is_euclidean());
@@ -223,7 +223,7 @@ impl<const D: usize> GlobalTopology<D> {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::topology::traits::topological_space::{TopologicalSpace, TopologyKind};
+/// use delaunay::prelude::topology::spaces::{TopologicalSpace, TopologyKind};
 ///
 /// // Future: EuclideanSpace will implement this trait
 /// // let space = EuclideanSpace::<3>::new();
@@ -243,7 +243,7 @@ pub trait TopologicalSpace {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::traits::topological_space::{TopologicalSpace, TopologyKind};
+    /// use delaunay::prelude::topology::spaces::{TopologicalSpace, TopologyKind};
     ///
     /// struct DummySpace;
     ///
@@ -280,7 +280,7 @@ pub trait TopologicalSpace {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::traits::topological_space::{TopologicalSpace, TopologyKind};
+    /// use delaunay::prelude::topology::spaces::{TopologicalSpace, TopologyKind};
     ///
     /// struct DummySpace {
     ///     allows: bool,
@@ -336,7 +336,7 @@ pub trait TopologicalSpace {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::traits::topological_space::{TopologicalSpace, TopologyKind};
+    /// use delaunay::prelude::topology::spaces::{TopologicalSpace, TopologyKind};
     ///
     /// struct ToroidalSpace {
     ///     domain: [f64; 2],
@@ -386,7 +386,7 @@ pub trait TopologicalSpace {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::topology::traits::topological_space::{TopologicalSpace, TopologyKind};
+    /// use delaunay::prelude::topology::spaces::{TopologicalSpace, TopologyKind};
     ///
     /// struct DummySpace {
     ///     domain: Option<[f64; 2]>,

--- a/src/triangulation/builder.rs
+++ b/src/triangulation/builder.rs
@@ -32,7 +32,7 @@
 //! ## Standard Euclidean construction
 //!
 //! ```rust
-//! use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
+//! use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
 //! use delaunay::vertex;
 //!
 //! let vertices = vec![
@@ -51,7 +51,7 @@
 //! ## Toroidal construction (Phase 1: canonicalization only)
 //!
 //! ```rust
-//! use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
+//! use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
 //! use delaunay::vertex;
 //!
 //! // Vertices that fall outside [0, 1)² are wrapped before triangulation.
@@ -76,8 +76,8 @@
 //! where boundary facets are identified and neighbor pointers are rewired periodically.
 //!
 //! ```rust,no_run
-//! use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-//! use delaunay::geometry::kernel::RobustKernel;
+//! use delaunay::prelude::geometry::RobustKernel;
+//! use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
 //! use delaunay::vertex;
 //!
 //! let vertices = vec![
@@ -298,8 +298,10 @@ fn search_closed_2d_selection(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
-/// use delaunay::triangulation::delaunay::DelaunayTriangulationConstructionError;
+/// use delaunay::prelude::triangulation::{
+///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
+///     ExplicitConstructionError,
+/// };
 /// use delaunay::vertex;
 ///
 /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
@@ -398,9 +400,9 @@ pub enum ExplicitConstructionError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-/// use delaunay::triangulation::delaunay::ConstructionOptions;
-/// use delaunay::core::triangulation::TopologyGuarantee;
+/// use delaunay::prelude::triangulation::{
+///     ConstructionOptions, DelaunayTriangulationBuilder, TopologyGuarantee,
+/// };
 /// use delaunay::vertex;
 ///
 /// let vertices = vec![
@@ -512,7 +514,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -559,10 +561,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::core::vertex::{Vertex, VertexBuilder};
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::{Coordinate, Point};
+    /// use delaunay::prelude::triangulation::{DelaunayTriangulationBuilder, Vertex, VertexBuilder};
     ///
     /// let vertices: Vec<Vertex<f32, (), 2>> = vec![
     ///     VertexBuilder::default().point(Point::new([0.0_f32, 0.0])).build().unwrap(),
@@ -603,10 +603,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::core::vertex::{Vertex, VertexBuilder};
-    /// use delaunay::geometry::point::Point;
-    /// use delaunay::geometry::traits::coordinate::Coordinate;
+    /// use delaunay::prelude::geometry::{Coordinate, Point};
+    /// use delaunay::prelude::triangulation::{DelaunayTriangulationBuilder, Vertex, VertexBuilder};
     ///
     /// // f32 vertices — new() is f64-only, so from_vertices is required here.
     /// let vertices: Vec<Vertex<f32, (), 2>> = vec![
@@ -649,7 +647,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -696,8 +694,8 @@ where
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -733,8 +731,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::core::triangulation::TopologyGuarantee;
+    /// use delaunay::prelude::triangulation::{DelaunayTriangulationBuilder, TopologyGuarantee};
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -773,8 +770,9 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
+    /// use delaunay::prelude::triangulation::{
+    ///     DelaunayTriangulationBuilder, GlobalTopology, ToroidalConstructionMode,
+    /// };
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -807,8 +805,9 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::triangulation::delaunay::{ConstructionOptions, InsertionOrderStrategy};
+    /// use delaunay::prelude::triangulation::{
+    ///     ConstructionOptions, DelaunayTriangulationBuilder, InsertionOrderStrategy,
+    /// };
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -992,7 +991,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -1043,8 +1042,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::builder::DelaunayTriangulationBuilder;
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulationBuilder;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -291,7 +291,7 @@ impl Drop for HeuristicRebuildRecursionGuard {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunay::DelaunayTriangulationConstructionError;
+/// use delaunay::prelude::triangulation::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -364,7 +364,7 @@ impl fmt::Display for DelaunayRepairOperation {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunay::DelaunayTriangulationValidationError;
+/// use delaunay::prelude::triangulation::DelaunayTriangulationValidationError;
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -450,7 +450,7 @@ pub enum DelaunayTriangulationValidationError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunay::{ConstructionOptions, InsertionOrderStrategy};
+/// use delaunay::prelude::triangulation::{ConstructionOptions, InsertionOrderStrategy};
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -506,7 +506,7 @@ pub enum InsertionOrderStrategy {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunay::{ConstructionOptions, DedupPolicy};
+/// use delaunay::prelude::triangulation::{ConstructionOptions, DedupPolicy};
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -568,7 +568,7 @@ pub enum InitialSimplexStrategy {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunay::{ConstructionOptions, RetryPolicy};
+/// use delaunay::prelude::triangulation::{ConstructionOptions, RetryPolicy};
 /// use delaunay::prelude::triangulation::*;
 ///
 /// let vertices = vec![
@@ -633,7 +633,7 @@ impl Default for RetryPolicy {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunay::{
+/// use delaunay::prelude::triangulation::{
 ///     ConstructionOptions, DedupPolicy, InsertionOrderStrategy, RetryPolicy,
 /// };
 ///
@@ -1908,7 +1908,7 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::{
+    /// use delaunay::prelude::triangulation::{
     ///     ConstructionOptions, DedupPolicy, InsertionOrderStrategy,
     /// };
     /// use delaunay::prelude::triangulation::*;
@@ -1953,7 +1953,7 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::TopologyGuarantee;
+    /// use delaunay::prelude::triangulation::TopologyGuarantee;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -2017,7 +2017,7 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::TopologyGuarantee;
+    /// use delaunay::prelude::triangulation::TopologyGuarantee;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -2116,7 +2116,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::triangulation::*;
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
     ///
     /// // Start with empty triangulation using robust kernel
     /// let mut dt: DelaunayTriangulation<RobustKernel<f64>, (), (), 4> =
@@ -2151,8 +2151,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::TopologyGuarantee;
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
+    /// use delaunay::prelude::triangulation::TopologyGuarantee;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let dt: DelaunayTriangulation<RobustKernel<f64>, (), (), 3> =
@@ -2204,8 +2204,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -2248,8 +2248,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::TopologyGuarantee;
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
+    /// use delaunay::prelude::triangulation::TopologyGuarantee;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -2295,11 +2295,11 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::{
+    /// use delaunay::prelude::triangulation::{
     ///     ConstructionOptions, DedupPolicy, InsertionOrderStrategy,
     /// };
-    /// use delaunay::core::triangulation::TopologyGuarantee;
-    /// use delaunay::geometry::kernel::RobustKernel;
+    /// use delaunay::prelude::geometry::RobustKernel;
+    /// use delaunay::prelude::triangulation::TopologyGuarantee;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let vertices = vec![
@@ -4453,7 +4453,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -4479,7 +4479,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -4507,7 +4507,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -4677,7 +4677,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -4736,8 +4736,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::geometry::algorithms::convex_hull::ConvexHull;
+    /// use delaunay::prelude::query::ConvexHull;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices: Vec<_> = vec![
@@ -5453,7 +5453,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::core::triangulation::TopologyGuarantee;
+    /// use delaunay::prelude::triangulation::TopologyGuarantee;
     /// use delaunay::prelude::triangulation::*;
     ///
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
@@ -5478,7 +5478,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -5508,7 +5508,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -5905,7 +5905,7 @@ where
     /// Using batch construction (traditional approach):
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// // Create initial triangulation with 5 vertices (4-simplex)
@@ -6710,9 +6710,8 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
-    /// use delaunay::core::tds::Tds;
-    /// use delaunay::geometry::kernel::FastKernel;
+    /// use delaunay::prelude::geometry::FastKernel;
+    /// use delaunay::prelude::triangulation::{DelaunayTriangulation, Tds};
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -6711,7 +6711,8 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::geometry::FastKernel;
-    /// use delaunay::prelude::triangulation::{DelaunayTriangulation, Tds};
+    /// use delaunay::prelude::tds::Tds;
+    /// use delaunay::prelude::triangulation::DelaunayTriangulation;
     /// use delaunay::vertex;
     ///
     /// let vertices = vec![
@@ -6802,6 +6803,7 @@ where
 ///
 /// ```rust
 /// # use delaunay::prelude::geometry::*;
+/// # use delaunay::prelude::tds::Tds;
 /// # use delaunay::prelude::triangulation::*;
 /// # fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// // Create and serialize a triangulation

--- a/src/triangulation/delaunayize.rs
+++ b/src/triangulation/delaunayize.rs
@@ -79,7 +79,7 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::triangulation::delaunayize::DelaunayizeConfig;
+/// use delaunay::prelude::triangulation::delaunayize::DelaunayizeConfig;
 ///
 /// let config = DelaunayizeConfig::default();
 /// assert_eq!(config.topology_max_iterations, 64);

--- a/tests/README.md
+++ b/tests/README.md
@@ -296,12 +296,12 @@ a point lies inside the circumsphere of a simplex in 2D, 3D, and 4D.
 
 ```bash
 # Run specific debug test functions with verbose output
-cargo test --test circumsphere_debug_tools test_2d_circumsphere_debug -- --nocapture
-cargo test --test circumsphere_debug_tools test_3d_circumsphere_debug -- --nocapture
-cargo test --test circumsphere_debug_tools test_all_debug -- --nocapture
+cargo test --test circumsphere_debug_tools --features diagnostics test_2d_circumsphere_debug -- --nocapture
+cargo test --test circumsphere_debug_tools --features diagnostics test_3d_circumsphere_debug -- --nocapture
+cargo test --test circumsphere_debug_tools --features diagnostics test_all_debug -- --nocapture
 
 # Run all debug tests at once (recommended)
-just test-debug
+just test-diagnostics
 ```
 
 **Available Test Functions:**
@@ -467,7 +467,7 @@ Memory allocation profiling and testing utilities for tracking memory usage patt
 just test-release
 
 # Run with verbose output for debugging
-just test-debug
+just test-diagnostics
 ```
 
 ### Individual Test Files
@@ -477,7 +477,7 @@ just test-debug
 cargo test --test <test_file_name>
 
 # Examples
-just test-debug                                  # circumsphere_debug_tools
+just test-diagnostics                            # circumsphere_debug_tools
 cargo test --test delaunay_incremental_insertion # specific integration test
 just test-allocation                             # allocation profiling
 ```
@@ -492,7 +492,7 @@ measurements, run tests in release mode:
 just test-release
 
 # Debug mode with verbose output
-just test-debug
+just test-diagnostics
 ```
 
 ### Test Output
@@ -501,7 +501,7 @@ Many integration tests produce detailed analysis output:
 
 ```bash
 # See detailed test output
-just test-debug
+just test-diagnostics
 ```
 
 ## Test Development Guidelines

--- a/tests/conflict_region_verification.rs
+++ b/tests/conflict_region_verification.rs
@@ -44,9 +44,14 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         DelaunayTriangulation::new(initial).expect("initial simplex should succeed");
 
     let kernel = AdaptiveKernel::<f64>::new();
-    #[allow(unused_mut)] // only mutated with test-debug diagnostics enabled
+    #[cfg(feature = "diagnostics")]
     let mut total_missed = 0_usize;
+    #[cfg(not(feature = "diagnostics"))]
+    let total_missed = 0_usize;
+    #[cfg(feature = "diagnostics")]
     let mut insertions_checked = 0_usize;
+    #[cfg(not(feature = "diagnostics"))]
+    let insertions_checked = 0_usize;
     let mut insert_errors: Vec<String> = Vec::new();
 
     for (i, v) in vertices[4..].iter().enumerate() {
@@ -65,7 +70,7 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         if let LocateResult::InsideCell(start_cell) = location {
             match find_conflict_region(dt.tds(), &kernel, &point, start_cell) {
                 Ok(conflict_cells) => {
-                    #[cfg(feature = "test-debug")]
+                    #[cfg(feature = "diagnostics")]
                     {
                         let missed =
                             delaunay::core::algorithms::locate::verify_conflict_region_completeness(
@@ -84,10 +89,9 @@ fn verify_conflict_region_diagnostic_3d_35v() {
                         total_missed += missed;
                         insertions_checked += 1;
                     }
-                    #[cfg(not(feature = "test-debug"))]
+                    #[cfg(not(feature = "diagnostics"))]
                     {
                         let _ = conflict_cells;
-                        insertions_checked += 1;
                     }
                 }
                 Err(e) => {

--- a/tests/conflict_region_verification.rs
+++ b/tests/conflict_region_verification.rs
@@ -44,7 +44,7 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         DelaunayTriangulation::new(initial).expect("initial simplex should succeed");
 
     let kernel = AdaptiveKernel::<f64>::new();
-    #[allow(unused_mut)] // only mutated under debug_assertions
+    #[allow(unused_mut)] // only mutated with test-debug diagnostics enabled
     let mut total_missed = 0_usize;
     let mut insertions_checked = 0_usize;
     let mut insert_errors: Vec<String> = Vec::new();
@@ -65,7 +65,7 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         if let LocateResult::InsideCell(start_cell) = location {
             match find_conflict_region(dt.tds(), &kernel, &point, start_cell) {
                 Ok(conflict_cells) => {
-                    #[cfg(debug_assertions)]
+                    #[cfg(feature = "test-debug")]
                     {
                         let missed =
                             delaunay::core::algorithms::locate::verify_conflict_region_completeness(
@@ -84,7 +84,7 @@ fn verify_conflict_region_diagnostic_3d_35v() {
                         total_missed += missed;
                         insertions_checked += 1;
                     }
-                    #[cfg(not(debug_assertions))]
+                    #[cfg(not(feature = "test-debug"))]
                     {
                         let _ = conflict_cells;
                         insertions_checked += 1;

--- a/tests/conflict_region_verification.rs
+++ b/tests/conflict_region_verification.rs
@@ -5,14 +5,16 @@
 //!
 //! These tests are `#[ignore]` by default — run with:
 //! ```bash
-//! cargo test --test conflict_region_verification -- --ignored --nocapture
+//! cargo test --test conflict_region_verification --features diagnostics -- --ignored --nocapture
 //! ```
 
 #![forbid(unsafe_code)]
+#![cfg(feature = "diagnostics")]
 
 use delaunay::core::algorithms::locate::{LocateResult, find_conflict_region, locate};
 use delaunay::geometry::kernel::AdaptiveKernel;
 use delaunay::geometry::util::generate_random_points_in_ball_seeded;
+use delaunay::prelude::diagnostics::verify_conflict_region_completeness;
 use delaunay::prelude::triangulation::*;
 
 /// Verify that `verify_conflict_region_completeness` runs without panicking on
@@ -44,14 +46,8 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         DelaunayTriangulation::new(initial).expect("initial simplex should succeed");
 
     let kernel = AdaptiveKernel::<f64>::new();
-    #[cfg(feature = "diagnostics")]
     let mut total_missed = 0_usize;
-    #[cfg(not(feature = "diagnostics"))]
-    let total_missed = 0_usize;
-    #[cfg(feature = "diagnostics")]
     let mut insertions_checked = 0_usize;
-    #[cfg(not(feature = "diagnostics"))]
-    let insertions_checked = 0_usize;
     let mut insert_errors: Vec<String> = Vec::new();
 
     for (i, v) in vertices[4..].iter().enumerate() {
@@ -70,29 +66,21 @@ fn verify_conflict_region_diagnostic_3d_35v() {
         if let LocateResult::InsideCell(start_cell) = location {
             match find_conflict_region(dt.tds(), &kernel, &point, start_cell) {
                 Ok(conflict_cells) => {
-                    #[cfg(feature = "diagnostics")]
-                    {
-                        let missed =
-                            delaunay::core::algorithms::locate::verify_conflict_region_completeness(
-                                dt.tds(),
-                                &kernel,
-                                &point,
-                                &conflict_cells,
-                            );
-                        if missed > 0 {
-                            println!(
-                                "[{i}] INCOMPLETE conflict region: {missed} cells missed \
-                                 (BFS found {}, brute-force found more)",
-                                conflict_cells.len()
-                            );
-                        }
-                        total_missed += missed;
-                        insertions_checked += 1;
+                    let missed = verify_conflict_region_completeness(
+                        dt.tds(),
+                        &kernel,
+                        &point,
+                        &conflict_cells,
+                    );
+                    if missed > 0 {
+                        println!(
+                            "[{i}] INCOMPLETE conflict region: {missed} cells missed \
+                             (BFS found {}, brute-force found more)",
+                            conflict_cells.len()
+                        );
                     }
-                    #[cfg(not(feature = "diagnostics"))]
-                    {
-                        let _ = conflict_cells;
-                    }
+                    total_missed += missed;
+                    insertions_checked += 1;
                 }
                 Err(e) => {
                     println!("[{i}] find_conflict_region failed: {e}");

--- a/tests/delaunay_edge_cases.rs
+++ b/tests/delaunay_edge_cases.rs
@@ -16,7 +16,7 @@ use rand::seq::SliceRandom;
 fn init_tracing() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
-        let default_filter = if cfg!(feature = "test-debug") {
+        let default_filter = if cfg!(feature = "diagnostics") {
             "info"
         } else {
             "warn"
@@ -32,12 +32,12 @@ fn init_tracing() {
 
 macro_rules! test_debug_info {
     ($($arg:tt)*) => {{
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         {
             init_tracing();
             tracing::info!($($arg)*);
         }
-        #[cfg(not(feature = "test-debug"))]
+        #[cfg(not(feature = "diagnostics"))]
         {
             let _ = format_args!($($arg)*);
         }
@@ -46,12 +46,12 @@ macro_rules! test_debug_info {
 
 macro_rules! test_debug_warn {
     ($($arg:tt)*) => {{
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         {
             init_tracing();
             tracing::warn!($($arg)*);
         }
-        #[cfg(not(feature = "test-debug"))]
+        #[cfg(not(feature = "diagnostics"))]
         {
             let _ = format_args!($($arg)*);
         }
@@ -274,7 +274,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
     }
 
     if let Err(err) = dt.is_valid() {
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         {
             delaunay::core::util::debug_print_first_delaunay_violation(dt.tds(), None);
         }

--- a/tests/delaunay_edge_cases.rs
+++ b/tests/delaunay_edge_cases.rs
@@ -274,7 +274,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
     }
 
     if let Err(err) = dt.is_valid() {
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "test-debug")]
         {
             delaunay::core::util::debug_print_first_delaunay_violation(dt.tds(), None);
         }

--- a/tests/delaunay_public_api_coverage.rs
+++ b/tests/delaunay_public_api_coverage.rs
@@ -8,7 +8,7 @@ use delaunay::prelude::triangulation::{
     DelaunayTriangulationConstructionError, InsertionOrderStrategy, RetryPolicy, TopologyGuarantee,
 };
 use delaunay::vertex;
-#[cfg(feature = "test-debug")]
+#[cfg(feature = "diagnostics")]
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 
 type Dt<const D: usize> = DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D>;
@@ -92,7 +92,7 @@ fn as_triangulation_mut_valid_view() {
 /// This remains ignored by default because it is nondeterministic and expensive.
 /// For deterministic coverage, see the forced heuristic rebuild tests in
 /// `src/triangulation/delaunay.rs`.
-#[cfg(feature = "test-debug")]
+#[cfg(feature = "diagnostics")]
 #[test]
 #[ignore = "manual search helper; run explicitly to discover natural repro cases"]
 fn find_stale_key_after_rebuild() {
@@ -143,7 +143,7 @@ fn find_stale_key_after_rebuild() {
             continue;
         }
 
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         {
             tracing::debug!(case, "FOUND stale key after insertion");
             tracing::debug!(vertex_key = ?vertex_key, inserted_uuid = %inserted_uuid);

--- a/tests/delaunay_repair_fallback.rs
+++ b/tests/delaunay_repair_fallback.rs
@@ -6,7 +6,7 @@
 
 use delaunay::prelude::triangulation::*;
 
-#[cfg(feature = "test-debug")]
+#[cfg(feature = "diagnostics")]
 fn init_tracing() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
@@ -19,17 +19,17 @@ fn init_tracing() {
     });
 }
 
-#[cfg(not(feature = "test-debug"))]
+#[cfg(not(feature = "diagnostics"))]
 const fn init_tracing() {}
 
 macro_rules! test_debug_info {
     ($($arg:tt)*) => {{
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         {
             init_tracing();
             tracing::info!($($arg)*);
         }
-        #[cfg(not(feature = "test-debug"))]
+        #[cfg(not(feature = "diagnostics"))]
         {
             let _ = format_args!($($arg)*);
         }
@@ -207,9 +207,9 @@ fn explicit_repair_call_validates_result() {
         .repair_delaunay_with_flips()
         .expect("Explicit repair should succeed");
 
-    #[cfg(feature = "test-debug")]
+    #[cfg(feature = "diagnostics")]
     test_debug_info!("Explicit repair stats: {stats:?}");
-    #[cfg(not(feature = "test-debug"))]
+    #[cfg(not(feature = "diagnostics"))]
     let _ = &stats;
 
     // Verify triangulation is valid after explicit repair

--- a/tests/euler_characteristic.rs
+++ b/tests/euler_characteristic.rs
@@ -12,6 +12,8 @@
 //!
 //! For property-based tests with random triangulations, see `proptest_euler_characteristic.rs`.
 
+use delaunay::prelude::query::BoundaryAnalysis;
+use delaunay::prelude::tds::Tds;
 use delaunay::prelude::triangulation::*;
 use delaunay::topology::characteristics::{euler, validation};
 

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -69,6 +69,7 @@ use delaunay::geometry::kernel::RobustKernel;
 use delaunay::geometry::util::{
     generate_random_points_in_ball_seeded, generate_random_points_seeded, safe_usize_to_scalar,
 };
+use delaunay::prelude::tds::{InvariantKind, TriangulationValidationReport};
 use delaunay::prelude::triangulation::*;
 use delaunay::triangulation::delaunay::{
     ConstructionOptions, ConstructionStatistics, DelaunayRepairHeuristicConfig,

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -4,13 +4,23 @@
 //! paths so doctests, integration tests, examples, and benchmarks have a small
 //! import contract to copy from.
 
+#[cfg(feature = "diagnostics")]
+use delaunay::prelude::collections::CellKeyBuffer;
+#[cfg(feature = "diagnostics")]
+use delaunay::prelude::diagnostics::{
+    debug_print_first_delaunay_violation, verify_conflict_region_completeness,
+};
 use delaunay::prelude::generators::generate_random_points_seeded;
+#[cfg(feature = "diagnostics")]
+use delaunay::prelude::geometry::Coordinate;
 use delaunay::prelude::geometry::{AdaptiveKernel, Point};
 use delaunay::prelude::ordering::{
     HilbertError, hilbert_index, hilbert_indices_prequantized, hilbert_quantize,
     hilbert_sort_by_stable, hilbert_sort_by_unstable, hilbert_sorted_indices,
 };
 use delaunay::prelude::query::ConvexHull;
+#[cfg(feature = "diagnostics")]
+use delaunay::prelude::tds::Tds;
 use delaunay::prelude::triangulation::delaunayize::{
     DelaunayizeConfig, DelaunayizeError, DelaunayizeOutcome, delaunayize_by_flips,
 };
@@ -102,6 +112,21 @@ fn diagnostic_preludes_cover_repair_apis() {
     assert!(!outcome.used_fallback_rebuild);
     let _typed_outcome: DelaunayizeOutcome<f64, (), (), 3> = outcome;
     let _typed_error: Option<DelaunayizeError> = None;
+}
+
+#[cfg(feature = "diagnostics")]
+#[test]
+fn diagnostics_prelude_covers_opt_in_helpers() {
+    let tds: Tds<f64, (), (), 2> = Tds::empty();
+    debug_print_first_delaunay_violation(&tds, None);
+
+    let kernel = AdaptiveKernel::new();
+    let point = Point::new([0.0, 0.0]);
+    let conflict_cells = CellKeyBuffer::new();
+    assert_eq!(
+        verify_conflict_region_completeness(&tds, &kernel, &point, &conflict_cells),
+        0
+    );
 }
 
 #[test]

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -39,7 +39,7 @@ use proptest::prelude::*;
 fn init_tracing() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
-        let default_filter = if cfg!(feature = "test-debug") {
+        let default_filter = if cfg!(feature = "diagnostics") {
             "info"
         } else {
             "warn"

--- a/tests/proptest_triangulation.rs
+++ b/tests/proptest_triangulation.rs
@@ -36,6 +36,7 @@
 
 use ::uuid::Uuid;
 use delaunay::prelude::geometry::*;
+use delaunay::prelude::tds::CellKey;
 use delaunay::prelude::triangulation::*;
 use proptest::prelude::*;
 use std::collections::HashMap;

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -4,7 +4,7 @@
 //! integration test crates, unless the case needs separate crate-level setup,
 //! feature flags, or profile isolation.
 
-#[cfg(feature = "test-debug")]
+#[cfg(feature = "diagnostics")]
 use delaunay::core::util::debug_print_first_delaunay_violation;
 use delaunay::geometry::kernel::RobustKernel;
 use delaunay::geometry::point::Point;
@@ -95,7 +95,7 @@ fn regression_empty_circumsphere_2d_minimal_case() {
         .unwrap();
 
     if dt.is_valid().is_err() {
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         debug_print_first_delaunay_violation(dt.tds(), None);
     }
 
@@ -125,7 +125,7 @@ fn regression_issue_120_minimal_failing_input_2d() {
         .unwrap();
 
     if let Err(err) = dt.validate() {
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         debug_print_first_delaunay_violation(dt.tds(), None);
         panic!("Issue #120 2D regression must validate Levels 1-4: {err}");
     }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -4,7 +4,7 @@
 //! integration test crates, unless the case needs separate crate-level setup,
 //! feature flags, or profile isolation.
 
-#[cfg(debug_assertions)]
+#[cfg(feature = "test-debug")]
 use delaunay::core::util::debug_print_first_delaunay_violation;
 use delaunay::geometry::kernel::RobustKernel;
 use delaunay::geometry::point::Point;
@@ -95,7 +95,7 @@ fn regression_empty_circumsphere_2d_minimal_case() {
         .unwrap();
 
     if dt.is_valid().is_err() {
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "test-debug")]
         debug_print_first_delaunay_violation(dt.tds(), None);
     }
 
@@ -125,7 +125,7 @@ fn regression_issue_120_minimal_failing_input_2d() {
         .unwrap();
 
     if let Err(err) = dt.validate() {
-        #[cfg(debug_assertions)]
+        #[cfg(feature = "test-debug")]
         debug_print_first_delaunay_violation(dt.tds(), None);
         panic!("Issue #120 2D regression must validate Levels 1-4: {err}");
     }

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -91,5 +91,7 @@ fn doctest_style_error_is_ignored() {}
 /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
 /// // ok: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
 /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+/// // ruleid: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
+/// # use delaunay::triangulation::delaunay::DelaunayTriangulation as HiddenDeepImport;
 /// ```
 fn triangulation_doctest_deep_import_fixture() {}

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -91,6 +91,8 @@ fn doctest_style_error_is_ignored() {}
 /// use delaunay::triangulation::delaunay::DelaunayTriangulation;
 /// // ok: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
 /// use delaunay::prelude::triangulation::DelaunayTriangulation;
+/// // ok: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
+/// # use delaunay::prelude::triangulation::DelaunayTriangulation as HiddenPreludeImport;
 /// // ruleid: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
 /// # use delaunay::triangulation::delaunay::DelaunayTriangulation as HiddenDeepImport;
 /// ```

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -85,3 +85,11 @@ trait ProductionDynamicErrors {
 
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 fn doctest_style_error_is_ignored() {}
+
+/// ```rust
+/// // ruleid: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
+/// use delaunay::triangulation::delaunay::DelaunayTriangulation;
+/// // ok: delaunay.rust.prefer-prelude-imports-in-triangulation-doctests
+/// use delaunay::prelude::triangulation::DelaunayTriangulation;
+/// ```
+fn triangulation_doctest_deep_import_fixture() {}

--- a/tests/serialization_vertex_preservation.rs
+++ b/tests/serialization_vertex_preservation.rs
@@ -12,6 +12,7 @@
 use delaunay::assert_jaccard_gte;
 use delaunay::core::util::extract_vertex_coordinate_set;
 use delaunay::prelude::geometry::*;
+use delaunay::prelude::tds::Tds;
 use delaunay::prelude::triangulation::*;
 use std::collections::HashSet;
 

--- a/tests/storage_backend_compatibility.rs
+++ b/tests/storage_backend_compatibility.rs
@@ -54,7 +54,7 @@ use delaunay::geometry::kernel::AdaptiveKernel;
 use delaunay::prelude::tds::Tds;
 use delaunay::prelude::triangulation::*;
 
-#[cfg(feature = "test-debug")]
+#[cfg(feature = "diagnostics")]
 fn init_tracing() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
@@ -67,17 +67,17 @@ fn init_tracing() {
     });
 }
 
-#[cfg(not(feature = "test-debug"))]
+#[cfg(not(feature = "diagnostics"))]
 const fn init_tracing() {}
 
 macro_rules! test_debug_info {
     ($($arg:tt)*) => {{
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         {
             init_tracing();
             tracing::info!($($arg)*);
         }
-        #[cfg(not(feature = "test-debug"))]
+        #[cfg(not(feature = "diagnostics"))]
         {
             let _ = format_args!($($arg)*);
         }
@@ -86,12 +86,12 @@ macro_rules! test_debug_info {
 
 macro_rules! test_debug_warn {
     ($($arg:tt)*) => {{
-        #[cfg(feature = "test-debug")]
+        #[cfg(feature = "diagnostics")]
         {
             init_tracing();
             tracing::warn!($($arg)*);
         }
-        #[cfg(not(feature = "test-debug"))]
+        #[cfg(not(feature = "diagnostics"))]
         {
             let _ = format_args!($($arg)*);
         }

--- a/tests/storage_backend_compatibility.rs
+++ b/tests/storage_backend_compatibility.rs
@@ -51,6 +51,7 @@
 use delaunay::assert_jaccard_gte;
 use delaunay::core::util::extract_edge_set;
 use delaunay::geometry::kernel::AdaptiveKernel;
+use delaunay::prelude::tds::Tds;
 use delaunay::prelude::triangulation::*;
 
 #[cfg(feature = "test-debug")]


### PR DESCRIPTION
- Skip empty Codacy SARIF runs before uploading results to GitHub Code Scanning.
- Limit Codacy code scanning uploads to repository-owned OpenGrep analysis.
- Migrate triangulation doctests to focused prelude imports for #355.
- Add Semgrep coverage to keep triangulation doctest imports on focused preludes.
- Clarify vertex point-constructor docs and avoid UUID-bearing facet assertion output.

Closes #355