### PR TITLE
test: cover fallback rebuild and flip roundtrips

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,6 +282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,12 +552,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -558,6 +595,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -972,15 +1020,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.38.4"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ab6a2f8bfe508deb3c6406578252e491d299cbbf3bc0529ecc3313aee4a52f"
+checksum = "cd9f9fe3d2b7b75cf4f2805e5b9926e8ac47146667b16b86298c4a8bf08cc469"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ criterion = { version = "0.8.2", features = [ "html_reports" ] }
 pastey = "0.2.2"
 proptest = "1.11.0"
 serde_json = "1.0.149"
-sysinfo = "0.38.4" # Process memory monitoring for benchmarks
+sysinfo = "0.39.0" # Process memory monitoring for benchmarks
 tracing-subscriber = { version = "0.3.23", features = [ "env-filter" ] }
 
 [features]

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -7864,6 +7864,7 @@ mod tests {
     use crate::triangulation::delaunay::DelaunayTriangulation;
     use crate::vertex;
     use approx::assert_relative_eq;
+    use proptest::prelude::*;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use slotmap::KeyData;
     use std::{iter::once, sync::Once};
@@ -7923,6 +7924,42 @@ mod tests {
             *coord = 0.11 * idx;
         }
         coords
+    }
+
+    /// Builds a translated and scaled simplex-basis coordinate for proptests.
+    fn translated_scaled_unit_vector<const D: usize>(
+        index: usize,
+        offset: f64,
+        scale: f64,
+    ) -> [f64; D] {
+        let mut coords = [offset; D];
+        coords[index] += scale;
+        coords
+    }
+
+    /// Creates a translated non-axis-aligned point for k=3 flip proptests.
+    fn translated_scaled_skewed_point<const D: usize>(offset: f64, scale: f64) -> [f64; D] {
+        let mut coords = [offset; D];
+        for (i, coord) in coords.iter_mut().enumerate().take(D) {
+            let idx = f64::from(u32::try_from(i + 1).expect("index fits in u32"));
+            *coord += scale * 0.11 * idx;
+        }
+        coords
+    }
+
+    /// Returns inserted-face vertices after verifying the expected flip arity.
+    fn inserted_face_vertices<const D: usize>(
+        info: &FlipInfo<D>,
+        expected: usize,
+    ) -> Result<Vec<VertexKey>, TestCaseError> {
+        let vertices: Vec<_> = info.inserted_face_vertices.iter().copied().collect();
+        if vertices.len() != expected {
+            return Err(TestCaseError::fail(format!(
+                "flip reported {} inserted-face vertices, expected {expected}",
+                vertices.len()
+            )));
+        }
+        Ok(vertices)
     }
 
     fn to_dynamic<const D: usize, const K: usize>(context: FlipContext<D, K>) -> FlipContextDyn<D> {
@@ -9234,6 +9271,316 @@ mod tests {
     }
 
     gen_trial_validation_rollback_tests!(2, 3, 4, 5);
+
+    /// Checks that a k=2 flip and its inverse preserve topology in dimension `D`.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The property fixture keeps k=2 setup, forward flip, inverse flip, and invariant checks together so failing cases shrink with full context."
+    )]
+    fn prop_bistellar_k2_roundtrip_for_dim<const D: usize>(
+        offset: f64,
+        scale: f64,
+    ) -> Result<(), TestCaseError> {
+        init_tracing();
+        let mut tds: Tds<f64, (), (), D> = Tds::empty();
+        let mut shared_vertices = Vec::with_capacity(D);
+        for i in 0..D {
+            let vertex = tds
+                .insert_vertex_with_mapping(vertex!(translated_scaled_unit_vector::<D>(
+                    i, offset, scale
+                )))
+                .map_err(|err| {
+                    TestCaseError::fail(format!("shared vertex insertion failed: {err:?}"))
+                })?;
+            shared_vertices.push(vertex);
+        }
+
+        let opposite_a = tds
+            .insert_vertex_with_mapping(vertex!([offset; D]))
+            .map_err(|err| TestCaseError::fail(format!("opposite A insertion failed: {err:?}")))?;
+        let opposite_b = tds
+            .insert_vertex_with_mapping(vertex!([offset + scale; D]))
+            .map_err(|err| TestCaseError::fail(format!("opposite B insertion failed: {err:?}")))?;
+
+        let mut vertices_with_first_opposite = shared_vertices.clone();
+        vertices_with_first_opposite.push(opposite_a);
+        let cell_a = tds
+            .insert_cell_with_mapping(
+                Cell::new(vertices_with_first_opposite, None).map_err(|err| {
+                    TestCaseError::fail(format!("cell A creation failed: {err:?}"))
+                })?,
+            )
+            .map_err(|err| TestCaseError::fail(format!("cell A insertion failed: {err:?}")))?;
+
+        let mut vertices_with_second_opposite = shared_vertices.clone();
+        vertices_with_second_opposite.push(opposite_b);
+        tds.insert_cell_with_mapping(
+            Cell::new(vertices_with_second_opposite, None)
+                .map_err(|err| TestCaseError::fail(format!("cell B creation failed: {err:?}")))?,
+        )
+        .map_err(|err| TestCaseError::fail(format!("cell B insertion failed: {err:?}")))?;
+
+        repair_neighbor_pointers(&mut tds)
+            .map_err(|err| TestCaseError::fail(format!("neighbor repair failed: {err:?}")))?;
+
+        let before = snapshot_topology(&tds);
+        let facet = FacetHandle::new(
+            cell_a,
+            u8::try_from(D).map_err(|err| {
+                TestCaseError::fail(format!("facet index conversion failed: {err:?}"))
+            })?,
+        );
+        let context = build_k2_flip_context(&tds, facet)
+            .map_err(|err| TestCaseError::fail(format!("k=2 context build failed: {err:?}")))?;
+        let info = apply_bistellar_flip_k2(&mut tds, &context)
+            .map_err(|err| TestCaseError::fail(format!("k=2 flip failed: {err:?}")))?;
+        tds.is_valid()
+            .map_err(|err| TestCaseError::fail(format!("post k=2 TDS invalid: {err:?}")))?;
+
+        if D == 2 {
+            let mut inverse_facet: Option<FacetHandle> = None;
+            for &cell_key in &info.new_cells {
+                let cell = tds
+                    .cell(cell_key)
+                    .ok_or_else(|| TestCaseError::fail("new k=2 cell missing"))?;
+                if cell.contains_vertex(opposite_a) && cell.contains_vertex(opposite_b) {
+                    let facet_index = cell
+                        .vertices()
+                        .iter()
+                        .position(|&vertex| vertex != opposite_a && vertex != opposite_b)
+                        .ok_or_else(|| TestCaseError::fail("missing inverse k=2 facet vertex"))?;
+                    inverse_facet = Some(FacetHandle::new(
+                        cell_key,
+                        u8::try_from(facet_index).map_err(|err| {
+                            TestCaseError::fail(format!(
+                                "inverse facet index conversion failed: {err:?}"
+                            ))
+                        })?,
+                    ));
+                    break;
+                }
+            }
+
+            let facet =
+                inverse_facet.ok_or_else(|| TestCaseError::fail("inverse k=2 facet not found"))?;
+            let context_back = build_k2_flip_context(&tds, facet).map_err(|err| {
+                TestCaseError::fail(format!("inverse k=2 context build failed: {err:?}"))
+            })?;
+            apply_bistellar_flip_k2(&mut tds, &context_back)
+                .map_err(|err| TestCaseError::fail(format!("inverse k=2 flip failed: {err:?}")))?;
+        } else {
+            let inserted = inserted_face_vertices(&info, 2)?;
+            let edge = match inserted.as_slice() {
+                [a, b] => EdgeKey::new(*a, *b),
+                _ => {
+                    return Err(TestCaseError::fail(
+                        "validated k=2 inserted-face arity changed",
+                    ));
+                }
+            };
+            let context_back = build_k2_flip_context_from_edge(&tds, edge).map_err(|err| {
+                TestCaseError::fail(format!("inverse k=2 context build failed: {err:?}"))
+            })?;
+            apply_bistellar_flip_dynamic(&mut tds, D, &context_back)
+                .map_err(|err| TestCaseError::fail(format!("inverse k=2 flip failed: {err:?}")))?;
+        }
+
+        tds.is_valid()
+            .map_err(|err| TestCaseError::fail(format!("post inverse k=2 TDS invalid: {err:?}")))?;
+        let after = snapshot_topology(&tds);
+        prop_assert_eq!(after.vertices, before.vertices);
+        prop_assert_eq!(after.cell_vertices, before.cell_vertices);
+        Ok(())
+    }
+
+    /// Checks that a k=3 flip and its inverse preserve topology in dimension `D`.
+    #[expect(
+        clippy::too_many_lines,
+        reason = "The property fixture keeps k=3 setup, forward flip, inverse flip, and invariant checks together so failing cases shrink with full context."
+    )]
+    fn prop_bistellar_k3_roundtrip_for_dim<const D: usize>(
+        offset: f64,
+        scale: f64,
+    ) -> Result<(), TestCaseError> {
+        init_tracing();
+        let ridge_vertex_count = D
+            .checked_sub(1)
+            .ok_or_else(|| TestCaseError::fail("k=3 fixture requires D >= 1"))?;
+        let mut tds: Tds<f64, (), (), D> = Tds::empty();
+        let mut ridge_vertices = Vec::with_capacity(ridge_vertex_count);
+        for i in 0..ridge_vertex_count {
+            let vertex = tds
+                .insert_vertex_with_mapping(vertex!(translated_scaled_unit_vector::<D>(
+                    i, offset, scale
+                )))
+                .map_err(|err| {
+                    TestCaseError::fail(format!("ridge vertex insertion failed: {err:?}"))
+                })?;
+            ridge_vertices.push(vertex);
+        }
+
+        let a = tds
+            .insert_vertex_with_mapping(vertex!([offset; D]))
+            .map_err(|err| TestCaseError::fail(format!("opposite A insertion failed: {err:?}")))?;
+        let b = tds
+            .insert_vertex_with_mapping(vertex!(translated_scaled_unit_vector::<D>(
+                ridge_vertex_count,
+                offset,
+                scale
+            )))
+            .map_err(|err| TestCaseError::fail(format!("opposite B insertion failed: {err:?}")))?;
+        let c = tds
+            .insert_vertex_with_mapping(vertex!(translated_scaled_skewed_point::<D>(offset, scale)))
+            .map_err(|err| TestCaseError::fail(format!("opposite C insertion failed: {err:?}")))?;
+
+        let mut first_vertices = ridge_vertices.clone();
+        first_vertices.push(a);
+        first_vertices.push(b);
+        let first_cell = tds
+            .insert_cell_with_mapping(
+                Cell::new(first_vertices, None).map_err(|err| {
+                    TestCaseError::fail(format!("cell A creation failed: {err:?}"))
+                })?,
+            )
+            .map_err(|err| TestCaseError::fail(format!("cell A insertion failed: {err:?}")))?;
+
+        let mut second_vertices = ridge_vertices.clone();
+        second_vertices.push(b);
+        second_vertices.push(c);
+        tds.insert_cell_with_mapping(
+            Cell::new(second_vertices, None)
+                .map_err(|err| TestCaseError::fail(format!("cell B creation failed: {err:?}")))?,
+        )
+        .map_err(|err| TestCaseError::fail(format!("cell B insertion failed: {err:?}")))?;
+
+        let mut third_vertices = ridge_vertices.clone();
+        third_vertices.push(c);
+        third_vertices.push(a);
+        tds.insert_cell_with_mapping(
+            Cell::new(third_vertices, None)
+                .map_err(|err| TestCaseError::fail(format!("cell C creation failed: {err:?}")))?,
+        )
+        .map_err(|err| TestCaseError::fail(format!("cell C insertion failed: {err:?}")))?;
+
+        repair_neighbor_pointers(&mut tds)
+            .map_err(|err| TestCaseError::fail(format!("neighbor repair failed: {err:?}")))?;
+
+        let before = snapshot_topology(&tds);
+        let ridge = RidgeHandle::new(
+            first_cell,
+            u8::try_from(ridge_vertex_count).map_err(|err| {
+                TestCaseError::fail(format!("ridge index conversion failed: {err:?}"))
+            })?,
+            u8::try_from(D).map_err(|err| {
+                TestCaseError::fail(format!("ridge index conversion failed: {err:?}"))
+            })?,
+        );
+        let context = build_k3_flip_context(&tds, ridge)
+            .map_err(|err| TestCaseError::fail(format!("k=3 context build failed: {err:?}")))?;
+        let info = apply_bistellar_flip_k3(&mut tds, &context)
+            .map_err(|err| TestCaseError::fail(format!("k=3 flip failed: {err:?}")))?;
+        tds.is_valid()
+            .map_err(|err| TestCaseError::fail(format!("post k=3 TDS invalid: {err:?}")))?;
+
+        if D == 3 {
+            let mut inverse_facet: Option<FacetHandle> = None;
+            for &cell_key in &info.new_cells {
+                let cell = tds
+                    .cell(cell_key)
+                    .ok_or_else(|| TestCaseError::fail("new k=3 cell missing"))?;
+                if cell.contains_vertex(a) && cell.contains_vertex(b) && cell.contains_vertex(c) {
+                    let facet_index = cell
+                        .vertices()
+                        .iter()
+                        .position(|&vertex| vertex != a && vertex != b && vertex != c)
+                        .ok_or_else(|| TestCaseError::fail("missing inverse k=3 facet vertex"))?;
+                    inverse_facet = Some(FacetHandle::new(
+                        cell_key,
+                        u8::try_from(facet_index).map_err(|err| {
+                            TestCaseError::fail(format!(
+                                "inverse facet index conversion failed: {err:?}"
+                            ))
+                        })?,
+                    ));
+                    break;
+                }
+            }
+
+            let facet =
+                inverse_facet.ok_or_else(|| TestCaseError::fail("inverse k=3 facet not found"))?;
+            let context_back = build_k2_flip_context(&tds, facet).map_err(|err| {
+                TestCaseError::fail(format!("inverse k=3 context build failed: {err:?}"))
+            })?;
+            apply_bistellar_flip_k2(&mut tds, &context_back)
+                .map_err(|err| TestCaseError::fail(format!("inverse k=3 flip failed: {err:?}")))?;
+        } else {
+            let inserted = inserted_face_vertices(&info, 3)?;
+            let triangle = match inserted.as_slice() {
+                [a, b, c] => TriangleHandle::new(*a, *b, *c),
+                _ => {
+                    return Err(TestCaseError::fail(
+                        "validated k=3 inserted-face arity changed",
+                    ));
+                }
+            };
+            let context_back =
+                build_k3_flip_context_from_triangle(&tds, triangle).map_err(|err| {
+                    TestCaseError::fail(format!("inverse k=3 context build failed: {err:?}"))
+                })?;
+            apply_bistellar_flip_dynamic(&mut tds, ridge_vertex_count, &context_back)
+                .map_err(|err| TestCaseError::fail(format!("inverse k=3 flip failed: {err:?}")))?;
+        }
+
+        tds.is_valid()
+            .map_err(|err| TestCaseError::fail(format!("post inverse k=3 TDS invalid: {err:?}")))?;
+        let after = snapshot_topology(&tds);
+        prop_assert_eq!(after.vertices, before.vertices);
+        prop_assert_eq!(after.cell_vertices, before.cell_vertices);
+        Ok(())
+    }
+
+    macro_rules! gen_bistellar_k2_roundtrip_properties {
+        ($($dim:literal),+ $(,)?) => {
+            pastey::paste! {
+                $(
+                    proptest! {
+                        #![proptest_config(ProptestConfig::with_cases(16))]
+
+                        #[test]
+                        fn [<prop_bistellar_k2_roundtrip_ $dim d>](
+                            offset in -2.0_f64..2.0,
+                            scale in 0.5_f64..2.0,
+                        ) {
+                            prop_bistellar_k2_roundtrip_for_dim::<$dim>(offset, scale)?;
+                        }
+                    }
+                )+
+            }
+        };
+    }
+
+    macro_rules! gen_bistellar_k3_roundtrip_properties {
+        ($($dim:literal),+ $(,)?) => {
+            pastey::paste! {
+                $(
+                    proptest! {
+                        #![proptest_config(ProptestConfig::with_cases(16))]
+
+                        #[test]
+                        fn [<prop_bistellar_k3_roundtrip_ $dim d>](
+                            offset in -2.0_f64..2.0,
+                            scale in 0.5_f64..2.0,
+                        ) {
+                            prop_bistellar_k3_roundtrip_for_dim::<$dim>(offset, scale)?;
+                        }
+                    }
+                )+
+            }
+        };
+    }
+
+    gen_bistellar_k2_roundtrip_properties!(2, 3, 4, 5);
+    gen_bistellar_k3_roundtrip_properties!(3, 4, 5);
 
     macro_rules! test_bistellar_roundtrip_dimension {
         ($dim:literal) => {

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -9559,6 +9559,18 @@ mod tests {
         };
     }
 
+    /// Exercises the 2D k=2 roundtrip fixture under non-proptest coverage runs.
+    #[test]
+    fn test_bistellar_k2_roundtrip_smoke_2d() {
+        prop_bistellar_k2_roundtrip_for_dim::<2>(0.25, 1.0).unwrap();
+    }
+
+    /// Exercises the higher-dimensional k=2 inverse path under non-proptest coverage runs.
+    #[test]
+    fn test_bistellar_k2_roundtrip_smoke_4d() {
+        prop_bistellar_k2_roundtrip_for_dim::<4>(-0.25, 1.25).unwrap();
+    }
+
     macro_rules! gen_bistellar_k3_roundtrip_properties {
         ($($dim:literal),+ $(,)?) => {
             pastey::paste! {
@@ -9577,6 +9589,18 @@ mod tests {
                 )+
             }
         };
+    }
+
+    /// Exercises the 3D k=3 roundtrip fixture under non-proptest coverage runs.
+    #[test]
+    fn test_bistellar_k3_roundtrip_smoke_3d() {
+        prop_bistellar_k3_roundtrip_for_dim::<3>(0.25, 1.0).unwrap();
+    }
+
+    /// Exercises the higher-dimensional k=3 inverse path under non-proptest coverage runs.
+    #[test]
+    fn test_bistellar_k3_roundtrip_smoke_4d() {
+        prop_bistellar_k3_roundtrip_for_dim::<4>(-0.25, 1.25).unwrap();
     }
 
     gen_bistellar_k2_roundtrip_properties!(2, 3, 4, 5);

--- a/src/geometry/util/circumsphere.rs
+++ b/src/geometry/util/circumsphere.rs
@@ -87,6 +87,7 @@ pub fn circumcenter<T, const D: usize>(
 where
     T: CoordinateScalar,
 {
+    // LCOV_EXCL_START
     #[cfg(debug_assertions)]
     if std::env::var_os("DELAUNAY_DEBUG_UNUSED_IMPORTS").is_some() {
         tracing::debug!(
@@ -95,6 +96,7 @@ where
             D
         );
     }
+    // LCOV_EXCL_STOP
     if points.is_empty() {
         return Err(CircumcenterError::EmptyPointSet);
     }
@@ -162,10 +164,12 @@ where
             // near-singular, so we pay for BigRational Gaussian elimination.
             // This path is cold — well-conditioned simplices return above.
             cold_path();
+            // LCOV_EXCL_START
             #[cfg(debug_assertions)]
             if std::env::var_os("DELAUNAY_DEBUG_LU_FALLBACK").is_some() {
                 tracing::debug!("circumcenter<{D}>: LU near-singular, using solve_exact_f64");
             }
+            // LCOV_EXCL_STOP
 
             a.solve_exact_f64(b_vec)
                 .map_err(|e| CircumcenterError::MatrixInversionFailed {

--- a/src/triangulation/delaunayize.rs
+++ b/src/triangulation/delaunayize.rs
@@ -51,6 +51,8 @@ pub use crate::core::algorithms::pl_manifold_repair::{
 pub use crate::core::cell::CellValidationError;
 pub use crate::triangulation::delaunay::DelaunayTriangulationConstructionError;
 
+#[cfg(test)]
+use crate::core::algorithms::flips::{DelaunayRepairDiagnostics, RepairQueueOrder};
 use crate::core::algorithms::pl_manifold_repair::{
     PlManifoldRepairConfig, repair_facet_oversharing,
 };
@@ -63,6 +65,54 @@ use crate::geometry::kernel::{ExactPredicates, Kernel};
 use crate::geometry::traits::coordinate::CoordinateScalar;
 use crate::triangulation::delaunay::{DelaunayRepairHeuristicConfig, DelaunayTriangulation};
 use thiserror::Error;
+
+#[cfg(test)]
+mod test_hooks {
+    use super::*;
+    use std::cell::Cell as ThreadCell;
+
+    thread_local! {
+        static FORCE_DELAUNAY_REPAIR_FAILURE: ThreadCell<bool> = const { ThreadCell::new(false) };
+    }
+
+    /// Enables or disables a synthetic Delaunay repair failure for branch tests.
+    pub(super) fn set_force_delaunay_repair_failure(enabled: bool) -> bool {
+        FORCE_DELAUNAY_REPAIR_FAILURE.with(|flag| {
+            let prior = flag.get();
+            flag.set(enabled);
+            prior
+        })
+    }
+
+    /// Restores the previous synthetic Delaunay repair failure state.
+    pub(super) fn restore_force_delaunay_repair_failure(prior: bool) {
+        FORCE_DELAUNAY_REPAIR_FAILURE.with(|flag| flag.set(prior));
+    }
+
+    /// Reports whether synthetic Delaunay repair failure is enabled.
+    pub(super) fn force_delaunay_repair_failure_enabled() -> bool {
+        FORCE_DELAUNAY_REPAIR_FAILURE.with(ThreadCell::get)
+    }
+
+    /// Builds the synthetic non-convergence error used by fallback branch tests.
+    pub(super) fn synthetic_repair_error() -> DelaunayRepairError {
+        DelaunayRepairError::NonConvergent {
+            max_flips: 0,
+            diagnostics: Box::new(DelaunayRepairDiagnostics {
+                facets_checked: 1,
+                flips_performed: 0,
+                max_queue_len: 1,
+                ambiguous_predicates: 0,
+                ambiguous_predicate_samples: Vec::new(),
+                predicate_failures: 0,
+                cycle_detections: 0,
+                cycle_signature_samples: Vec::new(),
+                attempt: 1,
+                queue_order: RepairQueueOrder::Fifo,
+            }),
+        }
+    }
+}
 
 // =============================================================================
 // CONFIGURATION
@@ -476,6 +526,27 @@ where
     Ok(rebuilt)
 }
 
+/// Runs the configured Delaunay repair strategy for the delaunayize workflow.
+fn run_configured_delaunay_repair<K, U, V, const D: usize>(
+    dt: &mut DelaunayTriangulation<K, U, V, D>,
+    config: DelaunayizeConfig,
+) -> Result<DelaunayRepairStats, DelaunayRepairError>
+where
+    K: Kernel<D> + ExactPredicates,
+    U: DataType,
+    V: DataType,
+{
+    if let Some(max_flips) = config.delaunay_max_flips {
+        dt.repair_delaunay_with_flips_advanced(DelaunayRepairHeuristicConfig {
+            max_flips: Some(max_flips),
+            ..DelaunayRepairHeuristicConfig::default()
+        })
+        .map(|outcome| outcome.stats)
+    } else {
+        dt.repair_delaunay_with_flips()
+    }
+}
+
 // =============================================================================
 // PUBLIC API
 // =============================================================================
@@ -580,15 +651,14 @@ where
     };
 
     // Step 2: Flip-based Delaunay repair.
-    let delaunay_result = if let Some(max_flips) = config.delaunay_max_flips {
-        dt.repair_delaunay_with_flips_advanced(DelaunayRepairHeuristicConfig {
-            max_flips: Some(max_flips),
-            ..DelaunayRepairHeuristicConfig::default()
-        })
-        .map(|outcome| outcome.stats)
+    #[cfg(test)]
+    let delaunay_result = if test_hooks::force_delaunay_repair_failure_enabled() {
+        Err(test_hooks::synthetic_repair_error())
     } else {
-        dt.repair_delaunay_with_flips()
+        run_configured_delaunay_repair(dt, config)
     };
+    #[cfg(not(test))]
+    let delaunay_result = run_configured_delaunay_repair(dt, config);
 
     match delaunay_result {
         Ok(delaunay_stats) => Ok(DelaunayizeOutcome {
@@ -639,6 +709,8 @@ mod tests {
     use super::*;
     use crate::core::{tds::VertexKey, triangulation::TriangulationConstructionError};
     use crate::geometry::kernel::AdaptiveKernel;
+    use crate::geometry::point::Point;
+    use crate::geometry::traits::coordinate::Coordinate;
     use crate::triangulation::builder::DelaunayTriangulationBuilder;
     use crate::vertex;
     use slotmap::KeyData;
@@ -658,6 +730,74 @@ mod tests {
                 message: "synthetic rebuild degeneracy".to_string(),
             },
         )
+    }
+
+    /// Builds the canonical D-simplex vertex set used by fallback rebuild tests.
+    fn unit_simplex_vertices<const D: usize>() -> Vec<Vertex<f64, (), D>> {
+        let mut points = Vec::with_capacity(D + 1);
+        points.push(Point::new([0.0; D]));
+        for axis in 0..D {
+            let mut coords = [0.0; D];
+            coords[axis] = 1.0;
+            points.push(Point::new(coords));
+        }
+        Vertex::from_points(&points)
+    }
+
+    /// Forces topology repair to fail on duplicate cells, then checks fallback rebuild.
+    fn assert_topology_repair_fallback_rebuilds_duplicate_simplex<const D: usize>() {
+        init_tracing();
+        let vertices = unit_simplex_vertices::<D>();
+        let mut dt: DelaunayTriangulation<_, (), (), D> =
+            DelaunayTriangulation::new(&vertices).unwrap();
+
+        let (_, existing_cell) = dt.cells().next().unwrap();
+        let duplicate_vertices = existing_cell.vertices().to_vec();
+        dt.tri
+            .tds
+            .insert_cell_with_mapping(Cell::new(duplicate_vertices.clone(), None).unwrap())
+            .unwrap();
+        dt.tri
+            .tds
+            .insert_cell_with_mapping(Cell::new(duplicate_vertices, None).unwrap())
+            .unwrap();
+
+        let outcome = delaunayize_by_flips(
+            &mut dt,
+            DelaunayizeConfig {
+                topology_max_cells_removed: 0,
+                fallback_rebuild: true,
+                ..DelaunayizeConfig::default()
+            },
+        )
+        .unwrap();
+
+        assert!(outcome.used_fallback_rebuild);
+        assert!(
+            !outcome.topology_repair.succeeded,
+            "fallback rebuild should not mark the failed topology repair as succeeded"
+        );
+        assert_eq!(dt.number_of_vertices(), vertices.len());
+        assert!(dt.validate().is_ok());
+    }
+
+    struct ForceDelaunayRepairFailureGuard {
+        prior: bool,
+    }
+
+    impl ForceDelaunayRepairFailureGuard {
+        /// Enables synthetic Delaunay repair failure until the guard is dropped.
+        fn enable() -> Self {
+            Self {
+                prior: test_hooks::set_force_delaunay_repair_failure(true),
+            }
+        }
+    }
+
+    impl Drop for ForceDelaunayRepairFailureGuard {
+        fn drop(&mut self) {
+            test_hooks::restore_force_delaunay_repair_failure(self.prior);
+        }
     }
 
     // =============================================================================
@@ -992,44 +1132,78 @@ mod tests {
     }
 
     #[test]
-    fn topology_repair_fallback_stats_failed() {
+    fn delaunay_repair_fallback_rebuilds_after_unsupported_dimension() {
         init_tracing();
-        let vertices = [
-            vertex!([0.0, 0.0]),
-            vertex!([1.0, 0.0]),
-            vertex!([0.0, 1.0]),
-        ];
-        let mut dt: DelaunayTriangulation<_, (), (), 2> =
+        let vertices = [vertex!([0.0]), vertex!([1.0])];
+        let mut dt: DelaunayTriangulation<_, (), (), 1> =
             DelaunayTriangulation::new(&vertices).unwrap();
-
-        let (_, existing_cell) = dt.cells().next().unwrap();
-        let duplicate_vertices = existing_cell.vertices().to_vec();
-        dt.tri
-            .tds
-            .insert_cell_with_mapping(Cell::new(duplicate_vertices.clone(), None).unwrap())
-            .unwrap();
-        dt.tri
-            .tds
-            .insert_cell_with_mapping(Cell::new(duplicate_vertices, None).unwrap())
-            .unwrap();
 
         let outcome = delaunayize_by_flips(
             &mut dt,
             DelaunayizeConfig {
-                topology_max_cells_removed: 0,
                 fallback_rebuild: true,
                 ..DelaunayizeConfig::default()
             },
         )
         .unwrap();
 
+        assert!(outcome.topology_repair.succeeded);
+        assert_eq!(outcome.topology_repair.cells_removed, 0);
+        assert_eq!(outcome.delaunay_repair.facets_checked, 0);
+        assert_eq!(outcome.delaunay_repair.flips_performed, 0);
+        assert_eq!(outcome.delaunay_repair.max_queue_len, 0);
         assert!(outcome.used_fallback_rebuild);
-        assert!(
-            !outcome.topology_repair.succeeded,
-            "fallback rebuild should not mark the failed topology repair as succeeded"
-        );
+        assert_eq!(dt.number_of_vertices(), vertices.len());
+        assert!(dt.tds().is_valid().is_ok());
+    }
+
+    #[test]
+    fn delaunay_repair_fallback_rebuilds_supported_2d_after_repair_failure() {
+        init_tracing();
+        let vertices = [
+            vertex!([0.0, 0.0]),
+            vertex!([1.0, 0.0]),
+            vertex!([0.0, 1.0]),
+            vertex!([1.0, 1.0]),
+        ];
+        let mut dt: DelaunayTriangulation<_, (), (), 2> =
+            DelaunayTriangulation::new(&vertices).unwrap();
+
+        let _guard = ForceDelaunayRepairFailureGuard::enable();
+        let outcome = delaunayize_by_flips(
+            &mut dt,
+            DelaunayizeConfig {
+                fallback_rebuild: true,
+                ..DelaunayizeConfig::default()
+            },
+        )
+        .unwrap();
+
+        assert!(outcome.topology_repair.succeeded);
+        assert!(outcome.used_fallback_rebuild);
+        assert_eq!(dt.number_of_vertices(), vertices.len());
         assert!(dt.validate().is_ok());
     }
+
+    #[test]
+    fn topology_repair_fallback_stats_failed() {
+        assert_topology_repair_fallback_rebuilds_duplicate_simplex::<2>();
+    }
+
+    macro_rules! gen_topology_repair_fallback_tests {
+        ($($dim:literal),* $(,)?) => {
+            pastey::paste! {
+                $(
+                    #[test]
+                    fn [<topology_repair_fallback_rebuilds_duplicate_simplex_ $dim d>]() {
+                        assert_topology_repair_fallback_rebuilds_duplicate_simplex::<$dim>();
+                    }
+                )*
+            }
+        };
+    }
+
+    gen_topology_repair_fallback_tests!(3, 4, 5);
 
     #[test]
     fn test_rebuild_restores_cell_data() {

--- a/tests/proptest_flips.rs
+++ b/tests/proptest_flips.rs
@@ -1,3 +1,5 @@
+#![forbid(unsafe_code)]
+
 //! Property-based tests for public bistellar flip invariants.
 //!
 //! Lower-level k=2/k=3 property fixtures live with `core::algorithms::flips`,
@@ -7,7 +9,9 @@
 //! dimensions 2D-5D.
 
 use ::uuid::Uuid;
-use delaunay::prelude::geometry::{AdaptiveKernel, Coordinate, Point};
+use delaunay::prelude::geometry::{
+    AdaptiveKernel, Coordinate, FastKernel, Kernel, Point, RobustKernel,
+};
 use delaunay::prelude::triangulation::flips::BistellarFlips;
 use delaunay::prelude::triangulation::{
     DelaunayTriangulation, TopologyGuarantee, Triangulation, Vertex,
@@ -23,14 +27,27 @@ struct TopologySnapshot {
 
 /// Generates bounded finite coordinates for stable simplex placement.
 fn finite_coordinate() -> impl Strategy<Value = f64> {
-    (-10.0..10.0).prop_filter("must be finite", |value: &f64| value.is_finite())
+    -10.0..10.0
+}
+
+/// Generates large but exactly finite coordinates for translated simplices.
+fn large_coordinate() -> impl Strategy<Value = f64> {
+    prop_oneof![-1_000_000.0..-1_000.0, 1_000.0..1_000_000.0]
+}
+
+/// Generates coordinates close to the origin boundary.
+fn near_boundary_origin() -> impl Strategy<Value = f64> {
+    -1.0e-9..1.0e-9
 }
 
 /// Generates positive edge lengths that keep test simplices well-conditioned.
 fn well_conditioned_edge_length() -> impl Strategy<Value = f64> {
-    (0.25_f64..10.0).prop_filter("must be finite and positive", |value: &f64| {
-        value.is_finite() && *value > 0.0
-    })
+    0.25_f64..10.0
+}
+
+/// Generates small positive edge lengths that stress near-degenerate simplices.
+fn near_degenerate_edge_length() -> impl Strategy<Value = f64> {
+    1.0e-4_f64..1.0e-2
 }
 
 /// Builds an axis-aligned D-simplex translated by `origin`.
@@ -160,6 +177,69 @@ fn assert_valid<const D: usize>(
     Ok(())
 }
 
+/// Checks positive exact cell orientation and fast/adaptive sign consistency.
+fn assert_positive_cell_orientations<const D: usize>(
+    triangulation: &Triangulation<AdaptiveKernel<f64>, (), (), D>,
+    context: &str,
+) -> Result<(), TestCaseError> {
+    let vertex_points: HashMap<_, _> = triangulation
+        .vertices()
+        .map(|(key, vertex)| (key, *vertex.point()))
+        .collect();
+    let fast_kernel = FastKernel::<f64>::new();
+    let robust_kernel = RobustKernel::<f64>::new();
+    let adaptive_kernel = AdaptiveKernel::<f64>::new();
+
+    for (cell_key, cell) in triangulation.cells() {
+        let mut points = Vec::with_capacity(D + 1);
+        for vertex_key in cell.vertices() {
+            let point = vertex_points.get(vertex_key).copied().ok_or_else(|| {
+                TestCaseError::fail(format!(
+                    "{context}: cell {cell_key:?} references missing vertex key {vertex_key:?}"
+                ))
+            })?;
+            points.push(point);
+        }
+
+        let exact = robust_kernel.orientation(&points).map_err(|err| {
+            TestCaseError::fail(format!(
+                "{context}: exact orientation failed for cell {cell_key:?}: {err:?}"
+            ))
+        })?;
+        let fast = fast_kernel.orientation(&points).map_err(|err| {
+            TestCaseError::fail(format!(
+                "{context}: fast orientation failed for cell {cell_key:?}: {err:?}"
+            ))
+        })?;
+        let adaptive = adaptive_kernel.orientation(&points).map_err(|err| {
+            TestCaseError::fail(format!(
+                "{context}: adaptive/SoS orientation failed for cell {cell_key:?}: {err:?}"
+            ))
+        })?;
+
+        prop_assert!(
+            exact > 0,
+            "{context}: cell {cell_key:?} must have positive non-degenerate exact orientation, got {exact}"
+        );
+        prop_assert_eq!(
+            fast,
+            adaptive,
+            "{}: fast and adaptive/SoS orientation signs disagreed for cell {:?}",
+            context,
+            cell_key,
+        );
+        prop_assert_eq!(
+            exact,
+            adaptive,
+            "{}: exact and adaptive/SoS orientation signs disagreed for cell {:?}",
+            context,
+            cell_key,
+        );
+    }
+
+    Ok(())
+}
+
 /// Verifies a public k=1 flip followed by its inverse is topology-preserving.
 fn check_k1_roundtrip<const D: usize>(
     origin: [f64; D],
@@ -179,6 +259,7 @@ fn check_k1_roundtrip<const D: usize>(
 
     let mut triangulation = simplex.as_triangulation().clone();
     assert_valid(&triangulation, "initial")?;
+    assert_positive_cell_orientations(&triangulation, "before k=1 insertion")?;
     let before = snapshot_topology(&triangulation)?;
     let before_chi = euler_characteristic(&triangulation)?;
 
@@ -193,18 +274,21 @@ fn check_k1_roundtrip<const D: usize>(
     prop_assert!(!inserted.new_cells.is_empty());
     prop_assert_eq!(euler_characteristic(&triangulation)?, before_chi);
     assert_valid(&triangulation, "after k=1 insertion")?;
+    assert_positive_cell_orientations(&triangulation, "after k=1 insertion")?;
 
     let inserted_vertex = inserted
         .inserted_face_vertices
         .first()
         .copied()
         .ok_or_else(|| TestCaseError::fail("k=1 insertion did not report an inserted vertex"))?;
+    assert_positive_cell_orientations(&triangulation, "before inverse k=1 removal")?;
     let removed = triangulation
         .flip_k1_remove(inserted_vertex)
         .map_err(|err| TestCaseError::fail(format!("inverse k=1 removal failed: {err:?}")))?;
     prop_assert!(!removed.removed_cells.is_empty());
     prop_assert_eq!(euler_characteristic(&triangulation)?, before_chi);
     assert_valid(&triangulation, "after inverse k=1 removal")?;
+    assert_positive_cell_orientations(&triangulation, "after inverse k=1 removal")?;
 
     let after = snapshot_topology(&triangulation)?;
     prop_assert_eq!(after, before);
@@ -220,8 +304,20 @@ macro_rules! gen_k1_roundtrip_properties {
 
                     #[test]
                     fn [<prop_k1_flip_roundtrip_preserves_topology_and_euler_ $dim d>](
-                        origin in prop::array::[<uniform $dim>](finite_coordinate()),
-                        edge_lengths in prop::array::[<uniform $dim>](well_conditioned_edge_length())
+                        (origin, edge_lengths) in prop_oneof![
+                            (
+                                prop::array::[<uniform $dim>](finite_coordinate()),
+                                prop::array::[<uniform $dim>](well_conditioned_edge_length()),
+                            ),
+                            (
+                                prop::array::[<uniform $dim>](large_coordinate()),
+                                prop::array::[<uniform $dim>](well_conditioned_edge_length()),
+                            ),
+                            (
+                                prop::array::[<uniform $dim>](near_boundary_origin()),
+                                prop::array::[<uniform $dim>](near_degenerate_edge_length()),
+                            ),
+                        ]
                     ) {
                         check_k1_roundtrip::<$dim>(origin, edge_lengths)?;
                     }

--- a/tests/proptest_flips.rs
+++ b/tests/proptest_flips.rs
@@ -1,0 +1,234 @@
+//! Property-based tests for public bistellar flip invariants.
+//!
+//! Lower-level k=2/k=3 property fixtures live with `core::algorithms::flips`,
+//! where the TDS construction helpers are available. This integration test keeps
+//! the public editing API under property pressure and verifies that k=1
+//! subdivision round-trips preserve topology and Euler characteristic across
+//! dimensions 2D-5D.
+
+use ::uuid::Uuid;
+use delaunay::prelude::geometry::{AdaptiveKernel, Coordinate, Point};
+use delaunay::prelude::triangulation::flips::BistellarFlips;
+use delaunay::prelude::triangulation::{
+    DelaunayTriangulation, TopologyGuarantee, Triangulation, Vertex,
+};
+use proptest::prelude::*;
+use std::collections::{BTreeSet, HashMap};
+
+#[derive(Debug, PartialEq, Eq)]
+struct TopologySnapshot {
+    vertices: Vec<Uuid>,
+    cell_vertices: Vec<Vec<Uuid>>,
+}
+
+/// Generates bounded finite coordinates for stable simplex placement.
+fn finite_coordinate() -> impl Strategy<Value = f64> {
+    (-10.0..10.0).prop_filter("must be finite", |value: &f64| value.is_finite())
+}
+
+/// Generates positive edge lengths that keep test simplices well-conditioned.
+fn well_conditioned_edge_length() -> impl Strategy<Value = f64> {
+    (0.25_f64..10.0).prop_filter("must be finite and positive", |value: &f64| {
+        value.is_finite() && *value > 0.0
+    })
+}
+
+/// Builds an axis-aligned D-simplex translated by `origin`.
+fn axis_aligned_simplex_vertices<const D: usize>(
+    origin: [f64; D],
+    edge_lengths: [f64; D],
+) -> Vec<Vertex<f64, (), D>> {
+    let mut points = Vec::with_capacity(D + 1);
+    points.push(Point::new(origin));
+
+    for (axis, edge_length) in edge_lengths.iter().copied().enumerate() {
+        let mut coordinates = origin;
+        coordinates[axis] += edge_length;
+        points.push(Point::new(coordinates));
+    }
+
+    Vertex::from_points(&points)
+}
+
+/// Places a vertex strictly inside the generated axis-aligned simplex.
+fn interior_simplex_vertex<const D: usize>(
+    origin: [f64; D],
+    edge_lengths: [f64; D],
+) -> Vertex<f64, (), D> {
+    let denominator = f64::from(u32::try_from(D + 1).expect("test dimension fits in u32"));
+    let mut coordinates = origin;
+    for (axis, edge_length) in edge_lengths.iter().copied().enumerate() {
+        coordinates[axis] += edge_length / denominator;
+    }
+    Vertex::from_point(Point::new(coordinates))
+}
+
+/// Captures the public vertex/cell incidence needed to check round-trips.
+fn snapshot_topology<const D: usize>(
+    triangulation: &Triangulation<AdaptiveKernel<f64>, (), (), D>,
+) -> Result<TopologySnapshot, TestCaseError> {
+    let key_to_uuid: HashMap<_, _> = triangulation
+        .vertices()
+        .map(|(key, vertex)| (key, vertex.uuid()))
+        .collect();
+    let mut vertices: Vec<Uuid> = key_to_uuid.values().copied().collect();
+    vertices.sort();
+
+    let mut cell_vertices = Vec::new();
+    for (_, cell) in triangulation.cells() {
+        let mut uuids = Vec::with_capacity(D + 1);
+        for vertex_key in cell.vertices() {
+            let uuid = key_to_uuid.get(vertex_key).copied().ok_or_else(|| {
+                TestCaseError::fail(format!(
+                    "cell references missing vertex key: {vertex_key:?}"
+                ))
+            })?;
+            uuids.push(uuid);
+        }
+        uuids.sort();
+        cell_vertices.push(uuids);
+    }
+    cell_vertices.sort();
+
+    Ok(TopologySnapshot {
+        vertices,
+        cell_vertices,
+    })
+}
+
+/// Recursively records all UUID-simplex combinations of a fixed size.
+fn record_uuid_combinations(
+    vertices: &[Uuid],
+    simplex_size: usize,
+    start: usize,
+    current: &mut Vec<Uuid>,
+    seen: &mut BTreeSet<Vec<Uuid>>,
+) {
+    if current.len() == simplex_size {
+        let mut simplex = current.clone();
+        simplex.sort();
+        seen.insert(simplex);
+        return;
+    }
+
+    for index in start..vertices.len() {
+        current.push(vertices[index]);
+        record_uuid_combinations(vertices, simplex_size, index + 1, current, seen);
+        current.pop();
+    }
+}
+
+/// Computes Euler characteristic from public cell/vertex iterators.
+fn euler_characteristic<const D: usize>(
+    triangulation: &Triangulation<AdaptiveKernel<f64>, (), (), D>,
+) -> Result<isize, TestCaseError> {
+    let cell_vertices = snapshot_topology(triangulation)?.cell_vertices;
+    let mut simplices_by_dim: Vec<BTreeSet<Vec<Uuid>>> = (0..=D).map(|_| BTreeSet::new()).collect();
+
+    for vertices in &cell_vertices {
+        for (simplex_dimension, simplices) in simplices_by_dim.iter_mut().enumerate().take(D + 1) {
+            let mut current = Vec::with_capacity(simplex_dimension + 1);
+            record_uuid_combinations(vertices, simplex_dimension + 1, 0, &mut current, simplices);
+        }
+    }
+
+    let mut chi = 0_isize;
+    for (simplex_dimension, simplices) in simplices_by_dim.iter().enumerate() {
+        let count = isize::try_from(simplices.len())
+            .map_err(|err| TestCaseError::fail(format!("simplex count overflowed: {err:?}")))?;
+        if simplex_dimension % 2 == 0 {
+            chi += count;
+        } else {
+            chi -= count;
+        }
+    }
+
+    Ok(chi)
+}
+
+/// Checks both public topology validation entry points after each edit.
+fn assert_valid<const D: usize>(
+    triangulation: &Triangulation<AdaptiveKernel<f64>, (), (), D>,
+    context: &str,
+) -> Result<(), TestCaseError> {
+    triangulation
+        .is_valid()
+        .map_err(|err| TestCaseError::fail(format!("{context} invariant check failed: {err:?}")))?;
+    triangulation
+        .validate()
+        .map_err(|err| TestCaseError::fail(format!("{context} validation failed: {err:?}")))?;
+    Ok(())
+}
+
+/// Verifies a public k=1 flip followed by its inverse is topology-preserving.
+fn check_k1_roundtrip<const D: usize>(
+    origin: [f64; D],
+    edge_lengths: [f64; D],
+) -> Result<(), TestCaseError> {
+    let vertices = axis_aligned_simplex_vertices::<D>(origin, edge_lengths);
+    let simplex =
+        DelaunayTriangulation::<AdaptiveKernel<f64>, (), (), D>::new_with_topology_guarantee(
+            &vertices,
+            TopologyGuarantee::PLManifold,
+        )
+        .map_err(|err| {
+            TestCaseError::fail(format!(
+                "{D}D axis-aligned simplex construction failed: {err:?}"
+            ))
+        })?;
+
+    let mut triangulation = simplex.as_triangulation().clone();
+    assert_valid(&triangulation, "initial")?;
+    let before = snapshot_topology(&triangulation)?;
+    let before_chi = euler_characteristic(&triangulation)?;
+
+    let cell_key = triangulation
+        .cells()
+        .next()
+        .map(|(key, _)| key)
+        .ok_or_else(|| TestCaseError::fail("constructed simplex should contain one cell"))?;
+    let inserted = triangulation
+        .flip_k1_insert(cell_key, interior_simplex_vertex::<D>(origin, edge_lengths))
+        .map_err(|err| TestCaseError::fail(format!("k=1 insertion failed: {err:?}")))?;
+    prop_assert!(!inserted.new_cells.is_empty());
+    prop_assert_eq!(euler_characteristic(&triangulation)?, before_chi);
+    assert_valid(&triangulation, "after k=1 insertion")?;
+
+    let inserted_vertex = inserted
+        .inserted_face_vertices
+        .first()
+        .copied()
+        .ok_or_else(|| TestCaseError::fail("k=1 insertion did not report an inserted vertex"))?;
+    let removed = triangulation
+        .flip_k1_remove(inserted_vertex)
+        .map_err(|err| TestCaseError::fail(format!("inverse k=1 removal failed: {err:?}")))?;
+    prop_assert!(!removed.removed_cells.is_empty());
+    prop_assert_eq!(euler_characteristic(&triangulation)?, before_chi);
+    assert_valid(&triangulation, "after inverse k=1 removal")?;
+
+    let after = snapshot_topology(&triangulation)?;
+    prop_assert_eq!(after, before);
+    Ok(())
+}
+
+macro_rules! gen_k1_roundtrip_properties {
+    ($($dim:literal),* $(,)?) => {
+        pastey::paste! {
+            $(
+                proptest! {
+                    #![proptest_config(ProptestConfig::with_cases(32))]
+
+                    #[test]
+                    fn [<prop_k1_flip_roundtrip_preserves_topology_and_euler_ $dim d>](
+                        origin in prop::array::[<uniform $dim>](finite_coordinate()),
+                        edge_lengths in prop::array::[<uniform $dim>](well_conditioned_edge_length())
+                    ) {
+                        check_k1_roundtrip::<$dim>(origin, edge_lengths)?;
+                    }
+                }
+            )*
+        }
+    };
+}
+
+gen_k1_roundtrip_properties!(2, 3, 4, 5);

--- a/tests/proptest_geometry.rs
+++ b/tests/proptest_geometry.rs
@@ -3,6 +3,7 @@
 //! This module uses proptest to verify fundamental geometric properties including:
 //! - Circumcenter equidistance (all simplex vertices equidistant from circumcenter)
 //! - Circumradius consistency (distance from circumcenter to any vertex)
+//! - Circumradius agreement between direct and precomputed-center code paths
 //! - Volume positivity for non-degenerate simplices
 //! - Distance and norm properties (triangle inequality, scaling, non-negativity)
 //! - Inradius positivity for non-degenerate simplices
@@ -21,8 +22,30 @@ fn finite_coordinate() -> impl Strategy<Value = f64> {
     (-100.0..100.0).prop_filter("must be finite", |x: &f64| x.is_finite())
 }
 
+fn well_conditioned_edge_length() -> impl Strategy<Value = f64> {
+    (0.25_f64..50.0).prop_filter("must be finite and positive", |x: &f64| {
+        x.is_finite() && *x > 0.0
+    })
+}
+
 fn nonzero_scale() -> impl Strategy<Value = f64> {
     (-90.0_f64..90.0).prop_map(|exponent| 10.0_f64.powf(exponent))
+}
+
+fn axis_aligned_simplex<const D: usize>(
+    base: [f64; D],
+    side_lengths: [f64; D],
+) -> Vec<Point<f64, D>> {
+    let mut simplex = Vec::with_capacity(D + 1);
+    simplex.push(Point::new(base));
+
+    for (axis, side_length) in side_lengths.iter().copied().enumerate() {
+        let mut coords = base;
+        coords[axis] += side_length;
+        simplex.push(Point::new(coords));
+    }
+
+    simplex
 }
 
 fn prop_assert_relative_close(actual: f64, expected: f64) -> Result<(), TestCaseError> {
@@ -92,6 +115,39 @@ macro_rules! test_geometry_properties {
                             prop_assert!((dist - radius).abs() < 1e-6 * radius.max(1.0));
                         }
                     }
+                }
+
+                /// Property: Circumradius agrees between direct and precomputed-center paths
+                #[test]
+                fn [<prop_circumradius_agrees_with_precomputed_center_ $dim d>](
+                    base in prop::array::[<uniform $dim>](finite_coordinate()),
+                    side_lengths in prop::array::[<uniform $dim>](well_conditioned_edge_length())
+                ) {
+                    let simplex = axis_aligned_simplex::<$dim>(base, side_lengths);
+                    let center = circumcenter(&simplex).map_err(|err| {
+                        TestCaseError::fail(format!(
+                            "{dim}D axis-aligned simplex should have a circumcenter: {err:?}",
+                            dim = $dim,
+                        ))
+                    })?;
+                    let direct = circumradius(&simplex).map_err(|err| {
+                        TestCaseError::fail(format!(
+                            "{dim}D axis-aligned simplex should have a direct circumradius: {err:?}",
+                            dim = $dim,
+                        ))
+                    })?;
+                    let with_center = circumradius_with_center(&simplex, &center).map_err(|err| {
+                        TestCaseError::fail(format!(
+                            "{dim}D axis-aligned simplex should have a circumradius from center: {err:?}",
+                            dim = $dim,
+                        ))
+                    })?;
+
+                    prop_assert!(direct.is_finite(), "direct radius must be finite");
+                    prop_assert!(with_center.is_finite(), "precomputed-center radius must be finite");
+                    prop_assert!(direct > 0.0, "direct radius must be positive");
+                    prop_assert!(with_center > 0.0, "precomputed-center radius must be positive");
+                    prop_assert_relative_close(with_center, direct)?;
                 }
 
                 /// Property: Volume of non-degenerate simplex is positive


### PR DESCRIPTION
- Add dimension-generic flip roundtrip properties for public k=1 and internal k=2/k=3 paths.
- Exercise fallback rebuilds after supported Delaunay repair failures and duplicate-simplex topology failures.
- Cover circumradius agreement between direct and precomputed-center paths.
- Exclude debug-only circumsphere logging branches from LCOV.

Fixes #331