### PR TITLE
docs(api): prefer builder-based fallible examples (#214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ archived under [docs/archive/changelog/](docs/archive/changelog/).
 
 The construction API has two entry points:
 
-- `DelaunayTriangulation::new(&vertices)` - simple constructor for the common case
-- [`DelaunayTriangulationBuilder`] - advanced configuration (custom options,
+- [`DelaunayTriangulationBuilder`] - primary construction interface for the common case and advanced configuration (custom options,
   toroidal topology, custom kernels)
+- `DelaunayTriangulation::new(&vertices)` - legacy convenience constructor
 
 Add the library to your crate:
 
@@ -318,29 +318,31 @@ regression testing:
 ```rust
 use delaunay::prelude::construction::{
     ConstructionOptions, DedupPolicy, DelaunayTriangulationBuilder, InsertionOrderStrategy,
-    RetryPolicy, TopologyGuarantee, vertex,
+    RetryPolicy, TopologyGuarantee, DelaunayTriangulationConstructionError, vertex,
 };
 use delaunay::prelude::validation::ValidationPolicy;
 
-let vertices = vec![
-    vertex!([0.0, 0.0]),
-    vertex!([1.0, 0.0]),
-    vertex!([0.0, 1.0]),
-];
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    let vertices = vec![
+        vertex!([0.0, 0.0]),
+        vertex!([1.0, 0.0]),
+        vertex!([0.0, 1.0]),
+    ];
 
-let options = ConstructionOptions::default()
-    .with_insertion_order(InsertionOrderStrategy::Input)
-    .with_dedup_policy(DedupPolicy::Exact)
-    .with_retry_policy(RetryPolicy::Disabled);
+    let options = ConstructionOptions::default()
+        .with_insertion_order(InsertionOrderStrategy::Input)
+        .with_dedup_policy(DedupPolicy::Exact)
+        .with_retry_policy(RetryPolicy::Disabled);
 
-let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    .topology_guarantee(TopologyGuarantee::PLManifold)
-    .construction_options(options)
-    .build::<()>()
-    .unwrap();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+        .topology_guarantee(TopologyGuarantee::PLManifold)
+        .construction_options(options)
+        .build::<()>()?;
 
-dt.set_validation_policy(ValidationPolicy::Always);
-assert!(dt.validate().is_ok());
+    dt.set_validation_policy(ValidationPolicy::Always);
+    assert!(dt.validate().is_ok());
+    Ok(())
+}
 ```
 
 For reproducible checks in CI/local runs, use `just check`, `just test`,

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -56,30 +56,33 @@ The library provides two distinct APIs for different use cases:
 
 ## Builder API Reference
 
-### Simple Construction: `DelaunayTriangulation::new()`
+### Simple Construction: `DelaunayTriangulationBuilder`
 
-For most use cases, the simple constructor is sufficient:
+For most use cases, the builder with default options is sufficient:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 
-// Simple construction from vertices (Euclidean space, default options)
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let mut dt: DelaunayTriangulation<_, (), (), 3> = 
-    DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Simple construction from vertices (Euclidean space, default options)
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// Incremental insertion (maintains Delaunay property)
-let new_vertex = vertex!([0.5, 0.5, 0.5]);
-dt.insert(new_vertex).unwrap();
+    // Incremental insertion (maintains Delaunay property)
+    let new_vertex = vertex!([0.5, 0.5, 0.5]);
+    dt.insert(new_vertex)?;
 
-// Vertex removal (topology-preserving, with automatic repair when enabled)
-let vertex_key = dt.vertices().next().unwrap().0;
-dt.remove_vertex(vertex_key).unwrap();
+    // Vertex removal (topology-preserving, with automatic repair when enabled)
+    if let Some((vertex_key, _)) = dt.vertices().next() {
+        dt.remove_vertex(vertex_key)?;
+    }
+    Ok(())
+}
 ```
 
 ### Advanced Construction: `DelaunayTriangulationBuilder`
@@ -93,23 +96,25 @@ use delaunay::prelude::construction::{
 };
 use delaunay::prelude::validation::ValidationPolicy;
 
-// Toroidal (periodic) triangulation in 2D
-let vertices = vec![
-    vertex!([0.1, 0.1]),
-    vertex!([0.9, 0.9]),
-    vertex!([0.5, 0.5]),
-];
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Toroidal (periodic) triangulation in 2D
+    let vertices = vec![
+        vertex!([0.1, 0.1]),
+        vertex!([0.9, 0.9]),
+        vertex!([0.5, 0.5]),
+    ];
 
-let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    .toroidal([1.0, 1.0]) // Phase 1: canonicalized toroidal construction
-    .topology_guarantee(TopologyGuarantee::PLManifoldStrict)
-    .build::<()>()
-    .unwrap();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+        .toroidal([1.0, 1.0]) // Phase 1: canonicalized toroidal construction
+        .topology_guarantee(TopologyGuarantee::PLManifoldStrict)
+        .build::<()>()?;
 
-dt.set_validation_policy(ValidationPolicy::Always);
+    dt.set_validation_policy(ValidationPolicy::Always);
 
-// Works like any other DelaunayTriangulation
-dt.insert(vertex!([0.25, 0.75])).unwrap();
+    // Works like any other DelaunayTriangulation
+    dt.insert(vertex!([0.25, 0.75]))?;
+    Ok(())
+}
 ```
 
 **When to use the Builder:**
@@ -153,46 +158,50 @@ for topology guarantee and validation policy details.
 The Edit API is exposed through the `BistellarFlips` trait in `prelude::flips`:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 use delaunay::prelude::flips::*;
 
-// Start with a valid triangulation
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let mut dt: DelaunayTriangulation<_, (), (), 3> = 
-    DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Start with a valid triangulation
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// k=1 move: Insert a vertex into a simplex (splits simplex into D+1 simplices)
-let simplex_key = dt.simplices().next().unwrap().0;
-let info = dt.flip_k1_insert(simplex_key, vertex!([0.25, 0.25, 0.25])).unwrap();
+    // k=1 move: Insert a vertex into a simplex (splits simplex into D+1 simplices)
+    let Some((simplex_key, _)) = dt.simplices().next() else {
+        return Ok(());
+    };
+    let info = dt.flip_k1_insert(simplex_key, vertex!([0.25, 0.25, 0.25]))?;
 
-// k=1 inverse: Remove a vertex (collapses its star)
-let vertex_key = info.inserted_face_vertices[0];
-dt.flip_k1_remove(vertex_key).unwrap();
+    // k=1 inverse: Remove a vertex (collapses its star)
+    let vertex_key = info.inserted_face_vertices[0];
+    dt.flip_k1_remove(vertex_key)?;
 
-// k=2 move: Flip a facet (2 simplices ↔ D simplices)
-let facet = /* FacetHandle */;
-let info = dt.flip_k2(facet).unwrap();
+    // k=2 move: Flip a facet (2 simplices ↔ D simplices)
+    let facet = /* FacetHandle */;
+    let info = dt.flip_k2(facet)?;
 
-// k=2 inverse: Flip from an edge star (D simplices ↔ 2 simplices)
-let edge = EdgeKey::new(info.inserted_face_vertices[0], info.inserted_face_vertices[1]);
-dt.flip_k2_inverse_from_edge(edge).unwrap();
+    // k=2 inverse: Flip from an edge star (D simplices ↔ 2 simplices)
+    let edge = EdgeKey::new(info.inserted_face_vertices[0], info.inserted_face_vertices[1]);
+    dt.flip_k2_inverse_from_edge(edge)?;
 
-// k=3 move: Flip a ridge (3 simplices ↔ D-1 simplices, requires D ≥ 3)
-let ridge = /* RidgeHandle */;
-let info = dt.flip_k3(ridge).unwrap();
+    // k=3 move: Flip a ridge (3 simplices ↔ D-1 simplices, requires D ≥ 3)
+    let ridge = /* RidgeHandle */;
+    let info = dt.flip_k3(ridge)?;
 
-// k=3 inverse: Flip from a triangle star (D-1 simplices ↔ 3 simplices)
-let triangle = TriangleHandle::new(
-    info.inserted_face_vertices[0],
-    info.inserted_face_vertices[1],
-    info.inserted_face_vertices[2],
-);
-dt.flip_k3_inverse_from_triangle(triangle).unwrap();
+    // k=3 inverse: Flip from a triangle star (D-1 simplices ↔ 3 simplices)
+    let triangle = TriangleHandle::new(
+        info.inserted_face_vertices[0],
+        info.inserted_face_vertices[1],
+        info.inserted_face_vertices[2],
+    );
+    dt.flip_k3_inverse_from_triangle(triangle)?;
+    Ok(())
+}
 ```
 
 ### Available Flip Operations
@@ -250,7 +259,7 @@ After applying flips, you should:
 1. Manually verify the Delaunay property if needed:
 
    ```rust
-   dt.is_valid().unwrap();  // Check Level 4 (Delaunay property)
+   assert!(dt.is_valid().is_ok()); // Check Level 4 (Delaunay property)
    ```
 
 2. Consider running a repair pass if you need the Delaunay property again (requires `K: ExactPredicates`):
@@ -262,30 +271,32 @@ After applying flips, you should:
 You can mix both APIs in the same workflow:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 use delaunay::prelude::flips::*;
 
-// 1. Build initial triangulation (Builder API)
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let mut dt: DelaunayTriangulation<_, (), (), 3> = 
-    DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 1. Build initial triangulation (Builder API)
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// 2. Add vertices using Builder API (maintains Delaunay)
-dt.insert(vertex!([0.5, 0.5, 0.5])).unwrap();
+    // 2. Add vertices using Builder API (maintains Delaunay)
+    dt.insert(vertex!([0.5, 0.5, 0.5]))?;
 
-// 3. Make custom topology edits (Edit API)
-let facet = /* ... */;
-dt.flip_k2(facet).unwrap();
+    // 3. Make custom topology edits (Edit API)
+    let facet = /* ... */;
+    dt.flip_k2(facet)?;
 
-// 4. Verify Delaunay property if needed
-if let Err(e) = dt.is_valid() {
-    eprintln!("Warning: Delaunay property violated after manual edit: {}", e);
-    // Optionally restore using Builder API or custom repair
+    // 4. Verify Delaunay property if needed
+    if let Err(e) = dt.is_valid() {
+        eprintln!("Warning: Delaunay property violated after manual edit: {}", e);
+        // Optionally restore using Builder API or custom repair
+    }
+    Ok(())
 }
 ```
 
@@ -313,13 +324,13 @@ Use the appropriate validation level for your needs:
 
 ```rust
 // Level 2: Structural only (fast)
-dt.tds().is_valid().unwrap();
+assert!(dt.tds().is_valid().is_ok());
 
 // Level 3: + Manifold topology
-dt.as_triangulation().is_valid().unwrap();
+assert!(dt.as_triangulation().is_valid().is_ok());
 
 // Level 4: + Delaunay property (most comprehensive)
-dt.is_valid().unwrap();
+assert!(dt.is_valid().is_ok());
 
 // Full diagnostic report
 let report = dt.validation_report();
@@ -357,22 +368,24 @@ The `delaunay::delaunayize` module provides a single entrypoint for the
 common "repair topology then restore Delaunay" workflow:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 use delaunay::prelude::delaunayize::{
     DelaunayizeConfig, delaunayize_by_flips,
 };
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let mut dt: DelaunayTriangulation<_, (), (), 3> =
-    DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-let outcome = delaunayize_by_flips(&mut dt, DelaunayizeConfig::default()).unwrap();
-assert!(outcome.topology_repair.succeeded);
+    let outcome = delaunayize_by_flips(&mut dt, DelaunayizeConfig::default())?;
+    assert!(outcome.topology_repair.succeeded);
+    Ok(())
+}
 ```
 
 ### Steps

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -65,19 +65,24 @@ delaunay = { version = "...", features = ["diagnostics"] }
 For most validation work, start with the always-available APIs:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let dt = DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-assert!(dt.validate().is_ok());
-let report = dt.validation_report();
-assert!(report.is_valid());
+    assert!(dt.validate().is_ok());
+    let report = dt.validation_report();
+    assert!(report.is_valid());
+    Ok(())
+}
 ```
 
 Use `validate()` when a pass/fail result is enough. Use `validation_report()`
@@ -108,18 +113,23 @@ empty-circumsphere violations:
 
 ```rust
 use delaunay::prelude::diagnostics::delaunay_violation_report;
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let dt = DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-let report = delaunay_violation_report(dt.tds(), None).unwrap();
-assert!(report.is_valid());
+    let report = delaunay_violation_report(dt.tds(), None)?;
+    assert!(report.is_valid());
+    Ok(())
+}
 ```
 
 Reports store `SimplexKey` and `VertexKey` values rather than copying every

--- a/docs/numerical_robustness_guide.md
+++ b/docs/numerical_robustness_guide.md
@@ -104,8 +104,9 @@ support through D ≤ 6, but the public exact repair contract is tied to exact
 insphere support and the currently tested triangulation envelope, so
 `ExactPredicates` stops at D ≤ 5.
 
-The convenience constructors (`DelaunayTriangulation::new()`, `::empty()`, etc.) use
-`AdaptiveKernel`. To opt into a different kernel, use the explicit-kernel constructors:
+`DelaunayTriangulationBuilder::new(&vertices).build::<()>()` and
+`DelaunayTriangulation::empty()` use `AdaptiveKernel`. To opt into a different
+kernel, use the explicit-kernel constructors:
 
 ```rust
 use delaunay::prelude::geometry::RobustKernel;
@@ -254,8 +255,10 @@ the triangulation interior.
 
 ### Layer 1: Hilbert-sort preprocessing dedup (batch construction)
 
-When vertices are inserted via batch constructors (`DelaunayTriangulation::new()`,
-`::with_kernel()`, etc.) using the default `InsertionOrderStrategy::Hilbert`, the
+When vertices are inserted via batch construction
+(`DelaunayTriangulationBuilder::new(&vertices).build::<()>()`,
+`DelaunayTriangulation::with_kernel()`, etc.) using the default
+`InsertionOrderStrategy::Hilbert`, the
 Hilbert ordering pass quantizes each coordinate to a fixed-width integer grid before
 computing the space-filling curve index. After sorting, vertices that map to the same
 quantized grid cell are adjacent and are removed in a single linear sweep.
@@ -354,7 +357,8 @@ and per-insertion checks handle any remaining cases.
 
 ## Practical recommendations
 
-- Start with the default `AdaptiveKernel` (`DelaunayTriangulation::new()` / `::empty()`).
+- Start with the default `AdaptiveKernel` (`DelaunayTriangulationBuilder::new(&vertices).build::<()>()` /
+  `DelaunayTriangulation::empty()`).
   This handles near-degenerate configurations correctly out of the box.
 - If you need explicit `BOUNDARY`/`DEGENERATE` signals (e.g. to detect and handle cospherical
   configurations yourself), switch to `RobustKernel`.

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -90,31 +90,35 @@ deviates from the happy-path and trips internal **suspicion flags**, e.g.:
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulation, TopologyGuarantee, Vertex, vertex,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
+    Vertex, vertex,
 };
 use delaunay::prelude::validation::ValidationPolicy;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
 
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// Default PL-manifold mode: caller-owned full validation checkpoints.
-assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
+    // Default PL-manifold mode: caller-owned full validation checkpoints.
+    assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
 
-// For test/debug: validate topology after every insertion.
-dt.set_validation_policy(ValidationPolicy::Always);
+    // For test/debug: validate topology after every insertion.
+    dt.set_validation_policy(ValidationPolicy::Always);
 
-// For caller-owned full validation checkpoints with the default PL-manifold guarantee.
-dt.try_set_validation_policy(ValidationPolicy::ExplicitOnly).unwrap();
+    // For caller-owned full validation checkpoints with the default PL-manifold guarantee.
+    dt.try_set_validation_policy(ValidationPolicy::ExplicitOnly)?;
 
-// `Never` is reserved for the relaxed pseudomanifold guarantee.
-dt.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold).unwrap();
-dt.try_set_validation_policy(ValidationPolicy::Never).unwrap();
+    // `Never` is reserved for the relaxed pseudomanifold guarantee.
+    dt.try_set_topology_guarantee(TopologyGuarantee::Pseudomanifold)?;
+    dt.try_set_validation_policy(ValidationPolicy::Never)?;
+    Ok(())
+}
 ```
 
 ---
@@ -143,25 +147,29 @@ PL-manifoldness. You can trigger that final certification via
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulation, TopologyGuarantee, Vertex, vertex,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
+    Vertex, vertex,
 };
 use delaunay::prelude::validation::ValidationPolicy;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
 
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
 
-// Optional: relax topology checks for speed (weaker guarantees).
-dt.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
+    // Optional: relax topology checks for speed (weaker guarantees).
+    dt.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
 
-// Now Level 3 skips vertex-link validation entirely.
-dt.as_triangulation().is_valid().unwrap();
+    // Now Level 3 skips vertex-link validation entirely.
+    assert!(dt.as_triangulation().is_valid().is_ok());
+    Ok(())
+}
 ```
 
 ### Strict: `PLManifoldStrict`
@@ -291,29 +299,33 @@ Validates the combinatorial structure of the Triangulation Data Structure.
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulation, TopologyGuarantee, Vertex, vertex,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
+    Vertex, vertex,
 };
 use delaunay::prelude::validation::ValidationPolicy;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let dt = DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// Quick structural check (Level 2)
-assert!(dt.tds().is_valid().is_ok());
+    // Quick structural check (Level 2)
+    assert!(dt.tds().is_valid().is_ok());
 
-// Detailed report showing all violations across Levels 1–4 (on failure)
-match dt.validation_report() {
-    Ok(()) => println!("✓ All invariants satisfied"),
-    Err(report) => {
-        for violation in report.violations {
-            eprintln!("Invariant violation: {:?}", violation);
+    // Detailed report showing all violations across Levels 1–4 (on failure)
+    match dt.validation_report() {
+        Ok(()) => println!("✓ All invariants satisfied"),
+        Err(report) => {
+            for violation in report.violations {
+                eprintln!("Invariant violation: {:?}", violation);
+            }
         }
     }
+    Ok(())
 }
 ```
 
@@ -372,23 +384,27 @@ Validates that the triangulation forms a valid topological manifold.
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulation, TopologyGuarantee, Vertex, vertex,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
+    Vertex, vertex,
 };
 use delaunay::prelude::validation::ValidationPolicy;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-    vertex!([0.25, 0.25, 0.25]), // Interior point
-];
-let dt = DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+        vertex!([0.25, 0.25, 0.25]), // Interior point
+    ];
+    let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// Thorough topology validation (includes Levels 1–2 TDS checks)
-match dt.as_triangulation().validate() {
-    Ok(()) => println!("✓ Valid manifold with correct Euler characteristic"),
-    Err(e) => eprintln!("✗ Topology validation failed: {}", e),
+    // Thorough topology validation (includes Levels 1–2 TDS checks)
+    match dt.as_triangulation().validate() {
+        Ok(()) => println!("✓ Valid manifold with correct Euler characteristic"),
+        Err(e) => eprintln!("✗ Topology validation failed: {}", e),
+    }
+    Ok(())
 }
 ```
 
@@ -438,22 +454,26 @@ Validates the geometric optimality of the triangulation.
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulation, TopologyGuarantee, Vertex, vertex,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
+    Vertex, vertex,
 };
 use delaunay::prelude::validation::ValidationPolicy;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let dt = DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// Delaunay property validation (Level 4)
-match dt.is_valid() {
-    Ok(()) => println!("✓ All simplices satisfy empty circumsphere property"),
-    Err(e) => eprintln!("✗ Delaunay violation: {}", e),
+    // Delaunay property validation (Level 4)
+    match dt.is_valid() {
+        Ok(()) => println!("✓ All simplices satisfy empty circumsphere property"),
+        Err(e) => eprintln!("✗ Delaunay violation: {}", e),
+    }
+    Ok(())
 }
 ```
 
@@ -532,8 +552,11 @@ pub fn my_algorithm(dt: &mut DelaunayTriangulation<FastKernel<f64>, (), (), 3>) 
 
     #[cfg(debug_assertions)]
     {
-        dt.tds().is_valid().expect("TDS structure violated");
-        dt.as_triangulation().is_valid().expect("Topology invariant violated");
+        debug_assert!(dt.tds().is_valid().is_ok(), "TDS structure violated");
+        debug_assert!(
+            dt.as_triangulation().is_valid().is_ok(),
+            "Topology invariant violated"
+        );
     }
 }
 ```

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -14,19 +14,24 @@ For the theoretical background and rationale behind the invariants, see [`invari
 For most use cases, construction is a single call:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
 
-let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// Optional verification (see docs/validation.md for when to use each):
-dt.is_valid().unwrap(); // Level 4 only (Delaunay property)
+    // Optional verification (see docs/validation.md for when to use each):
+    assert!(dt.is_valid().is_ok()); // Level 4 only (Delaunay property)
+    Ok(())
+}
 ```
 
 ## Builder API: topology guarantees and automatic validation
@@ -100,18 +105,21 @@ dt.set_delaunay_repair_policy(DelaunayRepairPolicy::Never);
 You can also run a global repair pass manually:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
 
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-let _stats = dt.repair_delaunay_with_flips().unwrap();
+    let _stats = dt.repair_delaunay_with_flips()?;
+    Ok(())
+}
 ```
 
 ### Topology and kernel requirements
@@ -147,26 +155,29 @@ If repair fails to converge within the flip budget, you get
 detections, etc.).
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 use delaunay::prelude::repair::DelaunayRepairError;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
 
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-match dt.repair_delaunay_with_flips() {
-    Ok(_stats) => {}
-    Err(DelaunayRepairError::NonConvergent { diagnostics, .. }) => {
-        eprintln!("repair non-convergent: {diagnostics}");
+    match dt.repair_delaunay_with_flips() {
+        Ok(_stats) => {}
+        Err(DelaunayRepairError::NonConvergent { diagnostics, .. }) => {
+            eprintln!("repair non-convergent: {diagnostics}");
+        }
+        Err(err) => {
+            eprintln!("repair failed: {err}");
+        }
     }
-    Err(err) => {
-        eprintln!("repair failed: {err}");
-    }
+    Ok(())
 }
 ```
 
@@ -188,24 +199,26 @@ You can provide explicit seeds for reproducibility; otherwise deterministic defa
 from the current vertex set.
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 use delaunay::prelude::repair::DelaunayRepairHeuristicConfig;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
 
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-let outcome = dt
-    .repair_delaunay_with_flips_advanced(DelaunayRepairHeuristicConfig::default())
-    .unwrap();
+    let outcome = dt
+        .repair_delaunay_with_flips_advanced(DelaunayRepairHeuristicConfig::default())?;
 
-if let Some(seeds) = outcome.heuristic {
-    eprintln!("heuristic rebuild used: {seeds:?}");
+    if let Some(seeds) = outcome.heuristic {
+        eprintln!("heuristic rebuild used: {seeds:?}");
+    }
+    Ok(())
 }
 ```
 
@@ -217,21 +230,23 @@ Toroidal triangulations handle periodic boundary conditions. Use
 ```rust
 use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 
-// 2D periodic triangulation with unit square domain
-let vertices = vec![
-    vertex!([0.1, 0.1]),
-    vertex!([0.9, 0.9]),
-    vertex!([0.5, 0.5]),
-];
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 2D periodic triangulation with unit square domain
+    let vertices = vec![
+        vertex!([0.1, 0.1]),
+        vertex!([0.9, 0.9]),
+        vertex!([0.5, 0.5]),
+    ];
 
-let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    .toroidal([1.0, 1.0]) // Phase 1: canonicalized toroidal construction
-    .build::<()>()
-    .unwrap();
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+        .toroidal([1.0, 1.0]) // Phase 1: canonicalized toroidal construction
+        .build::<()>()?;
 
-// Insert more points - they'll be wrapped to [0,1)×[0,1)
-dt.insert(vertex!([1.2, 0.3])).unwrap(); // wraps to [0.2, 0.3]
-dt.insert(vertex!([-0.1, 0.7])).unwrap(); // wraps to [0.9, 0.7]
+    // Insert more points - they'll be wrapped to [0,1)×[0,1)
+    dt.insert(vertex!([1.2, 0.3]))?; // wraps to [0.2, 0.3]
+    dt.insert(vertex!([-0.1, 0.7]))?; // wraps to [0.9, 0.7]
+    Ok(())
+}
 ```
 
 **Key points:**
@@ -254,33 +269,38 @@ and modified post-construction via `set_vertex_data` / `set_simplex_data`.
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, Vertex, vertex,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, Vertex, vertex,
 };
 
-// Attach integer labels at construction time
-let vertices: [Vertex<f64, i32, 2>; 3] = [
-    vertex!([0.0, 0.0], 10i32),
-    vertex!([1.0, 0.0], 20),
-    vertex!([0.0, 1.0], 30),
-];
-let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    .build::<()>()
-    .unwrap();
+fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    // Attach integer labels at construction time
+    let vertices: [Vertex<f64, i32, 2>; 3] = [
+        vertex!([0.0, 0.0], 10i32),
+        vertex!([1.0, 0.0], 20),
+        vertex!([0.0, 1.0], 30),
+    ];
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// Read vertex data
-for (_key, vertex) in dt.vertices() {
-    println!("data = {:?}", vertex.data()); // Some(10), Some(20), or Some(30)
+    // Read vertex data
+    for (_key, vertex) in dt.vertices() {
+        println!("data = {:?}", vertex.data()); // Some(10), Some(20), or Some(30)
+    }
+
+    // Modify vertex data (O(1), does not affect geometry or topology)
+    let Some((key, _)) = dt.vertices().next() else {
+        return Ok(());
+    };
+    let prev = dt.set_vertex_data(key, Some(99));
+    assert!(prev.is_some()); // returns the old Option<U>
+
+    // Simplex data works the same way
+    let Some((simplex_key, _)) = dt.simplices().next() else {
+        return Ok(());
+    };
+    dt.set_simplex_data(simplex_key, Some(42));
+    assert_eq!(dt.tds().simplex(simplex_key).map(|s| s.data()), Some(Some(&42)));
+    Ok(())
 }
-
-// Modify vertex data (O(1), does not affect geometry or topology)
-let key = dt.vertices().next().unwrap().0;
-let prev = dt.set_vertex_data(key, Some(99));
-assert!(prev.is_some()); // returns the old Option<U>
-
-// Simplex data works the same way
-let simplex_key = dt.simplices().next().unwrap().0;
-dt.set_simplex_data(simplex_key, Some(42));
-assert_eq!(dt.tds().simplex(simplex_key).unwrap().data(), Some(&42));
 ```
 
 `set_vertex_data` and `set_simplex_data` are safe O(1) operations — they modify only the
@@ -314,23 +334,24 @@ want to keep going after skipped vertices, use the explicitly best-effort
 use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
 use delaunay::prelude::insertion::InsertionOutcome;
 
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
 
-let (outcome, stats) = dt
-    .insert_best_effort_with_statistics(vertex!([0.5, 0.5, 0.5]))
-    .unwrap();
+    let (outcome, stats) = dt.insert_best_effort_with_statistics(vertex!([0.5, 0.5, 0.5]))?;
 
-if stats.used_perturbation() {
-    println!("used perturbation (attempts={})", stats.attempts);
-}
-
-match outcome {
-    InsertionOutcome::Inserted { vertex_key, hint: _ } => {
-        println!("inserted: {vertex_key:?}");
+    if stats.used_perturbation() {
+        println!("used perturbation (attempts={})", stats.attempts);
     }
-    InsertionOutcome::Skipped { error } => {
-        println!("skipped: {error}");
+
+    match outcome {
+        InsertionOutcome::Inserted { vertex_key, hint: _ } => {
+            println!("inserted: {vertex_key:?}");
+        }
+        InsertionOutcome::Skipped { error } => {
+            println!("skipped: {error}");
+        }
     }
+    Ok(())
 }
 ```
 
@@ -345,27 +366,32 @@ possible and fan retriangulation otherwise, then runs flip-based Delaunay repair
 the operation rolls back to the pre-removal triangulation.
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-    vertex!([0.2, 0.2, 0.2]),
-];
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+        vertex!([0.2, 0.2, 0.2]),
+    ];
 
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-let vertex_key = dt.vertices().next().unwrap().0;
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    let Some((vertex_key, _)) = dt.vertices().next() else {
+        return Ok(());
+    };
 
-let _simplices_removed = dt.remove_vertex(vertex_key).unwrap();
+    let _simplices_removed = dt.remove_vertex(vertex_key)?;
 
-// Topology should still be valid:
-assert!(dt.as_triangulation().validate().is_ok());
+    // Topology should still be valid:
+    assert!(dt.as_triangulation().validate().is_ok());
 
-// If automatic repair is enabled, successful removal has already attempted to
-// restore the Delaunay property.
-dt.is_valid().unwrap();
+    // If automatic repair is enabled, successful removal has already attempted to
+    // restore the Delaunay property.
+    assert!(dt.is_valid().is_ok());
+    Ok(())
+}
 ```
 
 When automatic repair fails after the mutation, `remove_vertex` reports
@@ -388,29 +414,34 @@ After using flips, you typically:
 See [`api_design.md`](api_design.md) for the full Builder vs Edit API design.
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 use delaunay::prelude::flips::*;
 
-let vertices = vec![
-    vertex!([0.0, 0.0, 0.0]),
-    vertex!([1.0, 0.0, 0.0]),
-    vertex!([0.0, 1.0, 0.0]),
-    vertex!([0.0, 0.0, 1.0]),
-];
-let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let vertices = vec![
+        vertex!([0.0, 0.0, 0.0]),
+        vertex!([1.0, 0.0, 0.0]),
+        vertex!([0.0, 1.0, 0.0]),
+        vertex!([0.0, 0.0, 1.0]),
+    ];
+    let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
-// k=1: split a simplex by inserting a vertex.
-let simplex_key = dt.simplices().next().unwrap().0;
-let info = dt.flip_k1_insert(simplex_key, vertex!([0.1, 0.1, 0.1])).unwrap();
-let inserted_vertex = info.inserted_face_vertices[0];
+    // k=1: split a simplex by inserting a vertex.
+    let Some((simplex_key, _)) = dt.simplices().next() else {
+        return Ok(());
+    };
+    let info = dt.flip_k1_insert(simplex_key, vertex!([0.1, 0.1, 0.1]))?;
+    let inserted_vertex = info.inserted_face_vertices[0];
 
-// k=1 inverse: remove the inserted vertex (collapse its star).
-let _ = dt.flip_k1_remove(inserted_vertex).unwrap();
+    // k=1 inverse: remove the inserted vertex (collapse its star).
+    let _ = dt.flip_k1_remove(inserted_vertex)?;
 
-// Validate the stack (Levels 1–3) after topological edits.
-assert!(dt.as_triangulation().validate().is_ok());
+    // Validate the stack (Levels 1–3) after topological edits.
+    assert!(dt.as_triangulation().validate().is_ok());
 
-// If you need Delaunay after edits (requires K: ExactPredicates):
-// dt.repair_delaunay_with_flips().unwrap();
-// dt.is_valid().unwrap();
+    // If you need Delaunay after edits (requires K: ExactPredicates):
+    // dt.repair_delaunay_with_flips()?;
+    // assert!(dt.is_valid().is_ok());
+    Ok(())
+}
 ```

--- a/src/core/adjacency.rs
+++ b/src/core/adjacency.rs
@@ -66,8 +66,16 @@ pub enum AdjacencyIndexBuildError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Two tetrahedra sharing a triangular facet.
 /// let vertices: Vec<_> = vec![
 ///     // Shared triangle
@@ -79,15 +87,20 @@ pub enum AdjacencyIndexBuildError {
 ///     vertex!([1.0, 0.7, -1.5]),
 /// ];
 ///
-/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, (), (), 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tri = dt.as_triangulation();
 ///
-/// let index = tri.build_adjacency_index().unwrap();
+/// let index = tri.build_adjacency_index()?;
 ///
 /// // Query incident simplices for some vertex key from the triangulation.
-/// let vk = tri.vertices().next().unwrap().0;
-/// let incident_simplices = index.vertex_to_simplices.get(&vk).unwrap();
+/// let Some((vk, _)) = tri.vertices().next() else { return Ok(()); };
+/// let Some(incident_simplices) = index.vertex_to_simplices.get(&vk) else {
+///     return Ok(());
+/// };
 /// assert!(!incident_simplices.is_empty());
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 #[non_exhaustive]
@@ -111,8 +124,16 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Two tetrahedra sharing a triangular facet.
     /// let vertices: Vec<_> = vec![
     ///     // Shared triangle
@@ -123,16 +144,21 @@ impl AdjacencyIndex {
     ///     vertex!([1.0, 0.7, 1.5]),
     ///     vertex!([1.0, 0.7, -1.5]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
-    /// let shared_vertex_key = tri
+    /// let Some(shared_vertex_key) = tri
     ///     .vertices()
     ///     .find_map(|(vk, _)| (tri.vertex_coords(vk)? == [0.0, 0.0, 0.0]).then_some(vk))
-    ///     .unwrap();
+    /// else {
+    ///     return Ok(());
+    /// };
     ///
-    /// let index = tri.build_adjacency_index().unwrap();
+    /// let index = tri.build_adjacency_index()?;
     /// assert_eq!(index.adjacent_simplices(shared_vertex_key).count(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use = "this iterator is lazy and does nothing unless consumed"]
     #[inline]
@@ -150,7 +176,15 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices: Vec<_> = vec![
     /// #     // Shared triangle
     /// #     vertex!([0.0, 0.0, 0.0]),
@@ -160,14 +194,19 @@ impl AdjacencyIndex {
     /// #     vertex!([1.0, 0.7, 1.5]),
     /// #     vertex!([1.0, 0.7, -1.5]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let shared_vertex_key = tri
+    /// # let Some(shared_vertex_key) = tri
     /// #     .vertices()
     /// #     .find_map(|(vk, _)| (tri.vertex_coords(vk)? == [0.0, 0.0, 0.0]).then_some(vk))
-    /// #     .unwrap();
-    /// # let index = tri.build_adjacency_index().unwrap();
+    /// # else {
+    /// #     return Ok(());
+    /// # };
+    /// # let index = tri.build_adjacency_index()?;
     /// assert_eq!(index.number_of_adjacent_simplices(shared_vertex_key), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     #[inline]
@@ -182,18 +221,29 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices = vec![
     /// #     vertex!([0.0, 0.0, 0.0]),
     /// #     vertex!([1.0, 0.0, 0.0]),
     /// #     vertex!([0.0, 1.0, 0.0]),
     /// #     vertex!([0.0, 0.0, 1.0]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let index = tri.build_adjacency_index().unwrap();
-    /// let v0 = tri.vertices().next().unwrap().0;
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((v0, _)) = tri.vertices().next() else { return Ok(()); };
     /// assert_eq!(index.incident_edges(v0).count(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use = "this iterator is lazy and does nothing unless consumed"]
     #[inline]
@@ -211,18 +261,29 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices = vec![
     /// #     vertex!([0.0, 0.0, 0.0]),
     /// #     vertex!([1.0, 0.0, 0.0]),
     /// #     vertex!([0.0, 1.0, 0.0]),
     /// #     vertex!([0.0, 0.0, 1.0]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let index = tri.build_adjacency_index().unwrap();
-    /// let v0 = tri.vertices().next().unwrap().0;
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((v0, _)) = tri.vertices().next() else { return Ok(()); };
     /// assert_eq!(index.number_of_incident_edges(v0), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     #[inline]
@@ -237,7 +298,15 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices: Vec<_> = vec![
     /// #     // Shared triangle
     /// #     vertex!([0.0, 0.0, 0.0]),
@@ -247,11 +316,14 @@ impl AdjacencyIndex {
     /// #     vertex!([1.0, 0.7, 1.5]),
     /// #     vertex!([1.0, 0.7, -1.5]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let index = tri.build_adjacency_index().unwrap();
-    /// let simplex_key = tri.simplices().next().unwrap().0;
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((simplex_key, _)) = tri.simplices().next() else { return Ok(()); };
     /// assert_eq!(index.simplex_neighbors(simplex_key).count(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use = "this iterator is lazy and does nothing unless consumed"]
     #[inline]
@@ -269,7 +341,15 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices: Vec<_> = vec![
     /// #     // Shared triangle
     /// #     vertex!([0.0, 0.0, 0.0]),
@@ -279,11 +359,14 @@ impl AdjacencyIndex {
     /// #     vertex!([1.0, 0.7, 1.5]),
     /// #     vertex!([1.0, 0.7, -1.5]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let index = tri.build_adjacency_index().unwrap();
-    /// let simplex_key = tri.simplices().next().unwrap().0;
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((simplex_key, _)) = tri.simplices().next() else { return Ok(()); };
     /// assert_eq!(index.number_of_simplex_neighbors(simplex_key), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     #[inline]
@@ -302,18 +385,29 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices = vec![
     /// #     vertex!([0.0, 0.0, 0.0]),
     /// #     vertex!([1.0, 0.0, 0.0]),
     /// #     vertex!([0.0, 1.0, 0.0]),
     /// #     vertex!([0.0, 0.0, 1.0]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let index = tri.build_adjacency_index().unwrap();
+    /// # let index = tri.build_adjacency_index()?;
     /// let edges: std::collections::HashSet<_> = index.edges().collect();
     /// assert_eq!(edges.len(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use = "this iterator is lazy and does nothing unless consumed"]
     pub fn edges(&self) -> impl Iterator<Item = EdgeKey> + '_ {
@@ -330,17 +424,28 @@ impl AdjacencyIndex {
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices = vec![
     /// #     vertex!([0.0, 0.0, 0.0]),
     /// #     vertex!([1.0, 0.0, 0.0]),
     /// #     vertex!([0.0, 1.0, 0.0]),
     /// #     vertex!([0.0, 0.0, 1.0]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let index = tri.build_adjacency_index().unwrap();
+    /// # let index = tri.build_adjacency_index()?;
     /// assert_eq!(index.number_of_edges(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_edges(&self) -> usize {

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -6198,6 +6198,7 @@ where
 /// use delaunay::prelude::repair::verify_delaunay_via_flip_predicates;
 /// use delaunay::prelude::geometry::AdaptiveKernel;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
@@ -6205,11 +6206,14 @@ where
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
 ///
-/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, (), (), 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let kernel = AdaptiveKernel::<f64>::new();
 ///
 /// // Fast O(N) verification
 /// assert!(verify_delaunay_via_flip_predicates(dt.tds(), &kernel).is_ok());
+/// # Ok(())
+/// # }
 /// ```
 pub fn verify_delaunay_via_flip_predicates<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
@@ -6242,6 +6246,7 @@ where
 /// use delaunay::prelude::*;
 /// use delaunay::prelude::repair::verify_delaunay_for_triangulation;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
@@ -6249,10 +6254,13 @@ where
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
 ///
-/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, (), (), 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// // Topology-aware O(N) verification
 /// assert!(verify_delaunay_for_triangulation(dt.as_triangulation()).is_ok());
+/// # Ok(())
+/// # }
 /// ```
 pub fn verify_delaunay_for_triangulation<K, U, V, const D: usize>(
     triangulation: &Triangulation<K, U, V, D>,

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -1744,21 +1744,32 @@ impl InsertionError {
 /// ```rust
 /// use delaunay::prelude::insertion::fill_cavity;
 /// use delaunay::prelude::tds::FacetHandle;
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, (), (), 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let mut tds = dt.tds().clone();
-/// let vkey = tds.vertex_keys().next().unwrap();
+/// let Some(vkey) = tds.vertex_keys().next() else { return Ok(()); };
 /// let boundary_facets: Vec<FacetHandle> = Vec::new();
 ///
-/// let new_simplices = fill_cavity(&mut tds, vkey, &boundary_facets).unwrap();
+/// let new_simplices = fill_cavity(&mut tds, vkey, &boundary_facets)?;
 /// assert!(new_simplices.is_empty());
+/// # Ok(())
+/// # }
 /// ```
 pub fn fill_cavity<T, U, V, const D: usize>(
     tds: &mut Tds<T, U, V, D>,
@@ -2727,7 +2738,7 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::{DelaunayTriangulation, vertex};
+/// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder, vertex};
 /// use delaunay::prelude::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::insertion::{
 ///     InsertionError, TdsMutationError, repair_neighbor_pointers_local,
@@ -2749,17 +2760,20 @@ where
 ///     vertex!([0.0, 1.0]),
 ///     vertex!([1.0, 1.1]),
 /// ];
-/// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices)?;
+/// let dt: DelaunayTriangulation<_, (), (), 2> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let mut tds = dt.tds().clone();
 ///
-/// let (simplex_key, facet_idx, neighbor_key) = tds
+/// let Some((simplex_key, facet_idx, neighbor_key)) = tds
 ///     .simplices()
 ///     .find_map(|(simplex_key, simplex)| {
 ///         simplex.neighbors()?.enumerate().find_map(|(facet_idx, neighbor)| {
 ///             neighbor.map(|neighbor_key| (simplex_key, facet_idx, neighbor_key))
 ///         })
 ///     })
-///     .expect("test triangulation should contain adjacent simplices");
+/// else {
+///     return Ok(());
+/// };
 ///
 /// tds.clear_all_neighbors();
 ///
@@ -2979,7 +2993,8 @@ where
 ///
 /// ```rust
 /// use delaunay::prelude::construction::{
-///     DelaunayTriangulation, DelaunayTriangulationConstructionError, vertex,
+///     DelaunayTriangulation, DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
+///     vertex,
 /// };
 /// use delaunay::prelude::insertion::{InsertionError, repair_neighbor_pointers};
 ///
@@ -2996,7 +3011,8 @@ where
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices)?;
+/// let dt: DelaunayTriangulation<_, (), (), 2> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let mut tds = dt.tds().clone();
 ///
 /// let _changed_slots = repair_neighbor_pointers(&mut tds)?;

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -715,8 +715,18 @@ pub(crate) struct LocateTrace {
 ///
 /// ```rust
 /// use delaunay::prelude::algorithms::*;
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Locate(#[from] delaunay::prelude::algorithms::LocateError),
+/// #     #[error(transparent)]
+/// #     Conflict(#[from] delaunay::prelude::algorithms::ConflictError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a 4D simplex (5 vertices)
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0, 0.0]),
@@ -725,24 +735,23 @@ pub(crate) struct LocateTrace {
 ///     vertex!([0.0, 0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let kernel = FastKernel::<f64>::new();
 ///
 /// // Point inside the 4-simplex
 /// let inside_point = Point::new([0.2, 0.2, 0.2, 0.2]);
-/// match locate(dt.tds(), &kernel, &inside_point, None) {
-///     Ok(LocateResult::InsideSimplex(simplex_key)) => {
-///         assert!(dt.tds().contains_simplex(simplex_key));
-///     }
-///     _ => panic!("Expected point to be inside a simplex"),
-/// }
+/// let inside = locate(dt.tds(), &kernel, &inside_point, None)?;
+/// assert!(matches!(
+///     inside,
+///     LocateResult::InsideSimplex(simplex_key) if dt.tds().contains_simplex(simplex_key)
+/// ));
 ///
 /// // Point outside the convex hull
 /// let outside_point = Point::new([2.0, 2.0, 2.0, 2.0]);
-/// match locate(dt.tds(), &kernel, &outside_point, None) {
-///     Ok(LocateResult::Outside) => { /* Expected */ }
-///     _ => panic!("Expected point to be outside convex hull"),
-/// }
+/// let outside = locate(dt.tds(), &kernel, &outside_point, None)?;
+/// assert!(matches!(outside, LocateResult::Outside));
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Using a hint simplex for faster location:
@@ -750,8 +759,18 @@ pub(crate) struct LocateTrace {
 /// ```rust
 /// use delaunay::prelude::geometry::RobustKernel;
 /// use delaunay::prelude::algorithms::*;
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Locate(#[from] delaunay::prelude::algorithms::LocateError),
+/// #     #[error(transparent)]
+/// #     Conflict(#[from] delaunay::prelude::algorithms::ConflictError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a 4D simplex
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0, 0.0]),
@@ -760,17 +779,19 @@ pub(crate) struct LocateTrace {
 ///     vertex!([0.0, 0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let kernel = RobustKernel::<f64>::default();
 ///
 /// // Get a simplex to use as hint (spatially close to query point)
-/// let hint_simplex = dt.tds().simplex_keys().next().unwrap();
+/// let Some(hint_simplex) = dt.tds().simplex_keys().next() else {
+///     return Ok(());
+/// };
 /// let query_point = Point::new([0.15, 0.15, 0.15, 0.15]);
 ///
-/// match locate(dt.tds(), &kernel, &query_point, Some(hint_simplex)) {
-///     Ok(LocateResult::InsideSimplex(_)) => { /* Success */ }
-///     _ => panic!("Expected to find simplex"),
-/// }
+/// let located = locate(dt.tds(), &kernel, &query_point, Some(hint_simplex))?;
+/// assert!(matches!(located, LocateResult::InsideSimplex(_)));
+/// # Ok(())
+/// # }
 /// ```
 pub fn locate<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
@@ -801,21 +822,34 @@ where
 ///
 /// ```rust
 /// use delaunay::prelude::algorithms::*;
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Locate(#[from] delaunay::prelude::algorithms::LocateError),
+/// #     #[error(transparent)]
+/// #     Conflict(#[from] delaunay::prelude::algorithms::ConflictError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, (), (), 2> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let kernel = FastKernel::<f64>::new();
 ///
 /// let query_point = Point::new([0.3, 0.3]);
-/// let (_result, stats) = locate_with_stats(dt.tds(), &kernel, &query_point, None).unwrap();
+/// let (_result, stats) = locate_with_stats(dt.tds(), &kernel, &query_point, None)?;
 ///
 /// // In well-conditioned cases, the facet-walk should converge without falling back.
 /// assert!(!stats.fell_back_to_scan());
+/// # Ok(())
+/// # }
 /// ```
 pub fn locate_with_stats<K, U, V, const D: usize>(
     tds: &Tds<K::Scalar, U, V, D>,
@@ -1088,12 +1122,22 @@ where
 ///
 /// ```rust
 /// use delaunay::prelude::algorithms::{locate, find_conflict_region, LocateResult};
-/// use delaunay::prelude::DelaunayTriangulation;
+/// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
 /// use delaunay::prelude::geometry::FastKernel;
 /// use delaunay::prelude::geometry::Point;
 /// use delaunay::prelude::geometry::Coordinate;
 /// use delaunay::vertex;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Locate(#[from] delaunay::prelude::algorithms::LocateError),
+/// #     #[error(transparent)]
+/// #     Conflict(#[from] delaunay::prelude::algorithms::ConflictError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a 4D simplex (5 vertices forming a 4-simplex)
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0, 0.0]),
@@ -1102,19 +1146,21 @@ where
 ///     vertex!([0.0, 0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let kernel = FastKernel::<f64>::new();
 /// // Point inside the 4-simplex
 /// let query_point = Point::new([0.2, 0.2, 0.2, 0.2]);
 ///
 /// // First locate the point
-/// let location = locate(dt.tds(), &kernel, &query_point, None).unwrap();
+/// let location = locate(dt.tds(), &kernel, &query_point, None)?;
 /// if let LocateResult::InsideSimplex(simplex_key) = location {
 ///     // Find all simplices whose circumspheres contain the point
-///     let conflict_simplices = find_conflict_region(dt.tds(), &kernel, &query_point, simplex_key).unwrap();
+///     let conflict_simplices = find_conflict_region(dt.tds(), &kernel, &query_point, simplex_key)?;
 ///     assert_eq!(conflict_simplices.len(), 1); // Single 4-simplex contains the point
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[expect(
     clippy::too_many_lines,
@@ -1495,20 +1541,33 @@ where
 /// use delaunay::prelude::collections::SimplexKeyBuffer;
 /// use delaunay::prelude::tds::Tds;
 ///
+/// # fn main() -> Result<(), delaunay::prelude::algorithms::ConflictError> {
 /// let tds: Tds<f64, (), (), 3> = Tds::empty();
-/// let boundary = extract_cavity_boundary(&tds, &SimplexKeyBuffer::new()).unwrap();
+/// let boundary = extract_cavity_boundary(&tds, &SimplexKeyBuffer::new())?;
 /// assert!(boundary.is_empty());
+/// # Ok(())
+/// # }
 /// ```
 ///
 ///
 /// ```rust
 /// use delaunay::prelude::algorithms::{locate, find_conflict_region, extract_cavity_boundary, LocateResult};
-/// use delaunay::prelude::DelaunayTriangulation;
+/// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
 /// use delaunay::prelude::geometry::FastKernel;
 /// use delaunay::prelude::geometry::Point;
 /// use delaunay::prelude::geometry::Coordinate;
 /// use delaunay::vertex;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Locate(#[from] delaunay::prelude::algorithms::LocateError),
+/// #     #[error(transparent)]
+/// #     Conflict(#[from] delaunay::prelude::algorithms::ConflictError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a 4D simplex
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0, 0.0]),
@@ -1517,22 +1576,24 @@ where
 ///     vertex!([0.0, 0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let kernel = FastKernel::<f64>::new();
 /// let query_point = Point::new([0.2, 0.2, 0.2, 0.2]);
 ///
 /// // Locate and find conflict region
-/// let location = locate(dt.tds(), &kernel, &query_point, None).unwrap();
+/// let location = locate(dt.tds(), &kernel, &query_point, None)?;
 /// if let LocateResult::InsideSimplex(simplex_key) = location {
-///     let conflict_simplices = find_conflict_region(dt.tds(), &kernel, &query_point, simplex_key).unwrap();
+///     let conflict_simplices = find_conflict_region(dt.tds(), &kernel, &query_point, simplex_key)?;
 ///     
 ///     // Extract cavity boundary
-///     let boundary_facets = extract_cavity_boundary(dt.tds(), &conflict_simplices).unwrap();
+///     let boundary_facets = extract_cavity_boundary(dt.tds(), &conflict_simplices)?;
 ///     
 ///     // For a single 4-simplex, all 5 facets are on the boundary (convex hull)
 ///     assert_eq!(boundary_facets.len(), 5);
 /// }
+/// # Ok(())
+/// # }
 /// ```
 #[expect(
     clippy::too_many_lines,

--- a/src/core/boundary.rs
+++ b/src/core/boundary.rs
@@ -70,8 +70,18 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create a simple 3D triangulation (single tetrahedron)
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -79,15 +89,16 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // High-level API returns `QueryError` if the underlying TDS is corrupted.
-    /// assert_eq!(dt.boundary_facets().unwrap().count(), 4);
+    /// assert_eq!(dt.boundary_facets()?.count(), 4);
     ///
     /// // TDS-level API (fallible): returns `TdsError` on corruption.
     /// let count = dt.tds().boundary_facets()?.count();
     /// assert_eq!(count, 4);
-    /// # Ok::<(), delaunay::tds::TdsError>(())
+    /// # Ok(())
+    /// # }
     /// ```
     fn boundary_facets(&self) -> Result<BoundaryFacetsIter<'_, T, U, V, D>, TdsError> {
         // Build a map from facet keys to the simplices that contain them
@@ -125,20 +136,34 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Get boundary facets using the new iterator API
-    /// let first_facet = dt.boundary_facets().unwrap().next().unwrap();
+    /// let Some(first_facet) = dt.boundary_facets()?.next() else {
+    ///     return Ok(());
+    /// };
     /// // In a single tetrahedron, all facets are boundary facets
-    /// assert!(dt.tds().is_boundary_facet(&first_facet).unwrap());
+    /// assert!(dt.tds().is_boundary_facet(&first_facet)?);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     fn is_boundary_facet(&self, facet: &FacetView<'_, T, U, V, D>) -> Result<bool, TdsError> {
@@ -169,26 +194,36 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Build the facet map once for multiple queries
-    /// let facet_to_simplices = dt.tds().build_facet_to_simplices_map()
-    ///     .expect("Should build facet map");
+    /// let facet_to_simplices = dt.tds().build_facet_to_simplices_map()?;
     ///
     /// // Check boundary facets efficiently using the iterator API
-    /// for facet in dt.boundary_facets().unwrap() {
-    ///     let is_boundary = dt.tds().is_boundary_facet_with_map(&facet, &facet_to_simplices)
-    ///         .expect("Should check if facet is boundary");
+    /// for facet in dt.boundary_facets()? {
+    ///     let is_boundary = dt.tds().is_boundary_facet_with_map(&facet, &facet_to_simplices)?;
     ///     println!("Facet is boundary: {is_boundary}");
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     fn is_boundary_facet_with_map(
@@ -230,19 +265,30 @@ impl<T, U, V, const D: usize> BoundaryAnalysis<T, U, V, D> for Tds<T, U, V, D> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // A single tetrahedron has 4 boundary facets
     /// assert_eq!(dt.tds().number_of_boundary_facets()?, 4);
-    /// # Ok::<(), delaunay::tds::TdsError>(())
+    /// # Ok(())
+    /// # }
     /// ```
     fn number_of_boundary_facets(&self) -> Result<usize, TdsError> {
         let facet_to_simplices = self.build_facet_to_simplices_map()?;

--- a/src/core/collections/key_maps.rs
+++ b/src/core/collections/key_maps.rs
@@ -59,11 +59,9 @@ pub type VertexUuidSet = FastHashSet<Uuid>;
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, _, _, 3> =
-///     DelaunayTriangulation::new_with_topology_guarantee(
-///         &vertices,
-///         TopologyGuarantee::PLManifold,
-///     )?;
+/// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulationBuilder::new(&vertices)
+///     .topology_guarantee(TopologyGuarantee::PLManifold)
+///     .build::<()>()?;
 /// println!("Topology guarantee: {:?}", dt.topology_guarantee());
 /// let tds = dt.tds();
 ///
@@ -115,11 +113,9 @@ pub type UuidToVertexKeyMap = FastHashMap<Uuid, VertexKey>;
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, _, _, 3> =
-///     DelaunayTriangulation::new_with_topology_guarantee(
-///         &vertices,
-///         TopologyGuarantee::PLManifold,
-///     )?;
+/// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulationBuilder::new(&vertices)
+///     .topology_guarantee(TopologyGuarantee::PLManifold)
+///     .build::<()>()?;
 /// assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
 /// let tds = dt.tds();
 ///

--- a/src/core/collections/secondary_maps.rs
+++ b/src/core/collections/secondary_maps.rs
@@ -33,13 +33,15 @@ use slotmap::SparseSecondaryMap;
 /// ```rust
 /// use delaunay::prelude::*;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, _, _, 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
 /// use delaunay::prelude::collections::SimplexSecondaryMap;
@@ -47,6 +49,8 @@ use slotmap::SparseSecondaryMap;
 /// for (simplex_key, _) in tds.simplices() {
 ///     in_conflict.insert(simplex_key, true);
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub type SimplexSecondaryMap<V> = SparseSecondaryMap<SimplexKey, V>;
 
@@ -73,13 +77,15 @@ pub type SimplexSecondaryMap<V> = SparseSecondaryMap<SimplexKey, V>;
 /// ```rust
 /// use delaunay::prelude::*;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, _, _, 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
 /// use delaunay::prelude::collections::VertexSecondaryMap;
@@ -87,6 +93,8 @@ pub type SimplexSecondaryMap<V> = SparseSecondaryMap<SimplexKey, V>;
 /// for (idx, (vertex_key, _)) in tds.vertices().enumerate() {
 ///     processing_order.insert(vertex_key, idx);
 /// }
+/// # Ok(())
+/// # }
 /// ```
 pub type VertexSecondaryMap<V> = SparseSecondaryMap<VertexKey, V>;
 

--- a/src/core/edge.rs
+++ b/src/core/edge.rs
@@ -47,24 +47,28 @@ impl EdgeKey {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// let mut it = tri.vertices();
-    /// let a = it.next().unwrap().0;
-    /// let b = it.next().unwrap().0;
+    /// let Some((a, _)) = it.next() else { return Ok(()); };
+    /// let Some((b, _)) = it.next() else { return Ok(()); };
     ///
     /// let e1 = EdgeKey::new(a, b);
     /// let e2 = EdgeKey::new(b, a);
     /// assert_eq!(e1, e2);
     /// assert!(e1.v0() <= e1.v1());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn new(a: VertexKey, b: VertexKey) -> Self {
@@ -85,24 +89,28 @@ impl EdgeKey {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// let mut it = tri.vertices();
-    /// let a = it.next().unwrap().0;
-    /// let b = it.next().unwrap().0;
+    /// let Some((a, _)) = it.next() else { return Ok(()); };
+    /// let Some((b, _)) = it.next() else { return Ok(()); };
     ///
     /// let e = EdgeKey::new(a, b);
     /// let v0 = e.v0();
     /// let v1 = e.v1();
     /// assert!(v0 <= v1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -115,24 +123,28 @@ impl EdgeKey {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// let mut it = tri.vertices();
-    /// let a = it.next().unwrap().0;
-    /// let b = it.next().unwrap().0;
+    /// let Some((a, _)) = it.next() else { return Ok(()); };
+    /// let Some((b, _)) = it.next() else { return Ok(()); };
     ///
     /// let e = EdgeKey::new(a, b);
     /// let v0 = e.v0();
     /// let v1 = e.v1();
     /// assert!(v0 <= v1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -145,25 +157,29 @@ impl EdgeKey {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// let mut it = tri.vertices();
-    /// let a = it.next().unwrap().0;
-    /// let b = it.next().unwrap().0;
+    /// let Some((a, _)) = it.next() else { return Ok(()); };
+    /// let Some((b, _)) = it.next() else { return Ok(()); };
     ///
     /// let e = EdgeKey::new(a, b);
     /// let (v0, v1) = e.endpoints();
     /// assert_eq!(v0, e.v0());
     /// assert_eq!(v1, e.v1());
     /// assert!(v0 <= v1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -37,6 +37,16 @@
 //! use delaunay::prelude::*;
 //! use delaunay::prelude::tds::FacetView;
 //!
+//! # #[derive(Debug, thiserror::Error)]
+//! # enum ExampleError {
+//! #     #[error(transparent)]
+//! #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+//! #     #[error(transparent)]
+//! #     Facet(#[from] delaunay::prelude::tds::FacetError),
+//! #     #[error(transparent)]
+//! #     Tds(#[from] delaunay::prelude::tds::TdsError),
+//! # }
+//! # fn main() -> Result<(), ExampleError> {
 //! // Create vertices for a tetrahedron
 //! let vertices = vec![
 //!     vertex!([0.0, 0.0, 0.0]),
@@ -46,12 +56,16 @@
 //! ];
 //!
 //! // Create a 3D triangulation
-//! let dt = DelaunayTriangulation::new(&vertices).unwrap();
-//! let simplex_key = dt.simplices().next().unwrap().0;
+//! let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+//! let Some((simplex_key, _)) = dt.simplices().next() else {
+//!     return Ok(());
+//! };
 //!
 //! // Create a facet view (facet 0 excludes vertex 0)
-//! let facet = FacetView::new(dt.tds(), simplex_key, 0).unwrap();
-//! assert_eq!(facet.vertices().unwrap().count(), 3);  // Facet (triangle) in 3D has 3 vertices
+//! let facet = FacetView::new(dt.tds(), simplex_key, 0)?;
+//! assert_eq!(facet.vertices()?.count(), 3);  // Facet (triangle) in 3D has 3 vertices
+//! # Ok(())
+//! # }
 //! ```
 
 #![forbid(unsafe_code)]
@@ -224,20 +238,35 @@ pub enum FacetError {
 /// use delaunay::prelude::*;
 /// use delaunay::prelude::tds::{FacetHandle, FacetView};
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-/// let simplex_key = dt.simplices().next().unwrap().0;
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
 ///
 /// // Create a facet handle
 /// let handle = FacetHandle::new(simplex_key, 0);
 ///
 /// // Use it to create a FacetView
-/// let facet = FacetView::new(dt.tds(), handle.simplex_key(), handle.facet_index()).unwrap();
+/// let facet = FacetView::new(dt.tds(), handle.simplex_key(), handle.facet_index())?;
+/// # let _ = facet;
+/// # Ok(())
+/// # }
 /// ```
 #[must_use]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
@@ -260,17 +289,22 @@ impl FacetHandle {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetHandle;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// let handle = FacetHandle::new(simplex_key, 0);
     /// assert_eq!(handle.simplex_key(), simplex_key);
     /// assert_eq!(handle.facet_index(), 0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub const fn new(simplex_key: SimplexKey, facet_index: u8) -> Self {
         Self {
@@ -287,16 +321,21 @@ impl FacetHandle {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetHandle;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// let handle = FacetHandle::new(simplex_key, 0);
     /// assert_eq!(handle.simplex_key(), simplex_key);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub const fn simplex_key(&self) -> SimplexKey {
@@ -311,16 +350,21 @@ impl FacetHandle {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetHandle;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// let handle = FacetHandle::new(simplex_key, 1);
     /// assert_eq!(handle.facet_index(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub const fn facet_index(&self) -> u8 {
@@ -446,17 +490,31 @@ impl<'tds, T, U, V, const D: usize> FacetView<'tds, T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetView;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let (simplex_key, _) = dt.simplices().next().unwrap();
-    /// let facet = FacetView::new(dt.tds(), simplex_key, 0).unwrap();
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let facet = FacetView::new(dt.tds(), simplex_key, 0)?;
     /// assert_eq!(facet.facet_index(), 0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(
         tds: &'tds Tds<T, U, V, D>,
@@ -509,19 +567,31 @@ impl<'tds, T, U, V, const D: usize> FacetView<'tds, T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetView;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// if let Some((simplex_key, _)) = dt.simplices().next() {
-    ///     let facet = FacetView::new(dt.tds(), simplex_key, 0).unwrap();
-    ///     let vertex_iter = facet.vertices().unwrap();
+    ///     let facet = FacetView::new(dt.tds(), simplex_key, 0)?;
+    ///     let vertex_iter = facet.vertices()?;
     ///     assert_eq!(vertex_iter.count(), 3); // 3D facet has 3 vertices
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn vertices(&self) -> Result<impl Iterator<Item = &'tds Vertex<T, U, D>>, FacetError> {
         let simplex = self
@@ -566,18 +636,32 @@ impl<'tds, T, U, V, const D: usize> FacetView<'tds, T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetView;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (simplex_key, _) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
-    /// let facet = FacetView::new(dt.tds(), simplex_key, 1).unwrap();
-    /// let opposite = facet.opposite_vertex().unwrap();
+    /// let facet = FacetView::new(dt.tds(), simplex_key, 1)?;
+    /// let opposite = facet.opposite_vertex()?;
     /// assert_eq!(opposite.point().coords().len(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn opposite_vertex(&self) -> Result<&'tds Vertex<T, U, D>, FacetError> {
         let simplex = self
@@ -617,18 +701,32 @@ impl<'tds, T, U, V, const D: usize> FacetView<'tds, T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetView;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (simplex_key, _) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
-    /// let facet = FacetView::new(dt.tds(), simplex_key, 2).unwrap();
-    /// let simplex = facet.simplex().unwrap();
+    /// let facet = FacetView::new(dt.tds(), simplex_key, 2)?;
+    /// let simplex = facet.simplex()?;
     /// assert_eq!(simplex.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplex(&self) -> Result<&'tds Simplex<T, U, V, D>, FacetError> {
         self.tds
@@ -656,19 +754,33 @@ impl<'tds, T, U, V, const D: usize> FacetView<'tds, T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::FacetView;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (simplex_key, _) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
-    /// let facet = FacetView::new(dt.tds(), simplex_key, 0).unwrap();
-    /// let facet_key = facet.key().unwrap();
-    /// let map = dt.tds().build_facet_to_simplices_map().unwrap();
+    /// let facet = FacetView::new(dt.tds(), simplex_key, 0)?;
+    /// let facet_key = facet.key()?;
+    /// let map = dt.tds().build_facet_to_simplices_map()?;
     /// assert!(map.contains_key(&facet_key));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn key(&self) -> Result<u64, FacetError> {
         self.tds
@@ -743,17 +855,31 @@ impl<T, U, V, const D: usize> Eq for FacetView<'_, T, U, V, D> {}
 /// use delaunay::prelude::*;
 /// use delaunay::prelude::tds::all_facets_for_simplex;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-/// let (simplex_key, _) = dt.simplices().next().unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
 ///
-/// let facets = all_facets_for_simplex(dt.tds(), simplex_key).unwrap();
+/// let facets = all_facets_for_simplex(dt.tds(), simplex_key)?;
 /// assert_eq!(facets.len(), 4);
+/// # Ok(())
+/// # }
 /// ```
 pub fn all_facets_for_simplex<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
@@ -787,16 +913,19 @@ pub fn all_facets_for_simplex<T, U, V, const D: usize>(
 /// use delaunay::prelude::tds::AllFacetsIter;
 /// use delaunay::prelude::*;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let count = AllFacetsIter::new(dt.tds()).count();
 /// assert_eq!(count, 4);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone)]
 pub struct AllFacetsIter<'tds, T, U, V, const D: usize> {
@@ -821,16 +950,19 @@ impl<'tds, T, U, V, const D: usize> AllFacetsIter<'tds, T, U, V, D> {
     /// use delaunay::prelude::tds::AllFacetsIter;
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// let mut iter = AllFacetsIter::new(dt.tds());
     /// assert!(iter.next().is_some());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn new(tds: &'tds Tds<T, U, V, D>) -> Self {
@@ -909,17 +1041,29 @@ impl<'tds, T, U, V, const D: usize> Iterator for AllFacetsIter<'tds, T, U, V, D>
 /// use delaunay::prelude::tds::BoundaryFacetsIter;
 /// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-/// let facet_map = dt.tds().build_facet_to_simplices_map().unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+/// let facet_map = dt.tds().build_facet_to_simplices_map()?;
 ///
 /// let count = BoundaryFacetsIter::new(dt.tds(), facet_map).count();
 /// assert_eq!(count, 4);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone)]
 pub struct BoundaryFacetsIter<'tds, T, U, V, const D: usize> {
@@ -936,17 +1080,29 @@ impl<'tds, T, U, V, const D: usize> BoundaryFacetsIter<'tds, T, U, V, D> {
     /// use delaunay::prelude::tds::BoundaryFacetsIter;
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let facet_map = dt.tds().build_facet_to_simplices_map().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let facet_map = dt.tds().build_facet_to_simplices_map()?;
     ///
     /// let mut iter = BoundaryFacetsIter::new(dt.tds(), facet_map);
     /// assert!(iter.next().is_some());
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn new(tds: &'tds Tds<T, U, V, D>, facet_to_simplices_map: FacetToSimplicesMap) -> Self {

--- a/src/core/query.rs
+++ b/src/core/query.rs
@@ -33,16 +33,26 @@ static VERTEX_TO_SIMPLICES_SPILL_EVENTS: AtomicU64 = AtomicU64::new(0);
 /// ```rust
 /// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Query(#[from] delaunay::query::QueryError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let boundary_count = dt.as_triangulation().boundary_facets().unwrap().count();
+/// let boundary_count = dt.as_triangulation().boundary_facets()?.count();
 /// assert_eq!(boundary_count, 4);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -69,12 +79,13 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// // Iterate over simplices
@@ -82,6 +93,8 @@ where
     ///     assert_eq!(simplex.number_of_vertices(), 3); // 2D triangle
     /// }
     /// assert_eq!(tri.simplices().count(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplices(&self) -> impl Iterator<Item = (SimplexKey, &Simplex<K::Scalar, U, V, D>)> {
         self.tds.simplices()
@@ -96,12 +109,13 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// // Iterate over vertices
@@ -109,6 +123,8 @@ where
     ///     assert_eq!(vertex.dim(), 2); // 2D vertices
     /// }
     /// assert_eq!(tri.vertices().count(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn vertices(&self) -> impl Iterator<Item = (VertexKey, &Vertex<K::Scalar, U, D>)> {
         self.tds.vertices()
@@ -121,14 +137,17 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.as_triangulation().number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_vertices(&self) -> usize {
@@ -142,14 +161,17 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.as_triangulation().number_of_simplices(), 1); // Single tetrahedron
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_simplices(&self) -> usize {
@@ -164,6 +186,7 @@ where
     /// use delaunay::prelude::geometry::*;
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// // Empty triangulation has dimension -1
     /// let empty: Triangulation<FastKernel<f64>, (), (), 3> =
     ///     Triangulation::new_empty(FastKernel::new());
@@ -176,8 +199,10 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.as_triangulation().dim(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn dim(&self) -> i32 {
@@ -199,17 +224,20 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Iterate over all facets
     /// let facet_count = dt.as_triangulation().facets().count();
     /// assert_eq!(facet_count, 4); // Tetrahedron has 4 facets
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn facets(&self) -> AllFacetsIter<'_, K::Scalar, U, V, D> {
         AllFacetsIter::new(&self.tds)
@@ -229,16 +257,26 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let boundary_count = dt.as_triangulation().boundary_facets().unwrap().count();
+    /// let boundary_count = dt.as_triangulation().boundary_facets()?.count();
     /// assert_eq!(boundary_count, 4); // All facets are on boundary
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -290,6 +328,7 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// // A single 3D tetrahedron has 6 unique edges.
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -297,11 +336,14 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// let edges: std::collections::HashSet<_> = tri.edges().collect();
     /// assert_eq!(edges.len(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn edges(&self) -> impl Iterator<Item = EdgeKey> + '_ {
         self.collect_edges().into_iter()
@@ -314,8 +356,16 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // A single 3D tetrahedron has 6 unique edges.
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -323,12 +373,15 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
-    /// let index = tri.build_adjacency_index().unwrap();
+    /// let index = tri.build_adjacency_index()?;
     /// let edges: std::collections::HashSet<_> = tri.edges_with_index(&index).collect();
     /// assert_eq!(edges.len(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn edges_with_index<'a>(
         &self,
@@ -347,16 +400,20 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// // A single 2D triangle has 3 unique edges.
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tri = dt.as_triangulation();
     ///
     /// assert_eq!(tri.number_of_edges(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_edges(&self) -> usize {
@@ -370,17 +427,28 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// # use delaunay::prelude::query::*;
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices = vec![
     /// #     vertex!([0.0, 0.0, 0.0]),
     /// #     vertex!([1.0, 0.0, 0.0]),
     /// #     vertex!([0.0, 1.0, 0.0]),
     /// #     vertex!([0.0, 0.0, 1.0]),
     /// # ];
-    /// # let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
-    /// # let index = tri.build_adjacency_index().unwrap();
+    /// # let index = tri.build_adjacency_index()?;
     /// assert_eq!(tri.number_of_edges_with_index(&index), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_edges_with_index(&self, index: &AdjacencyIndex) -> usize {

--- a/src/core/repair.rs
+++ b/src/core/repair.rs
@@ -878,26 +878,36 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulation;
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::triangulation::vertex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // A single simplex has no over-shared facets.
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// let simplex_keys: Vec<_> = dt.simplices().map(|(ck, _)| ck).collect();
     /// let issues = dt
     ///     .as_triangulation()
     ///     .detect_local_facet_issues(&simplex_keys)
-    ///     .unwrap();
+    ///     ?;
     /// assert!(issues.is_none());
     ///
     /// // Note: This method is most useful for checking newly created simplices
     /// // after insertion/removal operations.
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn detect_local_facet_issues(
         &self,
@@ -1141,7 +1151,7 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, DelaunayTriangulationConstructionError,
+    ///     DelaunayTriangulation, DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
     /// };
     /// use delaunay::prelude::insertion::InsertionError;
     /// use delaunay::prelude::triangulation::{FacetIssuesMap, vertex};
@@ -1160,7 +1170,8 @@ where
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Empty issues map => nothing to remove.
     /// let mut tri = dt.as_triangulation().clone();

--- a/src/core/simplex.rs
+++ b/src/core/simplex.rs
@@ -20,6 +20,7 @@
 //! ```rust
 //! use delaunay::prelude::*;
 //!
+//! # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 //! // Create vertices for a tetrahedron
 //! let vertices = vec![
 //!     vertex!([0.0, 0.0, 0.0]),
@@ -30,9 +31,14 @@
 //!
 //! // Create a 3D triangulation with simplices
 //! let dt: DelaunayTriangulation<_, (), (), 3> =
-//!     DelaunayTriangulation::new(&vertices).unwrap();
-//! let (simplex_key, simplex) = dt.simplices().next().unwrap();
+//!     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+//! let Some((simplex_key, simplex)) = dt.simplices().next() else {
+//!     return Ok(());
+//! };
 //! assert_eq!(simplex.number_of_vertices(), 4);
+//! # let _ = simplex_key;
+//! # Ok(())
+//! # }
 //! ```
 
 #![allow(clippy::similar_names)]
@@ -298,22 +304,30 @@ impl NeighborSlot {
 /// use delaunay::prelude::collections::Uuid;
 /// use delaunay::prelude::*;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// // Create a triangulation with some vertices
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// // Get first simplex and iterate over vertex keys
-/// let (simplex_key, simplex) = dt.simplices().next().unwrap();
+/// let Some((simplex_key, simplex)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
 /// let tds = dt.tds();
 /// for &vertex_key in simplex.vertices() {
-///     let vertex = &tds.vertex(vertex_key).unwrap();
+///     let Some(vertex) = tds.vertex(vertex_key) else {
+///         return Ok(());
+///     };
 ///     // use vertex...
 ///     assert!(vertex.uuid() != Uuid::nil());
 /// }
+/// # let _ = simplex_key;
+/// # Ok(())
+/// # }
 /// ```
 pub struct Simplex<T, U, V, const D: usize> {
     /// Keys to the vertices forming this simplex.
@@ -559,18 +573,23 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let vkey = simplex.vertices()[0];
     ///
     /// if simplex.contains_vertex(vkey) {
     ///     println!("Simplex contains vertex {:?}", vkey);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn contains_vertex(&self, vkey: VertexKey) -> bool {
@@ -594,20 +613,23 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     ///     vertex!([1.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let mut simplices_iter = dt.simplices().map(|(_, simplex)| simplex);
-    /// let simplex1 = simplices_iter.next().unwrap();
-    /// let simplex2 = simplices_iter.next().unwrap();
+    /// let Some(simplex1) = simplices_iter.next() else { return Ok(()); };
+    /// let Some(simplex2) = simplices_iter.next() else { return Ok(()); };
     ///
     /// if simplex1.has_vertex_in_common(simplex2) {
     ///     println!("Simplices share vertices");
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn has_vertex_in_common(&self, other: &Self) -> bool {
@@ -629,17 +651,22 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// for (idx, &vkey) in simplex.vertices_enumerated() {
     ///     println!("Vertex {:?} at position {}", vkey, idx);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn vertices_enumerated(&self) -> impl Iterator<Item = (usize, &VertexKey)> {
@@ -665,23 +692,31 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let tds = dt.tds();
     ///
     /// if let Some(neighbors) = simplex.neighbors() {
     ///     for (i, neighbor_key_opt) in neighbors.enumerate() {
     ///         if let Some(neighbor_key) = neighbor_key_opt {
-    ///             let neighbor_simplex = &tds.simplex(neighbor_key).unwrap();
+    ///             let Some(neighbor_simplex) = tds.simplex(neighbor_key) else {
+    ///                 continue;
+    ///             };
     ///             // neighbor_simplex is opposite to vertex i
+    ///             # let _ = neighbor_simplex;
     ///         }
     ///     }
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -730,24 +765,44 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::tds::NeighborSlot;
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let mut tds = dt.tds().clone();
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
     ///
-    /// tds.set_neighbors_by_key(simplex_key, &[None, None, None]).unwrap();
-    /// let simplex = tds.simplex(simplex_key).unwrap();
+    /// tds.set_neighbors_by_key(simplex_key, &[None, None, None])?;
+    /// let Some(simplex) = tds.simplex(simplex_key) else {
+    ///     return Ok(());
+    /// };
     ///
-    /// let slots = simplex
-    ///     .neighbor_slots()
-    ///     .expect("set_neighbors_by_key assigns boundary slots");
+    /// let Some(slots) = simplex.neighbor_slots() else {
+    ///     return Ok(());
+    /// };
     ///
     /// assert_eq!(slots.len(), 3);
     /// assert!(slots.iter().all(|slot| matches!(*slot, NeighborSlot::Boundary)));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -768,20 +823,38 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::collections::Uuid;
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let tds = dt.tds();
     ///
     /// for &vkey in simplex.vertices() {
-    ///     let vertex = &tds.vertex(vkey).unwrap();
+    ///     let Some(vertex) = tds.vertex(vkey) else {
+    ///         continue;
+    ///     };
     ///     // use vertex data...
     ///     assert!(vertex.uuid() != Uuid::nil());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Returns
@@ -978,17 +1051,35 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let tds = dt.tds();
-    /// let simplex = &tds.simplex(simplex_key).unwrap();
+    /// let Some(simplex) = tds.simplex(simplex_key) else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(simplex.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn number_of_vertices(&self) -> usize {
@@ -1007,6 +1098,18 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::collections::Uuid;
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 1.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -1014,9 +1117,13 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 0.0]),
     /// ];
     /// let dt: DelaunayTriangulation<_, (), (), 3> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// assert_ne!(simplex.uuid(), Uuid::nil());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub const fn uuid(&self) -> Uuid {
@@ -1031,16 +1138,30 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::Simplex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .build::<i32>()
-    ///     .unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<i32>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(simplex.data(), None); // No data set yet
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -1088,17 +1209,36 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     ///
     /// ```
     /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices = vec![
     /// #     vertex!([0.0, 0.0]),
     /// #     vertex!([1.0, 0.0]),
     /// #     vertex!([0.0, 1.0]),
     /// # ];
-    /// # let mut dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// # let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// // Note: clear_all_neighbors() is a Tds method, not on DelaunayTriangulation
     /// // This example is conceptual - actual usage requires accessing tds directly
-    /// # let simplex_key = dt.simplices().next().unwrap().0;
+    /// # let Some((simplex_key, _)) = dt.simplices().next() else {
+    /// #     return Ok(());
+    /// # };
     /// # let tds = dt.tds();
-    /// # // assert!(tds.simplex(simplex_key).unwrap().neighbors().is_none());
+    /// # // if let Some(simplex) = tds.simplex(simplex_key) {
+    /// # //     assert!(simplex.neighbors().is_none());
+    /// # // }
+    /// # let _ = (simplex_key, tds);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub(crate) fn clear_neighbors(&mut self) {
@@ -1128,18 +1268,36 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let tds = dt.tds();
-    /// let simplex = &tds.simplex(simplex_key).unwrap();
-    /// let uuids = simplex.vertex_uuids(tds).unwrap();
+    /// let Some(simplex) = tds.simplex(simplex_key) else {
+    ///     return Ok(());
+    /// };
+    /// let uuids = simplex.vertex_uuids(tds)?;
     /// assert_eq!(uuids.len(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn vertex_uuids(
@@ -1178,17 +1336,35 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let tds = dt.tds();
-    /// let simplex = &tds.simplex(simplex_key).unwrap();
-    /// let uuids: Vec<_> = simplex.vertex_uuid_iter(tds).collect::<Result<Vec<_>, _>>().unwrap();
+    /// let Some(simplex) = tds.simplex(simplex_key) else {
+    ///     return Ok(());
+    /// };
+    /// let uuids: Vec<_> = simplex.vertex_uuid_iter(tds).collect::<Result<Vec<_>, _>>()?;
     /// assert_eq!(uuids.len(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn vertex_uuid_iter<'a>(
@@ -1214,6 +1390,18 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::Simplex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 1.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
@@ -1221,9 +1409,13 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 0.0]),
     /// ];
     /// let dt: DelaunayTriangulation<_, (), (), 3> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(simplex.dim(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub const fn dim(&self) -> usize {
@@ -1251,6 +1443,18 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::Simplex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create two separate triangulations
     /// let vertices1 = vec![
     ///     vertex!([0.0, 0.0, 1.0]),
@@ -1265,11 +1469,17 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     ///     vertex!([1.0, 1.0, 2.0]),
     /// ];
     /// let dt1: DelaunayTriangulation<_, (), (), 3> =
-    ///     DelaunayTriangulation::new(&vertices1).unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices1).build::<()>()?;
     /// let dt2: DelaunayTriangulation<_, (), (), 3> =
-    ///     DelaunayTriangulation::new(&vertices2).unwrap();
-    /// let simplex1 = dt1.tds().simplices().next().unwrap().1.clone();
-    /// let simplex2 = dt2.tds().simplices().next().unwrap().1.clone();
+    ///     DelaunayTriangulationBuilder::new(&vertices2).build::<()>()?;
+    /// let Some((_, simplex1)) = dt1.tds().simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let Some((_, simplex2)) = dt2.tds().simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let simplex1 = simplex1.clone();
+    /// let simplex2 = simplex2.clone();
     ///
     /// let uuid1 = simplex1.uuid();
     /// let uuid2 = simplex2.uuid();
@@ -1277,9 +1487,11 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// let simplex_map = Simplex::into_hashmap([simplex1, simplex2]);
     ///
     /// // Access simplices by their UUIDs
-    /// assert_eq!(simplex_map.get(&uuid1).unwrap().uuid(), uuid1);
-    /// assert_eq!(simplex_map.get(&uuid2).unwrap().uuid(), uuid2);
+    /// assert_eq!(simplex_map.get(&uuid1).map(Simplex::uuid), Some(uuid1));
+    /// assert_eq!(simplex_map.get(&uuid2).map(Simplex::uuid), Some(uuid2));
     /// assert_eq!(simplex_map.len(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// ```
@@ -1333,6 +1545,18 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::Simplex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 1.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
@@ -1340,9 +1564,13 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 0.0]),
     /// ];
     /// let dt: DelaunayTriangulation<_, (), (), 3> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, simplex) = dt.simplices().next().unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// assert!(simplex.is_valid().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn is_valid(&self) -> Result<(), SimplexValidationError> {
         // Check if UUID is valid
@@ -1466,22 +1694,39 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::Simplex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, _, _, 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
-    /// let facet_views = Simplex::facet_views_from_tds(tds, simplex_key).expect("Failed to get facet views");
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
+    /// let facet_views = Simplex::facet_views_from_tds(tds, simplex_key)?;
     ///
     /// // Each facet should have 3 vertices (triangular faces of tetrahedron)
     /// for facet_view in &facet_views {
-    ///     assert_eq!(facet_view.vertices().unwrap().count(), 3);
+    ///     assert_eq!(facet_view.vertices()?.count(), 3);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn facet_views_from_tds(
         tds: &Tds<T, U, V, D>,
@@ -1531,27 +1776,59 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Example 1: Comparing simplices from different TDS instances with same coordinates
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt1: DelaunayTriangulation<_, _, _, 2> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let dt2: DelaunayTriangulation<_, _, _, 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt1: DelaunayTriangulation<_, _, _, 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let dt2: DelaunayTriangulation<_, _, _, 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds1 = dt1.tds();
     /// let tds2 = dt2.tds();
     ///
-    /// let simplex1 = tds1.simplices().next().unwrap().1;
-    /// let simplex2 = tds2.simplices().next().unwrap().1;
+    /// let Some((_, simplex1)) = tds1.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let Some((_, simplex2)) = tds2.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// // Different TDS instances, but same vertex coordinates
     /// assert!(simplex1.eq_by_vertices(tds1, simplex2, tds2));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Example 2: Comparing simplices with different coordinates returns false
     /// let vertices1 = vec![
     ///     vertex!([0.0, 0.0]),
@@ -1563,16 +1840,24 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     ///     vertex!([2.0, 0.0]),  // Different coordinate
     ///     vertex!([0.0, 2.0]),  // Different coordinate
     /// ];
-    /// let dt1: DelaunayTriangulation<_, _, _, 2> = DelaunayTriangulation::new(&vertices1).unwrap();
-    /// let dt2: DelaunayTriangulation<_, _, _, 2> = DelaunayTriangulation::new(&vertices2).unwrap();
+    /// let dt1: DelaunayTriangulation<_, _, _, 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices1).build::<()>()?;
+    /// let dt2: DelaunayTriangulation<_, _, _, 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices2).build::<()>()?;
     /// let tds1 = dt1.tds();
     /// let tds2 = dt2.tds();
     ///
-    /// let simplex1 = tds1.simplices().next().unwrap().1;
-    /// let simplex2 = tds2.simplices().next().unwrap().1;
+    /// let Some((_, simplex1)) = tds1.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let Some((_, simplex2)) = tds2.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// // Different coordinates mean simplices are not equal
     /// assert!(!simplex1.eq_by_vertices(tds1, simplex2, tds2));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn eq_by_vertices(
         &self,
@@ -1643,49 +1928,81 @@ impl<T, U, V, const D: usize> Simplex<T, U, V, D> {
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::Simplex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, _, _, 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
-    /// let facet_iter = Simplex::facet_view_iter(tds, simplex_key).expect("Failed to get facet iterator");
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
+    /// let facet_iter = Simplex::facet_view_iter(tds, simplex_key)?;
     ///
     /// // Iterator knows the exact count
     /// assert_eq!(facet_iter.len(), 4); // 4 facets for a tetrahedron
     ///
     /// // Process facets one at a time (zero allocation)
-    /// for (i, facet_result) in facet_iter.enumerate() {
-    ///     let facet_view = facet_result.expect("Facet creation should succeed");
-    ///     assert_eq!(facet_view.vertices().unwrap().count(), 3); // Each facet has 3 vertices
+    /// for facet_result in facet_iter {
+    ///     let facet_view = facet_result?;
+    ///     assert_eq!(facet_view.vertices()?.count(), 3); // Each facet has 3 vertices
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// ```
     /// use delaunay::prelude::*;
     /// use delaunay::prelude::tds::Simplex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, _, _, 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
-    /// let facet_iter = Simplex::facet_view_iter(tds, simplex_key).expect("Failed to get facet iterator");
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
+    /// let facet_iter = Simplex::facet_view_iter(tds, simplex_key)?;
     ///
     /// // Collect all facets and surface any construction error
-    /// let successful_facets: Vec<_> = facet_iter
-    ///     .collect::<Result<Vec<_>, _>>()
-    ///     .expect("facet creation should succeed");
+    /// let successful_facets: Vec<_> = facet_iter.collect::<Result<Vec<_>, _>>()?;
     /// assert_eq!(successful_facets.len(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn facet_view_iter(
         tds: &Tds<T, U, V, D>,

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -117,13 +117,33 @@
 //! ```rust
 //! use delaunay::prelude::*;
 //!
+//! # #[derive(Debug, thiserror::Error)]
+//! # enum ExampleError {
+//! #     #[error(transparent)]
+//! #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+//! #     #[error(transparent)]
+//! #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+//! #     #[error(transparent)]
+//! #     Tds(#[from] delaunay::prelude::tds::TdsError),
+//! #     #[error(transparent)]
+//! #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+//! #     #[error(transparent)]
+//! #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+//! #     #[error(transparent)]
+//! #     Facet(#[from] delaunay::prelude::tds::FacetError),
+//! #     #[error(transparent)]
+//! #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+//! #     #[error(transparent)]
+//! #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+//! # }
+//! # fn main() -> Result<(), ExampleError> {
 //! let vertices = [
 //!     vertex!([0.0, 0.0, 0.0]),
 //!     vertex!([1.0, 0.0, 0.0]),
 //!     vertex!([0.0, 1.0, 0.0]),
 //!     vertex!([0.0, 0.0, 1.0]),
 //! ];
-//! let dt = DelaunayTriangulation::new(&vertices).unwrap();
+//! let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 //!
 //! // Level 2: structural only (fast)
 //! assert!(dt.tds().is_valid().is_ok());
@@ -140,6 +160,8 @@
 //!         }
 //!     }
 //! }
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! See [`docs/validation.md`](https://github.com/acgetchell/delaunay/blob/main/docs/validation.md)
@@ -158,6 +180,26 @@
 //! ```rust
 //! use delaunay::prelude::*;
 //!
+//! # #[derive(Debug, thiserror::Error)]
+//! # enum ExampleError {
+//! #     #[error(transparent)]
+//! #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+//! #     #[error(transparent)]
+//! #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+//! #     #[error(transparent)]
+//! #     Tds(#[from] delaunay::prelude::tds::TdsError),
+//! #     #[error(transparent)]
+//! #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+//! #     #[error(transparent)]
+//! #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+//! #     #[error(transparent)]
+//! #     Facet(#[from] delaunay::prelude::tds::FacetError),
+//! #     #[error(transparent)]
+//! #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+//! #     #[error(transparent)]
+//! #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+//! # }
+//! # fn main() -> Result<(), ExampleError> {
 //! // Create vertices for a tetrahedron
 //! let vertices = [
 //!     vertex!([0.0, 0.0, 0.0]),
@@ -167,13 +209,15 @@
 //! ];
 //!
 //! // Create Delaunay triangulation
-//! let dt = DelaunayTriangulation::new(&vertices).unwrap();
+//! let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 //!
 //! // Query triangulation properties
 //! assert_eq!(dt.number_of_vertices(), 4);
 //! assert_eq!(dt.number_of_simplices(), 1);
 //! assert_eq!(dt.dim(), 3);
 //! assert!(dt.validate().is_ok());
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Adding Vertices to Existing Triangulation
@@ -181,6 +225,26 @@
 //! ```rust
 //! use delaunay::prelude::*;
 //!
+//! # #[derive(Debug, thiserror::Error)]
+//! # enum ExampleError {
+//! #     #[error(transparent)]
+//! #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+//! #     #[error(transparent)]
+//! #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+//! #     #[error(transparent)]
+//! #     Tds(#[from] delaunay::prelude::tds::TdsError),
+//! #     #[error(transparent)]
+//! #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+//! #     #[error(transparent)]
+//! #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+//! #     #[error(transparent)]
+//! #     Facet(#[from] delaunay::prelude::tds::FacetError),
+//! #     #[error(transparent)]
+//! #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+//! #     #[error(transparent)]
+//! #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+//! # }
+//! # fn main() -> Result<(), ExampleError> {
 //! // Start with initial vertices
 //! let initial_vertices = [
 //!     vertex!([0.0, 0.0, 0.0]),
@@ -189,14 +253,16 @@
 //!     vertex!([0.0, 0.0, 1.0]),
 //! ];
 //!
-//! let mut dt = DelaunayTriangulation::new(&initial_vertices).unwrap();
+//! let mut dt = DelaunayTriangulationBuilder::new(&initial_vertices).build::<()>()?;
 //!
 //! // Add a new vertex
 //! let new_vertex = vertex!([0.2, 0.2, 0.2]);
-//! dt.insert(new_vertex).unwrap();
+//! dt.insert(new_vertex)?;
 //!
 //! assert_eq!(dt.number_of_vertices(), 5);
 //! assert!(dt.validate().is_ok());
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## 4D Triangulation
@@ -204,6 +270,26 @@
 //! ```rust
 //! use delaunay::prelude::*;
 //!
+//! # #[derive(Debug, thiserror::Error)]
+//! # enum ExampleError {
+//! #     #[error(transparent)]
+//! #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+//! #     #[error(transparent)]
+//! #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+//! #     #[error(transparent)]
+//! #     Tds(#[from] delaunay::prelude::tds::TdsError),
+//! #     #[error(transparent)]
+//! #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+//! #     #[error(transparent)]
+//! #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+//! #     #[error(transparent)]
+//! #     Facet(#[from] delaunay::prelude::tds::FacetError),
+//! #     #[error(transparent)]
+//! #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+//! #     #[error(transparent)]
+//! #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+//! # }
+//! # fn main() -> Result<(), ExampleError> {
 //! // Create 4D triangulation with 5 vertices (needed for a 4-simplex)
 //! let vertices_4d = [
 //!     vertex!([0.0, 0.0, 0.0, 0.0]),  // Origin
@@ -213,11 +299,13 @@
 //!     vertex!([0.0, 0.0, 0.0, 1.0]),  // Unit vector along fourth dimension
 //! ];
 //!
-//! let dt_4d = DelaunayTriangulation::new(&vertices_4d).unwrap();
+//! let dt_4d = DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
 //! assert_eq!(dt_4d.dim(), 4);
 //! assert_eq!(dt_4d.number_of_vertices(), 5);
 //! assert_eq!(dt_4d.number_of_simplices(), 1);
 //! assert!(dt_4d.validate().is_ok());
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # References
@@ -407,6 +495,26 @@ pub enum GeometricError {
 /// ```
 /// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// #     #[error(transparent)]
+/// #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+/// #     #[error(transparent)]
+/// #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// #     #[error(transparent)]
+/// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+/// #     #[error(transparent)]
+/// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Build a simple 3D triangulation
 /// let vertices = [
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -414,9 +522,11 @@ pub enum GeometricError {
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// assert_eq!(dt.number_of_vertices(), 4);
 /// assert!(dt.is_valid().is_ok());
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Which side of a neighbor relationship is missing a shared-facet vertex.
@@ -1440,18 +1550,33 @@ new_key_type! {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use delaunay::prelude::*;
-    ///
-    /// let vertices = [
-    ///     vertex!([0.0, 0.0]),
-    ///     vertex!([1.0, 0.0]),
-    ///     vertex!([0.0, 1.0]),
-    /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let key = dt.tds().vertex_keys().next().unwrap();
-    /// let _ = key;
-    /// ```
+        /// ```
+        /// use delaunay::prelude::*;
+        ///
+        /// # #[derive(Debug, thiserror::Error)]
+        /// # enum ExampleError {
+        /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+        /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+        /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+        /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+        /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+        /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+        /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+        /// # }
+        /// # fn main() -> Result<(), ExampleError> {
+        /// let vertices = [
+        ///     vertex!([0.0, 0.0]),
+        ///     vertex!([1.0, 0.0]),
+        ///     vertex!([0.0, 1.0]),
+        /// ];
+        /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+        /// let Some(key) = dt.tds().vertex_keys().next() else {
+        ///     return Ok(());
+        /// };
+        /// let _ = key;
+        /// # Ok(())
+        /// # }
+        /// ```
     pub struct VertexKey;
 }
 
@@ -1465,18 +1590,33 @@ new_key_type! {
     ///
     /// # Examples
     ///
-    /// ```
-    /// use delaunay::prelude::*;
-    ///
-    /// let vertices = [
-    ///     vertex!([0.0, 0.0]),
-    ///     vertex!([1.0, 0.0]),
-    ///     vertex!([0.0, 1.0]),
-    /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let key = dt.tds().simplex_keys().next().unwrap();
-    /// let _ = key;
-    /// ```
+        /// ```
+        /// use delaunay::prelude::*;
+        ///
+        /// # #[derive(Debug, thiserror::Error)]
+        /// # enum ExampleError {
+        /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+        /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+        /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+        /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+        /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+        /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+        /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+        /// # }
+        /// # fn main() -> Result<(), ExampleError> {
+        /// let vertices = [
+        ///     vertex!([0.0, 0.0]),
+        ///     vertex!([1.0, 0.0]),
+        ///     vertex!([0.0, 1.0]),
+        /// ];
+        /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+        /// let Some(key) = dt.tds().simplex_keys().next() else {
+        ///     return Ok(());
+        /// };
+        /// let _ = key;
+        /// # Ok(())
+        /// # }
+        /// ```
     pub struct SimplexKey;
 }
 
@@ -1523,6 +1663,26 @@ new_key_type! {
 /// ```rust
 /// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// #     #[error(transparent)]
+/// #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+/// #     #[error(transparent)]
+/// #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// #     #[error(transparent)]
+/// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+/// #     #[error(transparent)]
+/// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create vertices for a 2D triangulation
 /// let vertices = [
 ///     vertex!([0.0, 0.0]),
@@ -1531,11 +1691,13 @@ new_key_type! {
 /// ];
 ///
 /// // Create a new triangulation
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// // Check the number of simplices and vertices
 /// assert_eq!(dt.number_of_simplices(), 1);
 /// assert_eq!(dt.number_of_vertices(), 3);
+/// # Ok(())
+/// # }
 /// ```
 pub struct Tds<T, U, V, const D: usize> {
     /// Storage map for vertices, allowing stable keys and efficient access.
@@ -1966,17 +2128,39 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// for (simplex_key, simplex) in dt.simplices() {
     ///     println!("Simplex {:?} has {} vertices", simplex_key, simplex.number_of_vertices());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplices(&self) -> impl Iterator<Item = (SimplexKey, &Simplex<T, U, V, D>)> {
         self.simplices.iter()
@@ -1997,17 +2181,39 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// #     #[error(transparent)]
+    /// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// for (_, simplex) in dt.simplices() {
     ///     println!("Simplex has {} vertices", simplex.number_of_vertices());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplices_values(&self) -> impl Iterator<Item = &Simplex<T, U, V, D>> {
         self.simplices.values()
@@ -2034,16 +2240,30 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.5, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// for (vertex_key, vertex) in dt.vertices() {
     ///     println!("Vertex {:?} at {:?}", vertex_key, vertex.point());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn vertices(&self) -> impl Iterator<Item = (VertexKey, &Vertex<T, U, D>)> {
         self.vertices.iter()
@@ -2060,14 +2280,28 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let keys: Vec<_> = dt.tds().vertex_keys().collect();
     /// assert_eq!(keys.len(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn vertex_keys(&self) -> impl Iterator<Item = VertexKey> + '_ {
         self.vertices.keys()
@@ -2084,14 +2318,28 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let keys: Vec<_> = dt.tds().simplex_keys().collect();
     /// assert_eq!(keys.len(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplex_keys(&self) -> impl Iterator<Item = SimplexKey> + '_ {
         self.simplices.keys()
@@ -2108,16 +2356,34 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
-    /// let simplex = tds.simplex(simplex_key).unwrap();
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
+    /// let Some(simplex) = tds.simplex(simplex_key) else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(simplex.number_of_vertices(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn simplex(&self, key: SimplexKey) -> Option<&Simplex<T, U, V, D>> {
@@ -2135,15 +2401,31 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
     /// assert!(tds.contains_simplex(simplex_key));
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn contains_simplex(&self, key: SimplexKey) -> bool {
@@ -2171,24 +2453,48 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// Count vertices after adding them:
     ///
     /// ```no_run
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     /// let vertex1: Vertex<f64, (), 3> = vertex!([1.0, 2.0, 3.0]);
     /// let vertex2: Vertex<f64, (), 3> = vertex!([4.0, 5.0, 6.0]);
     ///
-    /// dt.insert(vertex1).unwrap();
+    /// dt.insert(vertex1)?;
     /// assert_eq!(dt.number_of_vertices(), 1);
     ///
-    /// dt.insert(vertex2).unwrap();
+    /// dt.insert(vertex2)?;
     /// assert_eq!(dt.number_of_vertices(), 2);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Count vertices initialized from points:
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let points = [
     ///     Point::new([0.0, 0.0, 0.0]),
     ///     Point::new([1.0, 0.0, 0.0]),
@@ -2196,9 +2502,11 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let vertices = Vertex::from_points(&points);
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let vertices = Vertex::<f64, (), 3>::from_points(&points);
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_vertices(&self) -> usize {
@@ -2228,8 +2536,19 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// Dimension progression as vertices are added:
     ///
     /// ```no_run
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     ///
     /// // Start empty
@@ -2237,36 +2556,49 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///
     /// // Add vertices incrementally
     /// let vertex1: Vertex<f64, (), 3> = vertex!([0.0, 0.0, 0.0]);
-    /// dt.insert(vertex1).unwrap();
+    /// dt.insert(vertex1)?;
     /// assert_eq!(dt.dim(), 0);
     ///
     /// let vertex2: Vertex<f64, (), 3> = vertex!([1.0, 0.0, 0.0]);
-    /// dt.insert(vertex2).unwrap();
+    /// dt.insert(vertex2)?;
     /// assert_eq!(dt.dim(), 1);
     ///
     /// let vertex3: Vertex<f64, (), 3> = vertex!([0.0, 1.0, 0.0]);
-    /// dt.insert(vertex3).unwrap();
+    /// dt.insert(vertex3)?;
     /// assert_eq!(dt.dim(), 2);
     ///
     /// let vertex4: Vertex<f64, (), 3> = vertex!([0.0, 0.0, 1.0]);
-    /// dt.insert(vertex4).unwrap();
+    /// dt.insert(vertex4)?;
     /// assert_eq!(dt.number_of_vertices(), 4);
     /// assert_eq!(dt.dim(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Different dimensional triangulations:
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // 2D triangulation
     /// let points_2d = [
     ///     Point::new([0.0, 0.0]),
     ///     Point::new([1.0, 0.0]),
     ///     Point::new([0.5, 1.0]),
     /// ];
-    /// let vertices_2d = Vertex::from_points(&points_2d);
-    /// let dt_2d = DelaunayTriangulation::new(&vertices_2d).unwrap();
+    /// let vertices_2d = Vertex::<f64, (), 2>::from_points(&points_2d);
+    /// let dt_2d = DelaunayTriangulationBuilder::new(&vertices_2d).build::<()>()?;
     /// assert_eq!(dt_2d.dim(), 2);
     ///
     /// // 4D triangulation with 5 vertices (minimum for 4D simplex)
@@ -2277,9 +2609,11 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     Point::new([0.0, 0.0, 1.0, 0.0]),
     ///     Point::new([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let vertices_4d = Vertex::from_points(&points_4d);
-    /// let dt_4d = DelaunayTriangulation::new(&vertices_4d).unwrap();
+    /// let vertices_4d = Vertex::<f64, (), 4>::from_points(&points_4d);
+    /// let dt_4d = DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     /// assert_eq!(dt_4d.dim(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn dim(&self) -> i32 {
@@ -2301,8 +2635,19 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// Count simplices in a newly created triangulation:
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let points = [
     ///     Point::new([0.0, 0.0, 0.0]),
     ///     Point::new([1.0, 0.0, 0.0]),
@@ -2310,16 +2655,29 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let vertices = Vertex::from_points(&points);
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let vertices = Vertex::<f64, (), 3>::from_points(&points);
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_simplices(), 1); // Simplices are automatically created via triangulation
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Count simplices after triangulation:
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let points = [
     ///     Point::new([0.0, 0.0, 0.0]),
     ///     Point::new([1.0, 0.0, 0.0]),
@@ -2327,9 +2685,11 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let vertices = Vertex::from_points(&points);
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let vertices = Vertex::<f64, (), 3>::from_points(&points);
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_simplices(), 1); // One tetrahedron for 4 points in 3D
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Empty triangulation has no simplices:
@@ -2365,17 +2725,30 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert!(dt.tds().is_connected());
     ///
     /// let empty = dt.tds().number_of_simplices() == 0 || dt.tds().is_connected();
     /// assert!(empty);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn is_connected(&self) -> bool {
@@ -2817,16 +3190,31 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
-    /// let keys = tds.simplex_vertices(simplex_key).unwrap();
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
+    /// let keys = tds.simplex_vertices(simplex_key)?;
     /// assert_eq!(keys.len(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn simplex_vertices(&self, simplex_key: SimplexKey) -> Result<VertexKeyBuffer, TdsError> {
@@ -2877,6 +3265,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create a triangulation with some vertices
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -2885,16 +3284,20 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Get the first simplex and its UUID
-    /// let (simplex_key, simplex) = tds.simplices().next().unwrap();
+    /// let Some((simplex_key, simplex)) = tds.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let simplex_uuid = simplex.uuid();
     ///
     /// // Use the helper function to find the simplex key from its UUID
     /// let found_key = tds.simplex_key_from_uuid(&simplex_uuid);
     /// assert_eq!(found_key, Some(simplex_key));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Returns `None` for non-existent UUID:
@@ -2937,6 +3340,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create a triangulation with some vertices
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -2945,16 +3359,20 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Get the first vertex and its UUID
-    /// let (vertex_key, vertex) = tds.vertices().next().unwrap();
+    /// let Some((vertex_key, vertex)) = tds.vertices().next() else {
+    ///     return Ok(());
+    /// };
     /// let vertex_uuid = vertex.uuid();
     ///
     /// // Use the helper function to find the vertex key from its UUID
     /// let found_key = tds.vertex_key_from_uuid(&vertex_uuid);
     /// assert_eq!(found_key, Some(vertex_key));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Returns `None` for non-existent UUID:
@@ -2997,6 +3415,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create a triangulation with some vertices
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -3005,16 +3434,20 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Get the first simplex key and expected UUID
-    /// let (simplex_key, simplex) = tds.simplices().next().unwrap();
+    /// let Some((simplex_key, simplex)) = tds.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let expected_uuid = simplex.uuid();
     ///
     /// // Use the helper function to get UUID from the simplex key
     /// let found_uuid = tds.simplex_uuid_from_key(simplex_key);
     /// assert_eq!(found_uuid, Some(expected_uuid));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Round-trip conversion between UUID and key:
@@ -3022,6 +3455,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create a triangulation with some vertices
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -3030,17 +3474,23 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Get the first simplex's UUID
-    /// let (_, simplex) = tds.simplices().next().unwrap();
+    /// let Some((_, simplex)) = tds.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let original_uuid = simplex.uuid();
     ///
     /// // Convert UUID to key, then key back to UUID
-    /// let simplex_key = tds.simplex_key_from_uuid(&original_uuid).unwrap();
-    /// let round_trip_uuid = tds.simplex_uuid_from_key(simplex_key).unwrap();
-    /// assert_eq!(original_uuid, round_trip_uuid);
+    /// let Some(simplex_key) = tds.simplex_key_from_uuid(&original_uuid) else {
+    ///     return Ok(());
+    /// };
+    /// let round_trip_uuid = tds.simplex_uuid_from_key(simplex_key);
+    /// assert_eq!(Some(original_uuid), round_trip_uuid);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -3072,6 +3522,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create a triangulation with some vertices
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -3080,16 +3541,20 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Get the first vertex key and expected UUID
-    /// let (vertex_key, vertex) = tds.vertices().next().unwrap();
+    /// let Some((vertex_key, vertex)) = tds.vertices().next() else {
+    ///     return Ok(());
+    /// };
     /// let expected_uuid = vertex.uuid();
     ///
     /// // Use the helper function to get UUID from the vertex key
     /// let found_uuid = tds.vertex_uuid_from_key(vertex_key);
     /// assert_eq!(found_uuid, Some(expected_uuid));
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Round-trip conversion between UUID and key:
@@ -3097,6 +3562,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create a triangulation with some vertices
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -3105,17 +3581,23 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Get the first vertex's UUID
-    /// let (_, vertex) = tds.vertices().next().unwrap();
+    /// let Some((_, vertex)) = tds.vertices().next() else {
+    ///     return Ok(());
+    /// };
     /// let original_uuid = vertex.uuid();
     ///
     /// // Convert UUID to key, then key back to UUID
-    /// let vertex_key = tds.vertex_key_from_uuid(&original_uuid).unwrap();
-    /// let round_trip_uuid = tds.vertex_uuid_from_key(vertex_key).unwrap();
-    /// assert_eq!(original_uuid, round_trip_uuid);
+    /// let Some(vertex_key) = tds.vertex_key_from_uuid(&original_uuid) else {
+    ///     return Ok(());
+    /// };
+    /// let round_trip_uuid = tds.vertex_uuid_from_key(vertex_key);
+    /// assert_eq!(Some(original_uuid), round_trip_uuid);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -3172,15 +3654,30 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let vertex_key = tds.vertex_keys().next().unwrap();
+    /// let Some(vertex_key) = tds.vertex_keys().next() else {
+    ///     return Ok(());
+    /// };
     /// assert!(tds.vertex(vertex_key).is_some());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -3224,29 +3721,44 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices: [Vertex<f64, i32, 2>; 3] = [
     ///     vertex!([0.0, 0.0], 10i32),
     ///     vertex!([1.0, 0.0], 20),
     ///     vertex!([0.0, 1.0], 30),
     /// ];
-    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .build::<()>()
-    ///     .unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let mut tds = dt.tds().clone();
-    /// let key = tds.vertex_keys().next().unwrap();
+    /// let Some(key) = tds.vertex_keys().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// // Replace existing data
     /// let prev = tds.set_vertex_data(key, Some(99));
     /// assert!(prev.is_some()); // key was found
     ///
     /// // Verify new value
-    /// let vertex = tds.vertex(key).unwrap();
+    /// let Some(vertex) = tds.vertex(key) else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(vertex.data(), Some(&99));
     ///
     /// // Clear data
     /// let prev = tds.set_vertex_data(key, None);
     /// assert_eq!(prev, Some(Some(99)));
-    /// assert_eq!(tds.vertex(key).unwrap().data(), None);
+    /// assert_eq!(tds.vertex(key).and_then(|vertex| vertex.data()), None);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn set_vertex_data(&mut self, key: VertexKey, data: Option<U>) -> Option<Option<U>> {
@@ -3276,29 +3788,44 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .build::<i32>()
-    ///     .unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<i32>()?;
     /// let mut tds = dt.tds().clone();
-    /// let key = tds.simplex_keys().next().unwrap();
+    /// let Some(key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// // Set data on a simplex that had no data
     /// let prev = tds.set_simplex_data(key, Some(42));
     /// assert_eq!(prev, Some(None)); // key found, previous was None
     ///
     /// // Verify new value
-    /// let simplex = tds.simplex(key).unwrap();
+    /// let Some(simplex) = tds.simplex(key) else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(simplex.data(), Some(&42));
     ///
     /// // Clear data
     /// let prev = tds.set_simplex_data(key, None);
     /// assert_eq!(prev, Some(Some(42)));
-    /// assert_eq!(tds.simplex(key).unwrap().data(), None);
+    /// assert_eq!(tds.simplex(key).and_then(|simplex| simplex.data()), None);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn set_simplex_data(&mut self, key: SimplexKey, data: Option<V>) -> Option<Option<V>> {
@@ -3323,15 +3850,30 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
     /// assert!(tds.contains_simplex_key(simplex_key));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -3354,15 +3896,30 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let vertex_key = tds.vertex_keys().next().unwrap();
+    /// let Some(vertex_key) = tds.vertex_keys().next() else {
+    ///     return Ok(());
+    /// };
     /// assert!(tds.contains_vertex_key(vertex_key));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -3404,17 +3961,32 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let mut tds = dt.tds().clone();
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
     /// let removed = tds.remove_simplices_by_keys(&[simplex_key]);
     /// assert_eq!(removed, 1);
     /// assert_eq!(tds.number_of_simplices(), 0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn remove_simplices_by_keys(&mut self, simplex_keys: &[SimplexKey]) -> usize {
         if simplex_keys.is_empty() {
@@ -3803,23 +4375,39 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     ///     vertex!([1.0, 1.0]),
     /// ];
-    /// let mut dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Get a vertex key to remove
-    /// let vertex_key = dt.vertices().next().unwrap().0;
+    /// let Some((vertex_key, _)) = dt.vertices().next() else {
+    ///     return Ok(());
+    /// };
     /// let simplices_before = dt.number_of_simplices();
     ///
     /// // Remove the vertex and all simplices containing it
-    /// let simplices_removed = dt.remove_vertex(vertex_key).unwrap();
+    /// let simplices_removed = dt.remove_vertex(vertex_key)?;
     /// println!("Removed {} simplices along with the vertex", simplices_removed);
     ///
     /// assert!(dt.tds().validate().is_ok());
+    /// # let _ = simplices_before;
+    /// # Ok(())
+    /// # }
     /// ```
     #[expect(
         clippy::unnecessary_wraps,
@@ -3899,18 +4487,33 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let (simplex_key, _) = tds.simplices().next().unwrap();
+    /// let Some((simplex_key, _)) = tds.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// // Get neighbors for existing simplex
     /// let neighbors = tds.find_neighbors_by_key(simplex_key);
     /// assert_eq!(neighbors.len(), 3); // D+1 for 2D
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn find_neighbors_by_key(
@@ -4391,21 +4994,38 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let mut tds = dt.tds().clone();
-    /// let simplex_key = tds.simplex_keys().next().unwrap();
+    /// let Some(simplex_key) = tds.simplex_keys().next() else {
+    ///     return Ok(());
+    /// };
     /// let neighbors = vec![None; 3];
-    /// tds.set_neighbors_by_key(simplex_key, &neighbors).unwrap();
-    /// assert!(tds
-    ///     .simplex(simplex_key)
-    ///     .unwrap()
+    /// tds.set_neighbors_by_key(simplex_key, &neighbors)?;
+    /// let Some(simplex) = tds.simplex(simplex_key) else {
+    ///     return Ok(());
+    /// };
+    /// assert!(simplex
     ///     .neighbors()
     ///     .is_some_and(|mut neighbors| neighbors.all(|neighbor| neighbor.is_none())));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn set_neighbors_by_key(
         &mut self,
@@ -4470,16 +5090,32 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let vertex_key = tds.vertex_keys().next().unwrap();
+    /// let Some(vertex_key) = tds.vertex_keys().next() else {
+    ///     return Ok(());
+    /// };
     /// let simplices = tds.find_simplices_containing_vertex_by_key(vertex_key);
     /// assert_eq!(simplices.len(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn find_simplices_containing_vertex_by_key(&self, vertex_key: VertexKey) -> SimplexKeySet {
@@ -4531,16 +5167,30 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsMutation(#[from] delaunay::prelude::tds::TdsMutationError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let mut tds = dt.tds().clone();
-    /// tds.assign_incident_simplices().unwrap();
+    /// tds.assign_incident_simplices()?;
     /// let all_assigned = tds.vertices().all(|(_, v)| v.incident_simplex().is_some());
     /// assert!(all_assigned);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn assign_incident_simplices(&mut self) -> Result<(), TdsMutationError> {
         if self.simplices.is_empty() {
@@ -4642,6 +5292,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -4649,7 +5310,7 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Initially has neighbors assigned during construction
     /// // All simplices have neighbors
@@ -4657,6 +5318,8 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     // Check that simplices have properly assigned neighbors
     ///     println!("Simplex has neighbors: {:?}", simplex.neighbors().is_some());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn clear_all_neighbors(&mut self) {
@@ -4940,15 +5603,28 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
-    /// let facet_map = tds.build_facet_to_simplices_map().unwrap();
+    /// let facet_map = tds.build_facet_to_simplices_map()?;
     /// assert!(!facet_map.is_empty());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn build_facet_to_simplices_map(&self) -> Result<FacetToSimplicesMap, TdsError> {
         // Ensure facet indices fit in u8 range
@@ -5436,17 +6112,26 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, DelaunayTriangulationConstructionError, vertex,
-    /// };
+    /// use delaunay::prelude::*;
     ///
-    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// assert!(dt.tds().is_coherently_oriented());
     /// # Ok(())
@@ -5820,6 +6505,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices_4d = [
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -5828,10 +6524,12 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
     /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices_4d).unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     ///
     /// // Level 2: TDS structural validation
     /// assert!(dt.tds().is_valid().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn is_valid(&self) -> Result<(), TdsError> {
         // Fast-fail: return the first violated invariant.
@@ -5873,6 +6571,17 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)] Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)] Insertion(#[from] delaunay::prelude::insertion::InsertionError),
+    /// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)] TdsConstruction(#[from] delaunay::prelude::tds::TdsConstructionError),
+    /// #     #[error(transparent)] Invariant(#[from] delaunay::prelude::tds::InvariantError),
+    /// #     #[error(transparent)] Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)] Simplex(#[from] delaunay::prelude::tds::SimplexValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices_4d = [
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -5881,10 +6590,12 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
     /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices_4d).unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     ///
     /// // Levels 1–2: elements + TDS structure
     /// assert!(dt.tds().validate().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn validate(&self) -> Result<(), TdsError>
     where

--- a/src/core/traits/boundary_analysis.rs
+++ b/src/core/traits/boundary_analysis.rs
@@ -15,8 +15,18 @@ use crate::core::{
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Query(#[from] delaunay::query::QueryError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a simple 3D triangulation (single tetrahedron)
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -24,15 +34,18 @@ use crate::core::{
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, _, _, 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
 /// // Use the trait methods
-/// let boundary_facets = tds.boundary_facets().expect("Failed to get boundary facets");
+/// let boundary_facets = tds.boundary_facets()?;
 /// assert_eq!(boundary_facets.count(), 4); // Tetrahedron has 4 boundary faces
 ///
-/// let count = tds.number_of_boundary_facets();
-/// assert_eq!(count, Ok(4));
+/// let count = tds.number_of_boundary_facets()?;
+/// assert_eq!(count, 4);
+/// # Ok(())
+/// # }
 /// ```
 pub trait BoundaryAnalysis<T, U, V, const D: usize> {
     /// Identifies all boundary facets in the triangulation.
@@ -53,20 +66,33 @@ pub trait BoundaryAnalysis<T, U, V, const D: usize> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, _, _, 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // A single tetrahedron has 4 boundary facets (all facets are on the boundary)
-    /// let boundary_facets_iter = tds.boundary_facets().expect("Failed to get boundary facets iterator");
+    /// let boundary_facets_iter = tds.boundary_facets()?;
     /// assert_eq!(boundary_facets_iter.count(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     fn boundary_facets(&self) -> Result<BoundaryFacetsIter<'_, T, U, V, D>, TdsError>;
 
@@ -93,22 +119,37 @@ pub trait BoundaryAnalysis<T, U, V, const D: usize> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, _, _, 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Get a boundary facet using the new iterator API
-    /// let boundary_facets = tds.boundary_facets().unwrap();
-    /// let first_facet = boundary_facets.clone().next().unwrap();
+    /// let mut boundary_facets = tds.boundary_facets()?;
+    /// let Some(first_facet) = boundary_facets.next() else {
+    ///     return Ok(());
+    /// };
     /// // In a single tetrahedron, all facets are boundary facets
-    /// assert!(tds.is_boundary_facet(&first_facet).unwrap());
+    /// assert!(tds.is_boundary_facet(&first_facet)?);
+    /// # Ok(())
+    /// # }
     /// ```
     fn is_boundary_facet(&self, facet: &FacetView<'_, T, U, V, D>) -> Result<bool, TdsError>;
 
@@ -139,28 +180,41 @@ pub trait BoundaryAnalysis<T, U, V, const D: usize> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, _, _, 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Build the facet map once for multiple queries (efficient for batch operations)
-    /// let facet_to_simplices = tds.build_facet_to_simplices_map().expect("facet map should build");
+    /// let facet_to_simplices = tds.build_facet_to_simplices_map()?;
     ///
     /// // Check boundary facets efficiently using the iterator API and cached map
-    /// let boundary_facets = tds.boundary_facets().unwrap();
+    /// let boundary_facets = tds.boundary_facets()?;
     /// for facet in boundary_facets {
-    ///     let is_boundary = tds.is_boundary_facet_with_map(&facet, &facet_to_simplices).expect("Should not fail for valid facets");
+    ///     let is_boundary = tds.is_boundary_facet_with_map(&facet, &facet_to_simplices)?;
     ///     println!("Facet is boundary: {is_boundary}");
     ///     // In a single tetrahedron, all facets are boundary facets
     ///     assert!(is_boundary);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// [`build_facet_to_simplices_map`]: crate::core::tds::Tds::build_facet_to_simplices_map
@@ -187,23 +241,36 @@ pub trait BoundaryAnalysis<T, U, V, const D: usize> {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, _, _, 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, _, _, 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     ///
     /// // Direct API call (recommended for single queries)
-    /// assert_eq!(tds.number_of_boundary_facets().unwrap(), 4);
+    /// assert_eq!(tds.number_of_boundary_facets()?, 4);
     ///
     /// // Alternative: using iterator (useful for additional processing)
-    /// let count_via_iter = dt.boundary_facets().unwrap().count();
+    /// let count_via_iter = dt.boundary_facets()?.count();
     /// assert_eq!(count_via_iter, 4);
+    /// # Ok(())
+    /// # }
     /// ```
     fn number_of_boundary_facets(&self) -> Result<usize, TdsError>;
 }

--- a/src/core/traits/facet_cache.rs
+++ b/src/core/traits/facet_cache.rs
@@ -184,28 +184,37 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices)
-    ///     .expect("nondegenerate tetrahedron should construct");
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Build facet-to-simplices mapping
     /// let facet_map = dt
     ///     .tds()
     ///     .build_facet_to_simplices_map()
-    ///     .expect("valid triangulation should build a facet cache");
+    ///     ?;
     ///
     /// // Use the mapping for facet lookups
     /// for (facet_key, adjacent_simplices) in facet_map.iter() {
     ///     // Each facet has at most 2 adjacent simplices
     ///     assert!(adjacent_simplices.len() <= 2);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     fn try_get_or_build_facet_cache(
         &self,
@@ -303,19 +312,29 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::query::*;
+    /// use delaunay::prelude::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Build facet-to-simplices mapping
-    /// let facet_map = dt.tds().build_facet_to_simplices_map().unwrap();
+    /// let facet_map = dt.tds().build_facet_to_simplices_map()?;
     /// assert!(!facet_map.is_empty(), "Facet map should contain entries");
+    /// # Ok(())
+    /// # }
     /// ```
     fn invalidate_facet_cache(&self) {
         // Clear the cache - next access will rebuild

--- a/src/core/util/delaunay_validation.rs
+++ b/src/core/util/delaunay_validation.rs
@@ -86,15 +86,25 @@ pub enum DelaunayValidationError {
 /// use delaunay::prelude::diagnostics::delaunay_violation_report;
 /// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Validation(#[from] delaunay::DelaunayValidationError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let report = delaunay_violation_report(dt.tds(), None).unwrap();
+/// let report = delaunay_violation_report(dt.tds(), None)?;
 /// assert!(report.is_valid());
+/// # Ok(())
+/// # }
 /// ```
 #[cfg(any(test, feature = "diagnostics"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "diagnostics")))]
@@ -404,9 +414,17 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::repair::find_delaunay_violations;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Validation(#[from] delaunay::DelaunayValidationError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
@@ -414,12 +432,14 @@ where
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
 ///
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
 /// // Find all violating simplices (should be empty for valid Delaunay triangulation)
-/// let violations = find_delaunay_violations(tds, None).unwrap();
+/// let violations = find_delaunay_violations(tds, None)?;
 /// assert!(violations.is_empty());
+/// # Ok(())
+/// # }
 /// ```
 pub fn find_delaunay_violations<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
@@ -512,16 +532,26 @@ where
 /// use delaunay::prelude::diagnostics::delaunay_violation_report;
 /// use delaunay::prelude::*;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Validation(#[from] delaunay::DelaunayValidationError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let report = delaunay_violation_report(dt.tds(), None).unwrap();
+/// let report = delaunay_violation_report(dt.tds(), None)?;
 /// assert!(report.violating_simplices.is_empty());
+/// # Ok(())
+/// # }
 /// ```
 #[cfg(any(test, feature = "diagnostics"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "diagnostics")))]

--- a/src/core/util/facet_keys.rs
+++ b/src/core/util/facet_keys.rs
@@ -32,25 +32,35 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::tds::checked_facet_key_from_vertex_keys;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
 /// // Get facet vertex keys from a simplex - no need to materialize Vertex objects
 /// if let Some(simplex) = tds.simplices().map(|(_, simplex)| simplex).next() {
 ///     let facet_vertex_keys: Vec<_> = simplex.vertices().iter().skip(1).copied().collect(); // Skip 1 vertex to get D vertices
 ///     assert_eq!(facet_vertex_keys.len(), 3); // For 3D triangulation, facet has 3 vertices
-///     let facet_key = checked_facet_key_from_vertex_keys::<3>(&facet_vertex_keys).unwrap();
+///     let facet_key = checked_facet_key_from_vertex_keys::<3>(&facet_vertex_keys)?;
 ///     println!("Facet key: {}", facet_key);
 /// }
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Performance

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -195,20 +195,23 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::query::extract_vertex_coordinate_set;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
 /// let coord_set = extract_vertex_coordinate_set(tds);
 /// assert_eq!(coord_set.len(), 4);
+/// # Ok(())
+/// # }
 /// ```
 #[must_use]
 pub fn extract_vertex_coordinate_set<T, U, V, const D: usize>(
@@ -252,21 +255,31 @@ const fn canonical_edge(u: u128, v: u128) -> (u128, u128) {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::query::extract_edge_set;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
-/// let edge_set = extract_edge_set(tds).unwrap();
+/// let edge_set = extract_edge_set(tds)?;
 /// // A tetrahedron has 6 edges
 /// assert_eq!(edge_set.len(), 6);
+/// # Ok(())
+/// # }
 /// ```
 pub fn extract_edge_set<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
@@ -324,21 +337,31 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::query::extract_facet_identifier_set;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
-/// let facet_set = extract_facet_identifier_set(tds).unwrap();
+/// let facet_set = extract_facet_identifier_set(tds)?;
 /// // A tetrahedron has 4 facets
 /// assert_eq!(facet_set.len(), 4);
+/// # Ok(())
+/// # }
 /// ```
 pub fn extract_facet_identifier_set<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
@@ -388,11 +411,19 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::extract_hull_facet_set;
-/// use delaunay::prelude::DelaunayTriangulation;
-/// use delaunay::prelude::query::ConvexHull;
-/// use delaunay::vertex;
+/// use delaunay::prelude::*;
+/// use delaunay::prelude::query::{ConvexHull, extract_hull_facet_set};
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     ConvexHull(#[from] delaunay::geometry::ConvexHullConstructionError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices: Vec<_> = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
@@ -400,11 +431,13 @@ where
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
 /// let dt: DelaunayTriangulation<_, (), (), 3> =
-///     DelaunayTriangulation::new(&vertices).unwrap();
-/// let hull = ConvexHull::from_triangulation(dt.as_triangulation()).unwrap();
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+/// let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;
 ///
-/// let facet_set = extract_hull_facet_set(&hull, dt.as_triangulation()).unwrap();
+/// let facet_set = extract_hull_facet_set(&hull, dt.as_triangulation())?;
 /// assert_eq!(facet_set.len(), 4);
+/// # Ok(())
+/// # }
 /// ```
 pub fn extract_hull_facet_set<K, U, V, const D: usize>(
     hull: &ConvexHull<K, U, V, D>,

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -144,16 +144,20 @@ pub(crate) fn insertion_error_to_invariant_error(
 /// use delaunay::prelude::tds::InvariantError;
 /// use delaunay::prelude::*;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt: DelaunayTriangulation<_, (), (), 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let result: Result<(), InvariantError> = dt.as_triangulation().validate();
 /// assert!(result.is_ok());
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -436,18 +440,22 @@ impl Default for ValidationPolicy {
 /// ```rust
 /// use delaunay::prelude::*;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let mut dt: DelaunayTriangulation<_, (), (), 3> =
+///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
 ///
 /// // Optional: relax topology checks for speed (weaker guarantees).
 /// dt.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
 /// assert!(!dt.topology_guarantee().requires_vertex_links_at_completion());
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum TopologyGuarantee {
@@ -902,6 +910,7 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices_4d = [
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -910,10 +919,12 @@ where
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
     /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices_4d).unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     ///
     /// // Level 3: topology validation (manifold-with-boundary + Euler characteristic)
     /// assert!(dt.as_triangulation().is_valid().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn is_valid(&self) -> Result<(), InvariantError> {
         self.validate_topology_core()?;
@@ -1030,14 +1041,18 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert!(dt.as_triangulation().validate_at_completion().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn validate_at_completion(&self) -> Result<(), InvariantError> {
         if !self
@@ -1094,6 +1109,7 @@ where
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices_4d = [
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -1102,10 +1118,12 @@ where
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
     /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices_4d).unwrap();
+    ///     DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     ///
     /// // Levels 1–3: elements + TDS structure + topology
     /// assert!(dt.as_triangulation().validate().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn validate(&self) -> Result<(), InvariantError>
     where

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -360,15 +360,20 @@ impl<T, U, const D: usize> Vertex<T, U, D> {
     /// ```rust
     /// use delaunay::prelude::*;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let (_, vertex) = dt.vertices().next().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((_, vertex)) = dt.vertices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// assert!(vertex.incident_simplex().is_some());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -8,7 +8,7 @@
 //!
 //! | Situation | Recommended API |
 //! |---|---|
-//! | Simple Euclidean, default options | [`DelaunayTriangulation::new`] |
+//! | Simple Euclidean, default options | [`DelaunayTriangulationBuilder::new`] |
 //! | Custom `ConstructionOptions` or `TopologyGuarantee` | [`DelaunayTriangulationBuilder`] |
 //! | Toroidal Phase 1 (canonicalize only) | [`DelaunayTriangulationBuilder`] with [`.toroidal()`](DelaunayTriangulationBuilder::toroidal) |
 //! | Toroidal Phase 2 (true periodic, χ = 0) | [`DelaunayTriangulationBuilder`] with [`.toroidal_periodic()`](DelaunayTriangulationBuilder::toroidal_periodic) |

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -1916,8 +1916,9 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -1925,8 +1926,10 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(
         vertices: &[Vertex<f64, (), D>],
@@ -1951,8 +1954,9 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -1960,10 +1964,10 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let (dt, stats) = DelaunayTriangulation::new_with_construction_statistics(&vertices)
-    ///     .unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 4);
-    /// assert_eq!(stats.inserted, 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[expect(
         clippy::result_large_err,
@@ -2000,10 +2004,11 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     ConstructionOptions, DelaunayTriangulation, RetryPolicy, vertex,
+    ///     ConstructionOptions, DelaunayTriangulationBuilder, RetryPolicy, vertex,
     /// };
     /// use std::num::NonZeroUsize;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -2011,17 +2016,19 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
+    /// let Some(attempts) = NonZeroUsize::new(2) else {
+    ///     return Ok(());
+    /// };
     /// let options = ConstructionOptions::default().with_retry_policy(RetryPolicy::Shuffled {
-    ///     attempts: NonZeroUsize::new(2).unwrap(),
+    ///     attempts,
     ///     base_seed: Some(7),
     /// });
-    /// let (dt, stats) =
-    ///     DelaunayTriangulation::new_with_options_and_construction_statistics(
-    ///         &vertices,
-    ///         options,
-    ///     )
-    ///     .unwrap();
-    /// assert_eq!(dt.number_of_vertices(), stats.inserted);
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .construction_options(options)
+    ///     .build::<()>()?;
+    /// assert_eq!(dt.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[expect(
         clippy::result_large_err,
@@ -2050,9 +2057,11 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     ConstructionOptions, DedupPolicy, DelaunayTriangulation, InsertionOrderStrategy, vertex,
+    ///     ConstructionOptions, DedupPolicy, DelaunayTriangulationBuilder, InsertionOrderStrategy,
+    ///     vertex,
     /// };
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -2063,8 +2072,12 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///     .with_insertion_order(InsertionOrderStrategy::Hilbert)
     ///     .with_dedup_policy(DedupPolicy::Exact);
     ///
-    /// let dt = DelaunayTriangulation::new_with_options(&vertices, options).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .construction_options(options)
+    ///     .build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new_with_options(
         vertices: &[Vertex<f64, (), D>],
@@ -2095,16 +2108,17 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, TopologyGuarantee, vertex,
+    ///     DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
     /// };
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let dt = DelaunayTriangulation::new_with_topology_guarantee(
-    ///     &vertices,
-    ///     TopologyGuarantee::PLManifold,
-    /// )
-    /// .unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
     /// assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new_with_topology_guarantee(
         vertices: &[Vertex<f64, (), D>],
@@ -2159,11 +2173,14 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let dt = DelaunayTriangulation::builder(&vertices).build::<()>().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn builder(
@@ -3825,9 +3842,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     /// use delaunay::prelude::geometry::RobustKernel;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -3835,9 +3853,11 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     /// let kernel = RobustKernel::<f64>::new();
-    /// let dt: DelaunayTriangulation<RobustKernel<f64>, (), (), 3> =
-    ///     DelaunayTriangulation::with_kernel(&kernel, &vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .build_with_kernel::<_, ()>(&kernel)?;
     /// assert_eq!(dt.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_kernel(
         kernel: &K,
@@ -3862,10 +3882,11 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, TopologyGuarantee, vertex,
+    ///     DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
     /// };
     /// use delaunay::prelude::geometry::RobustKernel;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -3873,14 +3894,12 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     /// let kernel = RobustKernel::<f64>::new();
-    /// let dt: DelaunayTriangulation<RobustKernel<f64>, (), (), 3> =
-    ///     DelaunayTriangulation::with_topology_guarantee(
-    ///         &kernel,
-    ///         &vertices,
-    ///         TopologyGuarantee::PLManifold,
-    ///     )
-    ///     .unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build_with_kernel::<_, ()>(&kernel)?;
     /// assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_topology_guarantee(
         kernel: &K,
@@ -3910,10 +3929,11 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     ConstructionOptions, DelaunayTriangulation, TopologyGuarantee, vertex,
+    ///     ConstructionOptions, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
     /// };
     /// use delaunay::prelude::geometry::RobustKernel;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -3921,15 +3941,13 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     /// let kernel = RobustKernel::<f64>::new();
-    /// let dt: DelaunayTriangulation<RobustKernel<f64>, (), (), 3> =
-    ///     DelaunayTriangulation::with_topology_guarantee_and_options(
-    ///         &kernel,
-    ///         &vertices,
-    ///         TopologyGuarantee::PLManifold,
-    ///         ConstructionOptions::default(),
-    ///     )
-    ///     .unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .construction_options(ConstructionOptions::default())
+    ///     .build_with_kernel::<_, ()>(&kernel)?;
     /// assert_eq!(dt.number_of_vertices(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with_topology_guarantee_and_options(
         kernel: &K,
@@ -4038,6 +4056,7 @@ where
     /// };
     /// use delaunay::prelude::geometry::RobustKernel;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionErrorWithStatistics> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -4051,9 +4070,10 @@ where
     ///         &vertices,
     ///         TopologyGuarantee::PLManifold,
     ///         ConstructionOptions::default(),
-    ///     )
-    ///     .unwrap();
+    ///     )?;
     /// assert_eq!(dt.number_of_vertices(), stats.inserted);
+    /// # Ok(())
+    /// # }
     /// ```
     #[expect(
         clippy::result_large_err,

--- a/src/delaunay/delaunayize.rs
+++ b/src/delaunay/delaunayize.rs
@@ -22,14 +22,21 @@
 //! ```rust
 //! use delaunay::prelude::delaunayize::*;
 //!
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # #[derive(Debug, thiserror::Error)]
+//! # enum ExampleError {
+//! #     #[error(transparent)]
+//! #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+//! #     #[error(transparent)]
+//! #     Delaunayize(#[from] delaunay::prelude::delaunayize::DelaunayizeError),
+//! # }
+//! # fn main() -> Result<(), ExampleError> {
 //! let vertices = vec![
 //!     vertex!([0.0, 0.0, 0.0]),
 //!     vertex!([1.0, 0.0, 0.0]),
 //!     vertex!([0.0, 1.0, 0.0]),
 //!     vertex!([0.0, 0.0, 1.0]),
 //! ];
-//! let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+//! let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 //!
 //! let outcome = delaunayize_by_flips(&mut dt, DelaunayizeConfig::default())?;
 //! assert!(outcome.topology_repair.succeeded);
@@ -181,14 +188,21 @@ impl Default for DelaunayizeConfig {
 /// ```rust
 /// use delaunay::prelude::delaunayize::*;
 ///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Delaunayize(#[from] delaunay::prelude::delaunayize::DelaunayizeError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+/// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let outcome = delaunayize_by_flips(&mut dt, DelaunayizeConfig::default())?;
 /// assert!(outcome.topology_repair.succeeded);
@@ -594,14 +608,21 @@ where
 /// ```rust
 /// use delaunay::prelude::delaunayize::*;
 ///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Delaunayize(#[from] delaunay::prelude::delaunayize::DelaunayizeError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+/// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let outcome = delaunayize_by_flips(&mut dt, DelaunayizeConfig::default())?;
 /// assert!(outcome.topology_repair.succeeded);

--- a/src/delaunay/flips.rs
+++ b/src/delaunay/flips.rs
@@ -33,26 +33,29 @@ use crate::triangulation::DelaunayTriangulation;
 /// # Example
 ///
 /// ```rust
-/// use delaunay::prelude::construction::TopologyGuarantee;
+/// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, TopologyGuarantee};
 /// use delaunay::prelude::flips::*;
 ///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Flip(#[from] delaunay::flips::FlipError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let mut dt: DelaunayTriangulation<_, (), (), 3> =
-///     DelaunayTriangulation::new_with_topology_guarantee(
-///         &vertices,
-///         TopologyGuarantee::PLManifold,
-///     )?;
-/// let simplex_key = dt
-///     .simplices()
-///     .next()
-///     .map(|(key, _)| key)
-///     .ok_or_else(|| std::io::Error::other("empty triangulation"))?;
+/// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+///     .topology_guarantee(TopologyGuarantee::PLManifold)
+///     .build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
 ///
 /// // Split a simplex by inserting a vertex (k=1 move).
 /// let _info = dt.flip_k1_insert(simplex_key, vertex!([0.1, 0.1, 0.1]))?;
@@ -76,26 +79,29 @@ pub trait BistellarFlips<const D: usize> {
     /// # Example
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::TopologyGuarantee;
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, TopologyGuarantee};
     /// use delaunay::prelude::flips::*;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Flip(#[from] delaunay::flips::FlipError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 3> =
-    ///     DelaunayTriangulation::new_with_topology_guarantee(
-    ///         &vertices,
-    ///         TopologyGuarantee::PLManifold,
-    ///     )?;
-    /// let simplex_key = dt
-    ///     .simplices()
-    ///     .next()
-    ///     .map(|(key, _)| key)
-    ///     .ok_or_else(|| std::io::Error::other("empty triangulation"))?;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// // Insert a vertex into the simplex
     /// let info = dt.flip_k1_insert(simplex_key, vertex!([0.25, 0.25, 0.25]))?;
@@ -119,26 +125,29 @@ pub trait BistellarFlips<const D: usize> {
     /// # Example
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::TopologyGuarantee;
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, TopologyGuarantee};
     /// use delaunay::prelude::flips::*;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Flip(#[from] delaunay::flips::FlipError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 3> =
-    ///     DelaunayTriangulation::new_with_topology_guarantee(
-    ///         &vertices,
-    ///         TopologyGuarantee::PLManifold,
-    ///     )?;
-    /// let simplex_key = dt
-    ///     .simplices()
-    ///     .next()
-    ///     .map(|(key, _)| key)
-    ///     .ok_or_else(|| std::io::Error::other("empty triangulation"))?;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// let inserted = dt.flip_k1_insert(simplex_key, vertex!([0.25, 0.25, 0.25]))?;
     /// let inserted_vertex = inserted.inserted_face_vertices[0];
     ///
@@ -160,9 +169,10 @@ pub trait BistellarFlips<const D: usize> {
     /// # Example
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::flips::*;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -170,7 +180,7 @@ pub trait BistellarFlips<const D: usize> {
     ///     vertex!([0.0, 0.0, 1.0]),
     ///     vertex!([0.5, 0.5, 0.3]),
     /// ];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Find an interior facet and attempt a k=2 flip
     /// // Note: k=2 flips require specific geometric conditions
@@ -200,9 +210,10 @@ pub trait BistellarFlips<const D: usize> {
     /// # Example
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::flips::*;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -210,7 +221,7 @@ pub trait BistellarFlips<const D: usize> {
     ///     vertex!([0.0, 0.0, 1.0]),
     ///     vertex!([1.0, 1.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // k=3 flips require specific ridge configurations in 3D and above
     /// // This is an illustrative example; actual ridge selection depends on topology

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -126,35 +126,47 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::insertion::InsertionError;
     ///
+    /// # fn main() -> Result<(), InsertionError> {
     /// // Start with empty triangulation
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     /// assert_eq!(dt.number_of_vertices(), 0);
     /// assert_eq!(dt.number_of_simplices(), 0);
     ///
     /// // Insert vertices one by one - bootstrap phase (no simplices yet)
-    /// dt.insert(vertex!([0.0, 0.0, 0.0])).unwrap();
-    /// dt.insert(vertex!([1.0, 0.0, 0.0])).unwrap();
-    /// dt.insert(vertex!([0.0, 1.0, 0.0])).unwrap();
+    /// dt.insert(vertex!([0.0, 0.0, 0.0]))?;
+    /// dt.insert(vertex!([1.0, 0.0, 0.0]))?;
+    /// dt.insert(vertex!([0.0, 1.0, 0.0]))?;
     /// assert_eq!(dt.number_of_vertices(), 3);
     /// assert_eq!(dt.number_of_simplices(), 0); // Still no simplices
     ///
     /// // 4th vertex triggers initial simplex creation
-    /// dt.insert(vertex!([0.0, 0.0, 1.0])).unwrap();
+    /// dt.insert(vertex!([0.0, 0.0, 1.0]))?;
     /// assert_eq!(dt.number_of_vertices(), 4);
     /// assert_eq!(dt.number_of_simplices(), 1); // First simplex created!
     ///
     /// // Further insertions use cavity-based algorithm
-    /// dt.insert(vertex!([0.2, 0.2, 0.2])).unwrap();
+    /// dt.insert(vertex!([0.2, 0.2, 0.2]))?;
     /// assert_eq!(dt.number_of_vertices(), 5);
     /// assert!(dt.number_of_simplices() > 1);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Using batch construction (traditional approach):
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Insertion(#[from] delaunay::InsertionError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// // Create initial triangulation with 5 vertices (4-simplex)
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
@@ -163,14 +175,15 @@ where
     ///     vertex!([0.0, 0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 5);
     ///
     /// // Insert additional interior vertex
-    /// dt.insert(vertex!([0.2, 0.2, 0.2, 0.2])).unwrap();
+    /// dt.insert(vertex!([0.2, 0.2, 0.2, 0.2]))?;
     /// assert_eq!(dt.number_of_vertices(), 6);
     /// assert!(dt.number_of_simplices() > 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn insert(&mut self, vertex: Vertex<K::Scalar, U, D>) -> Result<VertexKey, InsertionError> {
         self.ensure_spatial_index_seeded();
@@ -271,11 +284,11 @@ where
     /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
     /// use delaunay::prelude::insertion::{InsertionError, InsertionOutcome};
     ///
+    /// # fn main() -> Result<(), InsertionError> {
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     ///
     /// let (outcome, stats) = dt
-    ///     .insert_with_statistics(vertex!([0.0, 0.0, 0.0]))
-    ///     .unwrap();
+    ///     .insert_with_statistics(vertex!([0.0, 0.0, 0.0]))?;
     ///
     /// assert!(stats.success());
     /// assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
@@ -285,6 +298,8 @@ where
     ///     duplicate,
     ///     Err(InsertionError::DuplicateCoordinates { .. })
     /// ));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn insert_with_statistics(
         &mut self,
@@ -315,23 +330,24 @@ where
     /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
     /// use delaunay::prelude::insertion::InsertionOutcome;
     ///
+    /// # fn main() -> Result<(), delaunay::InsertionError> {
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     ///
     /// let (outcome, stats) = dt
-    ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))
-    ///     .unwrap();
+    ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))?;
     ///
     /// assert!(stats.success());
     /// assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
     ///
     /// let vertices_before_duplicate = dt.number_of_vertices();
     /// let (duplicate_outcome, duplicate_stats) = dt
-    ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))
-    ///     .unwrap();
+    ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))?;
     ///
     /// assert!(matches!(duplicate_outcome, InsertionOutcome::Skipped { .. }));
     /// assert!(duplicate_stats.skipped_duplicate());
     /// assert_eq!(dt.number_of_vertices(), vertices_before_duplicate);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn insert_best_effort_with_statistics(
         &mut self,
@@ -674,8 +690,16 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Invariant(#[from] delaunay::tds::InvariantError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let interior = vertex!([0.3, 0.3]);
     /// let interior_uuid = interior.uuid();
     /// let vertices = [
@@ -684,44 +708,52 @@ where
     ///     vertex!([0.0, 1.0]),
     ///     interior,
     /// ];
-    /// let mut dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Find the key of a known interior vertex.
-    /// let vertex_key = dt
-    ///     .vertices()
-    ///     .find(|(_, v)| v.uuid() == interior_uuid)
-    ///     .map(|(k, _)| k)
-    ///     .unwrap();
+    /// let Some((vertex_key, _)) = dt.vertices().find(|(_, v)| v.uuid() == interior_uuid) else {
+    ///     return Ok(());
+    /// };
     ///
     /// // Remove the vertex and all simplices containing it
-    /// let simplices_removed = dt.remove_vertex(vertex_key).unwrap();
+    /// let simplices_removed = dt.remove_vertex(vertex_key)?;
     /// println!("Removed {} simplices along with the vertex", simplices_removed);
     ///
     /// // Vertex removal preserves topology; automatic repair is attempted when enabled.
     /// assert!(dt.as_triangulation().validate().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// Removals that would leave a non-manifold remnant fail and roll back:
     ///
     /// ```rust
-    /// use delaunay::prelude::*;
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+    /// use delaunay::prelude::tds::InvariantError;
+    /// use delaunay::prelude::triangulation::TriangulationValidationError;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
-    /// let vertex_key = dt.vertices().next().unwrap().0;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((vertex_key, _)) = dt.vertices().next() else {
+    ///     return Ok(());
+    /// };
     ///
-    /// let err = dt.remove_vertex(vertex_key).unwrap_err();
+    /// let err = dt
+    ///     .remove_vertex(vertex_key)
+    ///     .expect_err("removal should leave an isolated vertex");
     /// assert!(matches!(
     ///     err,
     ///     InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex { .. })
     /// ));
     /// assert_eq!(dt.number_of_vertices(), 3);
     /// assert_eq!(dt.number_of_simplices(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn remove_vertex(&mut self, vertex_key: VertexKey) -> Result<usize, InvariantError> {
         let Some(removed_vertex) = self.tri.tds.vertex(vertex_key) else {

--- a/src/delaunay/query.rs
+++ b/src/delaunay/query.rs
@@ -45,8 +45,9 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -56,9 +57,10 @@ where
     ///     vertex!([0.2, 0.2, 0.2, 0.2]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_vertices(&self) -> usize {
@@ -70,8 +72,9 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -80,10 +83,11 @@ where
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// // One 4-simplex in 4D
     /// assert_eq!(dt.number_of_simplices(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn number_of_simplices(&self) -> usize {
@@ -97,8 +101,9 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -107,9 +112,10 @@ where
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.dim(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn dim(&self) -> i32 {
@@ -129,8 +135,10 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -138,11 +146,13 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// for (simplex_key, simplex) in dt.simplices() {
     ///     println!("Simplex {:?} has {} vertices", simplex_key, simplex.number_of_vertices());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplices(&self) -> impl Iterator<Item = (SimplexKey, &Simplex<K::Scalar, U, V, D>)> {
         self.tri.tds.simplices()
@@ -161,8 +171,10 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -170,11 +182,13 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// for (vertex_key, vertex) in dt.vertices() {
     ///     println!("Vertex {:?} at {:?}", vertex_key, vertex.point());
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn vertices(&self) -> impl Iterator<Item = (VertexKey, &Vertex<K::Scalar, U, D>)> {
         self.tri.vertices()
@@ -195,18 +209,19 @@ where
     ///
     /// ```
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder, Vertex, vertex,
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, Vertex, vertex,
     /// };
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices: [Vertex<f64, i32, 2>; 3] = [
     ///     vertex!([0.0, 0.0], 10i32),
     ///     vertex!([1.0, 0.0], 20),
     ///     vertex!([0.0, 1.0], 30),
     /// ];
-    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .build::<()>()
-    ///     .unwrap();
-    /// let key = dt.vertices().next().unwrap().0;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((key, _)) = dt.vertices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// let prev = dt.set_vertex_data(key, Some(99));
     /// assert!(prev.is_some());
@@ -214,7 +229,9 @@ where
     /// // Clear data
     /// let prev = dt.set_vertex_data(key, None);
     /// assert_eq!(prev, Some(Some(99)));
-    /// assert_eq!(dt.tds().vertex(key).unwrap().data(), None);
+    /// assert_eq!(dt.tds().vertex(key).map(|v| v.data()), Some(None));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn set_vertex_data(&mut self, key: VertexKey, data: Option<U>) -> Option<Option<U>> {
@@ -235,19 +252,18 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder, vertex,
-    /// };
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .build::<i32>()
-    ///     .unwrap();
-    /// let key = dt.simplices().next().unwrap().0;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<i32>()?;
+    /// let Some((key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// let prev = dt.set_simplex_data(key, Some(42));
     /// assert_eq!(prev, Some(None));
@@ -255,7 +271,9 @@ where
     /// // Clear data
     /// let prev = dt.set_simplex_data(key, None);
     /// assert_eq!(prev, Some(Some(42)));
-    /// assert_eq!(dt.tds().simplex(key).unwrap().data(), None);
+    /// assert_eq!(dt.tds().simplex(key).map(|s| s.data()), Some(None));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn set_simplex_data(&mut self, key: SimplexKey, data: Option<V>) -> Option<Option<V>> {
@@ -270,8 +288,11 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    /// };
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -280,10 +301,11 @@ where
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let tds = dt.tds();
     /// assert_eq!(tds.number_of_vertices(), 5);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub const fn tds(&self) -> &Tds<K::Scalar, U, V, D> {
@@ -332,9 +354,18 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::ConvexHull;
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::vertex;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Hull(#[from] delaunay::query::ConvexHullConstructionError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices: Vec<_> = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -342,9 +373,11 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let hull = ConvexHull::from_triangulation(dt.as_triangulation()).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;
     /// assert_eq!(hull.number_of_facets(), 4);
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub const fn as_triangulation(&self) -> &Triangulation<K, U, V, D> {
@@ -363,18 +396,28 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let boundary_count = dt.boundary_facets().unwrap().count();
+    /// let boundary_count = dt.boundary_facets()?.count();
     /// assert_eq!(boundary_count, 4); // All facets are on boundary
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -397,19 +440,23 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    /// };
     /// use delaunay::prelude::validation::ValidationPolicy;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -514,14 +561,18 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    /// };
     /// use delaunay::prelude::repair::DelaunayRepairPolicy;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// assert_eq!(dt.delaunay_repair_policy(), DelaunayRepairPolicy::EveryInsertion);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -537,15 +588,19 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    /// };
     /// use delaunay::prelude::repair::DelaunayRepairPolicy;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// dt.set_delaunay_repair_policy(DelaunayRepairPolicy::Never);
     /// assert_eq!(dt.delaunay_repair_policy(), DelaunayRepairPolicy::Never);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub const fn set_delaunay_repair_policy(&mut self, policy: DelaunayRepairPolicy) {
@@ -557,14 +612,18 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    /// };
     /// use delaunay::prelude::repair::DelaunayCheckPolicy;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// assert_eq!(dt.delaunay_check_policy(), DelaunayCheckPolicy::EndOnly);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -580,17 +639,23 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    /// };
     /// use delaunay::prelude::repair::DelaunayCheckPolicy;
     /// use std::num::NonZeroUsize;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
-    /// let every_two = NonZeroUsize::new(2).unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some(every_two) = NonZeroUsize::new(2) else {
+    ///     return Ok(());
+    /// };
     ///
     /// dt.set_delaunay_check_policy(DelaunayCheckPolicy::EveryN(every_two));
     /// assert_eq!(dt.delaunay_check_policy(), DelaunayCheckPolicy::EveryN(every_two));
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub const fn set_delaunay_check_policy(&mut self, policy: DelaunayCheckPolicy) {
@@ -621,9 +686,12 @@ where
     ///     DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
     /// };
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -640,9 +708,12 @@ where
     ///     DelaunayTriangulationBuilder, GlobalTopology, vertex,
     /// };
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert!(dt.global_topology().is_euclidean());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -659,9 +730,12 @@ where
     ///     DelaunayTriangulationBuilder, TopologyKind, vertex,
     /// };
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.topology_kind(), TopologyKind::Euclidean);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     #[must_use]
@@ -678,10 +752,13 @@ where
     ///     DelaunayTriangulationBuilder, GlobalTopology, vertex,
     /// };
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
-    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>().unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// dt.set_global_topology(GlobalTopology::Euclidean);
     /// assert!(dt.global_topology().is_euclidean());
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub const fn set_global_topology(&mut self, global_topology: GlobalTopology<D>) {
@@ -723,18 +800,23 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    /// };
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// let facet_count = dt.facets().count();
     /// assert_eq!(facet_count, 4); // Tetrahedron has 4 facets
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn facets(&self) -> AllFacetsIter<'_, K::Scalar, U, V, D> {
         self.tri.facets()
@@ -753,9 +835,18 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
     /// // A single 3D tetrahedron has 6 unique edges.
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -763,10 +854,12 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let index = dt.build_adjacency_index().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let index = dt.build_adjacency_index()?;
     ///
     /// assert_eq!(index.number_of_edges(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn build_adjacency_index(&self) -> Result<AdjacencyIndex, AdjacencyIndexBuildError> {
@@ -781,9 +874,11 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
     /// // A single 3D tetrahedron has 6 unique edges.
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -791,9 +886,11 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let edges: std::collections::HashSet<_> = dt.edges().collect();
     /// assert_eq!(edges.len(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn edges(&self) -> impl Iterator<Item = EdgeKey> + '_ {
         self.as_triangulation().edges()
@@ -809,8 +906,17 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -818,11 +924,13 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let index = dt.build_adjacency_index().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let index = dt.build_adjacency_index()?;
     ///
     /// let edges: std::collections::HashSet<_> = dt.edges_with_index(&index).collect();
     /// assert_eq!(edges.len(), 6);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn edges_with_index<'a>(
         &self,
@@ -841,8 +949,10 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -850,11 +960,15 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let v0 = dt.vertices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((v0, _)) = dt.vertices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// // In a tetrahedron, each vertex has degree 3.
     /// assert_eq!(dt.incident_edges(v0).count(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn incident_edges(&self, v: VertexKey) -> impl Iterator<Item = EdgeKey> + '_ {
         self.as_triangulation().incident_edges(v)
@@ -871,8 +985,17 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -880,11 +1003,15 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let index = dt.build_adjacency_index().unwrap();
-    /// let v0 = dt.vertices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let index = dt.build_adjacency_index()?;
+    /// let Some((v0, _)) = dt.vertices().next() else {
+    ///     return Ok(());
+    /// };
     ///
     /// assert_eq!(dt.incident_edges_with_index(&index, v0).count(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn incident_edges_with_index<'a>(
         &self,
@@ -905,9 +1032,11 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
     /// // A single tetrahedron has no simplex neighbors.
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -915,9 +1044,13 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(dt.simplex_neighbors(simplex_key).count(), 0);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplex_neighbors(&self, c: SimplexKey) -> impl Iterator<Item = SimplexKey> + '_ {
         self.as_triangulation().simplex_neighbors(c)
@@ -933,9 +1066,18 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
     /// // Two tetrahedra sharing a triangular facet => each tetra has exactly one neighbor.
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices: Vec<_> = vec![
     ///     // Shared triangle
     ///     vertex!([0.0, 0.0, 0.0]),
@@ -946,11 +1088,15 @@ where
     ///     vertex!([1.0, 0.7, -1.5]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
-    /// let index = dt.build_adjacency_index().unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let index = dt.build_adjacency_index()?;
     ///
-    /// let simplex_key = dt.simplices().next().unwrap().0;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(dt.simplex_neighbors_with_index(&index, simplex_key).count(), 1);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn simplex_neighbors_with_index<'a>(
         &self,
@@ -971,18 +1117,26 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let simplex_key = dt.simplices().next().unwrap().0;
-    /// let simplex_vertices = dt.simplex_vertices(simplex_key).unwrap();
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let Some(simplex_vertices) = dt.simplex_vertices(simplex_key) else {
+    ///     return Ok(());
+    /// };
     /// assert_eq!(simplex_vertices.len(), 3); // D+1 for a 2D simplex
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn simplex_vertices(&self, c: SimplexKey) -> Option<&[VertexKey]> {
@@ -999,22 +1153,28 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Find the key for a known vertex by matching coordinates.
-    /// let v_key = dt
+    /// let Some(v_key) = dt
     ///     .vertices()
     ///     .find_map(|(vk, _)| (dt.vertex_coords(vk)? == [1.0, 0.0]).then_some(vk))
-    ///     .unwrap();
+    /// else {
+    ///     return Ok(());
+    /// };
     ///
-    /// assert_eq!(dt.vertex_coords(v_key).unwrap(), [1.0, 0.0]);
+    /// assert_eq!(dt.vertex_coords(v_key), Some([1.0, 0.0].as_slice()));
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub fn vertex_coords(&self, v: VertexKey) -> Option<&[K::Scalar]> {

--- a/src/delaunay/repair.rs
+++ b/src/delaunay/repair.rs
@@ -118,13 +118,14 @@ impl fmt::Display for DelaunayRepairOperation {
 /// use delaunay::prelude::repair::DelaunayRepairPolicy;
 /// use std::num::NonZeroUsize;
 ///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let every_four = NonZeroUsize::new(4).ok_or("repair cadence must be non-zero")?;
+/// # fn main() {
+/// let Some(every_four) = NonZeroUsize::new(4) else {
+///     return;
+/// };
 /// let policy = DelaunayRepairPolicy::EveryN(every_four);
 /// assert!(!policy.should_repair(0));
 /// assert!(!policy.should_repair(3));
 /// assert!(policy.should_repair(4));
-/// # Ok(())
 /// # }
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -287,12 +288,13 @@ impl DelaunayRepairOutcome {
 /// use delaunay::prelude::repair::DelaunayCheckPolicy;
 /// use std::num::NonZeroUsize;
 ///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
-/// let every_three = NonZeroUsize::new(3).ok_or("check cadence must be non-zero")?;
+/// # fn main() {
+/// let Some(every_three) = NonZeroUsize::new(3) else {
+///     return;
+/// };
 /// let policy = DelaunayCheckPolicy::EveryN(every_three);
 /// assert!(!policy.should_check(2));
 /// assert!(policy.should_check(3));
-/// # Ok(())
 /// # }
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -346,19 +348,29 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     /// use delaunay::prelude::repair::DelaunayRepairStats;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Repair(#[from] delaunay::flips::DelaunayRepairError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let stats = dt.repair_delaunay_with_flips().unwrap();
+    /// let stats = dt.repair_delaunay_with_flips()?;
     /// assert!(stats.facets_checked >= stats.flips_performed);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn repair_delaunay_with_flips(&mut self) -> Result<DelaunayRepairStats, DelaunayRepairError>
     where
@@ -551,21 +563,31 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
     /// use delaunay::prelude::repair::DelaunayRepairHeuristicConfig;
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Repair(#[from] delaunay::flips::DelaunayRepairError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// let outcome = dt
     ///     .repair_delaunay_with_flips_advanced(DelaunayRepairHeuristicConfig::default())
-    ///     .unwrap();
+    ///     ?;
     /// assert!(outcome.stats.facets_checked >= outcome.stats.flips_performed);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn repair_delaunay_with_flips_advanced(
         &mut self,

--- a/src/delaunay/serialization.rs
+++ b/src/delaunay/serialization.rs
@@ -44,22 +44,30 @@ where
 /// ```rust
 /// # use delaunay::prelude::geometry::*;
 /// # use delaunay::prelude::tds::Tds;
-/// # use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
-/// # fn example() {
+/// # use delaunay::prelude::construction::{DelaunayTriangulation, DelaunayTriangulationBuilder, vertex};
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Serde(#[from] serde_json::Error),
+/// #     #[error(transparent)]
+/// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+/// # }
+/// # fn example() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::<_, (), (), 3>::new(&vertices)
-///     .expect("nondegenerate tetrahedron should construct");
-/// let json = serde_json::to_string(&dt).expect("triangulation should serialize");
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+/// let json = serde_json::to_string(&dt)?;
 ///
-/// let tds: Tds<f64, (), (), 3> =
-///     serde_json::from_str(&json).expect("serialized triangulation should deserialize");
-/// let dt_adaptive = DelaunayTriangulation::try_from_tds(tds, AdaptiveKernel::new())
-///     .expect("deserialized TDS should validate");
+/// let tds: Tds<f64, (), (), 3> = serde_json::from_str(&json)?;
+/// let dt_adaptive = DelaunayTriangulation::try_from_tds(tds, AdaptiveKernel::new())?;
+/// # let _ = dt_adaptive;
+/// # Ok(())
 /// # }
 /// ```
 impl<'de, const D: usize> Deserialize<'de> for DelaunayTriangulation<RobustKernel<f64>, (), (), D>

--- a/src/delaunay/triangulation.rs
+++ b/src/delaunay/triangulation.rs
@@ -52,17 +52,22 @@ use crate::geometry::kernel::Kernel;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+/// use delaunay::prelude::construction::{
+///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+/// };
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// assert_eq!(dt.number_of_simplices(), 1);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Debug)]
 pub struct DelaunayTriangulation<K: Kernel<D>, U, V, const D: usize> {

--- a/src/delaunay/validation.rs
+++ b/src/delaunay/validation.rs
@@ -46,17 +46,17 @@ use thiserror::Error;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+/// use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 /// use delaunay::prelude::validation::DelaunayTriangulationValidationError;
 ///
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let result: Result<(), DelaunayTriangulationValidationError> = dt.validate();
 /// assert!(result.is_ok());
@@ -256,8 +256,10 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices_4d = [
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -265,11 +267,12 @@ where
     ///     vertex!([0.0, 0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices_4d).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     ///
     /// // Level 4: Delaunay property only
     /// assert!(dt.is_valid().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn is_valid(&self) -> Result<(), DelaunayTriangulationValidationError> {
         // Use fast flip-based verification (O(simplices) instead of O(simplices × vertices))
@@ -295,8 +298,10 @@ where
     /// # Examples
     ///
     /// ```
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
@@ -304,10 +309,12 @@ where
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
     ///
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Fast O(N) verification
     /// assert!(dt.is_delaunay_via_flips().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn is_delaunay_via_flips(&self) -> Result<(), DelaunayRepairError> {
         verify_delaunay_for_triangulation(&self.tri)
@@ -327,8 +334,10 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices_4d = [
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -336,11 +345,12 @@ where
     ///     vertex!([0.0, 0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices_4d).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     ///
     /// // Levels 1–4: elements + structure + topology + Delaunay property
     /// assert!(dt.validate().is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn validate(&self) -> Result<(), DelaunayTriangulationValidationError> {
         self.tri.validate().map_err(|e| match e {
@@ -368,19 +378,23 @@ where
     /// # Examples
     ///
     /// ```rust
+    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
     /// use delaunay::prelude::query::*;
     ///
+    /// # fn main() -> Result<(), delaunay::DelaunayTriangulationConstructionError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Returns Ok(()) on success; otherwise returns a report listing all violations.
     /// let report = dt.validation_report();
     /// assert!(report.is_ok());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn validation_report(&self) -> Result<(), TriangulationValidationReport> {
         // Levels 1–3: reuse the Triangulation layer report.
@@ -466,8 +480,18 @@ where
     /// ```rust
     /// use delaunay::prelude::geometry::FastKernel;
     /// use delaunay::prelude::tds::Tds;
-    /// use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
+    /// use delaunay::prelude::construction::{DelaunayTriangulation, DelaunayTriangulationBuilder, vertex};
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Serde(#[from] serde_json::Error),
+    /// #     #[error(transparent)]
+    /// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0, 0.0]),
@@ -475,16 +499,17 @@ where
     ///     vertex!([0.0, 0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 4> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Serialize just the Tds
-    /// let json = serde_json::to_string(dt.tds()).unwrap();
+    /// let json = serde_json::to_string(dt.tds())?;
     ///
     /// // Deserialize Tds and reconstruct DelaunayTriangulation
-    /// let tds: Tds<f64, (), (), 4> = serde_json::from_str(&json).unwrap();
-    /// let reconstructed = DelaunayTriangulation::try_from_tds(tds, FastKernel::new()).unwrap();
+    /// let tds: Tds<f64, (), (), 4> = serde_json::from_str(&json)?;
+    /// let reconstructed = DelaunayTriangulation::try_from_tds(tds, FastKernel::new())?;
     /// assert_eq!(reconstructed.number_of_vertices(), 5);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -513,28 +538,36 @@ where
     /// ```rust
     /// use delaunay::prelude::geometry::FastKernel;
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, TopologyGuarantee, vertex,
+    ///     DelaunayTriangulation, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
     /// };
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// let reconstructed = DelaunayTriangulation::try_from_tds_with_topology_guarantee(
     ///     dt.tds().clone(),
     ///     FastKernel::new(),
     ///     TopologyGuarantee::PLManifoldStrict,
-    /// )
-    /// .unwrap();
+    /// )?;
     ///
     /// assert_eq!(
     ///     reconstructed.topology_guarantee(),
     ///     TopologyGuarantee::PLManifoldStrict
     /// );
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -565,30 +598,39 @@ where
     /// ```rust
     /// use delaunay::prelude::geometry::FastKernel;
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, GlobalTopology, TopologyGuarantee, vertex,
+    ///     DelaunayTriangulation, DelaunayTriangulationBuilder, GlobalTopology, TopologyGuarantee,
+    ///     vertex,
     /// };
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 2> =
-    ///     DelaunayTriangulation::new(&vertices).unwrap();
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// let reconstructed = DelaunayTriangulation::try_from_tds_with_topology_context(
     ///     dt.tds().clone(),
     ///     FastKernel::new(),
     ///     TopologyGuarantee::PLManifoldStrict,
     ///     GlobalTopology::Euclidean,
-    /// )
-    /// .unwrap();
+    /// )?;
     ///
     /// assert_eq!(
     ///     reconstructed.topology_guarantee(),
     ///     TopologyGuarantee::PLManifoldStrict
     /// );
     /// assert_eq!(reconstructed.global_topology(), GlobalTopology::Euclidean);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -13,7 +13,7 @@
 //!
 //! # Example
 //! ```rust
-//! use delaunay::prelude::query::*;
+//! use delaunay::prelude::*;
 //!
 //! # #[derive(Debug, thiserror::Error)]
 //! # enum ExampleError {
@@ -33,7 +33,8 @@
 //!     vertex!([0.0, 1.0, 0.0]),
 //!     vertex!([0.0, 0.0, 1.0]),
 //! ];
-//! let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+//! let dt: DelaunayTriangulation<_, (), (), 3> =
+//!     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 //! let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;
 //! let outside = Point::new([2.0, 2.0, 2.0]);
 //! assert!(hull.is_point_outside(&outside, dt.as_triangulation())?);
@@ -296,7 +297,7 @@ pub enum ConvexHullConstructionError {
 /// Use `is_valid_for_triangulation()` to check if a hull is still valid for a given TDS:
 ///
 /// ```rust
-/// # use delaunay::prelude::DelaunayTriangulation;
+/// # use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
 /// # use delaunay::prelude::query::ConvexHull;
 /// # use delaunay::vertex;
 /// # #[derive(Debug, thiserror::Error)]
@@ -311,12 +312,12 @@ pub enum ConvexHullConstructionError {
 /// #     MissingFacet,
 /// # }
 /// # fn main() -> Result<(), ExampleError> {
-/// # let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vec![
+/// # let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulationBuilder::new(&vec![
 /// #     vertex!([0.0, 0.0, 0.0]),
 /// #     vertex!([1.0, 0.0, 0.0]),
 /// #     vertex!([0.0, 1.0, 0.0]),
 /// #     vertex!([0.0, 0.0, 1.0]),
-/// # ])?;
+/// # ]).build::<()>()?;
 /// let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;
 /// assert!(hull.is_valid_for_triangulation(dt.as_triangulation())); // Valid initially
 ///
@@ -337,7 +338,7 @@ pub enum ConvexHullConstructionError {
 /// ## Example: Correct Usage Pattern
 ///
 /// ```rust
-/// use delaunay::prelude::DelaunayTriangulation;
+/// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
 /// use delaunay::prelude::query::ConvexHull;
 /// use delaunay::vertex;
 ///
@@ -353,12 +354,12 @@ pub enum ConvexHullConstructionError {
 /// #     MissingFacet,
 /// # }
 /// # fn main() -> Result<(), ExampleError> {
-/// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vec![
+/// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulationBuilder::new(&vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
-/// ])?;
+/// ]).build::<()>()?;
 ///
 /// // Create initial hull (note: immutable binding)
 /// let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;
@@ -454,7 +455,7 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -477,7 +478,8 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -503,7 +505,7 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -526,7 +528,8 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -547,7 +550,7 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -572,7 +575,8 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -600,7 +604,7 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -627,7 +631,8 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     /// assert!(!hull.is_empty());
@@ -646,7 +651,7 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -668,7 +673,8 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let dt_2d: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::new(&vertices_2d)?;
+    /// let dt_2d: DelaunayTriangulation<_, (), (), 2> =
+    ///     DelaunayTriangulationBuilder::new(&vertices_2d).build::<()>()?;
     /// let hull_2d =
     ///     ConvexHull::from_triangulation(dt_2d.as_triangulation())?;
     /// assert_eq!(hull_2d.dimension(), 2);
@@ -679,7 +685,8 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt_3d: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices_3d)?;
+    /// let dt_3d: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices_3d).build::<()>()?;
     /// let hull_3d =
     ///     ConvexHull::from_triangulation(dt_3d.as_triangulation())?;
     /// assert_eq!(hull_3d.dimension(), 3);
@@ -716,7 +723,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -732,12 +739,12 @@ where
     /// #     MissingFacet,
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
-    /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vec![
+    /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulationBuilder::new(&vec![
     ///     vertex!([0.0, 0.0, 0.0]),
     ///     vertex!([1.0, 0.0, 0.0]),
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
-    /// ])?;
+    /// ]).build::<()>()?;
     ///
     /// // Create hull and verify it's valid
     /// let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;
@@ -888,7 +895,7 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -911,7 +918,8 @@ impl<K, U, V, const D: usize> ConvexHull<K, U, V, D> {
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -964,7 +972,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -987,7 +995,8 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt_3d: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices_3d)?;
+    /// let dt_3d: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices_3d).build::<()>()?;
     /// let hull_3d: ConvexHull<_, (), (), 3> =
     ///     ConvexHull::from_triangulation(dt_3d.as_triangulation())?;
     /// assert_eq!(hull_3d.number_of_facets(), 4); // Tetrahedron has 4 faces
@@ -1000,7 +1009,8 @@ where
     ///     vertex!([0.0, 0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 0.0, 1.0]),
     /// ];
-    /// let dt_4d: DelaunayTriangulation<_, (), (), 4> = DelaunayTriangulation::new(&vertices_4d)?;
+    /// let dt_4d: DelaunayTriangulation<_, (), (), 4> =
+    ///     DelaunayTriangulationBuilder::new(&vertices_4d).build::<()>()?;
     /// let hull_4d =
     ///     ConvexHull::from_triangulation(dt_4d.as_triangulation())?;
     /// assert_eq!(hull_4d.number_of_facets(), 5); // 4-simplex has 5 facets
@@ -1109,7 +1119,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::prelude::geometry::Point;
     /// use delaunay::prelude::geometry::Coordinate;
@@ -1134,7 +1144,8 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -1509,7 +1520,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::prelude::geometry::Point;
     /// use delaunay::prelude::geometry::Coordinate;
@@ -1534,7 +1545,8 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -1598,7 +1610,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::prelude::geometry::Point;
     /// use delaunay::prelude::geometry::Coordinate;
@@ -1623,7 +1635,8 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -1734,7 +1747,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::prelude::geometry::Point;
     /// use delaunay::prelude::geometry::Coordinate;
@@ -1759,7 +1772,8 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -1797,7 +1811,7 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::DelaunayTriangulation;
+    /// use delaunay::prelude::{DelaunayTriangulation, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::ConvexHull;
     /// use delaunay::vertex;
     ///
@@ -1820,7 +1834,8 @@ where
     ///     vertex!([0.0, 1.0, 0.0]),
     ///     vertex!([0.0, 0.0, 1.0]),
     /// ];
-    /// let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::new(&vertices)?;
+    /// let dt: DelaunayTriangulation<_, (), (), 3> =
+    ///     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let hull =
     ///     ConvexHull::from_triangulation(dt.as_triangulation())?;
     ///
@@ -1987,7 +2002,7 @@ mod tests {
 
     /// Helper function to create a Triangulation from vertices.
     ///
-    /// This uses `DelaunayTriangulation::new()` and returns a reference to the underlying `Triangulation`.
+    /// This uses `DelaunayTriangulationBuilder` and returns a reference to the underlying `Triangulation`.
     /// Since we need ownership, we create the `DelaunayTriangulation` and extract the `Triangulation`.
     fn create_triangulation<const D: usize>(
         vertices: &[Vertex<f64, (), D>],

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -2000,10 +2000,10 @@ mod tests {
     // HELPER FUNCTIONS
     // =============================================================================
 
-    /// Helper function to create a Triangulation from vertices.
+    /// Helper function to create a `DelaunayTriangulation` from vertices.
     ///
-    /// This uses `DelaunayTriangulationBuilder` and returns a reference to the underlying `Triangulation`.
-    /// Since we need ownership, we create the `DelaunayTriangulation` and extract the `Triangulation`.
+    /// This uses `DelaunayTriangulation::with_kernel` and returns the owned
+    /// triangulation directly.
     fn create_triangulation<const D: usize>(
         vertices: &[Vertex<f64, (), D>],
     ) -> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -342,21 +342,33 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::geometry::radius_ratio;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Quality(#[from] delaunay::prelude::geometry::QualityError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a 2D equilateral triangle
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.5, 0.866]), // approximately sqrt(3)/2
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-/// let simplex_key = dt.simplices().next().unwrap().0;
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
 ///
-/// let ratio = radius_ratio(dt.as_triangulation(), simplex_key).unwrap();
+/// let ratio = radius_ratio(dt.as_triangulation(), simplex_key)?;
 /// // For an equilateral triangle, ratio ≈ 2.0
 /// assert!(ratio > 1.5 && ratio < 2.5);
+/// # Ok(())
+/// # }
 /// ```
 pub fn radius_ratio<K, U, V, const D: usize>(
     tri: &Triangulation<K, U, V, D>,
@@ -437,20 +449,32 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::geometry::normalized_volume;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Quality(#[from] delaunay::prelude::geometry::QualityError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a 2D triangle
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
-/// let simplex_key = dt.simplices().next().unwrap().0;
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
 ///
-/// let norm_vol = normalized_volume(dt.as_triangulation(), simplex_key).unwrap();
+/// let norm_vol = normalized_volume(dt.as_triangulation(), simplex_key)?;
 /// assert!(norm_vol > 0.0);
+/// # Ok(())
+/// # }
 /// ```
 pub fn normalized_volume<K, U, V, const D: usize>(
     tri: &Triangulation<K, U, V, D>,

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -690,9 +690,19 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::geometry::surface_measure;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// #     #[error(transparent)]
+/// #     SurfaceMeasure(#[from] delaunay::prelude::geometry::SurfaceMeasureError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // Create a triangulation and calculate surface measure of boundary facets
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -700,15 +710,17 @@ where
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 /// let tds = dt.tds();
 ///
 /// // Get boundary facets as FacetViews
-/// let boundary_facets = tds.boundary_facets().unwrap().collect::<Vec<_>>();
+/// let boundary_facets = tds.boundary_facets()?.collect::<Vec<_>>();
 ///
 /// // Calculate surface area
-/// let surface_area = surface_measure(&boundary_facets).unwrap();
+/// let surface_area = surface_measure(&boundary_facets)?;
 /// assert!(surface_area > 0.0);
+/// # Ok(())
+/// # }
 /// ```
 pub fn surface_measure<T, U, V, const D: usize>(
     facets: &[FacetView<'_, T, U, V, D>],

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -278,7 +278,7 @@ where
 ///
 /// - [`generate_random_points`] - For generating points without triangulation
 /// - [`generate_random_points_seeded`] - For seeded random point generation only
-/// - [`DelaunayTriangulation::new`] - For creating triangulations from existing vertices
+/// - [`DelaunayTriangulationBuilder`](crate::DelaunayTriangulationBuilder) - For creating triangulations from existing vertices
 /// - [`RandomTriangulationBuilder`] - For more control over construction options
 pub fn generate_random_triangulation<T, U, V, const D: usize>(
     n_points: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,7 +269,7 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     DelaunayTriangulation, DelaunayTriangulationConstructionError, vertex,
+//!     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
 //! };
 //! use delaunay::prelude::insertion::InsertionError;
 //! use delaunay::prelude::validation::{ValidationConfigurationError, ValidationPolicy};
@@ -290,7 +290,7 @@
 //!     vertex!([0.0, 1.0, 0.0]),
 //!     vertex!([0.0, 0.0, 1.0]),
 //! ];
-//! let mut dt = DelaunayTriangulation::new(&vertices)?;
+//! let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 //!
 //! // Caller-owned validation mode: keep mandatory topology checks, but run full
 //! // Level 3 validation only through explicit validation calls.
@@ -1007,7 +1007,7 @@ pub use crate::validation::DelaunayTriangulationValidationError;
 ///
 /// ```rust
 /// use delaunay::prelude::construction::{
-///     DelaunayTriangulation, DelaunayTriangulationConstructionError, vertex,
+///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
 /// };
 /// use delaunay::prelude::topology::validation;
 ///
@@ -1025,7 +1025,7 @@ pub use crate::validation::DelaunayTriangulationValidationError;
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices)?;
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
 /// let result = validation::validate_triangulation_euler(dt.tds())?;
 /// assert_eq!(result.chi, 1);  // Tetrahedron has χ = 1
@@ -1528,11 +1528,11 @@ pub mod prelude {
     /// End-to-end "repair then delaunayize" workflow.
     ///
     /// Self-contained: a single `use delaunay::prelude::delaunayize::*`
-    /// import brings in [`DelaunayTriangulation`], [`vertex!`], and all
-    /// delaunayize-specific types.
+    /// import brings in [`DelaunayTriangulationBuilder`], [`DelaunayTriangulation`],
+    /// [`vertex!`], and all delaunayize-specific types.
     pub mod delaunayize {
-        pub use crate::DelaunayTriangulation;
         pub use crate::delaunayize::*;
+        pub use crate::{DelaunayTriangulation, DelaunayTriangulationBuilder};
         pub use crate::{PlManifoldRepairError, PlManifoldRepairStats};
 
         // Convenience macro (commonly used in docs/examples).

--- a/src/topology/characteristics/euler.rs
+++ b/src/topology/characteristics/euler.rs
@@ -6,20 +6,30 @@
 //! # Examples
 //!
 //! ```rust
-//! use delaunay::prelude::query::*;
+//! use delaunay::prelude::*;
 //! use delaunay::prelude::topology::validation::euler;
 //!
+//! # #[derive(Debug, thiserror::Error)]
+//! # enum ExampleError {
+//! #     #[error(transparent)]
+//! #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+//! #     #[error(transparent)]
+//! #     Topology(#[from] delaunay::topology::TopologyError),
+//! # }
+//! # fn main() -> Result<(), ExampleError> {
 //! let vertices = vec![
 //!     vertex!([0.0, 0.0, 0.0]),
 //!     vertex!([1.0, 0.0, 0.0]),
 //!     vertex!([0.0, 1.0, 0.0]),
 //!     vertex!([0.0, 0.0, 1.0]),
 //! ];
-//! let dt = DelaunayTriangulation::new(&vertices).unwrap();
+//! let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 //!
-//! let counts = euler::count_simplices(dt.tds()).unwrap();
+//! let counts = euler::count_simplices(dt.tds())?;
 //! let chi = euler::euler_characteristic(&counts);
 //! assert_eq!(chi, 1);  // Single tetrahedron has χ = 1
+//! # Ok(())
+//! # }
 //! ```
 
 #![forbid(unsafe_code)]
@@ -189,20 +199,30 @@ pub enum TopologyClassification {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation::euler;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Topology(#[from] delaunay::topology::TopologyError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.5, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let counts = euler::count_simplices(dt.tds()).unwrap();
+/// let counts = euler::count_simplices(dt.tds())?;
 /// assert_eq!(counts.count(0), 3);  // 3 vertices
 /// assert_eq!(counts.count(1), 3);  // 3 edges
 /// assert_eq!(counts.count(2), 1);  // 1 face
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors
@@ -368,9 +388,17 @@ fn insert_simplices_of_size(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation::euler;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Topology(#[from] delaunay::topology::TopologyError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// // 3D tetrahedron - boundary is S² (sphere)
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
@@ -378,11 +406,13 @@ fn insert_simplices_of_size(
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let boundary_counts = euler::count_boundary_simplices(dt.tds()).unwrap();
+/// let boundary_counts = euler::count_boundary_simplices(dt.tds())?;
 /// let boundary_chi = euler::euler_characteristic(&boundary_counts);
 /// assert_eq!(boundary_chi, 2);  // S² has χ = 2
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors
@@ -646,19 +676,29 @@ pub(crate) fn triangulated_surface_boundary_component_count(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation::{classify_triangulation, TopologyClassification};
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Topology(#[from] delaunay::topology::TopologyError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let classification = classify_triangulation(dt.tds()).unwrap();
+/// let classification = classify_triangulation(dt.tds())?;
 /// assert_eq!(classification, TopologyClassification::SingleSimplex(3));
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors

--- a/src/topology/characteristics/validation.rs
+++ b/src/topology/characteristics/validation.rs
@@ -22,20 +22,30 @@ use crate::topology::{
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Topology(#[from] delaunay::topology::TopologyError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let result = validation::validate_triangulation_euler(dt.tds()).unwrap();
+/// let result = validation::validate_triangulation_euler(dt.tds())?;
 /// assert_eq!(result.chi, 1);
 /// assert!(result.is_valid());
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TopologyCheckResult {
@@ -107,22 +117,32 @@ impl TopologyCheckResult {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::query::*;
+/// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Topology(#[from] delaunay::topology::TopologyError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0]),
 ///     vertex!([1.0, 0.0]),
 ///     vertex!([0.5, 1.0]),
 /// ];
-/// let dt = DelaunayTriangulation::new(&vertices).unwrap();
+/// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let result = validation::validate_triangulation_euler(dt.tds()).unwrap();
+/// let result = validation::validate_triangulation_euler(dt.tds())?;
 /// assert_eq!(result.chi, 1);
 /// assert_eq!(result.counts.count(0), 3);  // 3 vertices
 /// assert_eq!(result.counts.count(1), 3);  // 3 edges
 /// assert_eq!(result.counts.count(2), 1);  // 1 face
 /// assert!(result.is_valid());
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -299,16 +299,25 @@ pub enum ManifoldError {
 /// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation::validate_facet_degree;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+/// #     #[error(transparent)] Construction(#[from] delaunay::prelude::triangulation::TriangulationConstructionError),
+/// #     #[error(transparent)] Manifold(#[from] delaunay::prelude::topology::validation::ManifoldError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
-/// let facet_to_simplices = tds.build_facet_to_simplices_map().unwrap();
+/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices)?;
+/// let facet_to_simplices = tds.build_facet_to_simplices_map()?;
 ///
-/// validate_facet_degree(&facet_to_simplices).unwrap();
+/// validate_facet_degree(&facet_to_simplices)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn validate_facet_degree(
     facet_to_simplices: &FacetToSimplicesMap,
@@ -354,16 +363,25 @@ pub fn validate_facet_degree(
 /// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation::validate_closed_boundary;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+/// #     #[error(transparent)] Construction(#[from] delaunay::prelude::triangulation::TriangulationConstructionError),
+/// #     #[error(transparent)] Manifold(#[from] delaunay::prelude::topology::validation::ManifoldError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
-/// let facet_to_simplices = tds.build_facet_to_simplices_map().unwrap();
+/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices)?;
+/// let facet_to_simplices = tds.build_facet_to_simplices_map()?;
 ///
-/// validate_closed_boundary(&tds, &facet_to_simplices).unwrap();
+/// validate_closed_boundary(&tds, &facet_to_simplices)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn validate_closed_boundary<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
@@ -1269,15 +1287,23 @@ fn periodic_aware_ridge_star<T, U, V, const D: usize>(
 /// use delaunay::prelude::*;
 /// use delaunay::prelude::topology::validation::validate_ridge_links;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)] Construction(#[from] delaunay::prelude::triangulation::TriangulationConstructionError),
+/// #     #[error(transparent)] Manifold(#[from] delaunay::prelude::topology::validation::ManifoldError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
+/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices)?;
 ///
-/// validate_ridge_links(&tds).unwrap();
+/// validate_ridge_links(&tds)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn validate_ridge_links<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
@@ -1345,16 +1371,24 @@ pub fn validate_ridge_links<T, U, V, const D: usize>(
 /// use delaunay::prelude::topology::validation::validate_ridge_links_for_simplices;
 /// use delaunay::prelude::collections::SimplexKeyBuffer;
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)] Construction(#[from] delaunay::prelude::triangulation::TriangulationConstructionError),
+/// #     #[error(transparent)] Manifold(#[from] delaunay::prelude::topology::validation::ManifoldError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
+/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices)?;
 /// let simplices: SimplexKeyBuffer = tds.simplices().map(|(k, _)| k).collect();
 ///
-/// validate_ridge_links_for_simplices(&tds, &simplices).unwrap();
+/// validate_ridge_links_for_simplices(&tds, &simplices)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn validate_ridge_links_for_simplices<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,
@@ -1433,18 +1467,27 @@ pub fn validate_ridge_links_for_simplices<T, U, V, const D: usize>(
 ///     validate_closed_boundary, validate_facet_degree, validate_vertex_links,
 /// };
 ///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)] Tds(#[from] delaunay::prelude::tds::TdsError),
+/// #     #[error(transparent)] Construction(#[from] delaunay::prelude::triangulation::TriangulationConstructionError),
+/// #     #[error(transparent)] Manifold(#[from] delaunay::prelude::topology::validation::ManifoldError),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
 ///     vertex!([0.0, 0.0, 0.0]),
 ///     vertex!([1.0, 0.0, 0.0]),
 ///     vertex!([0.0, 1.0, 0.0]),
 ///     vertex!([0.0, 0.0, 1.0]),
 /// ];
-/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
-/// let facet_to_simplices = tds.build_facet_to_simplices_map().unwrap();
+/// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices)?;
+/// let facet_to_simplices = tds.build_facet_to_simplices_map()?;
 ///
-/// validate_facet_degree(&facet_to_simplices).unwrap();
-/// validate_closed_boundary(&tds, &facet_to_simplices).unwrap();
-/// validate_vertex_links(&tds, &facet_to_simplices).unwrap();
+/// validate_facet_degree(&facet_to_simplices)?;
+/// validate_closed_boundary(&tds, &facet_to_simplices)?;
+/// validate_vertex_links(&tds, &facet_to_simplices)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn validate_vertex_links<T, U, V, const D: usize>(
     tds: &Tds<T, U, V, D>,

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -27,7 +27,8 @@ use delaunay::prelude::construction::{
     InsertionOrderStrategy, SimplexValidationError, TopologyGuarantee, Vertex, vertex,
 };
 use delaunay::prelude::delaunayize::{
-    DelaunayizeConfig, DelaunayizeError, DelaunayizeOutcome, delaunayize_by_flips,
+    DelaunayTriangulationBuilder as DelaunayizeDelaunayTriangulationBuilder, DelaunayizeConfig,
+    DelaunayizeError, DelaunayizeOutcome, delaunayize_by_flips,
 };
 use delaunay::prelude::diagnostics::ConstructionTelemetry;
 #[cfg(feature = "diagnostics")]
@@ -396,7 +397,7 @@ fn diagnostic_preludes_cover_repair_apis() -> Result<(), PreludeExportTestError>
         vertex!([0.0, 1.0, 0.0]),
         vertex!([0.0, 0.0, 1.0]),
     ];
-    let mut dt = DelaunayTriangulation::new(&vertices)?;
+    let mut dt = DelaunayizeDelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
     let repair_stats = DelaunayRepairStats::default();
     let repair_outcome = DelaunayRepairOutcome {


### PR DESCRIPTION
- Present `DelaunayTriangulationBuilder` as the primary construction path while retaining `DelaunayTriangulation::new` as a legacy convenience constructor.
- Replace doctest `unwrap()` patterns with typed `?` propagation and explicit optional guards across construction, validation, repair, geometry, and topology examples.
- Re-export `DelaunayTriangulationBuilder` from `prelude::delaunayize` so single-prelude delaunayize examples can use the builder directly.