### PR TITLE
refactor(repair)!: box Delaunay repair flip errors

### DIFF
--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -13471,6 +13471,15 @@ mod tests {
             other => panic!("expected verification failure, got {other:?}"),
         }
 
+        let flip_reason =
+            FlipNeighborRepairFailure::from(DelaunayRepairError::from(FlipError::DuplicateSimplex));
+        assert_eq!(
+            flip_reason,
+            FlipNeighborRepairFailure::Flip {
+                source_kind: FlipFailureKind::DuplicateSimplex,
+            }
+        );
+
         let wiring_repair = FlipError::from(FlipNeighborWiringError::DelaunayRepair {
             reason: repair_reason,
         });

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -4307,10 +4307,18 @@ impl fmt::Display for DelaunayRepairVerificationContext {
 
 /// Errors that can occur during flip-based Delaunay repair.
 ///
+/// Large typed payloads are boxed to keep the public enum small and cheap to
+/// move, while scalar fields and short diagnostic strings stay inline. Boxed
+/// variants still preserve their concrete source type so callers can inspect
+/// or pattern-match the full error chain when they need repair diagnostics.
+/// For example, [`DelaunayRepairError::NonConvergent`] boxes
+/// [`DelaunayRepairDiagnostics`], and [`DelaunayRepairError::Flip`] boxes the
+/// underlying [`FlipError`].
+///
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::repair::{DelaunayRepairError, TopologyGuarantee};
+/// use delaunay::prelude::repair::{DelaunayRepairError, FlipError, TopologyGuarantee};
 ///
 /// let err = DelaunayRepairError::InvalidTopology {
 ///     required: TopologyGuarantee::PLManifold,
@@ -4318,6 +4326,13 @@ impl fmt::Display for DelaunayRepairVerificationContext {
 ///     message: "requires manifold",
 /// };
 /// assert!(matches!(err, DelaunayRepairError::InvalidTopology { .. }));
+///
+/// let flip_err = DelaunayRepairError::from(FlipError::DegenerateSimplex);
+/// assert!(matches!(
+///     flip_err,
+///     DelaunayRepairError::Flip { source }
+///         if matches!(source.as_ref(), FlipError::DegenerateSimplex)
+/// ));
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -4368,9 +4383,24 @@ pub enum DelaunayRepairError {
         /// Additional context for the rebuild failure.
         message: String,
     },
-    /// Underlying flip error.
-    #[error(transparent)]
-    Flip(#[from] FlipError),
+    /// A lower-level [`FlipError`] stopped repair.
+    ///
+    /// The source is boxed to keep [`DelaunayRepairError`] compact while
+    /// preserving the concrete flip failure for callers that need to inspect it.
+    #[error("flip error: {source}")]
+    Flip {
+        /// Typed flip failure that stopped repair.
+        #[source]
+        source: Box<FlipError>,
+    },
+}
+
+impl From<FlipError> for DelaunayRepairError {
+    fn from(source: FlipError) -> Self {
+        Self::Flip {
+            source: Box::new(source),
+        }
+    }
 }
 
 impl From<DelaunayRepairError> for FlipNeighborRepairFailure {
@@ -4407,8 +4437,8 @@ impl From<DelaunayRepairError> for FlipNeighborRepairFailure {
             DelaunayRepairError::HeuristicRebuildFailed { message } => {
                 Self::HeuristicRebuildFailed { message }
             }
-            DelaunayRepairError::Flip(source) => Self::Flip {
-                source_kind: FlipFailureKind::from(source),
+            DelaunayRepairError::Flip { source } => Self::Flip {
+                source_kind: FlipFailureKind::from(source.as_ref()),
             },
         }
     }
@@ -9506,7 +9536,7 @@ mod tests {
     use proptest::prelude::*;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use slotmap::KeyData;
-    use std::{iter::once, sync::Once};
+    use std::{error::Error as _, iter::once, sync::Once};
 
     fn init_tracing() {
         static INIT: Once = Once::new();
@@ -12907,9 +12937,11 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(DelaunayRepairError::Flip(FlipError::UnsupportedDimension {
-                dimension: 1
-            }))
+            Err(DelaunayRepairError::Flip { source })
+                if matches!(
+                    source.as_ref(),
+                    FlipError::UnsupportedDimension { dimension: 1 }
+                )
         ));
     }
 
@@ -13600,6 +13632,12 @@ mod tests {
         assert_eq!(verification_err, verification_err_copy);
         assert_ne!(verification_err, verification_other);
 
+        let flip_err = DelaunayRepairError::from(FlipError::DegenerateSimplex);
+        let flip_err_copy = DelaunayRepairError::from(FlipError::DegenerateSimplex);
+        let flip_other = DelaunayRepairError::from(FlipError::DuplicateSimplex);
+        assert_eq!(flip_err, flip_err_copy);
+        assert_ne!(flip_err, flip_other);
+
         let canonicalization_err = DelaunayRepairError::OrientationCanonicalizationFailed {
             message: "test".to_string(),
         };
@@ -13628,6 +13666,26 @@ mod tests {
         assert_ne!(post_test, topo_err);
         assert_ne!(post_test, verification_err);
         assert_ne!(post_test, canonicalization_err);
+    }
+
+    #[test]
+    fn test_delaunay_repair_error_boxes_large_flip_sources() {
+        assert!(
+            std::mem::size_of::<DelaunayRepairError>() < std::mem::size_of::<FlipError>(),
+            "DelaunayRepairError should box large FlipError payloads"
+        );
+
+        let err = DelaunayRepairError::from(FlipError::DegenerateSimplex);
+        let source = err.source().expect("boxed flip source should be exposed");
+        let source = source
+            .downcast_ref::<Box<FlipError>>()
+            .expect("source should remain a typed boxed FlipError");
+        assert!(matches!(source.as_ref(), FlipError::DegenerateSimplex));
+
+        let DelaunayRepairError::Flip { source } = err else {
+            panic!("expected boxed flip source");
+        };
+        assert!(matches!(source.as_ref(), FlipError::DegenerateSimplex));
     }
 
     #[test]

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -657,7 +657,7 @@ impl From<&DelaunayRepairError> for DelaunayRepairErrorKind {
             }
             DelaunayRepairError::InvalidTopology { .. } => Self::InvalidTopology,
             DelaunayRepairError::HeuristicRebuildFailed { .. } => Self::HeuristicRebuildFailed,
-            DelaunayRepairError::Flip(_) => Self::Flip,
+            DelaunayRepairError::Flip { .. } => Self::Flip,
         }
     }
 }
@@ -4910,7 +4910,7 @@ mod tests {
                 DelaunayRepairErrorKind::HeuristicRebuildFailed,
             ),
             (
-                DelaunayRepairError::Flip(FlipError::DegenerateSimplex),
+                DelaunayRepairError::from(FlipError::DegenerateSimplex),
                 DelaunayRepairErrorKind::Flip,
             ),
         ];

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -436,12 +436,14 @@ impl From<TriangulationConstructionError> for DelaunayConstructionFailure {
 
 /// Returns true when a repair error represents input geometry or predicate
 /// instability that shuffled construction may be able to resolve.
-const fn is_geometric_repair_error(repair_err: &DelaunayRepairError) -> bool {
+fn is_geometric_repair_error(repair_err: &DelaunayRepairError) -> bool {
     match repair_err {
         DelaunayRepairError::NonConvergent { .. }
         | DelaunayRepairError::PostconditionFailed { .. } => true,
-        DelaunayRepairError::VerificationFailed { source, .. } => is_geometric_flip_error(source),
-        DelaunayRepairError::Flip(source) => is_geometric_flip_error(source),
+        DelaunayRepairError::VerificationFailed { source, .. } => {
+            is_geometric_flip_error(source.as_ref())
+        }
+        DelaunayRepairError::Flip { source } => is_geometric_flip_error(source.as_ref()),
         DelaunayRepairError::OrientationCanonicalizationFailed { .. }
         | DelaunayRepairError::InvalidTopology { .. }
         | DelaunayRepairError::HeuristicRebuildFailed { .. } => false,
@@ -6423,7 +6425,7 @@ mod tests {
         assert!(TestDelaunay::<4>::can_soft_fail(&postcondition));
 
         let flip_error =
-            DelaunayRepairError::Flip(FlipError::UnsupportedDimension { dimension: 1 });
+            DelaunayRepairError::from(FlipError::UnsupportedDimension { dimension: 1 });
         assert!(!TestDelaunay::<4>::can_soft_fail(&flip_error));
 
         let topology_error = DelaunayRepairError::InvalidTopology {
@@ -6455,12 +6457,21 @@ mod tests {
                         phase: DelaunayConstructionRepairPhase::BatchLocal { index: 23 },
                         ref source,
                     }
-                ) if matches!(**source, DelaunayRepairError::Flip(FlipError::UnsupportedDimension { dimension: 1 }))
+                ) if matches!(
+                    source.as_ref(),
+                    DelaunayRepairError::Flip {
+                        source: flip_source
+                    }
+                        if matches!(
+                            flip_source.as_ref(),
+                            FlipError::UnsupportedDimension { dimension: 1 }
+                        )
+                )
             ),
             "deterministic hard D>=4 repair failures should stop shuffled retries: {mapped_hard:?}"
         );
 
-        let geometric_error = DelaunayRepairError::Flip(FlipError::DegenerateSimplex);
+        let geometric_error = DelaunayRepairError::from(FlipError::DegenerateSimplex);
         let mapped_geometric = TestDelaunay::<4>::map_hard_repair_error(24, geometric_error);
         assert!(
             matches!(
@@ -6885,7 +6896,7 @@ mod tests {
     #[test]
     fn test_map_insertion_error_hard_repair_is_internal() {
         let error = InsertionError::DelaunayRepairFailed {
-            source: Box::new(DelaunayRepairError::Flip(FlipError::UnsupportedDimension {
+            source: Box::new(DelaunayRepairError::from(FlipError::UnsupportedDimension {
                 dimension: 1,
             })),
             context: DelaunayRepairFailureContext::LocalRepair,

--- a/src/delaunay/repair.rs
+++ b/src/delaunay/repair.rs
@@ -1282,9 +1282,11 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(DelaunayRepairError::Flip(FlipError::UnsupportedDimension {
-                    dimension: 1
-                }))
+                Err(DelaunayRepairError::Flip { ref source })
+                    if matches!(
+                        source.as_ref(),
+                        FlipError::UnsupportedDimension { dimension: 1 }
+                    )
             ),
             "Expected Flip(UnsupportedDimension {{ dimension: 1 }}) for D=1, got: {result:?}"
         );
@@ -1306,9 +1308,11 @@ mod tests {
         assert!(
             matches!(
                 result,
-                Err(DelaunayRepairError::Flip(FlipError::UnsupportedDimension {
-                    dimension: 1
-                }))
+                Err(DelaunayRepairError::Flip { ref source })
+                    if matches!(
+                        source.as_ref(),
+                        FlipError::UnsupportedDimension { dimension: 1 }
+                    )
             ),
             "Expected non-retryable Flip(UnsupportedDimension) pass-through for D=1, got: {result:?}"
         );

--- a/src/geometry/matrix.rs
+++ b/src/geometry/matrix.rs
@@ -259,6 +259,18 @@ mod tests {
     }
 
     #[test]
+    fn stack_matrix_dispatch_error_clones_la_error_source() {
+        let source = LaError::Singular { pivot_col: 3 };
+        let error = StackMatrixDispatchError::La { source };
+
+        assert_eq!(error.clone(), error);
+        assert_eq!(
+            error.to_string(),
+            StackMatrixDispatchError::La { source }.to_string()
+        );
+    }
+
+    #[test]
     fn matrix_zero_like_returns_zero_matrix_of_same_size() {
         let k = 4;
         with_la_stack_matrix!(k, |original| {

--- a/src/geometry/traits/coordinate.rs
+++ b/src/geometry/traits/coordinate.rs
@@ -1024,6 +1024,18 @@ mod tests {
     }
 
     #[test]
+    fn coordinate_conversion_error_clones_linear_algebra_source() {
+        let source = LaError::NonFinite {
+            row: Some(1),
+            col: 2,
+        };
+        let converted = CoordinateConversionError::LinearAlgebraFailure { source };
+
+        assert_eq!(converted.clone(), converted);
+        assert!(converted.source().is_some());
+    }
+
+    #[test]
     fn degenerate_simplex_reason_display_covers_all_variants() {
         assert_eq!(
             DegenerateSimplexReason::ZeroOrientation.to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1882,6 +1882,7 @@ mod tests {
         },
         geometry::{
             Point, algorithms::convex_hull::ConvexHull, kernel::AdaptiveKernel, kernel::FastKernel,
+            util::CircumcenterError,
         },
         is_normal,
         prelude::delaunayize::{
@@ -1898,6 +1899,7 @@ mod tests {
         prelude::*,
         vertex,
     };
+    use la_stack::LaError;
 
     #[cfg(feature = "count-allocations")]
     use allocation_counter::measure;
@@ -1927,6 +1929,15 @@ mod tests {
         assert!(is_normal::<PlManifoldRepairStats<f64, (), (), 3>>());
         assert!(is_normal::<SimplexValidationError>());
         assert!(is_normal::<DelaunayTriangulationConstructionError>());
+    }
+
+    #[test]
+    fn circumcenter_error_clones_linear_algebra_source() {
+        let source = LaError::Overflow { index: Some(2) };
+        let error = CircumcenterError::LinearAlgebraFailure { source };
+
+        assert_eq!(error.clone(), error);
+        assert!(error.to_string().contains("Linear algebra"));
     }
 
     #[test]
@@ -1985,8 +1996,8 @@ mod tests {
         );
         assert_eq!(DelaunayCheckPolicy::default(), DelaunayCheckPolicy::EndOnly);
 
-        let err = DelaunayRepairError::Flip(FlipError::DegenerateSimplex);
-        assert!(matches!(err, DelaunayRepairError::Flip(_)));
+        let err = DelaunayRepairError::from(FlipError::DegenerateSimplex);
+        assert!(matches!(err, DelaunayRepairError::Flip { .. }));
         let context_err = FlipContextError::ReplacementPeriodicOffsetCountMismatch {
             simplex_count: 1,
             offset_count: 0,

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -424,8 +424,8 @@ fn diagnostic_preludes_cover_repair_apis() -> Result<(), PreludeExportTestError>
     };
     assert!(diagnostics.to_string().contains("checked"));
     assert!(matches!(
-        DelaunayRepairError::Flip(FlipError::DegenerateSimplex),
-        DelaunayRepairError::Flip(_)
+        DelaunayRepairError::from(FlipError::DegenerateSimplex),
+        DelaunayRepairError::Flip { .. }
     ));
     assert_send_sync_unpin::<FlipEdgeAdjacencyError>();
     assert_send_sync_unpin::<FlipTriangleAdjacencyError>();


### PR DESCRIPTION
- Box `DelaunayRepairError::Flip` sources while preserving typed `FlipError` inspection through `From<FlipError>` and `Error::source`.
- Update repair and construction mappings for the named boxed variant.
- Cover clone and source behavior for wrapped linear-algebra errors.

BREAKING CHANGE: `DelaunayRepairError::Flip` is now a named variant with `source: Box<FlipError>` instead of the tuple variant `Flip(FlipError)`. Callers that pattern-match this variant must use `Flip { source }` or construct it through `DelaunayRepairError::from`.

Closes #384