### PR TITLE
feat(insertion)!: split strict and best-effort insertion statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,8 @@ For the full periodic image-point method (Phase 2), see the
   canonicalization fails, and repair failures preserve typed source errors for
   debugging.
 - **Insertion outcomes and statistics** (`insert_with_statistics`,
-  `InsertionOutcome`, `InsertionStatistics`):
+  `insert_best_effort_with_statistics`, `InsertionOutcome`,
+  `InsertionStatistics`):
   see [`docs/workflows.md`](docs/workflows.md) and
   [`docs/numerical_robustness_guide.md`](docs/numerical_robustness_guide.md).
 - **Topology guarantees** (`TopologyGuarantee`) and **automatic topology

--- a/docs/numerical_robustness_guide.md
+++ b/docs/numerical_robustness_guide.md
@@ -176,14 +176,16 @@ With the default 3 retries, the ladder is:
 - attempt 2: `1e-6 × local_scale`
 - attempt 3: `1e-5 × local_scale`
 
-If all retries are exhausted, the vertex is skipped and you get
-`InsertionOutcome::Skipped { .. }` (the triangulation is unchanged).
+If all retries are exhausted, strict insertion APIs return an
+`InsertionError` and the triangulation is unchanged. The explicitly named
+best-effort API reports the same event as `InsertionOutcome::Skipped { .. }`
+with telemetry.
 
 **Note:** With the default `AdaptiveKernel`, SoS resolves most orientation degeneracies
 symbolically, so perturbation retries are rarely needed. The primary remaining retryable
 cases involve cavity/topology failures rather than predicate degeneracies.
 
-Use `insert_with_statistics()` to observe this behavior:
+Use `insert_best_effort_with_statistics()` to observe this behavior:
 
 ```rust
 use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
@@ -191,7 +193,9 @@ use delaunay::prelude::insertion::InsertionOutcome;
 
 let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
 
-let (outcome, stats) = dt.insert_with_statistics(vertex!([0.5, 0.5, 0.5])).unwrap();
+let (outcome, stats) = dt
+    .insert_best_effort_with_statistics(vertex!([0.5, 0.5, 0.5]))
+    .unwrap();
 
 if stats.used_perturbation() {
     println!("used perturbation (attempts={})", stats.attempts);
@@ -286,9 +290,11 @@ scale, with a small ULP-scaled floor for translated coordinate systems. The
 comparison is overflow-safe: it compares squared distances against
 `tolerance²` when possible and falls back to square roots for extreme scales.
 
-If a duplicate is detected, the vertex is skipped with
-`InsertionOutcome::Skipped { error: DuplicateCoordinates { .. } }` and the
-triangulation is unchanged.
+If a duplicate is detected, strict APIs return
+`InsertionError::DuplicateCoordinates` and the triangulation is unchanged.
+`insert_best_effort_with_statistics()` instead returns
+`InsertionOutcome::Skipped { error: DuplicateCoordinates { .. } }` with skip
+telemetry.
 
 This layer catches duplicates that survive Hilbert dedup (e.g. when using
 `InsertionOrderStrategy::Input`) and also protects single-vertex `insert()` calls.
@@ -367,9 +373,9 @@ and per-insertion checks handle any remaining cases.
   `RobustKernel` if you need manual repair control.
 - If you see retryable insertion errors, frequent perturbation retries, or skipped vertices,
   preprocess your input (dedup / rescale if appropriate).
-- Treat `InsertionOutcome::Skipped { .. }` as an expected outcome on pathological data; decide
-  at the application level whether to drop the vertex, perturb/rescale your point set, or
-  re-run with a different kernel.
+- Treat `InsertionOutcome::Skipped { .. }` from the best-effort API as an expected outcome on
+  pathological data; decide at the application level whether to drop the vertex,
+  perturb/rescale your point set, or re-run with a different kernel.
 
 ## Current limitations
 

--- a/docs/production_review_remediation_checklist.md
+++ b/docs/production_review_remediation_checklist.md
@@ -98,7 +98,7 @@ Treat partial items as still open until their acceptance notes are satisfied.
   setters, compatibility setters no longer commit rejected state, and builder
   construction continues to derive the initial validation policy from the
   selected topology guarantee. Tracked for v0.7.8 in #385.
-- [ ] **23. Reconsider skipped insertions as success outcomes.**
+- [x] **23. Reconsider skipped insertions as success outcomes.**
   Make skipped duplicate and degeneracy outcomes harder for callers to ignore.
   Tracked for v0.7.8 in #386.
 - [ ] **24. Make `Simplex` encapsulation consistent.**

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -59,10 +59,15 @@ Note: neighbor-pointer consistency is a **Level 2** structural invariant checked
 Automatic validation does **not** run Level 4 (the Delaunay empty-circumsphere property).
 If you need geometric verification, call `dt.is_valid()` or `dt.validate()` explicitly.
 
-### Default: `OnSuspicion`
+### Default: derived from `TopologyGuarantee`
 
-The default policy is `ValidationPolicy::OnSuspicion`: we validate Level 3 only when the
-insertion deviates from the happy-path and trips internal **suspicion flags**, e.g.:
+The initial policy is derived from the active `TopologyGuarantee`: `PLManifold`
+uses `ValidationPolicy::ExplicitOnly`, `PLManifoldStrict` uses
+`ValidationPolicy::Always`, and `Pseudomanifold` uses
+`ValidationPolicy::OnSuspicion`.
+
+With `ValidationPolicy::OnSuspicion`, Level 3 validation runs only when insertion
+deviates from the happy-path and trips internal **suspicion flags**, e.g.:
 
 - A perturbation retry was required (geometric degeneracy).
 - The insertion fell back to a conservative “star-split” of the containing simplex.
@@ -73,9 +78,11 @@ insertion deviates from the happy-path and trips internal **suspicion flags**, e
 
 - `ValidationPolicy::Never`: never run full Level 3 automatically; compatible only with
   `TopologyGuarantee::Pseudomanifold`.
-- `ValidationPolicy::ExplicitOnly`: run full Level 3 only through explicit validation
-  calls while still keeping topology checks required by the active `TopologyGuarantee`.
-- `ValidationPolicy::OnSuspicion` *(default)*: run Level 3 only when insertion is suspicious.
+- `ValidationPolicy::ExplicitOnly` *(default for `PLManifold`)*: run full Level 3
+  only through explicit validation calls while still keeping topology checks required
+  by the active `TopologyGuarantee`.
+- `ValidationPolicy::OnSuspicion` *(default for `Pseudomanifold`)*: run Level 3
+  only when insertion is suspicious.
 - `ValidationPolicy::Always`: run Level 3 after every insertion attempt (slowest, best for tests).
 - `ValidationPolicy::DebugOnly`: always run Level 3 in debug builds; in release behaves like `OnSuspicion`.
 
@@ -96,8 +103,8 @@ let vertices = vec![
 
 let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
 
-// Default: validate topology only when insertion is suspicious.
-assert_eq!(dt.validation_policy(), ValidationPolicy::OnSuspicion);
+// Default PL-manifold mode: caller-owned full validation checkpoints.
+assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
 
 // For test/debug: validate topology after every insertion.
 dt.set_validation_policy(ValidationPolicy::Always);
@@ -124,7 +131,8 @@ This is separate from [`ValidationPolicy`](#automatic-validation-during-incremen
 which controls *when* Level 3 is run automatically during incremental insertion.
 The builder keeps these axes coherent by deriving the initial validation policy
 from `TopologyGuarantee`: `PLManifoldStrict` starts with `ValidationPolicy::Always`,
-and `PLManifold` / `Pseudomanifold` start with `ValidationPolicy::OnSuspicion`.
+`PLManifold` starts with `ValidationPolicy::ExplicitOnly`, and
+`Pseudomanifold` starts with `ValidationPolicy::OnSuspicion`.
 
 ### Default: `PLManifold`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -305,8 +305,10 @@ for (order, (vertex_key, _)) in dt.vertices().enumerate() {
 
 ## Builder API: insertion statistics
 
-If you need observability (or you want to handle skipped vertices explicitly), use
-`insert_with_statistics()`.
+If you need strict observability where duplicate or retry-exhausted skipped
+insertions become errors, use `insert_with_statistics()`. If you intentionally
+want to keep going after skipped vertices, use the explicitly best-effort
+`insert_best_effort_with_statistics()`.
 
 ```rust
 use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
@@ -314,7 +316,9 @@ use delaunay::prelude::insertion::InsertionOutcome;
 
 let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
 
-let (outcome, stats) = dt.insert_with_statistics(vertex!([0.5, 0.5, 0.5])).unwrap();
+let (outcome, stats) = dt
+    .insert_best_effort_with_statistics(vertex!([0.5, 0.5, 0.5]))
+    .unwrap();
 
 if stats.used_perturbation() {
     println!("used perturbation (attempts={})", stats.attempts);

--- a/src/core/insertion.rs
+++ b/src/core/insertion.rs
@@ -3261,7 +3261,8 @@ mod tests {
             .expect("first insertion should succeed");
         assert_eq!(tri.number_of_vertices(), 1);
 
-        // Second insertion at same coordinates: insert() returns Err, insert_with_statistics() reports Skipped.
+        // Second insertion at same coordinates: insert() returns Err; the internal
+        // statistics helper reports Skipped so telemetry can classify the no-op.
         let err = insert(&mut tri, vertex!([0.0, 0.0, 0.0]), None, None).unwrap_err();
         assert!(matches!(err, InsertionError::DuplicateCoordinates { .. }));
 

--- a/src/core/operations.rs
+++ b/src/core/operations.rs
@@ -356,8 +356,12 @@ impl DelaunayInsertionState {
 ///   - The input vertex is a duplicate/near-duplicate (skipped immediately)
 ///   - A retryable geometric degeneracy exhausts all perturbation attempts
 ///
-/// Other non-recoverable structural failures are returned as `Err(InsertionError)` instead
-/// (e.g. duplicate UUID).
+/// Strict insertion APIs return skipped insertions as `Err(InsertionError)` so
+/// callers using `?` cannot miss them. The explicitly named
+/// `insert_best_effort_with_statistics` API preserves `Skipped` as an `Ok`
+/// outcome for diagnostics and best-effort ingestion. Other non-recoverable
+/// structural failures are returned as `Err(InsertionError)` instead (e.g.
+/// duplicate UUID).
 ///
 /// # Examples
 ///

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -355,7 +355,7 @@ impl From<ManifoldError> for InvariantError {
 /// `PLManifold` requires at least caller-owned completion validation to certify full
 /// PL-manifoldness. Use [`ValidationPolicy::ExplicitOnly`] when you want to run full
 /// topology validation only through explicit validation calls, [`ValidationPolicy::OnSuspicion`]
-/// (default) for best performance, or [`ValidationPolicy::Always`] for maximum safety during
+/// for suspicion-triggered validation, or [`ValidationPolicy::Always`] for maximum safety during
 /// incremental operations.
 ///
 /// # Examples
@@ -543,8 +543,10 @@ impl TopologyGuarantee {
     /// [`PLManifoldStrict`](Self::PLManifoldStrict) uses [`Always`](ValidationPolicy::Always)
     /// so that full Level-3 global validation (including vertex-link checks) runs
     /// after every insertion — this is the strongest and slowest setting.
-    /// All other guarantees default to
-    /// [`OnSuspicion`](ValidationPolicy::OnSuspicion).
+    /// [`PLManifold`](Self::PLManifold) uses [`ExplicitOnly`](ValidationPolicy::ExplicitOnly)
+    /// because insertion-time ridge-link checks are mandatory but full vertex-link validation
+    /// is a caller-owned completion checkpoint. [`Pseudomanifold`](Self::Pseudomanifold)
+    /// uses [`OnSuspicion`](ValidationPolicy::OnSuspicion).
     ///
     /// # Examples
     ///
@@ -557,7 +559,7 @@ impl TopologyGuarantee {
     /// );
     /// assert_eq!(
     ///     TopologyGuarantee::PLManifold.default_validation_policy(),
-    ///     ValidationPolicy::OnSuspicion,
+    ///     ValidationPolicy::ExplicitOnly,
     /// );
     /// ```
     #[inline]
@@ -565,7 +567,8 @@ impl TopologyGuarantee {
     pub const fn default_validation_policy(self) -> ValidationPolicy {
         match self {
             Self::PLManifoldStrict => ValidationPolicy::Always,
-            Self::Pseudomanifold | Self::PLManifold => ValidationPolicy::OnSuspicion,
+            Self::PLManifold => ValidationPolicy::ExplicitOnly,
+            Self::Pseudomanifold => ValidationPolicy::OnSuspicion,
         }
     }
 
@@ -684,7 +687,7 @@ where
     /// let tri: Triangulation<FastKernel<f64>, (), (), 2> =
     ///     Triangulation::new_empty(FastKernel::new());
     ///
-    /// assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
+    /// assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
     /// ```
     #[inline]
     #[must_use]
@@ -1615,10 +1618,6 @@ mod tests {
         (tds, shared)
     }
 
-    fn build_invalid_vertex_link_tds_2d() -> (Tds<f64, (), (), 2>, VertexKey) {
-        build_invalid_vertex_link_tds::<2>()
-    }
-
     fn build_disconnected_two_triangles_tds_2d() -> Tds<f64, (), (), 2> {
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
 
@@ -1852,7 +1851,7 @@ mod tests {
         );
         assert_eq!(
             TopologyGuarantee::PLManifold.default_validation_policy(),
-            ValidationPolicy::OnSuspicion
+            ValidationPolicy::ExplicitOnly
         );
         assert_eq!(
             TopologyGuarantee::Pseudomanifold.default_validation_policy(),
@@ -1895,166 +1894,173 @@ mod tests {
         );
     }
 
-    #[test]
-    fn validation_accessors_and_mutators_round_trip() {
-        let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
-            Triangulation::new_empty(FastKernel::new());
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
+    macro_rules! test_validation_configuration_paths {
+        ($($dim:expr),+ $(,)?) => {
+            pastey::paste! {
+                $(
+                    #[test]
+                    fn [<validation_accessors_and_mutators_round_trip_ $dim d>]() {
+                        let mut tri: Triangulation<FastKernel<f64>, (), (), $dim> =
+                            Triangulation::new_empty(FastKernel::new());
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
 
-        tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
-        tri.set_validation_policy(ValidationPolicy::Always);
+                        tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
+                        tri.set_validation_policy(ValidationPolicy::Always);
 
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::Always);
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::Always);
+                    }
+
+                    #[test]
+                    fn [<explicit_only_policy_supports_manual_pl_manifold_validation_ $dim d>]() {
+                        let mut tri: Triangulation<FastKernel<f64>, (), (), $dim> =
+                            Triangulation::new_empty(FastKernel::new());
+
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
+
+                        tri.try_set_validation_policy(ValidationPolicy::ExplicitOnly)
+                            .unwrap();
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
+                    }
+
+                    #[test]
+                    fn [<incompatible_policy_rejected_even_when_completion_validation_succeeds_ $dim d>]() {
+                        let mut tri: Triangulation<FastKernel<f64>, (), (), $dim> =
+                            Triangulation::new_empty(FastKernel::new());
+
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
+                        assert!(tri.validate_at_completion().is_ok());
+
+                        assert_eq!(
+                            tri.try_set_validation_policy(ValidationPolicy::Never),
+                            Err(
+                                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                                    topology_guarantee: TopologyGuarantee::PLManifold,
+                                    validation_policy: ValidationPolicy::Never,
+                                }
+                            )
+                        );
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
+
+                        tri.set_validation_policy(ValidationPolicy::Never);
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
+                    }
+
+                    #[test]
+                    fn [<incompatible_guarantee_rejected_even_when_completion_validation_succeeds_ $dim d>]() {
+                        let mut tri: Triangulation<FastKernel<f64>, (), (), $dim> =
+                            Triangulation::new_empty(FastKernel::new());
+
+                        tri.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)
+                            .unwrap();
+                        tri.try_set_validation_policy(ValidationPolicy::Never)
+                            .unwrap();
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+                        assert!(tri.validate_at_completion().is_ok());
+
+                        assert_eq!(
+                            tri.try_set_topology_guarantee(TopologyGuarantee::PLManifoldStrict),
+                            Err(
+                                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                                    topology_guarantee: TopologyGuarantee::PLManifoldStrict,
+                                    validation_policy: ValidationPolicy::Never,
+                                }
+                            )
+                        );
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+
+                        tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+                    }
+
+                    #[test]
+                    fn [<validate_at_completion_skips_for_pseudomanifold_ $dim d>]() {
+                        let vertices = unit_simplex_vertices::<$dim>();
+                        let tds =
+                            Triangulation::<FastKernel<f64>, (), (), $dim>::build_initial_simplex(&vertices)
+                                .unwrap();
+                        let mut tri =
+                            Triangulation::<FastKernel<f64>, (), (), $dim>::new_with_tds(FastKernel::new(), tds);
+
+                        tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
+                        assert!(tri.validate_at_completion().is_ok());
+                    }
+
+                    #[test]
+                    fn [<validate_at_completion_reports_invalid_vertex_link_ $dim d>]() {
+                        let (tds, expected_vertex_key) = build_invalid_vertex_link_tds::<$dim>();
+
+                        let mut tri =
+                            Triangulation::<FastKernel<f64>, (), (), $dim>::new_with_tds(FastKernel::new(), tds);
+                        tri.set_topology_guarantee(TopologyGuarantee::PLManifold);
+
+                        match tri.validate_at_completion() {
+                            Err(InvariantError::Triangulation(
+                                TriangulationValidationError::VertexLinkNotManifold { vertex_key, .. },
+                            )) => assert_eq!(vertex_key, expected_vertex_key),
+                            other => panic!("Expected VertexLinkNotManifold, got {other:?}"),
+                        }
+                    }
+
+                    #[test]
+                    fn [<incompatible_policy_rejected_when_completion_validation_fails_ $dim d>]() {
+                        let (tds, _) = build_invalid_vertex_link_tds::<$dim>();
+                        let mut tri =
+                            Triangulation::<FastKernel<f64>, (), (), $dim>::new_with_tds(FastKernel::new(), tds);
+
+                        assert!(matches!(
+                            tri.validate_at_completion(),
+                            Err(InvariantError::Triangulation(
+                                TriangulationValidationError::VertexLinkNotManifold { .. }
+                            ))
+                        ));
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
+                        assert_eq!(
+                            tri.try_set_validation_policy(ValidationPolicy::Never),
+                            Err(
+                                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                                    topology_guarantee: TopologyGuarantee::PLManifold,
+                                    validation_policy: ValidationPolicy::Never,
+                                }
+                            )
+                        );
+                        tri.set_validation_policy(ValidationPolicy::Never);
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
+                    }
+
+                    #[test]
+                    fn [<incompatible_guarantee_rejected_when_completion_validation_fails_ $dim d>]() {
+                        let (tds, _) = build_invalid_vertex_link_tds::<$dim>();
+                        let mut tri =
+                            Triangulation::<FastKernel<f64>, (), (), $dim>::new_with_tds(FastKernel::new(), tds);
+
+                        tri.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)
+                            .unwrap();
+                        tri.try_set_validation_policy(ValidationPolicy::Never)
+                            .unwrap();
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+                        assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
+                        assert_eq!(
+                            tri.try_set_topology_guarantee(TopologyGuarantee::PLManifoldStrict),
+                            Err(
+                                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+                                    topology_guarantee: TopologyGuarantee::PLManifoldStrict,
+                                    validation_policy: ValidationPolicy::Never,
+                                }
+                            )
+                        );
+                        tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
+                        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
+                    }
+                )+
+            }
+        };
     }
 
-    #[test]
-    fn explicit_only_policy_supports_manual_pl_manifold_validation() {
-        let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
-            Triangulation::new_empty(FastKernel::new());
-
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
-
-        tri.try_set_validation_policy(ValidationPolicy::ExplicitOnly)
-            .unwrap();
-        assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
-    }
-
-    #[test]
-    fn incompatible_policy_rejected_even_when_completion_validation_succeeds() {
-        let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
-            Triangulation::new_empty(FastKernel::new());
-
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::PLManifold);
-        assert!(tri.validate_at_completion().is_ok());
-
-        assert_eq!(
-            tri.try_set_validation_policy(ValidationPolicy::Never),
-            Err(
-                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
-                    topology_guarantee: TopologyGuarantee::PLManifold,
-                    validation_policy: ValidationPolicy::Never,
-                }
-            )
-        );
-        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
-
-        tri.set_validation_policy(ValidationPolicy::Never);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
-    }
-
-    #[test]
-    fn incompatible_guarantee_rejected_even_when_completion_validation_succeeds() {
-        let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
-            Triangulation::new_empty(FastKernel::new());
-
-        tri.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)
-            .unwrap();
-        tri.try_set_validation_policy(ValidationPolicy::Never)
-            .unwrap();
-        assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
-        assert!(tri.validate_at_completion().is_ok());
-
-        assert_eq!(
-            tri.try_set_topology_guarantee(TopologyGuarantee::PLManifoldStrict),
-            Err(
-                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
-                    topology_guarantee: TopologyGuarantee::PLManifoldStrict,
-                    validation_policy: ValidationPolicy::Never,
-                }
-            )
-        );
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
-
-        tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
-    }
-
-    #[test]
-    fn validate_at_completion_skips_for_pseudomanifold() {
-        let vertices = vec![
-            vertex!([0.0, 0.0]),
-            vertex!([1.0, 0.0]),
-            vertex!([0.0, 1.0]),
-        ];
-        let tds =
-            Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
-        let mut tri =
-            Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
-
-        tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
-        assert!(tri.validate_at_completion().is_ok());
-    }
-
-    #[test]
-    fn validate_at_completion_reports_invalid_vertex_link() {
-        let (tds, v0) = build_invalid_vertex_link_tds_2d();
-
-        let mut tri =
-            Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
-        tri.set_topology_guarantee(TopologyGuarantee::PLManifold);
-
-        match tri.validate_at_completion() {
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::VertexLinkNotManifold { vertex_key, .. },
-            )) => assert_eq!(vertex_key, v0),
-            other => panic!("Expected VertexLinkNotManifold, got {other:?}"),
-        }
-    }
-
-    #[test]
-    fn incompatible_policy_rejected_when_completion_validation_fails() {
-        let (tds, _) = build_invalid_vertex_link_tds_2d();
-        let mut tri =
-            Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
-
-        assert!(matches!(
-            tri.validate_at_completion(),
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::VertexLinkNotManifold { .. }
-            ))
-        ));
-        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
-        assert_eq!(
-            tri.try_set_validation_policy(ValidationPolicy::Never),
-            Err(
-                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
-                    topology_guarantee: TopologyGuarantee::PLManifold,
-                    validation_policy: ValidationPolicy::Never,
-                }
-            )
-        );
-        tri.set_validation_policy(ValidationPolicy::Never);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::OnSuspicion);
-    }
-
-    #[test]
-    fn incompatible_guarantee_rejected_when_completion_validation_fails() {
-        let (tds, _) = build_invalid_vertex_link_tds_2d();
-        let mut tri =
-            Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
-
-        tri.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)
-            .unwrap();
-        tri.try_set_validation_policy(ValidationPolicy::Never)
-            .unwrap();
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
-        assert_eq!(tri.validation_policy(), ValidationPolicy::Never);
-        assert_eq!(
-            tri.try_set_topology_guarantee(TopologyGuarantee::PLManifoldStrict),
-            Err(
-                ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
-                    topology_guarantee: TopologyGuarantee::PLManifoldStrict,
-                    validation_policy: ValidationPolicy::Never,
-                }
-            )
-        );
-        tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
-        assert_eq!(tri.topology_guarantee(), TopologyGuarantee::Pseudomanifold);
-    }
+    test_validation_configuration_paths!(2, 3, 4, 5);
 
     #[test]
     fn validate_after_insertion_skips_when_no_simplices() {
@@ -3111,7 +3117,7 @@ mod tests {
         for (i, point) in points.into_iter().enumerate() {
             let vertex = VertexBuilder::default().point(point).build().unwrap();
             let (outcome, stats) = dt
-                .insert_with_statistics(vertex)
+                .insert_best_effort_with_statistics(vertex)
                 .unwrap_or_else(|err| panic!("Non-retryable insertion error at i={i}: {err:?}"));
 
             if dt.number_of_simplices() > 0

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -2234,7 +2234,9 @@ where
                         let mut skipped = 0_usize;
                         let mut hard_errors = 0_usize;
                         for (insert_idx, &source_idx) in insertion_order.iter().enumerate() {
-                            match candidate_dt.insert_with_statistics(expanded[source_idx]) {
+                            match candidate_dt
+                                .insert_best_effort_with_statistics(expanded[source_idx])
+                            {
                                 Ok((InsertionOutcome::Inserted { .. }, _stats)) => {
                                     inserted = inserted.saturating_add(1);
                                 }

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -479,6 +479,10 @@ pub enum InsertionOrderStrategy {
 #[non_exhaustive]
 pub enum DedupPolicy {
     /// Do not apply explicit preprocessing dedup.
+    ///
+    /// Batch construction still keeps its built-in Hilbert and per-insertion
+    /// duplicate defenses; exact duplicates can still be skipped and reported
+    /// through [`ConstructionStatistics`].
     #[default]
     Off,
     /// Remove exact coordinate duplicates before construction.
@@ -1897,6 +1901,12 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// This convenience constructor uses [`AdaptiveKernel`] and the default
     /// construction options.
     ///
+    /// Batch construction is a best-effort ingestion path for duplicate or
+    /// degenerate inputs: a successful construction may contain fewer vertices
+    /// than the input slice. Use
+    /// [`new_with_construction_statistics`](Self::new_with_construction_statistics)
+    /// when skipped-input observability is required.
+    ///
     /// # Errors
     /// Returns an error if the initial simplex cannot be constructed, if
     /// insertion fails, or if final validation fails.
@@ -1924,6 +1934,12 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
 
     /// Creates a default `f64` triangulation and returns aggregate construction
     /// statistics.
+    ///
+    /// Batch construction is a best-effort ingestion path for duplicate or
+    /// degenerate inputs: a successful construction may have skipped some input
+    /// vertices. Inspect [`ConstructionStatistics::total_skipped`] and
+    /// [`ConstructionStatistics::skip_samples`] when the caller requires a
+    /// strict all-inputs-inserted contract.
     ///
     /// # Errors
     /// Returns [`DelaunayTriangulationConstructionErrorWithStatistics`] if
@@ -1966,6 +1982,12 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
 
     /// Creates a default `f64` triangulation with explicit construction options
     /// and returns aggregate construction statistics.
+    ///
+    /// Batch construction is a best-effort ingestion path for duplicate or
+    /// degenerate inputs: a successful construction may have skipped some input
+    /// vertices. Inspect [`ConstructionStatistics::total_skipped`] and
+    /// [`ConstructionStatistics::skip_samples`] when the caller requires a
+    /// strict all-inputs-inserted contract.
     ///
     /// # Errors
     /// Returns [`DelaunayTriangulationConstructionErrorWithStatistics`] if
@@ -2014,6 +2036,11 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
 
     /// Creates a default `f64` triangulation with explicit construction options.
     ///
+    /// This batch constructor may successfully build a triangulation after
+    /// skipping duplicate or retry-exhausted degenerate input vertices. Use
+    /// [`new_with_options_and_construction_statistics`](Self::new_with_options_and_construction_statistics)
+    /// when skipped-input observability is required.
+    ///
     /// # Errors
     /// Returns an error if construction fails, or if the selected options are invalid.
     ///
@@ -2051,6 +2078,12 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     }
 
     /// Creates a default `f64` triangulation with an explicit topology guarantee.
+    ///
+    /// Batch construction is a best-effort ingestion path for duplicate or
+    /// degenerate inputs: a successful construction may contain fewer vertices
+    /// than the input slice. Use
+    /// [`new_with_construction_statistics`](Self::new_with_construction_statistics)
+    /// when skipped-input observability is required.
     ///
     /// # Errors
     /// Returns an error if construction fails or if the requested topology
@@ -3778,6 +3811,12 @@ where
 
     /// Creates a Delaunay triangulation from vertices with an explicit kernel.
     ///
+    /// Batch construction is a best-effort ingestion path for duplicate or
+    /// degenerate inputs: a successful construction may contain fewer vertices
+    /// than the input slice. Use
+    /// [`with_options_and_statistics`](Self::with_options_and_statistics) when
+    /// skipped-input observability is required.
+    ///
     /// # Errors
     /// Returns an error if construction fails or final validation fails.
     ///
@@ -3806,6 +3845,12 @@ where
     }
 
     /// Creates a Delaunay triangulation with an explicit topology guarantee.
+    ///
+    /// Batch construction is a best-effort ingestion path for duplicate or
+    /// degenerate inputs: a successful construction may contain fewer vertices
+    /// than the input slice. Use
+    /// [`with_options_and_statistics`](Self::with_options_and_statistics) when
+    /// skipped-input observability is required.
     ///
     /// # Errors
     /// Returns an error if construction fails or if the requested topology
@@ -3849,6 +3894,11 @@ where
     }
 
     /// Creates a Delaunay triangulation with topology and construction options.
+    ///
+    /// This batch constructor may successfully build a triangulation after
+    /// skipping duplicate or retry-exhausted degenerate input vertices. Use
+    /// [`with_options_and_statistics`](Self::with_options_and_statistics) when
+    /// skipped-input observability is required.
     ///
     /// # Errors
     /// Returns an error if construction fails, if validation fails, or if the
@@ -3966,6 +4016,12 @@ where
     }
 
     /// Creates a Delaunay triangulation with construction statistics.
+    ///
+    /// Batch construction is a best-effort ingestion path for duplicate or
+    /// degenerate inputs: a successful construction may have skipped some input
+    /// vertices. Inspect [`ConstructionStatistics::total_skipped`] and
+    /// [`ConstructionStatistics::skip_samples`] when the caller requires a
+    /// strict all-inputs-inserted contract.
     ///
     /// # Errors
     /// Returns [`DelaunayTriangulationConstructionErrorWithStatistics`] if
@@ -6297,6 +6353,20 @@ mod tests {
         assert_eq!(
             pseudomanifold.validation_policy(),
             ValidationPolicy::OnSuspicion
+        );
+
+        let pl_manifold: DelaunayTriangulation<_, (), (), 3> =
+            DelaunayTriangulation::with_empty_kernel_and_topology_guarantee(
+                FastKernel::<f64>::new(),
+                TopologyGuarantee::PLManifold,
+            );
+        assert_eq!(
+            pl_manifold.topology_guarantee(),
+            TopologyGuarantee::PLManifold
+        );
+        assert_eq!(
+            pl_manifold.validation_policy(),
+            ValidationPolicy::ExplicitOnly
         );
     }
 

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -256,12 +256,58 @@ where
     ///
     /// This is a convenience wrapper around the triangulation-layer insertion-with-statistics
     /// implementation that also updates the internal `insertion_state.last_inserted_simplex` hint cache.
+    /// Unlike [`insert_best_effort_with_statistics`](Self::insert_best_effort_with_statistics),
+    /// skipped insertions are reported as [`InsertionError`] values so callers using `?`
+    /// cannot accidentally ignore a duplicate or retry-exhausted degeneracy.
     ///
     /// # Errors
     ///
-    /// Returns `Err(InsertionError)` only for non-retryable structural failures.
-    /// Retryable geometric degeneracies that exhaust all attempts return
-    /// `Ok((InsertionOutcome::Skipped { .. }, stats))`.
+    /// Returns [`InsertionError`] for structural failures, duplicate coordinates,
+    /// and retryable geometric degeneracies that exhaust all attempts.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::insertion::{InsertionError, InsertionOutcome};
+    ///
+    /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
+    ///
+    /// let (outcome, stats) = dt
+    ///     .insert_with_statistics(vertex!([0.0, 0.0, 0.0]))
+    ///     .unwrap();
+    ///
+    /// assert!(stats.success());
+    /// assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+    ///
+    /// let duplicate = dt.insert_with_statistics(vertex!([0.0, 0.0, 0.0]));
+    /// assert!(matches!(
+    ///     duplicate,
+    ///     Err(InsertionError::DuplicateCoordinates { .. })
+    /// ));
+    /// ```
+    pub fn insert_with_statistics(
+        &mut self,
+        vertex: Vertex<K::Scalar, U, D>,
+    ) -> Result<(InsertionOutcome, InsertionStatistics), InsertionError> {
+        match self.insert_best_effort_with_statistics(vertex)? {
+            (outcome @ InsertionOutcome::Inserted { .. }, stats) => Ok((outcome, stats)),
+            (InsertionOutcome::Skipped { error }, _stats) => Err(error),
+        }
+    }
+
+    /// Insert a vertex and return telemetry even when the vertex is skipped.
+    ///
+    /// This best-effort API is intended for diagnostics, bulk-style ingestion,
+    /// and workloads that deliberately continue after duplicate coordinates or
+    /// retry-exhausted geometric degeneracies. A skipped insertion returns
+    /// `Ok((InsertionOutcome::Skipped { .. }, stats))`; the triangulation is
+    /// left unchanged for that vertex.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`InsertionError`] for non-skip structural failures that cannot
+    /// be represented as an [`InsertionOutcome::Skipped`] value.
     ///
     /// # Examples
     ///
@@ -272,13 +318,22 @@ where
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     ///
     /// let (outcome, stats) = dt
-    ///     .insert_with_statistics(vertex!([0.0, 0.0, 0.0]))
+    ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))
     ///     .unwrap();
     ///
     /// assert!(stats.success());
     /// assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+    ///
+    /// let vertices_before_duplicate = dt.number_of_vertices();
+    /// let (duplicate_outcome, duplicate_stats) = dt
+    ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))
+    ///     .unwrap();
+    ///
+    /// assert!(matches!(duplicate_outcome, InsertionOutcome::Skipped { .. }));
+    /// assert!(duplicate_stats.skipped_duplicate());
+    /// assert_eq!(dt.number_of_vertices(), vertices_before_duplicate);
     /// ```
-    pub fn insert_with_statistics(
+    pub fn insert_best_effort_with_statistics(
         &mut self,
         vertex: Vertex<K::Scalar, U, D>,
     ) -> Result<(InsertionOutcome, InsertionStatistics), InsertionError> {

--- a/src/delaunay/query.rs
+++ b/src/delaunay/query.rs
@@ -398,6 +398,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::validation::ValidationPolicy;
     ///
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
@@ -408,10 +409,7 @@ where
     /// let dt: DelaunayTriangulation<_, (), (), 2> =
     ///     DelaunayTriangulation::new(&vertices).unwrap();
     ///
-    /// assert_eq!(
-    ///     dt.validation_policy(),
-    ///     delaunay::prelude::validation::ValidationPolicy::OnSuspicion
-    /// );
+    /// assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
     /// ```
     #[inline]
     #[must_use]
@@ -490,11 +488,12 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, TopologyGuarantee,
+    /// use delaunay::prelude::construction::DelaunayTriangulation;
+    /// use delaunay::prelude::validation::{
+    ///     TopologyGuarantee, ValidationConfigurationError,
     /// };
     ///
-    /// # fn main() -> Result<(), delaunay::prelude::validation::ValidationConfigurationError> {
+    /// # fn main() -> Result<(), ValidationConfigurationError> {
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     /// dt.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)?;
     ///
@@ -1143,11 +1142,11 @@ mod tests {
     }
 
     #[test]
-    fn test_validation_policy_defaults_to_on_suspicion() {
+    fn test_validation_policy_defaults_to_topology_guarantee_policy() {
         init_tracing();
-        // empty() -> Triangulation::new_empty() -> ValidationPolicy::default()
+        // empty() -> Triangulation::new_empty() -> TopologyGuarantee::DEFAULT policy.
         let dt_empty: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::empty();
-        assert_eq!(dt_empty.validation_policy(), ValidationPolicy::OnSuspicion);
+        assert_eq!(dt_empty.validation_policy(), ValidationPolicy::ExplicitOnly);
 
         let vertices = vec![
             vertex!([0.0, 0.0]),
@@ -1158,25 +1157,25 @@ mod tests {
         // new() -> with_kernel() -> explicit validation_policy initialization
         let dt_new: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::new(&vertices).unwrap();
-        assert_eq!(dt_new.validation_policy(), ValidationPolicy::OnSuspicion);
+        assert_eq!(dt_new.validation_policy(), ValidationPolicy::ExplicitOnly);
 
         // with_kernel() constructor path should also use the default policy
         let dt_with_kernel: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::with_kernel(&AdaptiveKernel::new(), &vertices).unwrap();
         assert_eq!(
             dt_with_kernel.validation_policy(),
-            ValidationPolicy::OnSuspicion
+            ValidationPolicy::ExplicitOnly
         );
 
         // try_from_tds() is a separate reconstruction path and should also
-        // default to OnSuspicion after validation succeeds.
+        // default to the topology guarantee policy after validation succeeds.
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
         let dt_from_tds: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_from_tds(tds, FastKernel::new()).unwrap();
         assert_eq!(
             dt_from_tds.validation_policy(),
-            ValidationPolicy::OnSuspicion
+            ValidationPolicy::ExplicitOnly
         );
     }
 
@@ -1193,8 +1192,8 @@ mod tests {
             DelaunayTriangulation::new(&vertices).unwrap();
 
         // Getter reflects the underlying Triangulation policy.
-        assert_eq!(dt.validation_policy(), ValidationPolicy::OnSuspicion);
-        assert_eq!(dt.tri.validation_policy, ValidationPolicy::OnSuspicion);
+        assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
+        assert_eq!(dt.tri.validation_policy, ValidationPolicy::ExplicitOnly);
 
         dt.set_validation_policy(ValidationPolicy::Always);
         assert_eq!(dt.validation_policy(), ValidationPolicy::Always);

--- a/src/delaunay/validation.rs
+++ b/src/delaunay/validation.rs
@@ -629,7 +629,10 @@ where
     /// The initial
     /// [`ValidationPolicy`](crate::ValidationPolicy) is derived from the guarantee:
     /// [`PLManifoldStrict`](TopologyGuarantee::PLManifoldStrict) uses
-    /// [`Always`](crate::ValidationPolicy::Always); all others default to
+    /// [`Always`](crate::ValidationPolicy::Always),
+    /// [`PLManifold`](TopologyGuarantee::PLManifold) uses
+    /// [`ExplicitOnly`](crate::ValidationPolicy::ExplicitOnly), and
+    /// [`Pseudomanifold`](TopologyGuarantee::Pseudomanifold) uses
     /// [`OnSuspicion`](crate::ValidationPolicy::OnSuspicion).
     #[must_use]
     pub(crate) const fn from_tds_with_topology_guarantee(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@
 //! let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 //!
 //! assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
-//! assert_eq!(dt.validation_policy(), ValidationPolicy::OnSuspicion);
+//! assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
 //!
 //! dt.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
 //! dt.set_validation_policy(ValidationPolicy::Always);
@@ -259,9 +259,11 @@
 //! automatic **Level 3** topology validation pass after insertion, controlled by
 //! [`ValidationPolicy`](crate::prelude::validation::ValidationPolicy).
 //!
-//! The default is [`ValidationPolicy::OnSuspicion`](crate::prelude::validation::ValidationPolicy::OnSuspicion):
-//! Level 3 validation runs only when insertion takes a suspicious path (e.g. perturbation retries,
-//! repair loops, or neighbor-pointer repairs that actually changed pointers).
+//! The initial policy is derived from the active topology guarantee. The default
+//! [`TopologyGuarantee::PLManifold`](crate::prelude::TopologyGuarantee::PLManifold)
+//! uses [`ValidationPolicy::ExplicitOnly`](crate::prelude::validation::ValidationPolicy::ExplicitOnly):
+//! mandatory local topology checks still run during insertion, while full Level 3 validation is a
+//! caller-owned explicit checkpoint.
 //!
 //! This automatic pass only runs Level 3 (`Triangulation::is_valid()`). It does **not** run Level 4.
 //!
@@ -1551,7 +1553,7 @@ pub mod prelude {
     pub mod validation {
         pub use crate::validation::*;
         pub use crate::{
-            DelaunayTriangulationValidationError, TriangulationValidationError,
+            DelaunayTriangulationValidationError, TopologyGuarantee, TriangulationValidationError,
             ValidationConfigurationError, ValidationPolicy,
         };
     }

--- a/tests/insert_with_statistics.rs
+++ b/tests/insert_with_statistics.rs
@@ -2,6 +2,7 @@
 //!
 //! This module tests:
 //! - `DelaunayTriangulation::insert_with_statistics`
+//! - `DelaunayTriangulation::insert_best_effort_with_statistics`
 //!
 //! Triangulation-layer insertion tests live in `core::triangulation` unit tests.
 //!
@@ -115,7 +116,7 @@ fn delaunay_insert_with_statistics_multiple_vertices_4d() {
     let mut skipped = 0;
 
     for v in vertices {
-        match dt.insert_with_statistics(v) {
+        match dt.insert_best_effort_with_statistics(v) {
             Ok((InsertionOutcome::Inserted { .. }, stats)) => {
                 total_attempts += stats.attempts;
                 successful_insertions += 1;
@@ -170,8 +171,20 @@ fn delaunay_insert_with_statistics_duplicate_coordinates_2d() {
     dt.insert_with_statistics(vertex!([1.0, 2.0]))
         .expect("first insertion should succeed");
 
-    // Try to insert vertex with same coordinates - should be skipped
+    // The strict statistics API reports skipped insertions as errors so callers
+    // using `?` cannot miss them.
     let result = dt.insert_with_statistics(vertex!([1.0, 2.0]));
+    assert!(
+        matches!(
+            result,
+            Err(InsertionError::DuplicateCoordinates { ref coordinates })
+                if coordinates.contains('1') && coordinates.contains('2')
+        ),
+        "expected duplicate coordinate error, got: {result:?}"
+    );
+
+    // The explicitly best-effort API preserves the skipped outcome plus telemetry.
+    let result = dt.insert_best_effort_with_statistics(vertex!([1.0, 2.0]));
 
     match result {
         Ok((
@@ -185,7 +198,9 @@ fn delaunay_insert_with_statistics_duplicate_coordinates_2d() {
             assert!(stats.skipped_duplicate());
             assert_eq!(stats.attempts, 1);
         }
-        other => panic!("expected Ok(Skipped) with DuplicateCoordinates, got: {other:?}"),
+        other => {
+            panic!("expected best-effort Ok(Skipped) with DuplicateCoordinates, got: {other:?}")
+        }
     }
 
     // Still in bootstrap (no simplices yet), so validate only Levels 1–2 (elements + structure).
@@ -208,7 +223,7 @@ fn delaunay_insert_with_statistics_bootstrap_happy_path_3d() {
     ];
 
     for v in vertices {
-        let (outcome, stats) = dt.insert_with_statistics(v).unwrap();
+        let (outcome, stats) = dt.insert_best_effort_with_statistics(v).unwrap();
         assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
         assert_eq!(stats.attempts, 1);
     }

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -1355,7 +1355,7 @@ where
                 let coords = *vertex.point().coords();
                 let uuid = vertex.uuid();
 
-                let inserted_this_loop = match dt.insert_with_statistics(vertex) {
+                let inserted_this_loop = match dt.insert_best_effort_with_statistics(vertex) {
                     Ok((InsertionOutcome::Inserted { .. }, stats)) => {
                         summary.record_inserted(stats);
                         true

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -72,7 +72,8 @@ use delaunay::prelude::triangulation::{
     ValidationPolicy as TriangulationValidationPolicy, vertex as triangulation_vertex,
 };
 use delaunay::prelude::validation::{
-    ValidationCadence, ValidationConfigurationError as FocusedValidationConfigurationError,
+    TopologyGuarantee as FocusedValidationTopologyGuarantee, ValidationCadence,
+    ValidationConfigurationError as FocusedValidationConfigurationError,
     ValidationPolicy as FocusedValidationPolicy,
 };
 use delaunay::prelude::{
@@ -150,7 +151,7 @@ fn root_exports_cover_flattened_public_api() -> Result<(), RootApiExportTestErro
     let mut dt: DelaunayTriangulation<_, (), (), 3> = builder.build::<()>()?;
 
     assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
-    assert_eq!(dt.validation_policy(), ValidationPolicy::OnSuspicion);
+    assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
     assert!(matches!(
         ValidationCadence::from_optional_every(Some(2)),
         ValidationCadence::EveryN(every) if every.get() == 2
@@ -327,14 +328,14 @@ fn construction_prelude_covers_explicit_error_summaries() {
 fn validation_prelude_covers_configuration_error() {
     let focused_error =
         FocusedValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
-            topology_guarantee: TopologyGuarantee::PLManifold,
+            topology_guarantee: FocusedValidationTopologyGuarantee::PLManifold,
             validation_policy: FocusedValidationPolicy::Never,
         };
     let root_error: RootValidationConfigurationError = focused_error;
     assert!(matches!(
         root_error,
         RootValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
-            topology_guarantee: TopologyGuarantee::PLManifold,
+            topology_guarantee: FocusedValidationTopologyGuarantee::PLManifold,
             validation_policy: FocusedValidationPolicy::Never,
         }
     ));

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -423,7 +423,7 @@ fn assert_on_suspicion_sequence_valid<const D: usize>(
     dt.set_validation_policy(ValidationPolicy::OnSuspicion);
 
     for (idx, point) in points.into_iter().enumerate() {
-        let result = dt.insert_with_statistics(vertex!(point));
+        let result = dt.insert_best_effort_with_statistics(vertex!(point));
 
         if dt.number_of_simplices() > 0 {
             let validation = dt.validate();
@@ -557,7 +557,7 @@ fn insert_vertices_3d_no_retry_or_skip(
     vertices: &[Vertex<f64, (), 3>],
 ) -> InsertionOrder3dRunStatus {
     for (idx, v) in vertices.iter().enumerate() {
-        let result = dt.insert_with_statistics(*v);
+        let result = dt.insert_best_effort_with_statistics(*v);
         let Ok((outcome, stats)) = result else {
             if std::env::var_os("DELAUNAY_PROPTEST_INSERT_ERRORS").is_some()
                 && let Err(err) = result
@@ -636,7 +636,7 @@ fn regression_insertion_order_3d_case_001() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     for (idx, v) in vertices.iter().enumerate() {
-        let result = dt.insert_with_statistics(*v);
+        let result = dt.insert_best_effort_with_statistics(*v);
         match result {
             Ok((InsertionOutcome::Inserted { .. }, _stats)) => {}
             Ok((InsertionOutcome::Skipped { error }, _stats)) => {
@@ -837,7 +837,7 @@ proptest! {
         let mut dt = dt.unwrap();
         prop_assert_levels_1_to_3_valid!(3, &dt, "initial triangulation");
 
-        let insert_result = dt.insert_with_statistics(additional_vertex);
+        let insert_result = dt.insert_best_effort_with_statistics(additional_vertex);
         if let Err(e) = &insert_result
             && std::env::var_os("DELAUNAY_PROPTEST_INSERT_ERRORS").is_some()
         {

--- a/tests/proptest_orientation.rs
+++ b/tests/proptest_orientation.rs
@@ -121,7 +121,7 @@ macro_rules! gen_orientation_incremental_props {
                         );
 
                     for vertex in vertices {
-                        let result = dt.insert_with_statistics(vertex);
+                        let result = dt.insert_best_effort_with_statistics(vertex);
                         if let Ok((InsertionOutcome::Inserted { .. }, _stats)) = result {
                             prop_assert!(
                                 dt.tds().is_coherently_oriented(),


### PR DESCRIPTION
- Make insert_with_statistics return typed insertion errors for skipped duplicate or retry-exhausted vertices so callers using ? cannot silently ignore skipped inputs.
- Add insert_best_effort_with_statistics for diagnostic and bulk-ingestion workflows that intentionally preserve skipped insertions as outcomes with telemetry.
- Derive the default validation policy from the active topology guarantee so PLManifold starts in ExplicitOnly mode while Pseudomanifold keeps OnSuspicion.
- Document skipped-input observability across construction, workflows, and robustness guidance.

BREAKING CHANGE: insert_with_statistics now reports skipped insertions as Err(InsertionError) instead of Ok(InsertionOutcome::Skipped).

Closes #386