### PR TITLE
ci: harden SARIF tooling

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -55,18 +55,26 @@ jobs:
 
       - name: Run clippy with SARIF output
         run: |
+          set -euo pipefail
           cargo clippy \
             --workspace \
             --all-targets \
             --all-features \
             --message-format=json \
-            -- -W clippy::pedantic -W clippy::nursery | \
+            -- -W clippy::pedantic -W clippy::nursery -W clippy::cargo | \
             clippy-sarif | \
             tee rust-clippy-results.sarif | \
             sarif-fmt
         continue-on-error: true
 
       - name: Upload SARIF results
+        if: >-
+          always()
+          && hashFiles('rust-clippy-results.sarif') != ''
+          && (
+            github.event_name != 'pull_request'
+            || github.event.pull_request.head.repo.full_name == github.repository
+          )
         uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
         with:
           sarif_file: rust-clippy-results.sarif

--- a/.github/workflows/semgrep-sarif.yml
+++ b/.github/workflows/semgrep-sarif.yml
@@ -1,0 +1,75 @@
+name: Repository Rule SARIF
+
+concurrency:
+  group: >
+    semgrep-sarif-${{ github.workflow }}-${{
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.number ||
+      github.ref
+    }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "42 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+  actions: read
+
+env:
+  UV_VERSION: "0.11.8"
+
+jobs:
+  semgrep-sarif:
+    name: Repository Rule SARIF Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Run repository Semgrep rules
+        id: semgrep
+        run: |
+          set +e
+          uv run semgrep \
+            --error \
+            --strict \
+            --timeout 30 \
+            --config semgrep.yaml \
+            --sarif \
+            --output semgrep-results.sarif \
+            .
+          status=$?
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload SARIF results
+        if: >-
+          always() &&
+          hashFiles('semgrep-results.sarif') != '' &&
+          (
+            github.event_name != 'pull_request' ||
+            github.event.pull_request.head.repo.full_name == github.repository
+          )
+        uses: github/codeql-action/upload-sarif@b25d0ebf40e5b63ee81e1bd6e5d2a12b7c2aeb61 # v4
+        with:
+          sarif_file: semgrep-results.sarif
+          category: semgrep-repository-rules
+          wait-for-processing: true
+
+      - name: Fail on repository rule findings
+        if: steps.semgrep.outputs.exit_code != '0'
+        run: exit 1

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -45,6 +45,20 @@ The useful updates ported in this pass are:
   constructors.
 - release documentation describing the no-temporary-tag changelog flow and
   final annotated tag creation from the generated changelog.
+- `scripts/tag_release.py` now normalizes archived changelog paths with
+  `as_posix()` before rendering GitHub URLs, with a regression test that
+  exercises a Windows-style archive path.
+- `just semgrep-test` now discovers all fixtures under `tests/semgrep` by
+  mirroring fixture paths to a temporary Semgrep config tree backed by the
+  repository `semgrep.yaml`, matching the causal-triangulations fixture
+  discovery model.
+- `.github/workflows/rust-clippy.yml` now matches the hardened SARIF pipeline:
+  `set -euo pipefail`, `clippy::cargo`, and guarded upload that skips missing
+  SARIF files and forked pull-request uploads.
+- `.github/workflows/semgrep-sarif.yml` adds the direct repository-rule SARIF
+  workflow used by causal-triangulations, pinned to this repository's current
+  uv version. It complements the Codacy Opengrep workflow by uploading
+  Semgrep-native SARIF and failing the workflow on repository-rule findings.
 
 ## Intentional Differences
 

--- a/justfile
+++ b/justfile
@@ -612,10 +612,23 @@ semgrep: _ensure-uv
 semgrep-test: _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    cd tests/semgrep
-    uv run semgrep scan --test --strict --config ../../semgrep.yaml src/core/algorithms/no_std_hash_collections.rs
-    uv run semgrep scan --test --strict --config ../../semgrep.yaml src/project_rules/rust_style.rs
-    uv run semgrep scan --test --strict --config ../../semgrep.yaml scripts/tests/python_exceptions.py
+    config_dir="$(mktemp -d "${TMPDIR:-/tmp}/delaunay-semgrep-config.XXXXXX")"
+    cleanup() {
+        find "$config_dir" -type l -exec unlink {} \;
+        find "$config_dir" -depth -type d -exec rmdir {} +
+    }
+    trap cleanup EXIT
+
+    # Semgrep directory test mode maps fixture paths to config paths, so mirror
+    # each fixture to the shared config while keeping semgrep.yaml authoritative.
+    while IFS= read -r -d '' fixture; do
+        rel="${fixture#tests/semgrep/}"
+        config_path="$config_dir/${rel%.*}.yaml"
+        mkdir -p "$(dirname "$config_path")"
+        ln -s "$PWD/semgrep.yaml" "$config_path"
+    done < <(find tests/semgrep -type f ! -name '*.fixed' -print0)
+
+    uv run semgrep scan --test --strict --config "$config_dir" tests/semgrep
 
 # Development setup
 setup: setup-tools


### PR DESCRIPTION
Closes #358

- Add a repository-rule Semgrep SARIF workflow for direct Code Scanning uploads.
- Harden Clippy SARIF generation with pipefail, cargo lint coverage, and guarded uploads.
- Discover Semgrep rule fixtures dynamically so new fixtures are tested automatically.
- Document the tooling parity updates ported from causal-triangulations.