### PR TITLE
refactor(validation)!: reconcile topology validation policy (#385)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,9 @@ For the full periodic image-point method (Phase 2), see the
 
 `TopologyGuarantee` controls which Level 3 manifold constraints are enforced,
 and `ValidationPolicy` controls when Level 3 checks run automatically during
-incremental insertion.
+incremental insertion. Incompatible combinations are rejected by the fallible
+`try_set_*` policy setters; use `ValidationPolicy::ExplicitOnly` for
+caller-owned full-validation checkpoints with the default PL-manifold guarantee.
 
 ## 🔬 Reproducibility
 

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -118,9 +118,10 @@ dt.insert(vertex!([0.25, 0.75])).unwrap();
   `.toroidal_periodic()` (Phase 2 periodic image-point) with explicit domain periods
 - **Custom topology guarantees**: Set stricter or more relaxed manifold checks
 - **Custom validation policies**: Configure `ValidationPolicy` via
-  `dt.set_validation_policy(...)` before or after build; the active policy controls
-  automatic topology validation for subsequent insert/remove and other modification
-  operations
+  `dt.try_set_validation_policy(...)` before or after build when callers need
+  typed feedback for incompatible policy/guarantee pairs. The compatibility
+  `dt.set_validation_policy(...)` setter leaves the previous policy unchanged
+  for incoherent combinations.
 - **Custom repair policies**: Configure Delaunay repair behavior
 
 See `docs/topology.md` for more on toroidal triangulations and `docs/validation.md`
@@ -144,7 +145,7 @@ for topology guarantee and validation policy details.
   typed repair diagnostics where available, for example
   `RepairOperationFailed { operation, source }`.
 - **Validation**: The active `ValidationPolicy` (set with
-  `dt.set_validation_policy(...)`) governs automatic topology validation for
+  `dt.try_set_validation_policy(...)` or `dt.set_validation_policy(...)`) governs automatic topology validation for
   subsequent construction/modification operations
 
 ## Edit API Reference

--- a/docs/production_review_remediation_checklist.md
+++ b/docs/production_review_remediation_checklist.md
@@ -93,9 +93,11 @@ Treat partial items as still open until their acceptance notes are satisfied.
 
 ## API Design Feedback
 
-- [ ] **22. Reconcile topology guarantee and validation policy combinations.**
-  Reject incoherent builder combinations or merge the overlapping policy axes.
-  Tracked for v0.7.8 in #385.
+- [x] **22. Reconcile topology guarantee and validation policy combinations.**
+  Incoherent runtime combinations are rejected through typed `try_set_*` policy
+  setters, compatibility setters no longer commit rejected state, and builder
+  construction continues to derive the initial validation policy from the
+  selected topology guarantee. Tracked for v0.7.8 in #385.
 - [ ] **23. Reconsider skipped insertions as success outcomes.**
   Make skipped duplicate and degeneracy outcomes harder for callers to ignore.
   Tracked for v0.7.8 in #386.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -71,7 +71,10 @@ insertion deviates from the happy-path and trips internal **suspicion flags**, e
 
 ### Available policies
 
-- `ValidationPolicy::Never`: never run Level 3 automatically (fastest, least guarded).
+- `ValidationPolicy::Never`: never run full Level 3 automatically; compatible only with
+  `TopologyGuarantee::Pseudomanifold`.
+- `ValidationPolicy::ExplicitOnly`: run full Level 3 only through explicit validation
+  calls while still keeping topology checks required by the active `TopologyGuarantee`.
 - `ValidationPolicy::OnSuspicion` *(default)*: run Level 3 only when insertion is suspicious.
 - `ValidationPolicy::Always`: run Level 3 after every insertion attempt (slowest, best for tests).
 - `ValidationPolicy::DebugOnly`: always run Level 3 in debug builds; in release behaves like `OnSuspicion`.
@@ -99,8 +102,12 @@ assert_eq!(dt.validation_policy(), ValidationPolicy::OnSuspicion);
 // For test/debug: validate topology after every insertion.
 dt.set_validation_policy(ValidationPolicy::Always);
 
-// For maximum performance (you can still validate explicitly when you choose).
-dt.set_validation_policy(ValidationPolicy::Never);
+// For caller-owned full validation checkpoints with the default PL-manifold guarantee.
+dt.try_set_validation_policy(ValidationPolicy::ExplicitOnly).unwrap();
+
+// `Never` is reserved for the relaxed pseudomanifold guarantee.
+dt.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold).unwrap();
+dt.try_set_validation_policy(ValidationPolicy::Never).unwrap();
 ```
 
 ---
@@ -115,6 +122,9 @@ Level 3 topology validation can be configured to enforce either:
 
 This is separate from [`ValidationPolicy`](#automatic-validation-during-incremental-insertion-validationpolicy),
 which controls *when* Level 3 is run automatically during incremental insertion.
+The builder keeps these axes coherent by deriving the initial validation policy
+from `TopologyGuarantee`: `PLManifoldStrict` starts with `ValidationPolicy::Always`,
+and `PLManifold` / `Pseudomanifold` start with `ValidationPolicy::OnSuspicion`.
 
 ### Default: `PLManifold`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -36,6 +36,10 @@ Two knobs are commonly used for insertion-time safety vs performance:
 - `TopologyGuarantee`: what Level 3 topology invariants are enforced.
 - `ValidationPolicy`: when Level 3 topology validation runs automatically during incremental insertion.
 
+Use the `try_set_*` policy setters when changing both axes programmatically; they
+return a typed error for incoherent combinations such as
+`TopologyGuarantee::PLManifold` with `ValidationPolicy::Never`.
+
 See [`validation.md`](validation.md) for details.
 
 ```rust

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -352,9 +352,11 @@ impl From<ManifoldError> for InvariantError {
 /// performance for stricter correctness checks during incremental operations.
 ///
 /// **Note**: [`TopologyGuarantee::PLManifold`] is incompatible with [`ValidationPolicy::Never`].
-/// `PLManifold` requires at least end-of-construction validation to certify full
-/// PL-manifoldness. Use [`ValidationPolicy::OnSuspicion`] (default) for best performance,
-/// or [`ValidationPolicy::Always`] for maximum safety during incremental operations.
+/// `PLManifold` requires at least caller-owned completion validation to certify full
+/// PL-manifoldness. Use [`ValidationPolicy::ExplicitOnly`] when you want to run full
+/// topology validation only through explicit validation calls, [`ValidationPolicy::OnSuspicion`]
+/// (default) for best performance, or [`ValidationPolicy::Always`] for maximum safety during
+/// incremental operations.
 ///
 /// # Examples
 ///
@@ -368,8 +370,18 @@ impl From<ManifoldError> for InvariantError {
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ValidationPolicy {
-    /// Never run global validation.
+    /// Never run full global validation automatically.
+    ///
+    /// This is only compatible with [`TopologyGuarantee::Pseudomanifold`]. Use
+    /// [`ValidationPolicy::ExplicitOnly`] when a stronger topology guarantee is active and
+    /// full validation checkpoints are owned by the caller.
     Never,
+
+    /// Run full topology validation only when callers invoke explicit validation APIs.
+    ///
+    /// Mandatory local topology checks required by the active [`TopologyGuarantee`] still run
+    /// during insertion, but suspicion-triggered full Level 3 validation is disabled.
+    ExplicitOnly,
 
     /// Validate only if the operation is suspicious (e.g. degeneracy).
     OnSuspicion,
@@ -388,7 +400,7 @@ impl ValidationPolicy {
     #[must_use]
     pub const fn should_validate(&self, suspicion: SuspicionFlags) -> bool {
         match self {
-            Self::Never => false,
+            Self::Never | Self::ExplicitOnly => false,
             Self::Always => true,
             Self::OnSuspicion => suspicion.is_suspicious(),
             Self::DebugOnly => cfg!(debug_assertions) || suspicion.is_suspicious(),
@@ -553,7 +565,7 @@ impl TopologyGuarantee {
     pub const fn default_validation_policy(self) -> ValidationPolicy {
         match self {
             Self::PLManifoldStrict => ValidationPolicy::Always,
-            _ => ValidationPolicy::OnSuspicion,
+            Self::Pseudomanifold | Self::PLManifold => ValidationPolicy::OnSuspicion,
         }
     }
 
@@ -568,6 +580,59 @@ impl TopologyGuarantee {
             Self::Pseudomanifold => true,
             Self::PLManifold | Self::PLManifoldStrict => !matches!(policy, ValidationPolicy::Never),
         }
+    }
+}
+
+/// Errors returned when validation scheduling and topology guarantees are incoherent.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::prelude::geometry::FastKernel;
+/// use delaunay::prelude::{
+///     TopologyGuarantee, Triangulation, ValidationConfigurationError, ValidationPolicy,
+/// };
+///
+/// let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
+///     Triangulation::new_empty(FastKernel::new());
+///
+/// assert!(matches!(
+///     tri.try_set_validation_policy(ValidationPolicy::Never),
+///     Err(ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+///         topology_guarantee: TopologyGuarantee::PLManifold,
+///         validation_policy: ValidationPolicy::Never,
+///     })
+/// ));
+/// ```
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum ValidationConfigurationError {
+    /// The requested validation policy cannot support the requested topology guarantee.
+    #[error(
+        "validation policy {validation_policy:?} is incompatible with topology guarantee {topology_guarantee:?}"
+    )]
+    IncompatibleTopologyAndValidationPolicy {
+        /// Topology guarantee that would be active.
+        topology_guarantee: TopologyGuarantee,
+        /// Validation policy that would be active.
+        validation_policy: ValidationPolicy,
+    },
+}
+
+/// Verifies that a topology guarantee and validation policy can coexist.
+const fn validate_configuration(
+    topology_guarantee: TopologyGuarantee,
+    validation_policy: ValidationPolicy,
+) -> Result<(), ValidationConfigurationError> {
+    if topology_guarantee.is_compatible_with_policy(validation_policy) {
+        Ok(())
+    } else {
+        Err(
+            ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                topology_guarantee,
+                validation_policy,
+            },
+        )
     }
 }
 
@@ -627,13 +692,46 @@ where
         self.validation_policy
     }
 
+    /// Tries to set the insertion-time global topology validation policy used by the triangulation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy`] when the
+    /// requested policy cannot support the current topology guarantee. For example,
+    /// [`ValidationPolicy::Never`] is rejected when the triangulation has
+    /// [`TopologyGuarantee::PLManifold`]; use [`ValidationPolicy::ExplicitOnly`] for
+    /// caller-owned full validation checkpoints with stronger topology guarantees.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::{Triangulation, ValidationPolicy};
+    /// use delaunay::prelude::geometry::FastKernel;
+    ///
+    /// # fn main() -> Result<(), delaunay::prelude::ValidationConfigurationError> {
+    /// let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
+    ///     Triangulation::new_empty(FastKernel::new());
+    ///
+    /// tri.try_set_validation_policy(ValidationPolicy::Always)?;
+    /// assert_eq!(tri.validation_policy(), ValidationPolicy::Always);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_set_validation_policy(
+        &mut self,
+        policy: ValidationPolicy,
+    ) -> Result<(), ValidationConfigurationError> {
+        validate_configuration(self.topology_guarantee, policy)?;
+        self.validation_policy = policy;
+        Ok(())
+    }
+
     /// Sets the insertion-time global topology validation policy used by the triangulation.
     ///
-    /// If the requested policy is incompatible with the current topology guarantee (for example,
-    /// `ValidationPolicy::Never` with `TopologyGuarantee::PLManifold`), this runs
-    /// [`Triangulation::validate_at_completion`](Self::validate_at_completion) to provide
-    /// immediate feedback and emits a warning. Call `validate_at_completion()` after batch
-    /// construction when using an incompatible combination.
+    /// Prefer [`try_set_validation_policy`](Self::try_set_validation_policy) when callers need
+    /// typed feedback for rejected combinations. This compatibility setter leaves the existing
+    /// policy unchanged and emits a warning if the requested combination is incoherent.
     ///
     /// # Examples
     ///
@@ -649,38 +747,47 @@ where
     /// ```
     #[inline]
     pub fn set_validation_policy(&mut self, policy: ValidationPolicy) {
-        if !self.topology_guarantee.is_compatible_with_policy(policy) {
-            let completion_result = self.validate_at_completion();
-
-            if let Err(err) = completion_result {
-                debug_assert!(
-                    false,
-                    "Validation policy {policy:?} is incompatible with topology guarantee {guarantee:?}; validate_at_completion failed: {err}",
-                    guarantee = self.topology_guarantee
-                );
-                tracing::warn!(
-                    "Validation policy {policy:?} is incompatible with topology guarantee {guarantee:?}; validate_at_completion failed: {err}. Validation policy not updated.",
-                    guarantee = self.topology_guarantee
-                );
-                return;
-            }
-
-            tracing::warn!(
-                "Validation policy {policy:?} is incompatible with topology guarantee {guarantee:?}; call validate_at_completion() after construction to certify PL-manifoldness.",
-                guarantee = self.topology_guarantee
-            );
+        if let Err(err) = self.try_set_validation_policy(policy) {
+            tracing::warn!("{err}. Validation policy not updated.");
         }
+    }
 
-        self.validation_policy = policy;
+    /// Tries to set the topology guarantee used for Level 3 topology validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy`] when the
+    /// requested guarantee cannot be represented with the current validation policy.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::{TopologyGuarantee, Triangulation};
+    /// use delaunay::prelude::geometry::FastKernel;
+    ///
+    /// # fn main() -> Result<(), delaunay::prelude::ValidationConfigurationError> {
+    /// let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
+    ///     Triangulation::new_empty(FastKernel::new());
+    /// tri.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)?;
+    /// assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_set_topology_guarantee(
+        &mut self,
+        guarantee: TopologyGuarantee,
+    ) -> Result<(), ValidationConfigurationError> {
+        validate_configuration(guarantee, self.validation_policy)?;
+        self.topology_guarantee = guarantee;
+        Ok(())
     }
 
     /// Sets the topology guarantee used for Level 3 topology validation.
     ///
-    /// If the requested guarantee is incompatible with the current validation policy (for
-    /// example, `ValidationPolicy::Never` with `TopologyGuarantee::PLManifold`), this runs
-    /// [`Triangulation::validate_at_completion`](Self::validate_at_completion) to provide
-    /// immediate feedback and emits a warning. Call `validate_at_completion()` after batch
-    /// construction when using an incompatible combination.
+    /// Prefer [`try_set_topology_guarantee`](Self::try_set_topology_guarantee) when callers need
+    /// typed feedback for rejected combinations. This compatibility setter leaves the existing
+    /// guarantee unchanged and emits a warning if the requested combination is incoherent.
     ///
     /// # Examples
     ///
@@ -695,33 +802,9 @@ where
     /// ```
     #[inline]
     pub fn set_topology_guarantee(&mut self, guarantee: TopologyGuarantee) {
-        if !guarantee.is_compatible_with_policy(self.validation_policy) {
-            let previous = self.topology_guarantee;
-            self.topology_guarantee = guarantee;
-            let completion_result = self.validate_at_completion();
-
-            if let Err(err) = completion_result {
-                self.topology_guarantee = previous;
-                debug_assert!(
-                    false,
-                    "Topology guarantee {guarantee:?} is incompatible with validation policy {policy:?}; validate_at_completion failed: {err}",
-                    policy = self.validation_policy
-                );
-                tracing::warn!(
-                    "Topology guarantee {guarantee:?} is incompatible with validation policy {policy:?}; validate_at_completion failed: {err}. Topology guarantee not updated.",
-                    policy = self.validation_policy
-                );
-                return;
-            }
-
-            self.topology_guarantee = previous;
-            tracing::warn!(
-                "Topology guarantee {guarantee:?} is incompatible with validation policy {policy:?}; call validate_at_completion() after construction to certify PL-manifoldness.",
-                policy = self.validation_policy
-            );
+        if let Err(err) = self.try_set_topology_guarantee(guarantee) {
+            tracing::warn!("{err}. Topology guarantee not updated.");
         }
-
-        self.topology_guarantee = guarantee;
     }
 
     /// Traverses the simplex neighbor graph for validation without assuming global connectivity.
@@ -1730,6 +1813,8 @@ mod tests {
 
         assert!(!ValidationPolicy::Never.should_validate(clean));
         assert!(!ValidationPolicy::Never.should_validate(suspicious));
+        assert!(!ValidationPolicy::ExplicitOnly.should_validate(clean));
+        assert!(!ValidationPolicy::ExplicitOnly.should_validate(suspicious));
         assert!(ValidationPolicy::Always.should_validate(clean));
         assert!(ValidationPolicy::Always.should_validate(suspicious));
         assert!(!ValidationPolicy::OnSuspicion.should_validate(clean));
@@ -1782,6 +1867,7 @@ mod tests {
 
         for policy in [
             ValidationPolicy::Never,
+            ValidationPolicy::ExplicitOnly,
             ValidationPolicy::OnSuspicion,
             ValidationPolicy::Always,
             ValidationPolicy::DebugOnly,
@@ -1792,6 +1878,13 @@ mod tests {
         assert!(!TopologyGuarantee::PLManifold.is_compatible_with_policy(ValidationPolicy::Never));
         assert!(
             !TopologyGuarantee::PLManifoldStrict.is_compatible_with_policy(ValidationPolicy::Never)
+        );
+        assert!(
+            TopologyGuarantee::PLManifold.is_compatible_with_policy(ValidationPolicy::ExplicitOnly)
+        );
+        assert!(
+            TopologyGuarantee::PLManifoldStrict
+                .is_compatible_with_policy(ValidationPolicy::ExplicitOnly)
         );
         assert!(
             TopologyGuarantee::PLManifold.is_compatible_with_policy(ValidationPolicy::OnSuspicion)
@@ -1817,31 +1910,67 @@ mod tests {
     }
 
     #[test]
-    fn incompatible_policy_updates_when_completion_validation_succeeds() {
+    fn explicit_only_policy_supports_manual_pl_manifold_validation() {
         let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
             Triangulation::new_empty(FastKernel::new());
 
         assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
         assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
 
-        tri.set_validation_policy(ValidationPolicy::Never);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
+        tri.try_set_validation_policy(ValidationPolicy::ExplicitOnly)
+            .unwrap();
+        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
     }
 
     #[test]
-    fn incompatible_guarantee_updates_when_completion_validation_succeeds() {
+    fn incompatible_policy_rejected_even_when_completion_validation_succeeds() {
         let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
             Triangulation::new_empty(FastKernel::new());
 
-        tri.set_validation_policy(ValidationPolicy::Never);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
         assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
+        assert!(tri.validate_at_completion().is_ok());
+
+        assert_eq!(
+            tri.try_set_validation_policy(ValidationPolicy::Never),
+            Err(
+                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                    topology_guarantee: TopologyGuarantee::PLManifold,
+                    validation_policy: ValidationPolicy::Never,
+                }
+            )
+        );
+        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
+
+        tri.set_validation_policy(ValidationPolicy::Never);
+        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
+    }
+
+    #[test]
+    fn incompatible_guarantee_rejected_even_when_completion_validation_succeeds() {
+        let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
+            Triangulation::new_empty(FastKernel::new());
+
+        tri.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)
+            .unwrap();
+        tri.try_set_validation_policy(ValidationPolicy::Never)
+            .unwrap();
+        assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
+        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+        assert!(tri.validate_at_completion().is_ok());
+
+        assert_eq!(
+            tri.try_set_topology_guarantee(TopologyGuarantee::PLManifoldStrict),
+            Err(
+                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                    topology_guarantee: TopologyGuarantee::PLManifoldStrict,
+                    validation_policy: ValidationPolicy::Never,
+                }
+            )
+        );
+        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
 
         tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
-        assert_eq!(
-            tri.topology_guarantee(),
-            TopologyGuarantee::PLManifoldStrict
-        );
+        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
     }
 
     #[test]
@@ -1889,14 +2018,16 @@ mod tests {
             ))
         ));
         assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            tri.set_validation_policy(ValidationPolicy::Never);
-        }));
-        if cfg!(debug_assertions) {
-            assert!(result.is_err());
-        } else {
-            assert!(result.is_ok());
-        }
+        assert_eq!(
+            tri.try_set_validation_policy(ValidationPolicy::Never),
+            Err(
+                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                    topology_guarantee: TopologyGuarantee::PLManifold,
+                    validation_policy: ValidationPolicy::Never,
+                }
+            )
+        );
+        tri.set_validation_policy(ValidationPolicy::Never);
         assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
     }
 
@@ -1906,18 +2037,22 @@ mod tests {
         let mut tri =
             Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
 
-        tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
-        tri.set_validation_policy(ValidationPolicy::Never);
+        tri.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)
+            .unwrap();
+        tri.try_set_validation_policy(ValidationPolicy::Never)
+            .unwrap();
         assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
         assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
-        }));
-        if cfg!(debug_assertions) {
-            assert!(result.is_err());
-        } else {
-            assert!(result.is_ok());
-        }
+        assert_eq!(
+            tri.try_set_topology_guarantee(TopologyGuarantee::PLManifoldStrict),
+            Err(
+                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                    topology_guarantee: TopologyGuarantee::PLManifoldStrict,
+                    validation_policy: ValidationPolicy::Never,
+                }
+            )
+        );
+        tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
         assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
     }
 
@@ -2963,13 +3098,14 @@ mod tests {
     }
 
     #[test]
-    fn pl_manifold_insertion_never_commits_invalid_topology_when_validation_policy_is_never() {
+    fn pl_manifold_insertion_keeps_valid_topology_with_explicit_only_validation() {
         let points = generate_random_points_seeded::<f64, 3>(25, (-100.0, 100.0), 123).unwrap();
 
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
-        dt.set_validation_policy(ValidationPolicy::Never);
+        dt.try_set_validation_policy(ValidationPolicy::ExplicitOnly)
+            .unwrap();
         dt.set_delaunay_repair_policy(DelaunayRepairPolicy::Never);
 
         for (i, point) in points.into_iter().enumerate() {

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -1303,6 +1303,9 @@ impl<'v, T, U, const D: usize> DelaunayTriangulationBuilder<'v, T, U, D> {
     /// Sets the [`TopologyGuarantee`]
     ///
     /// Defaults to [`TopologyGuarantee::DEFAULT`] (`PLManifold`).
+    /// The builder derives the initial [`ValidationPolicy`](crate::ValidationPolicy)
+    /// from this guarantee; it does not expose a separate construction-time validation
+    /// policy knob.
     ///
     /// # Examples
     ///

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -3767,7 +3767,8 @@ where
         let duplicate_tolerance = default_duplicate_tolerance::<K::Scalar>();
 
         let mut tri = Triangulation::new_empty(kernel);
-        tri.set_topology_guarantee(topology_guarantee);
+        tri.topology_guarantee = topology_guarantee;
+        tri.validation_policy = topology_guarantee.default_validation_policy();
         Self {
             tri,
             insertion_state: DelaunayInsertionState::new(),
@@ -4680,8 +4681,9 @@ mod tests {
     };
     use crate::core::algorithms::locate::{ConflictError, LocateError};
     use crate::core::tds::{EntityKind, GeometricError, InvariantError, SimplexKey, VertexKey};
-    use crate::core::validation::TopologyGuarantee;
-    use crate::core::validation::TriangulationValidationError;
+    use crate::core::validation::{
+        TopologyGuarantee, TriangulationValidationError, ValidationPolicy,
+    };
     use crate::core::vertex::VertexBuilder;
     use crate::diagnostics::BatchLocalRepairTrigger;
     use crate::geometry::kernel::{AdaptiveKernel, FastKernel, RobustKernel};
@@ -6267,6 +6269,35 @@ mod tests {
             .unwrap();
 
         assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
+    }
+
+    #[test]
+    fn test_empty_topology_guarantee_derives_validation_policy() {
+        init_tracing();
+
+        let strict: DelaunayTriangulation<_, (), (), 3> =
+            DelaunayTriangulation::empty_with_topology_guarantee(
+                TopologyGuarantee::PLManifoldStrict,
+            );
+        assert_eq!(
+            strict.topology_guarantee(),
+            TopologyGuarantee::PLManifoldStrict
+        );
+        assert_eq!(strict.validation_policy(), ValidationPolicy::Always);
+
+        let pseudomanifold: DelaunayTriangulation<_, (), (), 3> =
+            DelaunayTriangulation::with_empty_kernel_and_topology_guarantee(
+                FastKernel::<f64>::new(),
+                TopologyGuarantee::Pseudomanifold,
+            );
+        assert_eq!(
+            pseudomanifold.topology_guarantee(),
+            TopologyGuarantee::Pseudomanifold
+        );
+        assert_eq!(
+            pseudomanifold.validation_policy(),
+            ValidationPolicy::OnSuspicion
+        );
     }
 
     #[test]

--- a/src/delaunay/query.rs
+++ b/src/delaunay/query.rs
@@ -15,7 +15,7 @@ use crate::core::simplex::Simplex;
 use crate::core::tds::{SimplexKey, Tds, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
-use crate::core::validation::{TopologyGuarantee, ValidationPolicy};
+use crate::core::validation::{TopologyGuarantee, ValidationConfigurationError, ValidationPolicy};
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
 use crate::repair::{DelaunayCheckPolicy, DelaunayRepairPolicy};
@@ -419,43 +419,97 @@ where
         self.tri.validation_policy
     }
 
-    /// Sets the insertion-time global topology validation policy used by the underlying
+    /// Tries to set the insertion-time global topology validation policy used by the underlying
     /// triangulation.
     ///
     /// This affects subsequent incremental insertions. (Construction-time behavior is determined
     /// by the policy active during `new()` / `with_kernel()`.)
     ///
-    /// If the requested policy is incompatible with the current topology guarantee (for example,
-    /// `ValidationPolicy::Never` with `TopologyGuarantee::PLManifold`), this runs
-    /// [`Triangulation::validate_at_completion`](crate::Triangulation::validate_at_completion)
-    /// to provide immediate feedback and emits a warning. Call `validate_at_completion()` after
-    /// batch construction when using an incompatible combination.
+    /// # Errors
+    ///
+    /// Returns [`ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy`] when the
+    /// requested policy is incompatible with the current topology guarantee.
     ///
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
-    /// use delaunay::prelude::validation::ValidationPolicy;
+    /// use delaunay::prelude::construction::DelaunayTriangulation;
+    /// use delaunay::prelude::validation::{
+    ///     ValidationConfigurationError, ValidationPolicy,
+    /// };
     ///
-    /// let vertices = vec![
-    ///     vertex!([0.0, 0.0]),
-    ///     vertex!([1.0, 0.0]),
-    ///     vertex!([0.0, 1.0]),
-    /// ];
+    /// # fn main() -> Result<(), ValidationConfigurationError> {
+    /// let mut dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::empty();
     ///
-    /// let mut dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
-    ///
-    /// dt.set_validation_policy(ValidationPolicy::Always);
+    /// dt.try_set_validation_policy(ValidationPolicy::Always)?;
     /// assert_eq!(
     ///     dt.validation_policy(),
     ///     ValidationPolicy::Always
     /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_set_validation_policy(
+        &mut self,
+        policy: ValidationPolicy,
+    ) -> Result<(), ValidationConfigurationError> {
+        self.tri.try_set_validation_policy(policy)
+    }
+
+    /// Sets the insertion-time global topology validation policy used by the underlying
+    /// triangulation.
+    ///
+    /// Prefer [`try_set_validation_policy`](Self::try_set_validation_policy) when callers need
+    /// typed feedback for rejected combinations. This compatibility setter leaves the existing
+    /// policy unchanged and emits a warning if the requested combination is incoherent.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulation;
+    /// use delaunay::prelude::validation::ValidationPolicy;
+    ///
+    /// let mut dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::empty();
+    ///
+    /// dt.set_validation_policy(ValidationPolicy::Always);
+    /// assert_eq!(dt.validation_policy(), ValidationPolicy::Always);
     /// ```
     #[inline]
     pub fn set_validation_policy(&mut self, policy: ValidationPolicy) {
         self.tri.set_validation_policy(policy);
     }
+
+    /// Tries to set the topology guarantee used for Level 3 topology validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy`] when the
+    /// requested guarantee cannot be represented with the current validation policy.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulation, TopologyGuarantee,
+    /// };
+    ///
+    /// # fn main() -> Result<(), delaunay::prelude::validation::ValidationConfigurationError> {
+    /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
+    /// dt.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)?;
+    ///
+    /// assert_eq!(dt.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn try_set_topology_guarantee(
+        &mut self,
+        guarantee: TopologyGuarantee,
+    ) -> Result<(), ValidationConfigurationError> {
+        self.tri.try_set_topology_guarantee(guarantee)
+    }
+
     /// Returns the automatic Delaunay repair policy.
     ///
     /// # Examples
@@ -636,6 +690,10 @@ where
     }
 
     /// Sets the topology guarantee used for Level 3 topology validation.
+    ///
+    /// Prefer [`try_set_topology_guarantee`](Self::try_set_topology_guarantee) when callers need
+    /// typed feedback for rejected combinations. This compatibility setter leaves the existing
+    /// guarantee unchanged and emits a warning if the requested combination is incoherent.
     ///
     /// # Examples
     ///
@@ -1142,7 +1200,29 @@ mod tests {
         assert_eq!(dt.validation_policy(), ValidationPolicy::Always);
         assert_eq!(dt.tri.validation_policy, ValidationPolicy::Always);
 
+        dt.try_set_validation_policy(ValidationPolicy::ExplicitOnly)
+            .unwrap();
+        assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
+        assert_eq!(dt.tri.validation_policy, ValidationPolicy::ExplicitOnly);
+
         dt.set_validation_policy(ValidationPolicy::Never);
+        assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
+        assert_eq!(dt.tri.validation_policy, ValidationPolicy::ExplicitOnly);
+
+        assert_eq!(
+            dt.try_set_validation_policy(ValidationPolicy::Never),
+            Err(
+                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                    topology_guarantee: TopologyGuarantee::PLManifold,
+                    validation_policy: ValidationPolicy::Never,
+                }
+            )
+        );
+
+        dt.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)
+            .unwrap();
+        dt.try_set_validation_policy(ValidationPolicy::Never)
+            .unwrap();
         assert_eq!(dt.validation_policy(), ValidationPolicy::Never);
         assert_eq!(dt.tri.validation_policy, ValidationPolicy::Never);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,7 +270,7 @@
 //!     DelaunayTriangulation, DelaunayTriangulationConstructionError, vertex,
 //! };
 //! use delaunay::prelude::insertion::InsertionError;
-//! use delaunay::prelude::validation::ValidationPolicy;
+//! use delaunay::prelude::validation::{ValidationConfigurationError, ValidationPolicy};
 //!
 //! # #[derive(Debug, thiserror::Error)]
 //! # enum ExampleError {
@@ -278,6 +278,8 @@
 //! #     Construction(#[from] DelaunayTriangulationConstructionError),
 //! #     #[error(transparent)]
 //! #     Insertion(#[from] InsertionError),
+//! #     #[error(transparent)]
+//! #     ValidationConfiguration(#[from] ValidationConfigurationError),
 //! # }
 //! # fn main() -> Result<(), ExampleError> {
 //! let vertices = vec![
@@ -288,8 +290,9 @@
 //! ];
 //! let mut dt = DelaunayTriangulation::new(&vertices)?;
 //!
-//! // Performance mode: disable insertion-time Level 3 topology validation.
-//! dt.set_validation_policy(ValidationPolicy::Never);
+//! // Caller-owned validation mode: keep mandatory topology checks, but run full
+//! // Level 3 validation only through explicit validation calls.
+//! dt.try_set_validation_policy(ValidationPolicy::ExplicitOnly)?;
 //!
 //! // Do incremental work...
 //! dt.insert(vertex!([0.2, 0.2, 0.2]))?;
@@ -971,7 +974,7 @@ pub use crate::core::util::{
     delaunay_violation_report,
 };
 pub use crate::core::validation::{
-    TopologyGuarantee, TriangulationValidationError, ValidationPolicy,
+    TopologyGuarantee, TriangulationValidationError, ValidationConfigurationError, ValidationPolicy,
 };
 pub use crate::repair::{
     DelaunayCheckPolicy, DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds,
@@ -1259,7 +1262,8 @@ pub mod prelude {
         DuplicateDetectionMetrics, InitialSimplexStrategy, InsertionOrderStrategy, InsertionResult,
         PlManifoldRepairError, PlManifoldRepairStats, RepairDecision, RepairSkipReason,
         RetryPolicy, TopologicalOperation, TopologyGuarantee, Triangulation,
-        TriangulationConstructionError, TriangulationValidationError, ValidationPolicy,
+        TriangulationConstructionError, TriangulationValidationError, ValidationConfigurationError,
+        ValidationPolicy,
     };
 
     // Re-export utility items, but avoid exporting the util module names themselves.
@@ -1425,7 +1429,7 @@ pub mod prelude {
         };
         pub use crate::{
             InsertionError, TopologyGuarantee, Triangulation, TriangulationConstructionError,
-            TriangulationValidationError, ValidationPolicy,
+            TriangulationValidationError, ValidationConfigurationError, ValidationPolicy,
         };
 
         // Convenience macro for generic triangulation examples and tests.
@@ -1514,7 +1518,9 @@ pub mod prelude {
             DelaunayTriangulation, DelaunayTriangulationValidationError,
         };
         pub use crate::{DelaunayValidationError, find_delaunay_violations};
-        pub use crate::{TopologyGuarantee, Triangulation, ValidationPolicy};
+        pub use crate::{
+            TopologyGuarantee, Triangulation, ValidationConfigurationError, ValidationPolicy,
+        };
     }
 
     /// End-to-end "repair then delaunayize" workflow.
@@ -1545,7 +1551,8 @@ pub mod prelude {
     pub mod validation {
         pub use crate::validation::*;
         pub use crate::{
-            DelaunayTriangulationValidationError, TriangulationValidationError, ValidationPolicy,
+            DelaunayTriangulationValidationError, TriangulationValidationError,
+            ValidationConfigurationError, ValidationPolicy,
         };
     }
 

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -68,10 +68,16 @@ use delaunay::prelude::triangulation::{
     TdsError as TriangulationTdsError, TopologyGuarantee as TriangulationTopologyGuarantee,
     Triangulation as GenericTriangulation,
     TriangulationConstructionError as GenericTriangulationConstructionError,
+    ValidationConfigurationError as TriangulationValidationConfigurationError,
     ValidationPolicy as TriangulationValidationPolicy, vertex as triangulation_vertex,
 };
-use delaunay::prelude::validation::ValidationCadence;
-use delaunay::prelude::{SecureHashMap, SecureHashSet};
+use delaunay::prelude::validation::{
+    ValidationCadence, ValidationConfigurationError as FocusedValidationConfigurationError,
+    ValidationPolicy as FocusedValidationPolicy,
+};
+use delaunay::prelude::{
+    SecureHashMap, SecureHashSet, ValidationConfigurationError as RootValidationConfigurationError,
+};
 
 #[derive(Debug, thiserror::Error)]
 enum RootApiExportTestError {
@@ -315,6 +321,36 @@ fn construction_prelude_covers_explicit_error_summaries() {
         explicit_delaunay_validation.kind,
         ExplicitDelaunayValidationErrorKind::Tds
     );
+}
+
+#[test]
+fn validation_prelude_covers_configuration_error() {
+    let focused_error =
+        FocusedValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+            topology_guarantee: TopologyGuarantee::PLManifold,
+            validation_policy: FocusedValidationPolicy::Never,
+        };
+    let root_error: RootValidationConfigurationError = focused_error;
+    assert!(matches!(
+        root_error,
+        RootValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+            topology_guarantee: TopologyGuarantee::PLManifold,
+            validation_policy: FocusedValidationPolicy::Never,
+        }
+    ));
+
+    let triangulation_error =
+        TriangulationValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+            topology_guarantee: TriangulationTopologyGuarantee::PLManifoldStrict,
+            validation_policy: TriangulationValidationPolicy::Never,
+        };
+    assert!(matches!(
+        triangulation_error,
+        TriangulationValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+            topology_guarantee: TriangulationTopologyGuarantee::PLManifoldStrict,
+            validation_policy: TriangulationValidationPolicy::Never,
+        }
+    ));
 }
 
 #[test]

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -943,7 +943,8 @@ macro_rules! gen_duplicate_coords_test {
                     );
                     prop_assume!(dt.is_ok());
                     let mut dt = dt.unwrap();
-                    dt.set_validation_policy(ValidationPolicy::Never);
+                    dt.try_set_validation_policy(ValidationPolicy::ExplicitOnly)
+                        .expect("explicit-only validation policy should be compatible");
                     dt.set_delaunay_repair_policy(DelaunayRepairPolicy::Never);
                     // Select a vertex that is actually present in the triangulation.
                     // `DelaunayTriangulation::new_with_options` may skip some input vertices (e.g., due to degeneracy),

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -20,6 +20,7 @@ use delaunay::prelude::repair::DelaunayRepairError;
 use delaunay::prelude::tds::{InvariantErrorSummaryDetail, TriangulationValidationErrorKind};
 use delaunay::prelude::topology::spaces::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
 use delaunay::prelude::topology::validation::{count_simplices, euler_characteristic};
+use delaunay::prelude::validation::ValidationPolicy;
 
 // =============================================================================
 // Euclidean path
@@ -77,6 +78,25 @@ fn test_builder_topology_guarantee_propagated() {
         .build::<()>()
         .expect("build should succeed");
     assert_eq!(dt.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+}
+
+/// Builder derives validation policy from topology guarantee instead of exposing
+/// a separate construction-time policy axis.
+#[test]
+fn test_builder_validation_policy_derived_from_topology_guarantee() {
+    let vertices = vec![
+        vertex!([0.0_f64, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
+
+    let dt = DelaunayTriangulationBuilder::new(&vertices)
+        .topology_guarantee(TopologyGuarantee::PLManifoldStrict)
+        .build::<()>()
+        .expect("build should succeed");
+
+    assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifoldStrict);
+    assert_eq!(dt.validation_policy(), ValidationPolicy::Always);
 }
 
 /// Custom `ConstructionOptions` are accepted and the triangulation is valid.


### PR DESCRIPTION
- Add explicit caller-owned validation mode for PL-manifold topology guarantees.
- Reject incoherent topology guarantee and validation policy pairings through typed fallible setters.
- Keep compatibility setters non-committal when a requested pairing is invalid.
- Derive builder validation policy from the selected topology guarantee and document the compatibility matrix.

BREAKING CHANGE: `ValidationPolicy::Never` is now only coherent with `TopologyGuarantee::Pseudomanifold`; PL-manifold callers should use `ValidationPolicy::ExplicitOnly` for manual full-validation checkpoints.

Closes #385