### PR TITLE
refactor(core)!: replace public core module with focused facades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
 - Replace public core module with focused facades
+- Route low-level exports through public facades [#388](https://github.com/acgetchell/delaunay/pull/388)
+- Clarify bulk progress counters
 
 ### Merged Pull Requests
 
 - Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
 - Refactor/387 tds mutation boundaries [#390](https://github.com/acgetchell/delaunay/pull/390)
 - Refresh release docs and benchmark guidance [#389](https://github.com/acgetchell/delaunay/pull/389)
+- Route low-level exports through public facades [#388](https://github.com/acgetchell/delaunay/pull/388)
 
 ### Added
 
@@ -42,6 +45,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update downstream-style tests and doctests to stop relying on
     `delaunay::core`.
 
+- [**breaking**] Route low-level exports through public facades [#388](https://github.com/acgetchell/delaunay/pull/388)
+  [`69f4fc3`](https://github.com/acgetchell/delaunay/commit/69f4fc38ad75ade19bfff693d67dee2ea5f99d4f)
+
+  - Move public documentation, doctests, and prelude exports away from the private `crate::core` namespace.
+  - Keep point-location and conflict-region APIs canonical under `delaunay::algorithms` and `delaunay::prelude::algorithms`.
+  - Expose repair, insertion, flip, and validation contracts through the triangulation and TDS facades.
+  - Harden `toml-check` by passing TOML filenames to Python via argv.
+
 ### Documentation
 
 - Refresh release docs and benchmark guidance [#389](https://github.com/acgetchell/delaunay/pull/389)
@@ -59,6 +70,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   - Update generated benchmark-summary guidance to surface `just bench-perf-summary`,
     current Criterion metadata, and large-scale characterization defaults.
+
+### Fixed
+
+- [**breaking**] Clarify bulk progress counters [`393e463`](https://github.com/acgetchell/delaunay/commit/393e4637adf64fd23a7a32c0ec53fbfb2033a5c3)
+
+  - Report the effective batch progress cadence in the large-scale debug harness, including the canonical `DELAUNAY_BULK_PROGRESS_EVERY` fallback behavior.
+  - Rename bulk progress tracing fields so post-initial-simplex counters are distinct from total input and final insertion statistics.
+  - Point public docs and downstream-style API tests at curated low-level modules and construction prelude imports.
+  - Regenerate the changelog so the core facade break appears in Unreleased.
 
 ## [0.7.7] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚠️ Breaking Changes
 
 - Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
+- Replace public core module with focused facades
 
 ### Merged Pull Requests
 
@@ -30,6 +31,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor/387 tds mutation boundaries [#390](https://github.com/acgetchell/delaunay/pull/390)
   [`da30293`](https://github.com/acgetchell/delaunay/commit/da3029302e8484d26d2a88d1291050c332e6b822)
+
+- [**breaking**] Replace public core module with focused facades
+  [`3fc95ea`](https://github.com/acgetchell/delaunay/commit/3fc95ea62325111c927127a48d4fbd39873dabda)
+
+  - Make `crate::core` private and expose low-level APIs through curated
+    `tds`, `collections`, `algorithms`, and `query` modules.
+
+  - Add focused prelude/docs coverage for the new public import paths.
+  - Update downstream-style tests and doctests to stop relying on
+    `delaunay::core`.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### ⚠️ Breaking Changes
+
+- Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
+
+### Merged Pull Requests
+
+- Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
+- Refactor/387 tds mutation boundaries [#390](https://github.com/acgetchell/delaunay/pull/390)
+- Refresh release docs and benchmark guidance [#389](https://github.com/acgetchell/delaunay/pull/389)
+
+### Added
+
+- [**breaking**] Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
+  [`5fb2d4a`](https://github.com/acgetchell/delaunay/commit/5fb2d4a22927231ba3396950cf2bbbc481f69285)
+
+  - Preserve periodic vertex offsets when bistellar flips build replacement cells.
+  - Align external-facet parity checks across periodic cell frames instead of rejecting periodic external cells.
+  - Surface replacement periodic-offset shape and frame conflicts with typed flip-context errors.
+
+### Changed
+
+- Refactor/387 tds mutation boundaries [#390](https://github.com/acgetchell/delaunay/pull/390)
+  [`da30293`](https://github.com/acgetchell/delaunay/commit/da3029302e8484d26d2a88d1291050c332e6b822)
+
+### Documentation
+
+- Refresh release docs and benchmark guidance [#389](https://github.com/acgetchell/delaunay/pull/389)
+  [`526583c`](https://github.com/acgetchell/delaunay/commit/526583c627d32d9336910bce1913b7f458ca413c)
+
+  - Update the README pitch, feature list, references, and docs.rs-facing guidance
+    around exact predicates, SoS, PL-manifold validation, and bistellar repair.
+
+  - Refresh roadmap, release, limitation, robustness, orientation, invariant,
+    diagnostics, property-testing, workflow, and validation docs for the v0.7.8
+    cleanup path and v0.8.0 paper-facing work.
+
+  - Align contributor and script docs around non-mutating `just` checks before
+    mutating fixes.
+
+  - Update generated benchmark-summary guidance to surface `just bench-perf-summary`,
+    current Criterion metadata, and large-scale characterization defaults.
+
 ## [0.7.7] - 2026-05-15
 
 ### ⚠️ Breaking Changes
@@ -3376,6 +3420,7 @@ Older releases are archived by minor series:
 - [0.3.x](docs/archive/changelog/0.3.md)
 - [0.2.x](docs/archive/changelog/0.2.md)
 
+[Unreleased]: https://github.com/acgetchell/delaunay/compare/v0.7.7...HEAD
 [0.7.7]: https://github.com/acgetchell/delaunay/compare/v0.7.6...v0.7.7
 [0.7.6]: https://github.com/acgetchell/delaunay/compare/v0.7.5...v0.7.6
 [0.7.5]: https://github.com/acgetchell/delaunay/compare/v0.7.4...v0.7.5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -714,6 +714,33 @@ Follow the patterns documented in [code organization documentation][code-organiz
 7. Trait implementations
 8. Tests (comprehensive with subsections)
 
+### Public Namespace Policy
+
+`src/core/` is the internal implementation namespace for the low-level TDS and
+algorithm layer. Do not make `crate::core` public or add a broad
+`delaunay::core` facade. The public low-level surface should stay explicit and
+workflow-oriented:
+
+- `delaunay::tds` for cells, facets, vertex keys, TDS validation, and generic
+  triangulation data structures
+- `delaunay::collections` for collection aliases, small buffers, and secondary
+  maps
+- `delaunay::algorithms` for low-level algorithms such as point location and
+  Hilbert ordering
+- `delaunay::query` for read-only traversal, convex hull extraction, boundary
+  analysis, and diagnostics helpers
+
+Expose new low-level APIs through those curated modules and their focused
+preludes when the item is useful to downstream callers. Keep high-level
+Delaunay construction, repair, validation policy, and workflow APIs separate
+from this layer so imports describe the level of abstraction being used.
+
+During pre-1.0 development, breaking import changes are acceptable when they
+improve correctness, orthogonality, or performance. When changing the public
+surface, update the facade modules in `src/lib.rs`, the focused preludes,
+README import guidance, code-organization docs, doctests, and any
+downstream-style integration tests that demonstrate supported imports.
+
 ## Testing
 
 ### Test Categories

--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ intent. The broad `delaunay::prelude::triangulation::*` import is retained for
 compatibility, but new docs and tests should prefer the narrow workflow preludes
 above.
 
+### Low-level imports
+
+`delaunay::core` is an internal implementation namespace. Public low-level APIs
+are exposed through `delaunay::tds`, `delaunay::collections`,
+`delaunay::algorithms`, and `delaunay::query`, plus the matching focused
+preludes. Contributors should follow the namespace policy in
+[CONTRIBUTING.md](CONTRIBUTING.md) and [docs/code_organization.md](docs/code_organization.md).
+
 ```rust
 use delaunay::prelude::triangulation::construction::{
     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -427,6 +427,13 @@ The `benchmark-utils` CLI provides integrated benchmark workflow functionality, 
   - `canonical_points.rs` - Canonical vertex-ordering helpers for geometric predicate call sites (SoS consistency)
 - `operations.rs` - Semantic classification and telemetry for topological operations
 
+Public namespace policy: `crate::core` is the internal implementation namespace
+for the low-level TDS and algorithm layer. The public low-level surface is
+exposed through curated modules and focused preludes (`delaunay::tds`,
+`delaunay::collections`, `delaunay::algorithms`, `delaunay::query`, and their
+`delaunay::prelude::*` counterparts) rather than a broad public
+`delaunay::core` module.
+
 **`src/geometry/`** - Geometric algorithms and predicates:
 
 - `kernel.rs` - Kernel abstraction (`AdaptiveKernel` default, `RobustKernel`, `FastKernel`) and `ExactPredicates` marker trait

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -41,7 +41,7 @@ This matters for large-scale investigations that need to run under
 | Variable | Activation | Module | Description |
 |---|---|---|---|
 | `DELAUNAY_INSERT_TRACE` | presence | `triangulation.rs` | `[release]` Per-insertion summary (vertex index, location, conflict size, suspicion flags) |
-| `DELAUNAY_BULK_PROGRESS_EVERY` | **value** (integer) | `triangulation/delaunay.rs` | `[release]` Periodic batch progress plus retry-boundary output. |
+| `DELAUNAY_BULK_PROGRESS_EVERY` | **value** (integer) | `triangulation/delaunay.rs` | `[release]` Periodic batch progress for post-simplex bulk vertices. |
 | `DELAUNAY_DEBUG_CAVITY_REDUCTION_ONCE` | presence | `triangulation.rs` | `[release]` One-shot trace of first cavity reduction chain + re-extractions. |
 | `DELAUNAY_DEBUG_RETRYABLE_SKIP` | presence | `triangulation.rs` | `[release]` Retryable conflict skip trace with attempt and rollback context. |
 | `DELAUNAY_DEBUG_SHUFFLE` | presence | `triangulation.rs` | Logs vertex shuffle order during batch construction |
@@ -132,7 +132,7 @@ and release builds.
 | `DELAUNAY_LARGE_DEBUG_INITIAL_SIMPLEX` | **value** | Batch initial simplex strategy: `max-volume` (default), `balanced`, or `first` |
 | `DELAUNAY_LARGE_DEBUG_DEBUG_MODE` | **value** | `cadenced` (ridge-link) or `strict` (per-insertion vertex-link) |
 | `DELAUNAY_LARGE_DEBUG_SHUFFLE_SEED` | **value** | Vertex shuffle seed |
-| `DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY` | **value** | Progress logging interval |
+| `DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY` | **value** | Incremental progress interval; batch fallback if the canonical knob is unset |
 | `DELAUNAY_LARGE_DEBUG_VALIDATE_EVERY` | **value** | Validation interval |
 | `DELAUNAY_LARGE_DEBUG_REPAIR_EVERY` | **value** | Batch/incremental repair interval (default: 1) |
 | `DELAUNAY_LARGE_DEBUG_REPAIR_MAX_FLIPS` | **value** | Flip budget override |

--- a/docs/numerical_robustness_guide.md
+++ b/docs/numerical_robustness_guide.md
@@ -315,7 +315,7 @@ See `validate_cell_coordinate_uniqueness` in
 ### User-facing dedup utilities
 
 For explicit preprocessing, the crate provides public deduplication functions in
-`core::util`:
+`delaunay::prelude::triangulation`:
 
 - `dedup_vertices_exact(&[Vertex])` — removes exact coordinate duplicates (O(n²))
 - `dedup_vertices_epsilon(&[Vertex], epsilon)` — removes near-duplicates within

--- a/docs/production_review_remediation_checklist.md
+++ b/docs/production_review_remediation_checklist.md
@@ -102,9 +102,10 @@ Treat partial items as still open until their acceptance notes are satisfied.
 - [ ] **25. Protect `Vertex::incident_cell` mutation.**
   Introduce a checked setter or newtype so invalid incident-cell links are
   harder to construct. Tracked for v0.7.8 in #387.
-- [ ] **26. Revisit public `core` module naming.**
-  Decide whether to keep the shadowing surface, rename it, or hide it behind
-  curated exports. Tracked for v0.7.8 in #388.
+- [x] **26. Revisit public `core` module naming.**
+  Keep `crate::core` as the internal implementation namespace, and expose the
+  public low-level surface through curated modules and focused preludes such as
+  `tds`, `collections`, `algorithms`, and `query`. Tracked for v0.7.8 in #388.
 - [ ] **27. Normalize boxing policy in Delaunay repair error variants.**
   Pick a consistent enum-size and payload strategy. Tracked for v0.7.8 in #384.
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -571,12 +571,12 @@ converge, consider the opt-in heuristic rebuild fallback via
 
 | Level | Method | Module | Complexity |
 |-------|--------|--------|------------|
-| 1 | `Cell::is_valid()` | `core::cell` | O(1) |
-| 1 | `Vertex::is_valid()` | `core::vertex` | O(1) |
-| 2 | `Tds::is_valid()` | `core::tds` | O(N×D²) |
-| 2 | `Tds::validate()` | `core::tds` | O(N×D²) |
-| 3 | `Triangulation::is_valid()` | `core::triangulation` | O(N×D²) |
-| 3 | `Triangulation::validate()` | `core::triangulation` | O(N×D²) |
+| 1 | `Cell::is_valid()` | `tds` | O(1) |
+| 1 | `Vertex::is_valid()` | `tds` | O(1) |
+| 2 | `Tds::is_valid()` | `tds` | O(N×D²) |
+| 2 | `Tds::validate()` | `tds` | O(N×D²) |
+| 3 | `Triangulation::is_valid()` | `triangulation` | O(N×D²) |
+| 3 | `Triangulation::validate()` | `triangulation` | O(N×D²) |
 | 4 | `DelaunayTriangulation::is_valid()` | `triangulation::delaunay` | O(cells) |
 | 4 | `DelaunayTriangulation::validate()` | `triangulation::delaunay` | O(cells × D²) + O(cells) |
 | — | `DelaunayTriangulation::validation_report()` | `triangulation::delaunay` | O(cells × D²) + O(cells) |

--- a/justfile
+++ b/justfile
@@ -951,7 +951,7 @@ toml-check: _ensure-uv
         files+=("$file")
     done < <(git ls-files -z '*.toml')
     if [ "${#files[@]}" -gt 0 ]; then
-        printf '%s\0' "${files[@]}" | xargs -0 -I {} uv run python -c "import sys, tomllib; tomllib.load(open(sys.argv[1], 'rb')); print(f'{sys.argv[1]} is valid TOML')" {}
+        printf '%s\0' "${files[@]}" | xargs -0 -I {} uv run python -c "import sys, tomllib; exec(\"with open(sys.argv[1], 'rb') as f:\\n    tomllib.load(f)\"); print(f'{sys.argv[1]} is valid TOML')" {}
     else
         echo "No TOML files found to check."
     fi

--- a/justfile
+++ b/justfile
@@ -11,6 +11,7 @@ cargo_llvm_cov_version := "0.8.5"
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes benches/examples from reports while allowing integration tests to
 # exercise library code.
+[private]
 _coverage_base_args := '''--ignore-filename-regex '(^|/)(benches|examples)/' \
   --workspace --lib --tests \
   --verbose'''
@@ -25,7 +26,7 @@ _ensure-cargo-llvm-cov:
     set -euo pipefail
     if ! command -v cargo-llvm-cov >/dev/null; then
         echo "❌ 'cargo-llvm-cov' not found. See 'just setup-tools' or install:"
-        echo "   cargo install --locked cargo-llvm-cov --version {{cargo_llvm_cov_version}}"
+        echo "   cargo install --locked cargo-llvm-cov --version {{ cargo_llvm_cov_version }}"
         exit 1
     fi
 
@@ -162,12 +163,12 @@ changelog: _ensure-git-cliff python-sync
     uv run archive-changelog
 
 changelog-tag version:
-    just tag {{version}}
+    just tag {{ version }}
 
 changelog-unreleased version: _ensure-git-cliff python-sync
     #!/usr/bin/env bash
     set -euo pipefail
-    GIT_CLIFF_OFFLINE=true git-cliff --tag {{version}} -o CHANGELOG.md
+    GIT_CLIFF_OFFLINE=true git-cliff --tag {{ version }} -o CHANGELOG.md
     uv run postprocess-changelog
     uv run archive-changelog
 
@@ -192,7 +193,7 @@ ci: check test examples
 # CI followed by an explicit persistent local baseline refresh.
 ci-baseline ref="main":
     just ci
-    just perf-baseline {{ref}}
+    just perf-baseline {{ ref }}
 
 # CI + slow/stress tests (100+ vertices, stress tests)
 ci-slow: ci test-slow
@@ -219,25 +220,25 @@ clippy:
 # Coverage analysis for local development (HTML output)
 coverage: _ensure-cargo-llvm-cov
     mkdir -p target/llvm-cov
-    cargo llvm-cov {{_coverage_base_args}} --html --output-dir target/llvm-cov
+    cargo llvm-cov {{ _coverage_base_args }} --html --output-dir target/llvm-cov
     @echo "📊 Coverage report generated: target/llvm-cov/html/index.html"
 
 # Coverage analysis for CI (XML output for codecov/codacy)
 coverage-ci: _ensure-cargo-llvm-cov
     mkdir -p coverage
-    cargo llvm-cov {{_coverage_base_args}} --cobertura --output-path coverage/cobertura.xml -- --skip prop_
+    cargo llvm-cov {{ _coverage_base_args }} --cobertura --output-path coverage/cobertura.xml -- --skip prop_
 
 debug-large-scale-2d n="36000" repair_every="1":
-    DELAUNAY_BULK_PROGRESS_EVERY=2000 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_2D={{n}} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{repair_every}} cargo test --release --test large_scale_debug debug_large_scale_2d -- --ignored --exact --nocapture
+    DELAUNAY_BULK_PROGRESS_EVERY=2000 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_2D={{ n }} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{ repair_every }} cargo test --release --test large_scale_debug debug_large_scale_2d -- --ignored --exact --nocapture
 
 debug-large-scale-3d n="8000" repair_every="1":
-    DELAUNAY_BULK_PROGRESS_EVERY=500 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_3D={{n}} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{repair_every}} cargo test --release --test large_scale_debug debug_large_scale_3d -- --ignored --exact --nocapture
+    DELAUNAY_BULK_PROGRESS_EVERY=500 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_3D={{ n }} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{ repair_every }} cargo test --release --test large_scale_debug debug_large_scale_3d -- --ignored --exact --nocapture
 
 debug-large-scale-4d n="900" repair_every="1":
-    DELAUNAY_BULK_PROGRESS_EVERY=100 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_4D={{n}} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{repair_every}} cargo test --release --test large_scale_debug debug_large_scale_4d -- --ignored --exact --nocapture
+    DELAUNAY_BULK_PROGRESS_EVERY=100 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_4D={{ n }} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{ repair_every }} cargo test --release --test large_scale_debug debug_large_scale_4d -- --ignored --exact --nocapture
 
 debug-large-scale-5d n="140" repair_every="1":
-    DELAUNAY_BULK_PROGRESS_EVERY=20 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_5D={{n}} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{repair_every}} cargo test --release --test large_scale_debug debug_large_scale_5d -- --ignored --exact --nocapture
+    DELAUNAY_BULK_PROGRESS_EVERY=20 DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=1800 DELAUNAY_LARGE_DEBUG_N_5D={{ n }} DELAUNAY_LARGE_DEBUG_REPAIR_EVERY={{ repair_every }} cargo test --release --test large_scale_debug debug_large_scale_5d -- --ignored --exact --nocapture
 
 # Default recipe shows available commands
 default:
@@ -361,15 +362,15 @@ markdown-lint: markdown-check
 perf-baseline ref="main": _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    uv run benchmark-utils generate-ref-baseline --ref "{{ref}}" --out baseline-artifact --dev
+    uv run benchmark-utils generate-ref-baseline --ref "{{ ref }}" --out baseline-artifact --dev
 
 perf-baseline-to out ref="main": _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    uv run benchmark-utils generate-ref-baseline --ref "{{ref}}" --out "{{out}}" --dev
+    uv run benchmark-utils generate-ref-baseline --ref "{{ ref }}" --out "{{ out }}" --dev
 
 perf-compare file threshold="7.5": _ensure-uv
-    uv run benchmark-utils compare --baseline "{{file}}" --threshold {{threshold}} --dev
+    uv run benchmark-utils compare --baseline "{{ file }}" --threshold {{ threshold }} --dev
 
 perf-help:
     @echo "Performance Analysis Commands:"
@@ -422,7 +423,7 @@ perf-large-scale-smoke max_secs="60":
     #!/usr/bin/env bash
     set -euo pipefail
 
-    max_secs="{{max_secs}}"
+    max_secs="{{ max_secs }}"
     if [[ ! "$max_secs" =~ ^[1-9][0-9]*$ ]]; then
         echo "❌ max_secs must be a positive integer, got: $max_secs" >&2
         exit 2
@@ -471,7 +472,7 @@ perf-large-scale-smoke max_secs="60":
 
 # Fast pre-PR performance guard against a cached same-machine main baseline.
 perf-no-regressions threshold="7.5": _ensure-uv
-    uv run benchmark-utils compare-ref --ref main --threshold {{threshold}} --dev --output benches/worktree_vs_main_compare_results.txt
+    uv run benchmark-utils compare-ref --ref main --threshold {{ threshold }} --dev --output benches/worktree_vs_main_compare_results.txt
 
 # Run the selected CI benchmark suite for one compiler/code pair.
 profile toolchain="" code_ref="current":
@@ -481,8 +482,8 @@ profile toolchain="" code_ref="current":
     command -v rustup >/dev/null || { echo "❌ 'rustup' not found. Install Rust via https://rustup.rs"; exit 1; }
 
     repo_root="$(pwd)"
-    requested_toolchain="{{toolchain}}"
-    requested_ref="{{code_ref}}"
+    requested_toolchain="{{ toolchain }}"
+    requested_ref="{{ code_ref }}"
     workdir="$repo_root"
     cleanup_worktree=0
 
@@ -774,8 +775,8 @@ setup-tools:
     fi
 
     if ! have cargo-llvm-cov; then
-        echo "  ⏳ Installing cargo-llvm-cov {{cargo_llvm_cov_version}} (cargo)..."
-        cargo install --locked cargo-llvm-cov --version {{cargo_llvm_cov_version}}
+        echo "  ⏳ Installing cargo-llvm-cov {{ cargo_llvm_cov_version }} (cargo)..."
+        cargo install --locked cargo-llvm-cov --version {{ cargo_llvm_cov_version }}
     else
         echo "  ✓ cargo-llvm-cov"
     fi
@@ -886,11 +887,11 @@ spell-check: _ensure-typos
 
 # Create an annotated git tag from the CHANGELOG.md section for the given version
 tag version: python-sync
-    uv run tag-release {{version}}
+    uv run tag-release {{ version }}
 
 # Replace an existing annotated tag from the CHANGELOG.md section.
 tag-force version: python-sync
-    uv run tag-release {{version}} --force
+    uv run tag-release {{ version }} --force
 
 # Testing
 # test: runs default-profile benchmark/release compile checks plus all tests.
@@ -950,7 +951,7 @@ toml-check: _ensure-uv
         files+=("$file")
     done < <(git ls-files -z '*.toml')
     if [ "${#files[@]}" -gt 0 ]; then
-        printf '%s\0' "${files[@]}" | xargs -0 -I {} uv run python -c "import tomllib; tomllib.load(open('{}', 'rb')); print('{} is valid TOML')"
+        printf '%s\0' "${files[@]}" | xargs -0 -I {} uv run python -c "import sys, tomllib; tomllib.load(open(sys.argv[1], 'rb')); print(f'{sys.argv[1]} is valid TOML')" {}
     else
         echo "No TOML files found to check."
     fi

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -54,8 +54,6 @@ use crate::triangulation::delaunay::DelaunayTriangulationValidationError;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 
-pub use crate::core::operations::{InsertionOutcome, InsertionResult, InsertionStatistics};
-
 /// Reason for hull extension failure.
 ///
 /// # Examples

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -1332,7 +1332,7 @@ where
 /// assert_eq!(missed, 0);
 /// # }
 /// ```
-#[cfg(any(test, feature = "diagnostics"))]
+#[cfg(any(feature = "diagnostics", all(test, debug_assertions)))]
 #[cfg_attr(docsrs, doc(cfg(feature = "diagnostics")))]
 pub fn verify_conflict_region_completeness<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -71,7 +71,7 @@ fn ridge_fan_dump_enabled() -> bool {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::LocateResult;
+/// use delaunay::prelude::algorithms::LocateResult;
 /// use delaunay::prelude::tds::VertexKey;
 /// use slotmap::KeyData;
 ///
@@ -98,7 +98,7 @@ pub enum LocateResult {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::LocateError;
+/// use delaunay::prelude::algorithms::LocateError;
 ///
 /// let err = LocateError::EmptyTriangulation;
 /// assert!(matches!(err, LocateError::EmptyTriangulation));
@@ -131,7 +131,7 @@ pub enum LocateError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::ConflictError;
+/// use delaunay::prelude::algorithms::ConflictError;
 /// use delaunay::prelude::tds::CellKey;
 /// use slotmap::KeyData;
 ///
@@ -298,7 +298,7 @@ pub enum ConflictError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::{ConflictError, InternalInconsistencySite};
+/// use delaunay::prelude::algorithms::{ConflictError, InternalInconsistencySite};
 ///
 /// let site = InternalInconsistencySite::RidgeFanExtraFacetOutOfBounds {
 ///     index: 7,
@@ -590,7 +590,7 @@ fn collect_ridge_fan_extra_cells(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::LocateFallbackReason;
+/// use delaunay::prelude::algorithms::LocateFallbackReason;
 ///
 /// let reason = LocateFallbackReason::StepLimit;
 /// assert_eq!(reason, LocateFallbackReason::StepLimit);
@@ -608,7 +608,7 @@ pub enum LocateFallbackReason {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::{LocateFallback, LocateFallbackReason};
+/// use delaunay::prelude::algorithms::{LocateFallback, LocateFallbackReason};
 ///
 /// let fallback = LocateFallback {
 ///     reason: LocateFallbackReason::CycleDetected,
@@ -632,7 +632,7 @@ pub struct LocateFallback {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::LocateStats;
+/// use delaunay::prelude::algorithms::LocateStats;
 /// use delaunay::prelude::tds::CellKey;
 /// use slotmap::KeyData;
 ///
@@ -1081,7 +1081,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::{locate, find_conflict_region, LocateResult};
+/// use delaunay::prelude::algorithms::{locate, find_conflict_region, LocateResult};
 /// use delaunay::prelude::DelaunayTriangulation;
 /// use delaunay::prelude::geometry::FastKernel;
 /// use delaunay::prelude::geometry::Point;
@@ -1483,7 +1483,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::extract_cavity_boundary;
+/// use delaunay::prelude::algorithms::extract_cavity_boundary;
 /// use delaunay::prelude::collections::CellKeyBuffer;
 /// use delaunay::prelude::tds::Tds;
 ///
@@ -1494,7 +1494,7 @@ where
 ///
 ///
 /// ```rust
-/// use delaunay::prelude::query::{locate, find_conflict_region, extract_cavity_boundary, LocateResult};
+/// use delaunay::prelude::algorithms::{locate, find_conflict_region, extract_cavity_boundary, LocateResult};
 /// use delaunay::prelude::DelaunayTriangulation;
 /// use delaunay::prelude::geometry::FastKernel;
 /// use delaunay::prelude::geometry::Point;

--- a/src/core/boundary.rs
+++ b/src/core/boundary.rs
@@ -30,7 +30,7 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     /// Any facet shared by 0, 3, or more cells indicates a topological error in the triangulation.
     ///
     /// For a comprehensive discussion of all topological invariants in Delaunay triangulations,
-    /// see the [Topological Invariants](crate::core::tds#topological-invariants)
+    /// see the [Topological Invariants](crate::tds::Tds#topological-invariants)
     /// section in the triangulation data structure documentation.
     ///
     /// # Returns
@@ -66,7 +66,7 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     /// // TDS-level API (fallible): returns `TdsError` on corruption.
     /// let count = dt.tds().boundary_facets()?.count();
     /// assert_eq!(count, 4);
-    /// # Ok::<(), delaunay::core::tds::TdsError>(())
+    /// # Ok::<(), delaunay::tds::TdsError>(())
     /// ```
     fn boundary_facets(&self) -> Result<BoundaryFacetsIter<'_, T, U, V, D>, TdsError> {
         // Build a map from facet keys to the cells that contain them
@@ -202,7 +202,7 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     ///
     /// // A single tetrahedron has 4 boundary facets
     /// assert_eq!(dt.tds().number_of_boundary_facets()?, 4);
-    /// # Ok::<(), delaunay::core::tds::TdsError>(())
+    /// # Ok::<(), delaunay::tds::TdsError>(())
     /// ```
     fn number_of_boundary_facets(&self) -> Result<usize, TdsError> {
         self.build_facet_to_cells_map()

--- a/src/core/traits/facet_cache.rs
+++ b/src/core/traits/facet_cache.rs
@@ -35,6 +35,7 @@ use std::sync::{
 /// ```
 /// use delaunay::prelude::tds::FacetCacheProvider;
 /// use delaunay::prelude::tds::Tds;
+/// use delaunay::prelude::collections::FacetToCellsMap;
 /// use delaunay::prelude::geometry::CoordinateScalar;
 /// use delaunay::prelude::triangulation::DataType;
 /// use std::sync::Arc;
@@ -43,7 +44,7 @@ use std::sync::{
 /// use arc_swap::ArcSwapOption;
 ///
 /// struct MyAlgorithm {
-///     facet_to_cells_cache: ArcSwapOption<delaunay::core::collections::FacetToCellsMap>,
+///     facet_to_cells_cache: ArcSwapOption<FacetToCellsMap>,
 ///     cached_generation: AtomicU64,
 /// }
 ///
@@ -62,7 +63,7 @@ use std::sync::{
 ///     U: DataType,
 ///     V: DataType,
 /// {
-///     fn facet_cache(&self) -> &ArcSwapOption<delaunay::core::collections::FacetToCellsMap> {
+///     fn facet_cache(&self) -> &ArcSwapOption<FacetToCellsMap> {
 ///         &self.facet_to_cells_cache
 ///     }
 ///     
@@ -333,9 +334,9 @@ where
 mod tests {
     use super::*;
     use crate::core::tds::Tds;
-    use crate::core::vertex;
     use crate::geometry::kernel::AdaptiveKernel;
     use crate::triangulation::delaunay::DelaunayTriangulation;
+    use crate::vertex;
     use std::sync::Arc;
     use std::sync::Barrier;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -572,11 +572,11 @@ macro_rules! assert_jaccard_gte {
         let threshold = $threshold;
 
         // Use jaccard_index function for safety and consistency
-        let jaccard_index = $crate::core::util::jaccard_index(a_ref, b_ref)
+        let jaccard_index = $crate::query::jaccard_index(a_ref, b_ref)
             .expect("Jaccard computation should not overflow for reasonable test sets");
 
         if jaccard_index < threshold {
-            let report = $crate::core::util::format_jaccard_report(
+            let report = $crate::query::format_jaccard_report(
                 a_ref,
                 b_ref,
                 "Set A",

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -238,7 +238,7 @@ impl<T, U, const D: usize> VertexBuilder<T, U, D> {
 macro_rules! vertex {
     // Pattern 1: Just coordinates - no data (defaults to ())
     ($coords:expr) => {
-        $crate::core::vertex::VertexBuilder::<_, (), _>::default()
+        $crate::prelude::triangulation::construction::VertexBuilder::<_, (), _>::default()
             .point($crate::geometry::point::Point::try_from($coords)
                 .expect("Failed to convert coordinates to Point: invalid or out-of-range values"))
             .build()
@@ -247,7 +247,7 @@ macro_rules! vertex {
 
     // Pattern 2: Coordinates with data
     ($coords:expr, $data:expr) => {
-        $crate::core::vertex::VertexBuilder::default()
+        $crate::prelude::triangulation::construction::VertexBuilder::default()
             .point($crate::geometry::point::Point::try_from($coords)
                 .expect("Failed to convert coordinates to Point: invalid or out-of-range values"))
             .data($data)

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -238,7 +238,7 @@ impl<T, U, const D: usize> VertexBuilder<T, U, D> {
 macro_rules! vertex {
     // Pattern 1: Just coordinates - no data (defaults to ())
     ($coords:expr) => {
-        $crate::prelude::triangulation::construction::VertexBuilder::<_, (), _>::default()
+        $crate::tds::VertexBuilder::<_, (), _>::default()
             .point($crate::geometry::point::Point::try_from($coords)
                 .expect("Failed to convert coordinates to Point: invalid or out-of-range values"))
             .build()
@@ -247,7 +247,7 @@ macro_rules! vertex {
 
     // Pattern 2: Coordinates with data
     ($coords:expr, $data:expr) => {
-        $crate::prelude::triangulation::construction::VertexBuilder::default()
+        $crate::tds::VertexBuilder::default()
             .point($crate::geometry::point::Point::try_from($coords)
                 .expect("Failed to convert coordinates to Point: invalid or out-of-range values"))
             .data($data)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,8 @@
 //!
 //! ## Public low-level namespace policy
 //!
-//! The implementation namespace remains `crate::core`, but the public
-//! low-level surface is exposed through curated modules:
+//! The low-level implementation namespace is private. The public low-level
+//! surface is exposed through curated modules:
 //! [`tds`](crate::tds), [`collections`](crate::collections),
 //! [`algorithms`](crate::algorithms), and [`query`](crate::query), plus the
 //! matching focused preludes. These names describe the data structures and
@@ -181,18 +181,18 @@
 //! The crate is organized as a small **validation stack**, where each layer adds additional
 //! invariants on top of the preceding one:
 //!
-//! - [`Vertex`](crate::core::vertex::Vertex) and [`Cell`](crate::core::cell::Cell) provide
+//! - [`Vertex`](crate::tds::Vertex) and [`Cell`](crate::tds::Cell) provide
 //!   **element validity** checks.
 //!   Level 1 (elements) validation checks invariants such as:
 //!   - **Vertex coordinates** – finite (no NaN/∞) and UUID is non-nil.
 //!   - **Cell shape** – exactly D+1 distinct vertex keys, valid UUID, and neighbor buffer length
 //!     (if present) is D+1.
 //!
-//!   These checks are surfaced via [`Vertex::is_valid`](crate::core::vertex::Vertex::is_valid) and
-//!   [`Cell::is_valid`](crate::core::cell::Cell::is_valid), and are automatically run by
-//!   [`Tds::validate`](crate::core::tds::Tds::validate) (Levels 1–2).
+//!   These checks are surfaced via [`Vertex::is_valid`](crate::tds::Vertex::is_valid) and
+//!   [`Cell::is_valid`](crate::tds::Cell::is_valid), and are automatically run by
+//!   [`Tds::validate`](crate::tds::Tds::validate) (Levels 1–2).
 //!
-//! - [`Tds`](crate::core::tds::Tds) (Triangulation Data Structure)
+//! - [`Tds`](crate::tds::Tds) (Triangulation Data Structure)
 //!   stores the **combinatorial / structural** representation.
 //!   Level 2 (structural) validation checks invariants such as:
 //!   - **Vertex mappings** – every vertex UUID has a corresponding key and vice versa.
@@ -201,16 +201,16 @@
 //!   - **Facet sharing** – each facet is shared by at most 2 cells (1 on the boundary, 2 in the interior).
 //!   - **Neighbor consistency** – neighbor relationships are mutual and reference a shared facet.
 //!
-//!   These checks are surfaced via [`Tds::is_valid`](crate::core::tds::Tds::is_valid)
-//!   (structural only) and [`Tds::validate`](crate::core::tds::Tds::validate)
+//!   These checks are surfaced via [`Tds::is_valid`](crate::tds::Tds::is_valid)
+//!   (structural only) and [`Tds::validate`](crate::tds::Tds::validate)
 //!   (Levels 1–2, elements + structural). For cumulative diagnostics across the full stack,
 //!   use [`DelaunayTriangulation::validation_report`](triangulation::delaunay::DelaunayTriangulation::validation_report).
 //!
-//! - [`Triangulation`](crate::core::triangulation::Triangulation) builds on the TDS and validates
+//! - [`Triangulation`](crate::triangulation::Triangulation) builds on the TDS and validates
 //!   **manifold topology**.
 //!   Level 3 (topology) validation is performed by
-//!   [`Triangulation::is_valid`](crate::core::triangulation::Triangulation::is_valid) (Level 3 only) and
-//!   [`Triangulation::validate`](crate::core::triangulation::Triangulation::validate) (Levels 1–3), which:
+//!   [`Triangulation::is_valid`](crate::triangulation::Triangulation::is_valid) (Level 3 only) and
+//!   [`Triangulation::validate`](crate::triangulation::Triangulation::validate) (Levels 1–3), which:
 //!   - Strengthens facet sharing to the **manifold facet property**: each facet belongs to
 //!     exactly 1 cell (boundary) or exactly 2 cells (interior).
 //!   - Checks the **Euler characteristic** of the triangulation (using the topology module).
@@ -245,9 +245,9 @@
 //!
 //! In addition to explicit validation calls, incremental construction (`new()` / `insert*()`) can run an
 //! automatic **Level 3** topology validation pass after insertion, controlled by
-//! [`ValidationPolicy`](crate::core::triangulation::ValidationPolicy).
+//! [`ValidationPolicy`](crate::prelude::triangulation::validation::ValidationPolicy).
 //!
-//! The default is [`ValidationPolicy::OnSuspicion`](crate::core::triangulation::ValidationPolicy::OnSuspicion):
+//! The default is [`ValidationPolicy::OnSuspicion`](crate::prelude::triangulation::validation::ValidationPolicy::OnSuspicion):
 //! Level 3 validation runs only when insertion takes a suspicious path (e.g. perturbation retries,
 //! repair loops, or neighbor-pointer repairs that actually changed pointers).
 //!
@@ -294,20 +294,20 @@
 //! definitions and rationale live in `docs/invariants.md`.
 //!
 //! Level 3 topology validation is parameterized by
-//! [`TopologyGuarantee`](crate::core::triangulation::TopologyGuarantee). This is separate from
+//! [`TopologyGuarantee`](crate::prelude::triangulation::construction::TopologyGuarantee). This is separate from
 //! `ValidationPolicy`: it controls *what* invariants Level 3 enforces, not *when* automatic
 //! validation runs.
 //!
-//! - [`TopologyGuarantee::PLManifold`](crate::core::triangulation::TopologyGuarantee::PLManifold)
+//! - [`TopologyGuarantee::PLManifold`](crate::prelude::triangulation::construction::TopologyGuarantee::PLManifold)
 //!   (default): enforces manifold facet degree, boundary closure, connectedness, Euler characteristic,
 //!   and link-based manifold conditions. Ridge-link checks are applied incrementally during insertion,
 //!   with vertex-link validation performed at construction completion.
 //!
 //!   The formal topological definitions, link conditions, and rationale for this validation strategy
 //!   are documented in `docs/invariants.md`.
-//! - [`TopologyGuarantee::PLManifoldStrict`](crate::core::triangulation::TopologyGuarantee::PLManifoldStrict):
+//! - [`TopologyGuarantee::PLManifoldStrict`](crate::prelude::triangulation::construction::TopologyGuarantee::PLManifoldStrict):
 //!   vertex-link validation after every insertion (slowest, maximum safety).
-//! - [`TopologyGuarantee::Pseudomanifold`](crate::core::triangulation::TopologyGuarantee::Pseudomanifold):
+//! - [`TopologyGuarantee::Pseudomanifold`](crate::prelude::triangulation::construction::TopologyGuarantee::Pseudomanifold):
 //!   skips vertex-link validation (may be faster), but bistellar flip convergence is not guaranteed and
 //!   you may want to validate the Delaunay property explicitly for near-degenerate inputs.
 //!
@@ -363,9 +363,9 @@
 //!   previous state.
 //! - **Duplicate detection**: Near-duplicate coordinates are rejected using a scale-aware
 //!   Euclidean tolerance based on nearby geometry and floating-point resolution, returning
-//!   [`InsertionError::DuplicateCoordinates`](core::algorithms::incremental_insertion::InsertionError::DuplicateCoordinates).
+//!   [`InsertionError::DuplicateCoordinates`](crate::prelude::triangulation::insertion::InsertionError::DuplicateCoordinates).
 //!   Duplicate UUIDs return
-//!   [`InsertionError::DuplicateUuid`](core::algorithms::incremental_insertion::InsertionError::DuplicateUuid).
+//!   [`InsertionError::DuplicateUuid`](crate::prelude::triangulation::insertion::InsertionError::DuplicateUuid).
 //! - **Explicit verification**: Use `dt.validate()` for cumulative verification (Levels 1–4), or
 //!   `dt.is_valid()` for Level 4 only.
 
@@ -382,10 +382,10 @@
 /// Internal low-level triangulation data structures and algorithms.
 ///
 /// This module backs the curated public low-level modules. It includes
-/// [`Tds`](crate::core::tds::Tds), [`Cell`](crate::core::cell::Cell),
-/// [`FacetView`](crate::core::facet::FacetView),
-/// [`Vertex`](crate::core::vertex::Vertex), the generic
-/// [`Triangulation`](crate::core::triangulation::Triangulation) wrapper, and
+/// [`Tds`](crate::tds::Tds), [`Cell`](crate::tds::Cell),
+/// [`FacetView`](crate::tds::FacetView),
+/// [`Vertex`](crate::tds::Vertex), the generic
+/// [`Triangulation`](crate::triangulation::Triangulation) wrapper, and
 /// algorithm building blocks used by the crate.
 ///
 /// Public docs, examples, benchmarks, and downstream-style tests should prefer
@@ -461,8 +461,8 @@ mod core {
     /// - Using user-provided keys without validation
     /// - Network-facing applications with external input
     ///
-    /// Use [`SecureHashMap`](crate::core::collections::SecureHashMap) or
-    /// [`SecureHashSet`](crate::core::collections::SecureHashSet) when keys
+    /// Use [`SecureHashMap`](crate::collections::SecureHashMap) or
+    /// [`SecureHashSet`](crate::collections::SecureHashSet) when keys
     /// are derived from public input.
     ///
     /// ## Small Collections
@@ -1321,8 +1321,8 @@ pub mod prelude {
         /// exports for callers that need small by-value diagnostics instead of full insertion
         /// error payloads.
         ///
-        /// [`InsertionErrorSummary`]: crate::core::algorithms::incremental_insertion::InsertionErrorSummary
-        /// [`InsertionErrorKind`]: crate::core::algorithms::incremental_insertion::InsertionErrorKind
+        /// [`InsertionErrorSummary`]: crate::prelude::triangulation::insertion::InsertionErrorSummary
+        /// [`InsertionErrorKind`]: crate::prelude::triangulation::insertion::InsertionErrorKind
         pub mod insertion {
             pub use crate::core::algorithms::incremental_insertion::{
                 CavityFillingError, CavityRepairStage, DelaunayRepairErrorKind,
@@ -1352,8 +1352,8 @@ pub mod prelude {
         /// exports for APIs that need repair categories without retaining full repair
         /// diagnostics.
         ///
-        /// [`DelaunayRepairErrorSummary`]: crate::core::algorithms::incremental_insertion::DelaunayRepairErrorSummary
-        /// [`DelaunayRepairErrorKind`]: crate::core::algorithms::incremental_insertion::DelaunayRepairErrorKind
+        /// [`DelaunayRepairErrorSummary`]: crate::prelude::triangulation::repair::DelaunayRepairErrorSummary
+        /// [`DelaunayRepairErrorKind`]: crate::prelude::triangulation::repair::DelaunayRepairErrorKind
         pub mod repair {
             pub use crate::core::algorithms::flips::{
                 DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,6 +68,20 @@
 //! | Legacy broad triangulation import | `use delaunay::prelude::triangulation::*` |
 //! | Everything (kitchen sink) | `use delaunay::prelude::*` |
 //!
+//! ## Public low-level namespace policy
+//!
+//! The implementation namespace remains `crate::core`, but the public
+//! low-level surface is exposed through curated modules:
+//! [`tds`](crate::tds), [`collections`](crate::collections),
+//! [`algorithms`](crate::algorithms), and [`query`](crate::query), plus the
+//! matching focused preludes. These names describe the data structures and
+//! workflows users compose without colliding with Rust's standard `core`
+//! vocabulary.
+//!
+//! Prefer these curated modules and focused preludes in examples, doctests,
+//! benchmarks, and downstream-style integration tests. High-level Delaunay
+//! construction remains outside the low-level TDS/query surface.
+//!
 //! ## Examples (contract-oriented)
 //!
 //! ### Validation hierarchy (Levels 1–4)
@@ -339,7 +353,8 @@
 //! # }
 //! ```
 //!
-//! For implementation details on invariant enforcement, see [`core::algorithms::incremental_insertion`].
+//! For implementation details on invariant enforcement, see the incremental
+//! insertion implementation.
 //!
 //! # Programming contract (high-level)
 //!
@@ -364,20 +379,35 @@
 // Forbid unsafe code throughout the entire crate
 #![forbid(unsafe_code)]
 
-/// The `core` module contains the primary data structures and algorithms for
-/// building and manipulating triangulations.
+/// Internal low-level triangulation data structures and algorithms.
 ///
-/// It includes the [`Tds`](crate::core::tds::Tds) struct, which represents the
-/// triangulation data structure, as well as [`Cell`](crate::core::cell::Cell),
-/// [`FacetView`](crate::core::facet::FacetView), and
-/// [`Vertex`](crate::core::vertex::Vertex) components. High-level Delaunay
-/// construction and builder APIs live under [`crate::triangulation`] and the
-/// focused preludes, not under `core`.
+/// This module backs the curated public low-level modules. It includes
+/// [`Tds`](crate::core::tds::Tds), [`Cell`](crate::core::cell::Cell),
+/// [`FacetView`](crate::core::facet::FacetView),
+/// [`Vertex`](crate::core::vertex::Vertex), the generic
+/// [`Triangulation`](crate::core::triangulation::Triangulation) wrapper, and
+/// algorithm building blocks used by the crate.
 ///
-/// ```compile_fail
-/// delaunay::core::DelaunayTriangulation::empty();
-/// ```
-pub mod core {
+/// Public docs, examples, benchmarks, and downstream-style tests should prefer
+/// the curated public modules and focused preludes:
+///
+/// - [`crate::tds`] / [`crate::prelude::tds`] for TDS cells, facets, keys,
+///   validation reports, and helpers.
+/// - [`crate::collections`] / [`crate::prelude::collections`] for public
+///   collection aliases and small buffers.
+/// - [`crate::algorithms`] / [`crate::prelude::algorithms`] for point-location
+///   and conflict-region algorithms.
+/// - [`crate::query`] / [`crate::prelude::query`] for read-only traversal,
+///   adjacency, convex hull, and set-comparison helpers.
+///
+/// High-level Delaunay construction and builder APIs live under
+/// [`crate::triangulation`] and the focused Delaunay-facing preludes, not under
+/// `core`.
+#[expect(
+    clippy::redundant_pub_crate,
+    reason = "`pub(crate)` keeps internal cross-module intent visible while `core` is private"
+)]
+mod core {
     /// Triangulation algorithms for construction, maintenance, and querying.
     pub mod algorithms {
         /// Flip-based algorithms (Delaunay repair, diagnostics, and related utilities).
@@ -556,21 +586,12 @@ pub mod core {
         pub mod facet_cache;
         pub use boundary_analysis::*;
         pub use data_type::*;
-        pub use facet_cache::*;
     }
 
-    // Re-export the low-level `core` modules.
-    pub use adjacency::*;
-    pub use cell::*;
-    pub use edge::*;
-    pub use facet::*;
-    pub use tds::*;
-    pub use traits::*;
-    pub use util::*;
-    pub use vertex::*;
-
-    // Note: collections module not re-exported here to avoid namespace pollution
-    // Import specific types via prelude or use crate::core::collections::
+    // Import concrete internal modules directly via `crate::core::<module>`.
+    // Public low-level access is exposed through crate-root facades such as
+    // `crate::tds`, `crate::collections`, `crate::algorithms`, and
+    // `crate::query`.
 }
 
 /// Contains geometric types including the `Point` struct and geometry predicates.
@@ -955,6 +976,174 @@ pub mod topology {
     pub use traits::*;
 }
 
+/// Public collection aliases and small-buffer types used by low-level APIs.
+///
+/// This module is the public replacement for reaching through the internal
+/// implementation namespace. It keeps common map, set, key-map, and
+/// small-buffer aliases convenient without importing every algorithm-specific
+/// scratch buffer.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::collections::{FastHashMap, SmallBuffer};
+///
+/// let mut counts: FastHashMap<&'static str, usize> = FastHashMap::default();
+/// counts.insert("cells", 3);
+///
+/// let mut scratch: SmallBuffer<usize, 4> = SmallBuffer::new();
+/// scratch.push(counts["cells"]);
+///
+/// assert_eq!(scratch.as_slice(), &[3]);
+/// ```
+pub mod collections {
+    pub use crate::core::collections::{
+        CellKeyBuffer, CellKeySet, CellNeighborsMap, CellSecondaryMap, CellToVertexUuidsMap,
+        CellVertexBuffer, CellVertexKeysMap, CellVertexUuidBuffer, CellVerticesMap, Entry,
+        FacetIndex, FacetIssuesMap, FacetSharingCellsBuffer, FacetToCellsMap, FacetVertexMap,
+        FastBuildHasher, FastHashMap, FastHashSet, FastHasher, KeyBasedCellMap, KeyBasedVertexMap,
+        MAX_PRACTICAL_DIMENSION_SIZE, NeighborBuffer, PeriodicOffsetBuffer, SecureHashMap,
+        SecureHashSet, SimplexVertexBuffer, SmallBuffer, Uuid, UuidToCellKeyMap,
+        UuidToVertexKeyMap, VertexKeyBuffer, VertexKeySet, VertexSecondaryMap, VertexToCellsMap,
+        VertexUuidBuffer, VertexUuidSet, fast_hash_map_with_capacity, fast_hash_set_with_capacity,
+        small_buffer_with_capacity_2, small_buffer_with_capacity_8, small_buffer_with_capacity_16,
+    };
+
+    /// Expert aliases for algorithm-local scratch buffers.
+    ///
+    /// These remain public for advanced users and APIs that expose exact buffer
+    /// shapes, but they are separated from the common collection aliases to
+    /// avoid accidental broad imports.
+    pub mod algorithm_buffers {
+        pub use crate::core::collections::{
+            BadCellBuffer, CLEANUP_OPERATION_BUFFER_SIZE, CavityBoundaryBuffer, CellRemovalBuffer,
+            FacetInfoBuffer, GeometricPointBuffer, PointBuffer, ValidCellsBuffer, ViolationBuffer,
+        };
+    }
+}
+
+/// Public low-level topology data structures and TDS helpers.
+///
+/// Use this module when you need cells, facets, keys, the
+/// [`Tds`](crate::tds::Tds) container, validation reports, or TDS-specific
+/// helpers without reaching into the internal implementation namespace.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::tds::Tds;
+///
+/// let tds: Tds<f64, (), (), 2> = Tds::empty();
+///
+/// assert_eq!(tds.number_of_vertices(), 0);
+/// assert_eq!(tds.number_of_cells(), 0);
+/// ```
+pub mod tds {
+    pub use crate::core::adjacency::*;
+    pub use crate::core::cell::*;
+    pub use crate::core::collections::{
+        CellKeyBuffer, FacetIndex, FastHashMap, FastHashSet, NeighborBuffer, PeriodicOffsetBuffer,
+        SmallBuffer, Uuid,
+    };
+    pub use crate::core::edge::*;
+    pub use crate::core::facet::*;
+    pub use crate::core::tds::*;
+    pub use crate::core::traits::facet_cache::*;
+    pub use crate::core::util::{
+        UuidValidationError, checked_facet_key_from_vertex_keys, facet_view_to_vertices,
+        facet_views_are_adjacent, format_jaccard_report, jaccard_distance, jaccard_index,
+        make_uuid, measure_with_result, stable_hash_u64_slice, usize_to_u8, validate_uuid,
+        verify_facet_index_consistency,
+    };
+    pub use crate::core::vertex::*;
+}
+
+/// Public low-level algorithms that are useful outside full construction.
+///
+/// This module currently exposes point-location and conflict-region building
+/// blocks. Higher-level Delaunay construction, repair, and editing APIs remain
+/// under [`triangulation`] and the matching focused preludes.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::algorithms::{LocateError, locate};
+/// use delaunay::prelude::geometry::{AdaptiveKernel, Coordinate, Point};
+/// use delaunay::tds::Tds;
+///
+/// let tds: Tds<f64, (), (), 2> = Tds::empty();
+/// let kernel = AdaptiveKernel::new();
+/// let point = Point::new([0.0, 0.0]);
+///
+/// assert!(matches!(
+///     locate(&tds, &kernel, &point, None),
+///     Err(LocateError::EmptyTriangulation)
+/// ));
+/// ```
+pub mod algorithms {
+    pub use crate::core::algorithms::locate::{
+        ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
+        LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
+        find_conflict_region, locate, locate_with_stats,
+    };
+}
+
+/// Public read-only traversal, adjacency, convex-hull, and set-comparison APIs.
+///
+/// This module is intended for callers who need to inspect a triangulation or
+/// compare derived topology without importing construction and repair surfaces.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::collections::HashSet;
+///
+/// use delaunay::query::{JaccardComputationError, jaccard_index};
+///
+/// # fn main() -> Result<(), JaccardComputationError> {
+/// let a: HashSet<_> = [1, 2, 3].into_iter().collect();
+/// let b: HashSet<_> = [3, 4].into_iter().collect();
+///
+/// let score = jaccard_index(&a, &b)?;
+/// assert!((score - 0.25).abs() < 1e-12);
+/// # Ok(())
+/// # }
+/// ```
+pub mod query {
+    pub use crate::assert_jaccard_gte;
+    pub use crate::core::adjacency::{AdjacencyIndex, AdjacencyIndexBuildError};
+    pub use crate::core::algorithms::locate::{
+        ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
+        LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
+        find_conflict_region, locate, locate_with_stats,
+    };
+    pub use crate::core::cell::Cell;
+    pub use crate::core::edge::EdgeKey;
+    pub use crate::core::facet::FacetView;
+    pub use crate::core::tds::{CellKey, VertexKey};
+    pub use crate::core::traits::boundary_analysis::BoundaryAnalysis;
+    pub use crate::core::traits::data_type::{
+        DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde, DataSerialize, DataType,
+    };
+    pub use crate::core::triangulation::Triangulation;
+    pub use crate::core::util::{
+        JaccardComputationError, extract_edge_set, extract_facet_identifier_set,
+        extract_hull_facet_set, extract_vertex_coordinate_set, format_jaccard_report,
+        jaccard_distance, jaccard_index, measure_with_result,
+    };
+    pub use crate::core::vertex::Vertex;
+    pub use crate::geometry::Point;
+    pub use crate::geometry::algorithms::convex_hull::{
+        ConvexHull, ConvexHullConstructionError, ConvexHullValidationError,
+    };
+    pub use crate::geometry::kernel::{
+        AdaptiveKernel, ExactPredicates, FastKernel, Kernel, RobustKernel,
+    };
+    pub use crate::geometry::traits::coordinate::Coordinate;
+    pub use crate::geometry::{insphere, insphere_distance, insphere_lifted};
+    pub use crate::triangulation::delaunay::DelaunayTriangulation;
+}
+
 /// A prelude module that re-exports commonly used types and macros.
 /// This makes it easier to import the most commonly used items from the crate.
 pub mod prelude {
@@ -1251,7 +1440,7 @@ pub mod prelude {
     ///
     /// This prelude keeps common map, set, key-map, and small-buffer aliases
     /// convenient without importing every algorithm-specific scratch buffer.
-    /// Expert-only buffers remain available from [`crate::core::collections`]
+    /// Expert-only buffers remain available from [`crate::collections`]
     /// or the nested [`crate::prelude::collections::algorithm_buffers`] module.
     ///
     /// ```compile_fail
@@ -1286,6 +1475,17 @@ pub mod prelude {
     }
 
     /// Focused exports for low-level topology data structures.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::tds::Tds;
+    ///
+    /// let tds: Tds<f64, (), (), 2> = Tds::empty();
+    ///
+    /// assert_eq!(tds.number_of_vertices(), 0);
+    /// assert_eq!(tds.number_of_cells(), 0);
+    /// ```
     pub mod tds {
         pub use crate::core::adjacency::*;
         pub use crate::core::cell::*;
@@ -1339,6 +1539,23 @@ pub mod prelude {
     }
 
     /// Focused exports for core algorithms.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::algorithms::{LocateError, locate};
+    /// use delaunay::prelude::geometry::{AdaptiveKernel, Coordinate, Point};
+    /// use delaunay::prelude::tds::Tds;
+    ///
+    /// let tds: Tds<f64, (), (), 2> = Tds::empty();
+    /// let kernel = AdaptiveKernel::new();
+    /// let point = Point::new([0.0, 0.0]);
+    ///
+    /// assert!(matches!(
+    ///     locate(&tds, &kernel, &point, None),
+    ///     Err(LocateError::EmptyTriangulation)
+    /// ));
+    /// ```
     pub mod algorithms {
         pub use crate::core::algorithms::locate::{
             ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
@@ -1352,6 +1569,14 @@ pub mod prelude {
     /// These helpers are compiled only with the `diagnostics` feature because
     /// they are intended for explicit debugging and verification workflows, not
     /// the default public API surface.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::diagnostics::NeighborSlot;
+    ///
+    /// assert!(NeighborSlot::Boundary.is_boundary());
+    /// ```
     #[cfg(feature = "diagnostics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "diagnostics")))]
     pub mod diagnostics {
@@ -1376,6 +1601,23 @@ pub mod prelude {
     /// - Zero-allocation geometry accessors: [`DelaunayTriangulation::vertex_coords`],
     ///   [`DelaunayTriangulation::cell_vertices`]
     /// - Convex hull extraction: [`ConvexHull::from_triangulation`]
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::collections::HashSet;
+    ///
+    /// use delaunay::prelude::query::{JaccardComputationError, jaccard_index};
+    ///
+    /// # fn main() -> Result<(), JaccardComputationError> {
+    /// let a: HashSet<_> = [1, 2, 3].into_iter().collect();
+    /// let b: HashSet<_> = [3, 4].into_iter().collect();
+    ///
+    /// let score = jaccard_index(&a, &b)?;
+    /// assert!((score - 0.25).abs() < 1e-12);
+    /// # Ok(())
+    /// # }
+    /// ```
     pub mod query {
         // Core read-only traversal / adjacency
         pub use crate::core::adjacency::{AdjacencyIndex, AdjacencyIndexBuildError};
@@ -1392,12 +1634,13 @@ pub mod prelude {
         };
 
         // Common input/output types (kept intentionally small)
+        pub use crate::core::cell::Cell;
         pub use crate::core::facet::FacetView;
         pub use crate::core::traits::boundary_analysis::BoundaryAnalysis;
         pub use crate::core::traits::data_type::{
             DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde, DataSerialize, DataType,
         };
-        pub use crate::core::{Cell, Vertex};
+        pub use crate::core::vertex::Vertex;
         pub use crate::geometry::Point;
         pub use crate::geometry::kernel::{
             AdaptiveKernel, ExactPredicates, FastKernel, Kernel, RobustKernel,
@@ -1421,7 +1664,7 @@ pub mod prelude {
         // Instrumentation helpers (no-op unless features enable extra tracking)
         pub use crate::core::util::measure_with_result;
 
-        // Convenience macro (commonly used in docs/tests/examples) without importing full `prelude::*`.
+        // Fixture construction macro used by query doctests, examples, and benchmarks.
         pub use crate::vertex;
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,7 +565,7 @@ mod core {
         pub mod measurement;
         pub mod uuid;
 
-        // Re-export public items for ergonomic `crate::core::util::*` access.
+        // Re-export utility internals within the private core namespace.
         pub use deduplication::*;
         pub use delaunay_validation::*;
         pub use facet_keys::*;
@@ -840,7 +840,7 @@ pub mod geometry {
         pub enum SurfaceMeasureError {
             /// Error retrieving vertices from a facet.
             #[error("Failed to retrieve facet vertices: {0}")]
-            FacetError(#[from] crate::core::facet::FacetError),
+            FacetError(#[from] crate::tds::FacetError),
             /// Error computing geometry measure.
             #[error("Geometry computation failed: {0}")]
             GeometryError(#[from] CircumcenterError),
@@ -967,7 +967,7 @@ pub mod topology {
     }
 
     // Re-export commonly used types
-    pub use crate::core::triangulation::TopologyGuarantee;
+    pub use crate::triangulation::TopologyGuarantee;
     pub use characteristics::*;
     pub use manifold::{
         ManifoldError, validate_closed_boundary, validate_facet_degree, validate_ridge_links,
@@ -1081,6 +1081,8 @@ pub mod tds {
 /// ));
 /// ```
 pub mod algorithms {
+    #[cfg(any(feature = "diagnostics", all(test, debug_assertions)))]
+    pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
     pub use crate::core::algorithms::locate::{
         ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
         LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
@@ -1111,27 +1113,15 @@ pub mod algorithms {
 /// ```
 pub mod query {
     pub use crate::assert_jaccard_gte;
-    pub use crate::core::adjacency::{AdjacencyIndex, AdjacencyIndexBuildError};
-    pub use crate::core::algorithms::locate::{
-        ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
-        LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
-        find_conflict_region, locate, locate_with_stats,
-    };
-    pub use crate::core::cell::Cell;
-    pub use crate::core::edge::EdgeKey;
-    pub use crate::core::facet::FacetView;
-    pub use crate::core::tds::{CellKey, VertexKey};
     pub use crate::core::traits::boundary_analysis::BoundaryAnalysis;
     pub use crate::core::traits::data_type::{
         DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde, DataSerialize, DataType,
     };
-    pub use crate::core::triangulation::Triangulation;
     pub use crate::core::util::{
         JaccardComputationError, extract_edge_set, extract_facet_identifier_set,
         extract_hull_facet_set, extract_vertex_coordinate_set, format_jaccard_report,
         jaccard_distance, jaccard_index, measure_with_result,
     };
-    pub use crate::core::vertex::Vertex;
     pub use crate::geometry::Point;
     pub use crate::geometry::algorithms::convex_hull::{
         ConvexHull, ConvexHullConstructionError, ConvexHullValidationError,
@@ -1141,63 +1131,76 @@ pub mod query {
     };
     pub use crate::geometry::traits::coordinate::Coordinate;
     pub use crate::geometry::{insphere, insphere_distance, insphere_lifted};
+    pub use crate::tds::{
+        AdjacencyIndex, AdjacencyIndexBuildError, Cell, CellKey, EdgeKey, FacetView, Vertex,
+        VertexKey,
+    };
+    pub use crate::triangulation::Triangulation;
     pub use crate::triangulation::delaunay::DelaunayTriangulation;
 }
 
 /// A prelude module that re-exports commonly used types and macros.
 /// This makes it easier to import the most commonly used items from the crate.
 pub mod prelude {
-    // Re-export from core
-    pub use crate::core::{
-        adjacency::*,
-        cell::*,
-        edge::*,
-        facet::*,
-        tds::*,
-        traits::{boundary_analysis::*, data_type::*},
-        triangulation::*,
-        vertex::*,
+    // Re-export the public low-level facades.
+    pub use crate::query::{
+        BoundaryAnalysis, DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde,
+        DataSerialize, DataType,
     };
+    pub use crate::tds::*;
     pub use crate::triangulation::delaunay::*;
+    pub use crate::triangulation::*;
 
     // Re-export utility items, but avoid exporting the util module names themselves.
     //
-    // In particular, exporting `core::util::uuid` as `uuid` conflicts with the external `uuid`
+    // In particular, exporting a local `uuid` module conflicts with the external `uuid`
     // crate name, making `use uuid::Uuid;` ambiguous for downstream users.
-    pub use crate::core::util::delaunay_validation::{
-        DelaunayValidationError, find_delaunay_violations,
+    pub use self::ordering::{
+        HilbertError, hilbert_index, hilbert_indices_prequantized, hilbert_quantize,
+        hilbert_sort_by_stable, hilbert_sort_by_unstable, hilbert_sorted_indices,
     };
-    pub use crate::core::util::{
-        deduplication::*, facet_keys::*, facet_utils::*, hashing::*, hilbert::*, jaccard::*,
-        measurement::*, uuid::*,
+    pub use self::triangulation::repair::{DelaunayValidationError, find_delaunay_violations};
+    pub use self::triangulation::{
+        DeduplicationError, dedup_vertices_epsilon, dedup_vertices_exact,
+        filter_vertices_excluding, try_dedup_vertices_epsilon,
+    };
+    pub use crate::query::{
+        JaccardComputationError, extract_edge_set, extract_facet_identifier_set,
+        extract_hull_facet_set, extract_vertex_coordinate_set, format_jaccard_report,
+        jaccard_distance, jaccard_index, measure_with_result,
+    };
+    pub use crate::tds::{
+        UuidValidationError, checked_facet_key_from_vertex_keys, facet_view_to_vertices,
+        facet_views_are_adjacent, make_uuid, stable_hash_u64_slice, usize_to_u8, validate_uuid,
+        verify_facet_index_consistency,
     };
 
-    // Re-export point location algorithms from core::algorithms
-    pub use crate::core::algorithms::locate::{
+    // Re-export point location algorithms from the public algorithms facade.
+    pub use crate::algorithms::{
         ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
         LocateFallbackReason, LocateResult, LocateStats, locate, locate_with_stats,
     };
 
     // Re-export incremental insertion types
-    pub use crate::core::algorithms::incremental_insertion::{
+    pub use crate::triangulation::{
         CavityFillingError, CavityRepairStage, DelaunayRepairErrorKind, DelaunayRepairErrorSummary,
         DelaunayRepairFailureContext, HullExtensionReason, InitialSimplexConstructionError,
         InsertionError, InsertionErrorKind, InsertionErrorSourceKind, InsertionErrorSummary,
         NeighborRebuildError, NeighborWiringError, TdsConstructionFailure, TdsValidationFailure,
     };
-    pub use crate::core::operations::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
+    pub use crate::triangulation::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
 
     // Re-export diagnostic types for scientific analysis of construction and repair
-    pub use crate::core::algorithms::flips::{
+    pub use crate::triangulation::flips::{
         DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats,
         DelaunayRepairVerificationContext, FlipContextError, FlipEdgeAdjacencyError, FlipError,
         FlipMutationError, FlipNeighborWiringError, FlipPredicateError, FlipPredicateOperation,
         FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RepairQueueOrder,
     };
 
-    // Re-export commonly used collection types from core::collections
+    // Re-export commonly used collection types from the public collections facade.
     // These are frequently used in advanced examples and downstream code
-    pub use crate::core::collections::{
+    pub use crate::collections::{
         CellNeighborsMap, CellSecondaryMap, FacetToCellsMap, FastHashMap, FastHashSet,
         SecureHashMap, SecureHashSet, SmallBuffer, VertexSecondaryMap, VertexToCellsMap,
         fast_hash_map_with_capacity, fast_hash_set_with_capacity,
@@ -1211,23 +1214,25 @@ pub mod prelude {
 
     /// Focused exports for triangulation construction and mutation.
     pub mod triangulation {
-        pub use crate::core::operations::{InsertionOutcome, InsertionStatistics, SuspicionFlags};
-        pub use crate::core::traits::data_type::{
+        pub use crate::core::util::{
+            DeduplicationError, dedup_vertices_epsilon, dedup_vertices_exact,
+            filter_vertices_excluding, try_dedup_vertices_epsilon,
+        };
+        pub use crate::query::{
             DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde, DataSerialize, DataType,
         };
-        pub use crate::core::triangulation::{
-            DuplicateDetectionMetrics, TopologyGuarantee, Triangulation,
-            TriangulationConstructionError, TriangulationValidationError, ValidationPolicy,
-        };
-        pub use crate::core::util::{
-            dedup_vertices_epsilon, dedup_vertices_exact, filter_vertices_excluding,
-        };
-        pub use crate::core::vertex::{
-            Vertex, VertexBuilder, VertexBuilderError, VertexValidationError,
-        };
+        pub use crate::tds::{Vertex, VertexBuilder, VertexBuilderError, VertexValidationError};
         pub use crate::topology::traits::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
         pub use crate::triangulation::builder::*;
         pub use crate::triangulation::delaunay::*;
+        pub use crate::triangulation::{
+            DuplicateDetectionMetrics, TopologyGuarantee, Triangulation,
+            TriangulationConstructionError, TriangulationValidationError, ValidationPolicy,
+        };
+        pub use crate::triangulation::{
+            InsertionOutcome, InsertionStatistics, RepairDecision, RepairSkipReason,
+            SuspicionFlags, TopologicalOperation,
+        };
 
         /// Batch construction options, builders, and construction errors.
         ///
@@ -1256,10 +1261,7 @@ pub mod prelude {
         /// # }
         /// ```
         pub mod construction {
-            pub use crate::core::triangulation::{
-                TopologyGuarantee, Triangulation, TriangulationConstructionError,
-            };
-            pub use crate::core::vertex::{
+            pub use crate::tds::{
                 Vertex, VertexBuilder, VertexBuilderError, VertexValidationError,
             };
             pub use crate::topology::traits::{
@@ -1280,6 +1282,9 @@ pub mod prelude {
                 DelaunayTriangulationConstructionErrorWithStatistics, InitialSimplexStrategy,
                 InsertionOrderStrategy, RetryPolicy,
             };
+            pub use crate::triangulation::{
+                TopologyGuarantee, Triangulation, TriangulationConstructionError,
+            };
             // Convenience macro (commonly used in docs/examples).
             pub use crate::vertex;
         }
@@ -1294,11 +1299,18 @@ pub mod prelude {
         /// ```
         ///
         pub mod flips {
-            pub use crate::core::algorithms::flips::{BistellarMove, ConstK};
-            pub use crate::core::collections::{
+            pub use crate::collections::{
                 CellKeyBuffer, MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer,
             };
-            pub use crate::core::tds::{CellKey, VertexKey};
+            pub use crate::tds::{CellKey, EdgeKey, FacetHandle, VertexKey};
+            pub use crate::triangulation::delaunay::DelaunayTriangulation;
+            pub use crate::triangulation::flips::{
+                BistellarFlipKind, BistellarFlips, FlipContextError, FlipDirection,
+                FlipEdgeAdjacencyError, FlipError, FlipInfo, FlipMutationError,
+                FlipNeighborWiringError, FlipPredicateError, FlipPredicateOperation,
+                FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RidgeHandle, TriangleHandle,
+            };
+            pub use crate::triangulation::flips::{BistellarMove, ConstK};
             #[deprecated(
                 since = "0.7.7",
                 note = "import TopologyGuarantee from delaunay::prelude::triangulation or delaunay::prelude::triangulation::repair"
@@ -1306,10 +1318,7 @@ pub mod prelude {
             /// Deprecated compatibility re-export; prefer
             /// [`crate::prelude::triangulation::TopologyGuarantee`] or
             /// [`crate::prelude::triangulation::repair::TopologyGuarantee`].
-            pub use crate::core::triangulation::TopologyGuarantee;
-            pub use crate::core::triangulation::Triangulation;
-            pub use crate::triangulation::delaunay::DelaunayTriangulation;
-            pub use crate::triangulation::flips::*;
+            pub use crate::triangulation::{TopologyGuarantee, Triangulation};
 
             // Convenience macro (commonly used in docs/examples).
             pub use crate::vertex;
@@ -1324,7 +1333,10 @@ pub mod prelude {
         /// [`InsertionErrorSummary`]: crate::prelude::triangulation::insertion::InsertionErrorSummary
         /// [`InsertionErrorKind`]: crate::prelude::triangulation::insertion::InsertionErrorKind
         pub mod insertion {
-            pub use crate::core::algorithms::incremental_insertion::{
+            pub use crate::collections::CellKeyBuffer;
+            pub use crate::tds::FacetHandle;
+            pub use crate::tds::{CellKey, Tds, TdsMutationError, VertexKey};
+            pub use crate::triangulation::{
                 CavityFillingError, CavityRepairStage, DelaunayRepairErrorKind,
                 DelaunayRepairErrorSummary, DelaunayRepairFailureContext, HullExtensionReason,
                 InitialSimplexConstructionError, InsertionError, InsertionErrorKind,
@@ -1333,17 +1345,17 @@ pub mod prelude {
                 fill_cavity, repair_neighbor_pointers, repair_neighbor_pointers_local,
                 wire_cavity_neighbors,
             };
-            pub use crate::core::collections::CellKeyBuffer;
-            pub use crate::core::facet::FacetHandle;
-            pub use crate::core::operations::{
+            pub use crate::triangulation::{
                 InsertionOutcome, InsertionResult, InsertionStatistics,
             };
-            pub use crate::core::tds::{CellKey, Tds, TdsMutationError, VertexKey};
         }
 
         /// Topological operation telemetry and repair decisions.
         pub mod operations {
-            pub use crate::core::operations::*;
+            pub use crate::triangulation::{
+                InsertionOutcome, InsertionResult, InsertionStatistics, RepairDecision,
+                RepairSkipReason, SuspicionFlags, TopologicalOperation,
+            };
         }
 
         /// Flip-based Delaunay repair, diagnostics, and Level 4 validation.
@@ -1355,7 +1367,12 @@ pub mod prelude {
         /// [`DelaunayRepairErrorSummary`]: crate::prelude::triangulation::repair::DelaunayRepairErrorSummary
         /// [`DelaunayRepairErrorKind`]: crate::prelude::triangulation::repair::DelaunayRepairErrorKind
         pub mod repair {
-            pub use crate::core::algorithms::flips::{
+            pub use crate::triangulation::delaunay::{
+                DelaunayCheckPolicy, DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds,
+                DelaunayRepairOperation, DelaunayRepairOutcome, DelaunayRepairPolicy,
+                DelaunayTriangulation, DelaunayTriangulationValidationError,
+            };
+            pub use crate::triangulation::flips::{
                 DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats,
                 DelaunayRepairVerificationContext, FlipContextError, FlipEdgeAdjacencyError,
                 FlipError, FlipMutationError, FlipNeighborWiringError, FlipPredicateError,
@@ -1363,18 +1380,9 @@ pub mod prelude {
                 RepairQueueOrder, verify_delaunay_for_triangulation,
                 verify_delaunay_via_flip_predicates,
             };
-            pub use crate::core::algorithms::incremental_insertion::{
-                DelaunayRepairErrorKind, DelaunayRepairErrorSummary,
-            };
-            pub use crate::core::triangulation::{
-                TopologyGuarantee, Triangulation, ValidationPolicy,
-            };
-            pub use crate::core::util::{DelaunayValidationError, find_delaunay_violations};
-            pub use crate::triangulation::delaunay::{
-                DelaunayCheckPolicy, DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds,
-                DelaunayRepairOperation, DelaunayRepairOutcome, DelaunayRepairPolicy,
-                DelaunayTriangulation, DelaunayTriangulationValidationError,
-            };
+            pub use crate::triangulation::{DelaunayRepairErrorKind, DelaunayRepairErrorSummary};
+            pub use crate::triangulation::{DelaunayValidationError, find_delaunay_violations};
+            pub use crate::triangulation::{TopologyGuarantee, Triangulation, ValidationPolicy};
         }
 
         /// End-to-end "repair then delaunayize" workflow.
@@ -1383,11 +1391,9 @@ pub mod prelude {
         /// import brings in [`DelaunayTriangulation`], [`vertex!`], and all
         /// delaunayize-specific types.
         pub mod delaunayize {
-            pub use crate::core::algorithms::pl_manifold_repair::{
-                PlManifoldRepairError, PlManifoldRepairStats,
-            };
             pub use crate::triangulation::delaunay::DelaunayTriangulation;
             pub use crate::triangulation::delaunayize::*;
+            pub use crate::triangulation::{PlManifoldRepairError, PlManifoldRepairStats};
 
             // Convenience macro (commonly used in docs/examples).
             pub use crate::vertex;
@@ -1421,12 +1427,12 @@ pub mod prelude {
         /// assert!(cadence.should_validate(32));
         /// ```
         pub mod validation {
-            pub use crate::core::triangulation::{TriangulationValidationError, ValidationPolicy};
             pub use crate::triangulation::delaunay::DelaunayTriangulationValidationError;
             pub use crate::triangulation::validation::*;
+            pub use crate::triangulation::{TriangulationValidationError, ValidationPolicy};
         }
 
-        pub use crate::core::algorithms::incremental_insertion::{
+        pub use crate::triangulation::{
             CavityFillingError, CavityRepairStage, DelaunayRepairErrorKind,
             DelaunayRepairErrorSummary, DelaunayRepairFailureContext, HullExtensionReason,
             InsertionError, InsertionErrorKind, InsertionErrorSourceKind, InsertionErrorSummary,
@@ -1447,7 +1453,7 @@ pub mod prelude {
     /// use delaunay::prelude::collections::CellRemovalBuffer;
     /// ```
     pub mod collections {
-        pub use crate::core::collections::{
+        pub use crate::collections::{
             CellKeyBuffer, CellKeySet, CellNeighborsMap, CellSecondaryMap, CellToVertexUuidsMap,
             CellVertexBuffer, CellVertexKeysMap, CellVertexUuidBuffer, CellVerticesMap, Entry,
             FacetIndex, FacetIssuesMap, FacetSharingCellsBuffer, FacetToCellsMap, FastBuildHasher,
@@ -1466,7 +1472,7 @@ pub mod prelude {
         /// exact buffer shapes, but they are separated from the common
         /// collections prelude to avoid accidental broad imports.
         pub mod algorithm_buffers {
-            pub use crate::core::collections::{
+            pub use crate::collections::algorithm_buffers::{
                 BadCellBuffer, CLEANUP_OPERATION_BUFFER_SIZE, CavityBoundaryBuffer,
                 CellRemovalBuffer, FacetInfoBuffer, GeometricPointBuffer, PointBuffer,
                 ValidCellsBuffer, ViolationBuffer,
@@ -1487,23 +1493,11 @@ pub mod prelude {
     /// assert_eq!(tds.number_of_cells(), 0);
     /// ```
     pub mod tds {
-        pub use crate::core::adjacency::*;
-        pub use crate::core::cell::*;
-        pub use crate::core::collections::{
+        pub use crate::collections::{
             CellKeyBuffer, FacetIndex, FastHashMap, FastHashSet, NeighborBuffer,
             PeriodicOffsetBuffer, SmallBuffer, Uuid,
         };
-        pub use crate::core::edge::*;
-        pub use crate::core::facet::*;
-        pub use crate::core::tds::*;
-        pub use crate::core::traits::facet_cache::*;
-        pub use crate::core::util::{
-            UuidValidationError, checked_facet_key_from_vertex_keys, facet_view_to_vertices,
-            facet_views_are_adjacent, format_jaccard_report, jaccard_distance, jaccard_index,
-            make_uuid, measure_with_result, stable_hash_u64_slice, usize_to_u8, validate_uuid,
-            verify_facet_index_consistency,
-        };
-        pub use crate::core::vertex::*;
+        pub use crate::tds::*;
     }
 
     /// Focused exports for geometry types, predicates, and helpers.
@@ -1557,7 +1551,7 @@ pub mod prelude {
     /// ));
     /// ```
     pub mod algorithms {
-        pub use crate::core::algorithms::locate::{
+        pub use crate::algorithms::{
             ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
             LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
             find_conflict_region, locate, locate_with_stats,
@@ -1580,9 +1574,9 @@ pub mod prelude {
     #[cfg(feature = "diagnostics")]
     #[cfg_attr(docsrs, doc(cfg(feature = "diagnostics")))]
     pub mod diagnostics {
-        pub use crate::core::algorithms::locate::verify_conflict_region_completeness;
-        pub use crate::core::cell::NeighborSlot;
-        pub use crate::core::util::{
+        pub use crate::algorithms::verify_conflict_region_completeness;
+        pub use crate::tds::NeighborSlot;
+        pub use crate::triangulation::{
             DelaunayViolationDetail, DelaunayViolationReport, debug_print_first_delaunay_violation,
             delaunay_violation_report,
         };
@@ -1620,49 +1614,39 @@ pub mod prelude {
     /// ```
     pub mod query {
         // Core read-only traversal / adjacency
-        pub use crate::core::adjacency::{AdjacencyIndex, AdjacencyIndexBuildError};
-        pub use crate::core::edge::EdgeKey;
-        pub use crate::core::tds::{CellKey, VertexKey};
-        pub use crate::core::triangulation::Triangulation;
+        pub use crate::tds::{
+            AdjacencyIndex, AdjacencyIndexBuildError, CellKey, EdgeKey, VertexKey,
+        };
+        pub use crate::triangulation::Triangulation;
         pub use crate::triangulation::delaunay::DelaunayTriangulation;
 
-        // Locate and conflict-region queries
-        pub use crate::core::algorithms::locate::{
-            ConflictError, InternalInconsistencySite, LocateError, LocateFallback,
-            LocateFallbackReason, LocateResult, LocateStats, extract_cavity_boundary,
-            find_conflict_region, locate, locate_with_stats,
-        };
-
         // Common input/output types (kept intentionally small)
-        pub use crate::core::cell::Cell;
-        pub use crate::core::facet::FacetView;
-        pub use crate::core::traits::boundary_analysis::BoundaryAnalysis;
-        pub use crate::core::traits::data_type::{
-            DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde, DataSerialize, DataType,
-        };
-        pub use crate::core::vertex::Vertex;
         pub use crate::geometry::Point;
         pub use crate::geometry::kernel::{
             AdaptiveKernel, ExactPredicates, FastKernel, Kernel, RobustKernel,
         };
         pub use crate::geometry::traits::coordinate::Coordinate;
+        pub use crate::query::{
+            BoundaryAnalysis, Cell, DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde,
+            DataSerialize, DataType, FacetView, Vertex,
+        };
 
         // Read-only predicates (useful in benchmarks / lightweight geometry checks)
         pub use crate::geometry::{insphere, insphere_distance, insphere_lifted};
 
         // Read-only algorithms
         pub use crate::assert_jaccard_gte;
-        pub use crate::core::util::{
+        pub use crate::geometry::algorithms::convex_hull::{
+            ConvexHull, ConvexHullConstructionError, ConvexHullValidationError,
+        };
+        pub use crate::query::{
             JaccardComputationError, extract_edge_set, extract_facet_identifier_set,
             extract_hull_facet_set, extract_vertex_coordinate_set, format_jaccard_report,
             jaccard_distance, jaccard_index,
         };
-        pub use crate::geometry::algorithms::convex_hull::{
-            ConvexHull, ConvexHullConstructionError, ConvexHullValidationError,
-        };
 
         // Instrumentation helpers (no-op unless features enable extra tracking)
-        pub use crate::core::util::measure_with_result;
+        pub use crate::query::measure_with_result;
 
         // Fixture construction macro used by query doctests, examples, and benchmarks.
         pub use crate::vertex;
@@ -1691,7 +1675,6 @@ pub mod prelude {
     /// # }
     /// ```
     pub mod generators {
-        pub use crate::core::triangulation::TopologyGuarantee;
         pub use crate::geometry::util::{
             RandomPointGenerationError, RandomTriangulationBuilder, generate_grid_points,
             generate_poisson_points, generate_random_points, generate_random_points_in_ball,
@@ -1699,6 +1682,7 @@ pub mod prelude {
             generate_random_points_seeded, generate_random_triangulation,
             generate_random_triangulation_with_topology_guarantee, scaled_bounds_by_point_count,
         };
+        pub use crate::triangulation::TopologyGuarantee;
         pub use crate::triangulation::delaunay::InsertionOrderStrategy;
     }
 

--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -3,8 +3,8 @@
 //! This module is the public facade for triangulation workflows.  It deliberately
 //! stays thin:
 //!
-//! - [`crate::core::triangulation`] owns the generic `Triangulation` container
-//!   and low-level mutation invariants.
+//! - [`crate::prelude::triangulation::Triangulation`] owns the generic
+//!   triangulation container and low-level mutation invariants.
 //! - [`crate::triangulation`] owns higher-level construction, Delaunay repair,
 //!   diagnostics, validation scheduling, editing, and builder workflows.
 //! - Submodules under this namespace keep those concerns separate while this

--- a/src/triangulation.rs
+++ b/src/triangulation.rs
@@ -51,6 +51,31 @@ pub(crate) mod locality;
 pub mod validation;
 
 // Re-export commonly used triangulation types for discoverability.
-pub use crate::core::triangulation::Triangulation;
+pub use crate::core::algorithms::incremental_insertion::{
+    CavityFillingError, CavityRepairStage, DelaunayRepairErrorKind, DelaunayRepairErrorSummary,
+    DelaunayRepairFailureContext, HullExtensionReason, InitialSimplexConstructionError,
+    InsertionError, InsertionErrorKind, InsertionErrorSourceKind, InsertionErrorSummary,
+    NeighborRebuildError, NeighborWiringError, TdsConstructionFailure, TdsValidationFailure,
+    extend_hull, fill_cavity, repair_neighbor_pointers, repair_neighbor_pointers_local,
+    wire_cavity_neighbors,
+};
+pub use crate::core::algorithms::pl_manifold_repair::{
+    PlManifoldRepairError, PlManifoldRepairStats,
+};
+pub use crate::core::operations::{
+    InsertionOutcome, InsertionResult, InsertionStatistics, RepairDecision, RepairSkipReason,
+    SuspicionFlags, TopologicalOperation,
+};
+pub use crate::core::triangulation::{
+    DuplicateDetectionMetrics, TopologyGuarantee, Triangulation, TriangulationConstructionError,
+    TriangulationValidationError, ValidationPolicy,
+};
+pub use crate::core::util::DeduplicationError;
+pub use crate::core::util::{DelaunayValidationError, find_delaunay_violations};
+#[cfg(feature = "diagnostics")]
+pub use crate::core::util::{
+    DelaunayViolationDetail, DelaunayViolationReport, debug_print_first_delaunay_violation,
+    delaunay_violation_report,
+};
 pub use crate::triangulation::builder::DelaunayTriangulationBuilder;
 pub use crate::triangulation::delaunay::DelaunayTriangulation;

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -2265,9 +2265,9 @@ fn duration_nanos_saturating(duration: Duration) -> u64 {
 #[derive(Clone, Copy, Debug)]
 /// Snapshot of one batch-construction progress sample.
 struct BatchProgressSample {
-    processed: usize,
-    inserted: usize,
-    skipped: usize,
+    bulk_processed: usize,
+    bulk_inserted: usize,
+    bulk_skipped: usize,
     cell_count: usize,
     perturbation_seed: u64,
 }
@@ -2275,7 +2275,9 @@ struct BatchProgressSample {
 #[derive(Clone, Copy, Debug)]
 /// Rolling state used to compute periodic batch throughput summaries.
 struct BatchProgressState {
-    total_vertices: usize,
+    input_vertices: usize,
+    initial_simplex_vertices: usize,
+    bulk_vertices: usize,
     progress_every: usize,
     started: Instant,
     last_progress: Instant,
@@ -2292,23 +2294,23 @@ fn log_bulk_progress_if_due(sample: BatchProgressSample, state: &mut Option<Batc
     let Some(state) = state.as_mut() else {
         return;
     };
-    if sample.processed == 0 {
+    if sample.bulk_processed == 0 {
         return;
     }
 
     // Always log the final sample, even when the total is not an exact multiple of the
     // requested cadence, so interrupted runs still end with a complete progress line.
-    let should_log = sample.processed == state.total_vertices
-        || sample.processed.is_multiple_of(state.progress_every);
+    let should_log = sample.bulk_processed == state.bulk_vertices
+        || sample.bulk_processed.is_multiple_of(state.progress_every);
     if !should_log {
         return;
     }
 
     let elapsed = state.started.elapsed();
     let chunk_elapsed = state.last_progress.elapsed();
-    let chunk_processed = sample.processed.saturating_sub(state.last_processed);
+    let chunk_processed = sample.bulk_processed.saturating_sub(state.last_processed);
 
-    let overall_rate = safe_usize_to_scalar::<f64>(sample.processed)
+    let overall_rate = safe_usize_to_scalar::<f64>(sample.bulk_processed)
         .ok()
         .map(|processed| processed / elapsed.as_secs_f64().max(1e-9));
     let chunk_rate = safe_usize_to_scalar::<f64>(chunk_processed)
@@ -2318,10 +2320,12 @@ fn log_bulk_progress_if_due(sample: BatchProgressSample, state: &mut Option<Batc
     tracing::debug!(
         target: "delaunay::bulk_progress",
         perturbation_seed = format_args!("0x{:X}", sample.perturbation_seed),
-        processed = sample.processed,
-        total_vertices = state.total_vertices,
-        inserted = sample.inserted,
-        skipped = sample.skipped,
+        input_vertices = state.input_vertices,
+        initial_simplex_vertices = state.initial_simplex_vertices,
+        bulk_processed = sample.bulk_processed,
+        bulk_vertices = state.bulk_vertices,
+        bulk_inserted = sample.bulk_inserted,
+        bulk_skipped = sample.bulk_skipped,
         cells = sample.cell_count,
         elapsed = ?elapsed,
         total_rate_pts_per_s = ?overall_rate,
@@ -2330,7 +2334,7 @@ fn log_bulk_progress_if_due(sample: BatchProgressSample, state: &mut Option<Batc
     );
 
     state.last_progress = Instant::now();
-    state.last_processed = sample.processed;
+    state.last_processed = sample.bulk_processed;
 }
 
 /// Emits retry-boundary events for release-mode large-scale construction runs.
@@ -4598,12 +4602,15 @@ where
 
         let trace_insertion = env::var_os("DELAUNAY_INSERT_TRACE").is_some();
         let mut batch_progress = bulk_progress_every_from_env().map(|progress_every| {
+            let initial_simplex_vertices = vertices.len().min(D + 1);
             let started = Instant::now();
             BatchProgressState {
                 // The initial simplex is already present when this loop starts, so progress
                 // and throughput only count the remaining bulk vertices — the counters live
                 // in a "bulk-only" frame, 0…(input_len - (D+1)).
-                total_vertices: vertices.len().saturating_sub(D + 1),
+                input_vertices: vertices.len(),
+                initial_simplex_vertices,
+                bulk_vertices: vertices.len().saturating_sub(initial_simplex_vertices),
                 progress_every,
                 started,
                 last_progress: started,
@@ -4723,9 +4730,9 @@ where
                             }
                             log_bulk_progress_if_due(
                                 BatchProgressSample {
-                                    processed: offset + 1,
-                                    inserted: inserted_vertices,
-                                    skipped: skipped_vertices,
+                                    bulk_processed: offset + 1,
+                                    bulk_inserted: inserted_vertices,
+                                    bulk_skipped: skipped_vertices,
                                     cell_count: self.tri.tds.number_of_cells(),
                                     perturbation_seed,
                                 },
@@ -4763,9 +4770,9 @@ where
                             }
                             log_bulk_progress_if_due(
                                 BatchProgressSample {
-                                    processed: offset + 1,
-                                    inserted: inserted_vertices,
-                                    skipped: skipped_vertices,
+                                    bulk_processed: offset + 1,
+                                    bulk_inserted: inserted_vertices,
+                                    bulk_skipped: skipped_vertices,
                                     cell_count: self.tri.tds.number_of_cells(),
                                     perturbation_seed,
                                 },
@@ -4930,9 +4937,9 @@ where
                             }
                             log_bulk_progress_if_due(
                                 BatchProgressSample {
-                                    processed: offset + 1,
-                                    inserted: inserted_vertices,
-                                    skipped: skipped_vertices,
+                                    bulk_processed: offset + 1,
+                                    bulk_inserted: inserted_vertices,
+                                    bulk_skipped: skipped_vertices,
                                     cell_count: self.tri.tds.number_of_cells(),
                                     perturbation_seed,
                                 },
@@ -5008,9 +5015,9 @@ where
                             }
                             log_bulk_progress_if_due(
                                 BatchProgressSample {
-                                    processed: offset + 1,
-                                    inserted: inserted_vertices,
-                                    skipped: skipped_vertices,
+                                    bulk_processed: offset + 1,
+                                    bulk_inserted: inserted_vertices,
+                                    bulk_skipped: skipped_vertices,
                                     cell_count: self.tri.tds.number_of_cells(),
                                     perturbation_seed,
                                 },
@@ -8401,9 +8408,9 @@ mod tests {
     #[test]
     fn test_log_bulk_progress_if_due_updates_progress_state_only_when_due() {
         let sample = BatchProgressSample {
-            processed: 5,
-            inserted: 4,
-            skipped: 1,
+            bulk_processed: 5,
+            bulk_inserted: 4,
+            bulk_skipped: 1,
             cell_count: 7,
             perturbation_seed: 0xCAFE,
         };
@@ -8413,7 +8420,9 @@ mod tests {
         assert!(disabled.is_none());
 
         let mut state = Some(BatchProgressState {
-            total_vertices: 10,
+            input_vertices: 13,
+            initial_simplex_vertices: 3,
+            bulk_vertices: 10,
             progress_every: 5,
             started: Instant::now(),
             last_progress: Instant::now(),
@@ -8422,7 +8431,7 @@ mod tests {
 
         log_bulk_progress_if_due(
             BatchProgressSample {
-                processed: 0,
+                bulk_processed: 0,
                 ..sample
             },
             &mut state,
@@ -8431,7 +8440,7 @@ mod tests {
 
         log_bulk_progress_if_due(
             BatchProgressSample {
-                processed: 3,
+                bulk_processed: 3,
                 ..sample
             },
             &mut state,
@@ -8443,9 +8452,9 @@ mod tests {
 
         log_bulk_progress_if_due(
             BatchProgressSample {
-                processed: 10,
-                inserted: 8,
-                skipped: 2,
+                bulk_processed: 10,
+                bulk_inserted: 8,
+                bulk_skipped: 2,
                 cell_count: 11,
                 perturbation_seed: 0xBEEF,
             },

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -5725,7 +5725,7 @@ where
     ///
     /// assert_eq!(
     ///     dt.validation_policy(),
-    ///     delaunay::core::triangulation::ValidationPolicy::OnSuspicion
+    ///     delaunay::prelude::triangulation::validation::ValidationPolicy::OnSuspicion
     /// );
     /// ```
     #[inline]

--- a/src/triangulation/delaunay.rs
+++ b/src/triangulation/delaunay.rs
@@ -2565,12 +2565,12 @@ where
 /// - ✅ Hull extension for outside points - [`extend_hull`]
 /// - ✅ Flip-based Delaunay repair (k=2/k=3 bistellar flips)
 ///
-/// [`locate`]: crate::core::algorithms::locate::locate
-/// [`find_conflict_region`]: crate::core::algorithms::locate::find_conflict_region
-/// [`extract_cavity_boundary`]: crate::core::algorithms::locate::extract_cavity_boundary
-/// [`fill_cavity`]: crate::core::algorithms::incremental_insertion::fill_cavity
-/// [`wire_cavity_neighbors`]: crate::core::algorithms::incremental_insertion::wire_cavity_neighbors
-/// [`extend_hull`]: crate::core::algorithms::incremental_insertion::extend_hull
+/// [`locate`]: crate::algorithms::locate
+/// [`find_conflict_region`]: crate::algorithms::find_conflict_region
+/// [`extract_cavity_boundary`]: crate::algorithms::extract_cavity_boundary
+/// [`fill_cavity`]: crate::triangulation::fill_cavity
+/// [`wire_cavity_neighbors`]: crate::triangulation::wire_cavity_neighbors
+/// [`extend_hull`]: crate::triangulation::extend_hull
 ///
 /// # Examples
 ///
@@ -5749,7 +5749,7 @@ where
     ///
     /// If the requested policy is incompatible with the current topology guarantee (for example,
     /// `ValidationPolicy::Never` with `TopologyGuarantee::PLManifold`), this runs
-    /// [`Triangulation::validate_at_completion`](crate::core::triangulation::Triangulation::validate_at_completion)
+    /// [`Triangulation::validate_at_completion`](crate::triangulation::Triangulation::validate_at_completion)
     /// to provide immediate feedback and emits a warning. Call `validate_at_completion()` after
     /// batch construction when using an incompatible combination.
     ///
@@ -6492,7 +6492,7 @@ where
     /// Builds an immutable adjacency index for fast repeated topology queries.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::build_adjacency_index`](crate::core::triangulation::Triangulation::build_adjacency_index).
+    /// [`Triangulation::build_adjacency_index`](crate::triangulation::Triangulation::build_adjacency_index).
     ///
     /// # Errors
     ///
@@ -6525,7 +6525,7 @@ where
     /// Returns an iterator over all unique edges in the triangulation.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::edges`](crate::core::triangulation::Triangulation::edges).
+    /// [`Triangulation::edges`](crate::triangulation::Triangulation::edges).
     ///
     /// # Examples
     ///
@@ -6553,7 +6553,7 @@ where
     /// This avoids per-call deduplication and allocations.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::edges_with_index`](crate::core::triangulation::Triangulation::edges_with_index).
+    /// [`Triangulation::edges_with_index`](crate::triangulation::Triangulation::edges_with_index).
     ///
     /// # Examples
     ///
@@ -6583,7 +6583,7 @@ where
     /// Returns an iterator over all unique edges incident to a vertex.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::incident_edges`](crate::core::triangulation::Triangulation::incident_edges).
+    /// [`Triangulation::incident_edges`](crate::triangulation::Triangulation::incident_edges).
     ///
     /// If `v` is not present in this triangulation, the iterator is empty.
     ///
@@ -6615,7 +6615,7 @@ where
     /// If `v` is not present in the index, the iterator is empty.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::incident_edges_with_index`](crate::core::triangulation::Triangulation::incident_edges_with_index).
+    /// [`Triangulation::incident_edges_with_index`](crate::triangulation::Triangulation::incident_edges_with_index).
     ///
     /// # Examples
     ///
@@ -6649,7 +6649,7 @@ where
     /// present, the iterator is empty.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::cell_neighbors`](crate::core::triangulation::Triangulation::cell_neighbors).
+    /// [`Triangulation::cell_neighbors`](crate::triangulation::Triangulation::cell_neighbors).
     ///
     /// # Examples
     ///
@@ -6677,7 +6677,7 @@ where
     /// If `c` is not present in the index, the iterator is empty.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::cell_neighbors_with_index`](crate::core::triangulation::Triangulation::cell_neighbors_with_index).
+    /// [`Triangulation::cell_neighbors_with_index`](crate::triangulation::Triangulation::cell_neighbors_with_index).
     ///
     /// # Examples
     ///
@@ -6714,7 +6714,7 @@ where
     /// This is a zero-allocation accessor. If `c` is not present, returns `None`.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::cell_vertices`](crate::core::triangulation::Triangulation::cell_vertices).
+    /// [`Triangulation::cell_vertices`](crate::triangulation::Triangulation::cell_vertices).
     ///
     /// # Examples
     ///
@@ -6742,7 +6742,7 @@ where
     /// This is a zero-allocation accessor. If `v` is not present, returns `None`.
     ///
     /// This is a convenience wrapper around
-    /// [`Triangulation::vertex_coords`](crate::core::triangulation::Triangulation::vertex_coords).
+    /// [`Triangulation::vertex_coords`](crate::triangulation::Triangulation::vertex_coords).
     ///
     /// # Examples
     ///
@@ -7527,7 +7527,7 @@ where
     /// Performs cumulative validation for Levels 1–4.
     ///
     /// This validates:
-    /// - **Levels 1–3** via [`Triangulation::validate`](crate::core::triangulation::Triangulation::validate)
+    /// - **Levels 1–3** via [`Triangulation::validate`](crate::triangulation::Triangulation::validate)
     /// - **Level 4** via [`DelaunayTriangulation::is_valid`](Self::is_valid)
     ///
     /// # Errors

--- a/src/triangulation/delaunayize.rs
+++ b/src/triangulation/delaunayize.rs
@@ -3,7 +3,7 @@
 //! This module provides `delaunayize_by_flips`, a single public entrypoint that
 //! takes an existing [`DelaunayTriangulation`], performs bounded deterministic
 //! topology repair toward
-//! [`TopologyGuarantee::PLManifold`](crate::core::triangulation::TopologyGuarantee::PLManifold),
+//! [`TopologyGuarantee::PLManifold`](crate::triangulation::TopologyGuarantee::PLManifold),
 //! and then applies
 //! standard flip-based Delaunay repair.
 //!
@@ -44,12 +44,10 @@
 
 // Re-export outcome/error field types so users can name the public contract
 // without reaching into lower-level modules.
-pub use crate::core::algorithms::flips::{DelaunayRepairError, DelaunayRepairStats};
-pub use crate::core::algorithms::pl_manifold_repair::{
-    PlManifoldRepairError, PlManifoldRepairStats,
-};
-pub use crate::core::cell::CellValidationError;
+pub use crate::tds::CellValidationError;
 pub use crate::triangulation::delaunay::DelaunayTriangulationConstructionError;
+pub use crate::triangulation::flips::{DelaunayRepairError, DelaunayRepairStats};
+pub use crate::triangulation::{PlManifoldRepairError, PlManifoldRepairStats};
 
 #[cfg(test)]
 use crate::core::algorithms::flips::{DelaunayRepairDiagnostics, RepairQueueOrder};
@@ -707,11 +705,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::{tds::VertexKey, triangulation::TriangulationConstructionError};
     use crate::geometry::kernel::AdaptiveKernel;
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::Coordinate;
-    use crate::triangulation::builder::DelaunayTriangulationBuilder;
+    use crate::tds::VertexKey;
+    use crate::triangulation::{DelaunayTriangulationBuilder, TriangulationConstructionError};
     use crate::vertex;
     use slotmap::KeyData;
     use std::error::Error as StdError;

--- a/src/triangulation/flips.rs
+++ b/src/triangulation/flips.rs
@@ -9,14 +9,14 @@
 #![forbid(unsafe_code)]
 
 pub use crate::core::algorithms::flips::{
-    BistellarFlipKind, FlipContextError, FlipDirection, FlipEdgeAdjacencyError, FlipError,
-    FlipInfo, FlipMutationError, FlipNeighborWiringError, FlipPredicateError,
-    FlipPredicateOperation, FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RidgeHandle,
-    TriangleHandle,
+    BistellarFlipKind, BistellarMove, ConstK, DelaunayRepairDiagnostics, DelaunayRepairError,
+    DelaunayRepairStats, DelaunayRepairVerificationContext, FlipContextError, FlipDirection,
+    FlipEdgeAdjacencyError, FlipError, FlipInfo, FlipMutationError, FlipNeighborWiringError,
+    FlipPredicateError, FlipPredicateOperation, FlipTriangleAdjacencyError,
+    FlipVertexAdjacencyError, RepairQueueOrder, RidgeHandle, TriangleHandle,
+    verify_delaunay_for_triangulation, verify_delaunay_via_flip_predicates,
 };
-pub use crate::core::edge::EdgeKey;
-pub use crate::core::facet::FacetHandle;
-pub use crate::core::tds::{CellKey, VertexKey};
+pub use crate::tds::{CellKey, EdgeKey, FacetHandle, VertexKey};
 
 use crate::core::algorithms::flips::{
     apply_bistellar_flip_dynamic, apply_bistellar_flip_k1, apply_bistellar_flip_k1_inverse,
@@ -340,6 +340,7 @@ mod tests {
     use super::*;
 
     use crate::geometry::kernel::{AdaptiveKernel, FastKernel};
+    use crate::triangulation::TopologyGuarantee;
     use crate::vertex;
     use slotmap::KeyData;
 
@@ -354,7 +355,7 @@ mod tests {
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new_with_topology_guarantee(
                 &vertices,
-                crate::core::triangulation::TopologyGuarantee::PLManifold,
+                TopologyGuarantee::PLManifold,
             )
             .unwrap();
         let mut tri = dt.as_triangulation().clone();
@@ -383,7 +384,7 @@ mod tests {
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new_with_topology_guarantee(
                 &vertices,
-                crate::core::triangulation::TopologyGuarantee::PLManifold,
+                TopologyGuarantee::PLManifold,
             )
             .unwrap();
         let mut tri = dt.as_triangulation().clone();

--- a/src/triangulation/validation.rs
+++ b/src/triangulation/validation.rs
@@ -10,9 +10,9 @@ use std::num::NonZeroUsize;
 
 /// Cadence for explicit validation checkpoints during construction diagnostics.
 ///
-/// This is separate from [`ValidationPolicy`](crate::core::triangulation::ValidationPolicy),
+/// This is separate from [`ValidationPolicy`](crate::triangulation::ValidationPolicy),
 /// which controls automatic insertion-time validation inside
-/// [`Triangulation`](crate::core::triangulation::Triangulation). Diagnostic
+/// [`Triangulation`](crate::triangulation::Triangulation). Diagnostic
 /// harnesses can use this cadence for explicit periodic
 /// [`DelaunayTriangulation::is_valid`](crate::triangulation::delaunay::DelaunayTriangulation::is_valid)
 /// checks without overloading repair policy or exposing raw `Option<usize>`

--- a/tests/README.md
+++ b/tests/README.md
@@ -585,12 +585,12 @@ floating-point precision variations and near-degenerate cases.
 
 ### Available Utilities
 
-#### Extraction Helpers (`delaunay::core::util`)
+#### Extraction Helpers (`delaunay::prelude::query`)
 
 Canonical set extraction functions for comparing triangulation topology:
 
 ```rust
-use delaunay::core::util::{
+use delaunay::prelude::query::{
     extract_vertex_coordinate_set,    // HashSet<Point<T, D>>
     extract_edge_set,                  // HashSet<(u128, u128)>
     extract_facet_identifier_set,      // Result<HashSet<u64>, FacetError>
@@ -634,7 +634,7 @@ assert_jaccard_gte!(&before, &after, 0.99);
 #### Diagnostic Reporting
 
 ```rust
-use delaunay::core::util::format_jaccard_report;
+use delaunay::prelude::query::format_jaccard_report;
 
 let report = format_jaccard_report(
     &set_a,
@@ -660,7 +660,7 @@ println!("{}", report);
 
 ```rust
 use delaunay::assert_jaccard_gte;
-use delaunay::core::util::extract_vertex_coordinate_set;
+use delaunay::prelude::query::extract_vertex_coordinate_set;
 
 let original_coords = extract_vertex_coordinate_set(&tds);
 // ... perform operation (serialization, transformation, etc.) ...
@@ -677,7 +677,7 @@ assert_jaccard_gte!(
 #### Edge Set Comparison
 
 ```rust
-use delaunay::core::util::extract_edge_set;
+use delaunay::prelude::query::extract_edge_set;
 
 let edges_a = extract_edge_set(&tds_a);
 let edges_b = extract_edge_set(&tds_b);
@@ -693,7 +693,7 @@ assert_jaccard_gte!(
 #### Hull Facet Topology
 
 ```rust
-use delaunay::core::util::extract_hull_facet_set;
+use delaunay::prelude::query::extract_hull_facet_set;
 use delaunay::geometry::algorithms::convex_hull::ConvexHull;
 
 let hull1 = ConvexHull::from_triangulation(&tds)?;
@@ -745,7 +745,8 @@ assert_jaccard_gte!(
 ### Related Documentation
 
 - **[Jaccard Similarity Theory](../docs/archive/jaccard.md)**: Mathematical background, adoption plan (completed in v0.5.4)
-- **API Documentation**: `cargo doc --open` → `delaunay::core::util` module
+- **API Documentation**: `cargo doc --open` → `delaunay::query` or
+  `delaunay::prelude::query` for curated test helpers
 
 ## Related Documentation
 

--- a/tests/allocation_api.rs
+++ b/tests/allocation_api.rs
@@ -6,8 +6,8 @@
 #![cfg(feature = "count-allocations")]
 
 use allocation_counter::AllocationInfo;
+use delaunay::prelude::algorithms::{LocateError, LocateResult, locate_with_stats};
 use delaunay::prelude::geometry::{Coordinate, FastKernel, Point};
-use delaunay::prelude::query::{LocateError, LocateResult, locate_with_stats};
 use delaunay::prelude::tds::{
     CellKey, TdsError, VertexKey, facet_key_from_vertices, measure_with_result,
 };

--- a/tests/check_perturbation_stats.rs
+++ b/tests/check_perturbation_stats.rs
@@ -4,10 +4,9 @@
 //! never commit a triangulation with invalid vertex links, independent of
 //! `ValidationPolicy`.
 
-use delaunay::core::vertex::VertexBuilder;
 use delaunay::geometry::util::generate_random_points_seeded;
 use delaunay::prelude::triangulation::construction::{
-    DelaunayRepairPolicy, DelaunayTriangulation, TopologyGuarantee,
+    DelaunayRepairPolicy, DelaunayTriangulation, TopologyGuarantee, VertexBuilder,
 };
 use delaunay::prelude::triangulation::insertion::InsertionOutcome;
 use delaunay::prelude::triangulation::validation::ValidationPolicy;

--- a/tests/delaunay_incremental_insertion.rs
+++ b/tests/delaunay_incremental_insertion.rs
@@ -10,14 +10,13 @@
 //! - Different kernels (Fast vs Robust)
 
 use approx::assert_relative_eq;
-use delaunay::core::vertex::Vertex;
 use delaunay::geometry::kernel::RobustKernel;
 use delaunay::prelude::algorithms::{LocateResult, find_conflict_region, locate};
 use delaunay::prelude::collections::MAX_PRACTICAL_DIMENSION_SIZE;
 use delaunay::prelude::geometry::{AdaptiveKernel, Coordinate, Point};
 use delaunay::prelude::tds::{Cell, CellKey, SmallBuffer, VertexKey, facet_key_from_vertices};
 use delaunay::prelude::triangulation::construction::{
-    ConstructionOptions, DedupPolicy, DelaunayTriangulation, TopologyGuarantee, vertex,
+    ConstructionOptions, DedupPolicy, DelaunayTriangulation, TopologyGuarantee, Vertex, vertex,
 };
 use uuid::Uuid;
 

--- a/tests/delaunay_public_api_coverage.rs
+++ b/tests/delaunay_public_api_coverage.rs
@@ -10,9 +10,9 @@ use delaunay::prelude::geometry::AdaptiveKernel;
 use delaunay::prelude::triangulation::construction::{
     ConstructionOptions, DedupPolicy, DelaunayTriangulation,
     DelaunayTriangulationConstructionError, InsertionOrderStrategy, RetryPolicy, TopologyGuarantee,
+    vertex,
 };
 use delaunay::prelude::triangulation::insertion::InsertionError;
-use delaunay::vertex;
 #[cfg(feature = "diagnostics")]
 use rand::{RngExt, SeedableRng, rngs::StdRng};
 

--- a/tests/delaunayize_workflow.rs
+++ b/tests/delaunayize_workflow.rs
@@ -8,7 +8,7 @@
 //! - Repeat-run determinism for outcome stats
 //! - Multi-dimensional coverage (2D–3D)
 
-use delaunay::core::triangulation::TriangulationConstructionError;
+use delaunay::prelude::triangulation::construction::TriangulationConstructionError;
 use delaunay::prelude::triangulation::delaunayize::*;
 use delaunay::prelude::triangulation::flips::BistellarFlips;
 use delaunay::triangulation::flips::FacetHandle;

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -56,7 +56,7 @@
 //! DELAUNAY_LARGE_DEBUG_DEBUG_MODE=cadenced \
 //! # Deterministically shuffle insertion order (incremental mode only)
 //! DELAUNAY_LARGE_DEBUG_SHUFFLE_SEED=123 \
-//! # Print progress every N insertions (incremental mode only)
+//! # Print progress every N insertions (incremental mode, or batch fallback)
 //! DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY=1000 \
 //! # (Optional) validate topology every N insertions once cells exist (incremental mode only; can be expensive)
 //! DELAUNAY_LARGE_DEBUG_VALIDATE_EVERY=2000 \
@@ -72,7 +72,9 @@
 //! DELAUNAY_BATCH_REPAIR_TRACE=1 \
 //! # Hard wall-clock cap in seconds before the harness aborts (0 = no cap; default: 600)
 //! DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS=600 \
-//! # Optional: emit periodic batch-construction summaries for new()/Hilbert runs
+//! # Optional: emit periodic batch-construction summaries for new()/Hilbert runs.
+//! # This is the canonical batch progress knob and takes precedence over
+//! # DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY.
 //! DELAUNAY_BULK_PROGRESS_EVERY=100 \
 //! # Optional: dump the first cavity reduction chain once per run
 //! DELAUNAY_DEBUG_CAVITY_REDUCTION_ONCE=1 \
@@ -346,6 +348,12 @@ fn env_usize(name: &str) -> Option<usize> {
     })
 }
 
+fn bulk_progress_every_from_env() -> Option<usize> {
+    env_usize("DELAUNAY_BULK_PROGRESS_EVERY")
+        .or_else(|| env_usize("DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY"))
+        .filter(|every| *every > 0)
+}
+
 fn env_flag(name: &str) -> bool {
     env::var(name).ok().is_some_and(|v| {
         let v = v.trim();
@@ -367,6 +375,7 @@ fn init_tracing() {
             "DELAUNAY_REPAIR_DEBUG_POSTCONDITION_FACET",
             "DELAUNAY_REPAIR_DEBUG_RIDGE_MIN_MULTIPLICITY",
             "DELAUNAY_BULK_PROGRESS_EVERY",
+            "DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY",
             "DELAUNAY_BATCH_REPAIR_TRACE",
             "DELAUNAY_DEBUG_SHUFFLE",
         ];
@@ -1168,6 +1177,7 @@ where
     let progress_every = env_usize("DELAUNAY_LARGE_DEBUG_PROGRESS_EVERY")
         .unwrap_or(1000)
         .max(1);
+    let bulk_progress_every = bulk_progress_every_from_env();
 
     let allow_skips = env_flag("DELAUNAY_LARGE_DEBUG_ALLOW_SKIPS");
     let max_skip_pct = max_skip_pct_from_env();
@@ -1213,7 +1223,15 @@ where
     println!("  debug_mode:    {}", debug_mode.name());
     println!("  topology_guarantee: {topology_guarantee:?}");
     println!("  shuffle_seed:  {shuffle_seed:?}");
-    println!("  progress_every:{progress_every}");
+    match mode {
+        ConstructionMode::New => {
+            let bulk_progress = bulk_progress_every
+                .map_or_else(|| "disabled".to_owned(), |every| every.to_string());
+            println!("  bulk_progress_every:{bulk_progress}");
+            println!("  bulk_progress_scope: remaining vertices after initial simplex");
+        }
+        ConstructionMode::Incremental => println!("  progress_every:{progress_every}"),
+    }
     println!("  validation_cadence: {validation_cadence:?}");
     println!("  allow_skips:   {allow_skips}");
     println!("  max_skip_pct:  {max_skip_pct}");

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -44,7 +44,7 @@ use delaunay::prelude::triangulation::construction::{
     ExplicitDelaunayValidationError, ExplicitDelaunayValidationErrorKind,
     ExplicitDelaunayValidationSourceKind, ExplicitInsertionError, ExplicitInsertionErrorKind,
     ExplicitInvariantError, ExplicitInvariantErrorKind, ExplicitTdsError, ExplicitTdsErrorKind,
-    InsertionOrderStrategy, TopologyGuarantee, Vertex,
+    InsertionOrderStrategy, TopologyGuarantee, Vertex, vertex,
 };
 use delaunay::prelude::triangulation::delaunayize::{
     DelaunayizeConfig, DelaunayizeError, DelaunayizeOutcome, delaunayize_by_flips,
@@ -64,7 +64,6 @@ use delaunay::prelude::triangulation::repair::{
 };
 use delaunay::prelude::triangulation::validation::ValidationCadence;
 use delaunay::prelude::{SecureHashMap, SecureHashSet};
-use delaunay::vertex;
 
 #[derive(Debug, thiserror::Error)]
 enum PreludeExportTestError {

--- a/tests/proptest_convex_hull.rs
+++ b/tests/proptest_convex_hull.rs
@@ -10,7 +10,6 @@
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
 use delaunay::assert_jaccard_gte;
-use delaunay::core::util::extract_hull_facet_set;
 use delaunay::prelude::query::*;
 use delaunay::prelude::topology::validation::*;
 use proptest::prelude::*;

--- a/tests/proptest_facet.rs
+++ b/tests/proptest_facet.rs
@@ -8,8 +8,8 @@
 //!
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
-use delaunay::core::facet::facet_key_from_vertices;
 use delaunay::prelude::query::*;
+use delaunay::prelude::tds::facet_key_from_vertices;
 use delaunay::prelude::topology::validation::*;
 use proptest::prelude::*;
 use std::collections::HashMap;

--- a/tests/proptest_orientation.rs
+++ b/tests/proptest_orientation.rs
@@ -10,8 +10,8 @@
 
 #![forbid(unsafe_code)]
 
-use delaunay::core::tds::{Tds, TdsError};
 use delaunay::prelude::geometry::*;
+use delaunay::prelude::tds::{Tds, TdsError};
 use delaunay::prelude::triangulation::construction::{
     DelaunayTriangulation, TopologyGuarantee, Vertex,
 };

--- a/tests/proptest_tds.rs
+++ b/tests/proptest_tds.rs
@@ -21,10 +21,9 @@
 //!
 //! All tests use `dt.tds().is_valid()` (Level 2 structural validation).
 
-use delaunay::core::collections::{CellVertexBuffer, SimplexVertexBuffer};
-use delaunay::core::tds::Tds;
-use delaunay::core::util::jaccard::jaccard_index;
+use delaunay::prelude::collections::{CellVertexBuffer, SimplexVertexBuffer};
 use delaunay::prelude::query::*;
+use delaunay::prelude::tds::{Tds, jaccard_index};
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestCaseError, TestRunner};
 use std::cell::RefCell;

--- a/tests/proptest_vertex.rs
+++ b/tests/proptest_vertex.rs
@@ -12,7 +12,8 @@
 
 #![allow(unused_imports)] // Imports used in macro expansion
 
-use delaunay::prelude::query::*;
+use delaunay::prelude::geometry::Point;
+use delaunay::prelude::triangulation::construction::{Vertex, vertex};
 use proptest::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::hash::{Hash, Hasher};

--- a/tests/public_topology_api.rs
+++ b/tests/public_topology_api.rs
@@ -8,7 +8,9 @@
 
 use delaunay::prelude::TopologyGuarantee;
 use delaunay::prelude::query::*;
-use delaunay::prelude::triangulation::DelaunayTriangulationConstructionError;
+use delaunay::prelude::triangulation::{
+    DelaunayTriangulationConstructionError, construction::vertex,
+};
 use std::collections::HashSet;
 
 #[derive(Debug, thiserror::Error)]

--- a/tests/serialization_vertex_preservation.rs
+++ b/tests/serialization_vertex_preservation.rs
@@ -10,8 +10,8 @@
 //! or a bug in serialization/deserialization.
 
 use delaunay::assert_jaccard_gte;
-use delaunay::core::util::extract_vertex_coordinate_set;
 use delaunay::prelude::geometry::*;
+use delaunay::prelude::query::extract_vertex_coordinate_set;
 use delaunay::prelude::tds::Tds;
 use delaunay::prelude::triangulation::construction::{
     ConstructionOptions, DelaunayTriangulation, InsertionOrderStrategy, TopologyGuarantee, Vertex,

--- a/tests/tds_orientation.rs
+++ b/tests/tds_orientation.rs
@@ -3,8 +3,7 @@
 #![forbid(unsafe_code)]
 
 use delaunay::prelude::tds::{Tds, TdsError};
-use delaunay::prelude::triangulation::construction::DelaunayTriangulation;
-use delaunay::vertex;
+use delaunay::prelude::triangulation::construction::{DelaunayTriangulation, vertex};
 macro_rules! coherent_orientation_test {
     ($name:ident, $dim:literal, $vertices:expr) => {
         #[test]

--- a/tests/tds_orientation.rs
+++ b/tests/tds_orientation.rs
@@ -2,8 +2,8 @@
 
 #![forbid(unsafe_code)]
 
-use delaunay::core::tds::{Tds, TdsError};
-use delaunay::triangulation::delaunay::DelaunayTriangulation;
+use delaunay::prelude::tds::{Tds, TdsError};
+use delaunay::prelude::triangulation::construction::DelaunayTriangulation;
 use delaunay::vertex;
 macro_rules! coherent_orientation_test {
     ($name:ident, $dim:literal, $vertices:expr) => {

--- a/tests/trait_bound_ergonomics.rs
+++ b/tests/trait_bound_ergonomics.rs
@@ -1,7 +1,7 @@
 //! Compile coverage for read-only APIs with non-`DataType` payloads.
 
-use delaunay::core::traits::BoundaryAnalysis;
 use delaunay::prelude::geometry::FastKernel;
+use delaunay::prelude::query::BoundaryAnalysis;
 use delaunay::prelude::tds::{CellKey, Tds, verify_facet_index_consistency};
 use delaunay::prelude::topology::validation::validate_triangulation_euler;
 use delaunay::prelude::triangulation::Triangulation;


### PR DESCRIPTION
- Make `crate::core` private and expose low-level APIs through curated `tds`, `collections`, `algorithms`, and `query` modules.
- Add focused prelude/docs coverage for the new public import paths.
- Update downstream-style tests and doctests to stop relying on `delaunay::core`.

BREAKING CHANGE: `delaunay::core` is no longer a public module. Downstream callers should import low-level APIs from `delaunay::tds`, `delaunay::collections`, `delaunay::algorithms`, `delaunay::query`, or the matching focused preludes.

Fixes #388