### PR TITLE
docs(api): use typed errors in public examples (#365)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,9 @@ complete technical background.
   orientation and in-sphere configurations
 - [x]  [PL-manifold] topology validation by default, with [Pseudomanifold]
   available as an explicit opt-out
-- [x]  Toroidal (periodic) triangulations via [`DelaunayTriangulationBuilder`]
-  with Phase 1 (canonicalization) and Phase 2 (image-point method) support
+- [x]  Toroidal (periodic) triangulations via [`DelaunayTriangulationBuilder`]:
+  `.toroidal(...)` canonicalizes points into the fundamental domain, while
+  `.toroidal_periodic(...)` builds a true periodic image-point quotient
 - [x]  Geometry quality metrics for simplices: radius ratio and normalized
   volume (dimension-agnostic)
 - [x]  Serialization/deserialization of all data structures to/from [JSON]
@@ -256,8 +257,9 @@ fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 }
 ```
 
-For the full periodic image-point method (Phase 2), see the
-[`DelaunayTriangulationBuilder`] documentation.
+For boundary-facet identification and periodic neighbor pointers, use
+`.toroidal_periodic([..])`; see the [toroidal construction workflow] for the
+full recipe.
 
 ### Need more control?
 
@@ -554,4 +556,5 @@ Portions of this library were developed with the assistance of these AI tools:
 [PL-manifold]: https://en.wikipedia.org/wiki/Piecewise_linear_manifold
 [Delaunay repair]: https://link.springer.com/article/10.1007/BF01975867
 [Pachner moves]: https://en.wikipedia.org/wiki/Pachner_move
-[`DelaunayTriangulationBuilder`]: https://docs.rs/delaunay/latest/delaunay/builder/struct.DelaunayTriangulationBuilder.html
+[`DelaunayTriangulationBuilder`]: src/delaunay/builder.rs
+[toroidal construction workflow]: docs/workflows.md#builder-api-toroidal-periodic-triangulations

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -61,9 +61,23 @@ The library provides two distinct APIs for different use cases:
 For most use cases, the builder with default options is sufficient:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
+use delaunay::prelude::insertion::InsertionError;
+use delaunay::prelude::tds::InvariantError;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum ExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Insertion(#[from] InsertionError),
+    #[error(transparent)]
+    Topology(#[from] InvariantError),
+}
+
+fn main() -> Result<(), ExampleError> {
     // Simple construction from vertices (Euclidean space, default options)
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
@@ -92,11 +106,21 @@ use `DelaunayTriangulationBuilder`:
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
+    vertex,
 };
+use delaunay::prelude::insertion::InsertionError;
 use delaunay::prelude::validation::ValidationPolicy;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum ExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Insertion(#[from] InsertionError),
+}
+
+fn main() -> Result<(), ExampleError> {
     // Toroidal (periodic) triangulation in 2D
     let vertices = vec![
         vertex!([0.1, 0.1]),
@@ -158,10 +182,20 @@ for topology guarantee and validation policy details.
 The Edit API is exposed through the `BistellarFlips` trait in `prelude::flips`:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
 use delaunay::prelude::flips::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum ExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Flip(#[from] FlipError),
+}
+
+fn main() -> Result<(), ExampleError> {
     // Start with a valid triangulation
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
@@ -271,10 +305,23 @@ After applying flips, you should:
 You can mix both APIs in the same workflow:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
 use delaunay::prelude::flips::*;
+use delaunay::prelude::insertion::InsertionError;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum ExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Insertion(#[from] InsertionError),
+    #[error(transparent)]
+    Flip(#[from] FlipError),
+}
+
+fn main() -> Result<(), ExampleError> {
     // 1. Build initial triangulation (Builder API)
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
@@ -368,12 +415,22 @@ The `delaunay::delaunayize` module provides a single entrypoint for the
 common "repair topology then restore Delaunay" workflow:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
 use delaunay::prelude::delaunayize::{
-    DelaunayizeConfig, delaunayize_by_flips,
+    DelaunayizeConfig, DelaunayizeError, delaunayize_by_flips,
 };
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum ExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Delaunayize(#[from] DelaunayizeError),
+}
+
+fn main() -> Result<(), ExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),

--- a/docs/archive/topology_integration_design_historical.md
+++ b/docs/archive/topology_integration_design_historical.md
@@ -817,7 +817,7 @@ mod random_topology_tests {
 // Addition to tests/circumsphere_debug_tools.rs
 
 #[test]
-fn test_topology_debug_analysis() -> Result<(), Box<dyn std::error::Error>> {
+fn test_topology_debug_analysis() -> Result<(), TdsConstructionError> {
     println!("=== Topology Debug Analysis ===");
 
     // Test across multiple dimensions
@@ -835,7 +835,7 @@ fn test_topology_debug_analysis() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn test_2d_topology_debug() -> Result<(), Box<dyn std::error::Error>> {
+fn test_2d_topology_debug() -> Result<(), TdsConstructionError> {
     let vertices = vec![
         vertex!([0.0, 0.0]),
         vertex!([1.0, 0.0]),

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -361,11 +361,11 @@ InvalidFacetIndex(u8, usize),
 
 ### Preserve typed sources — no boxing, no `dyn Error`
 
-Source and "secondary" errors must be stored **by value as typed enums**,
-not as `Box<dyn Error>`, not as `anyhow::Error`, and not stringified into a
-`message: String` field. The whole point of the taxonomy is that consumers
-can pattern-match the full structured error, while [`Error::source`]
-exposes whichever field is annotated as the primary source.
+Source and "secondary" errors must be stored **by value as typed enums**.
+Do not erase them behind dynamic error objects, `anyhow::Error`, or
+`message: String` fields. The whole point of the taxonomy is that consumers
+can pattern-match the full structured error, while [`Error::source`] exposes
+whichever field is annotated as the primary source.
 
 - Use `#[source]` (and `#[from]` where the conversion is unambiguous) on
   the typed field so `thiserror` wires up the source chain.
@@ -445,8 +445,8 @@ pub enum FooError { ... }
   (integers, strings, UUIDs, keys, other `Eq` enums, `Arc<T>` /
   `Box<T>` where `T: Eq`). All error enums in this crate satisfy
   this today. Skip these only when a payload genuinely cannot be `Eq`
-  (e.g. `f64`, `io::Error`, `Box<dyn Error>`) — none of which belong in
-  error values anyway.
+  (e.g. `f64`, `io::Error`, dynamically erased error objects) — none of
+  which belong in error values anyway.
 - `#[non_exhaustive]` — new variants must remain additive; downstream
   matches need a `_` arm.
 
@@ -605,7 +605,8 @@ Example:
 ///
 /// ```rust
 /// # use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # use delaunay::prelude::insertion::InsertionError;
+/// # fn main() -> Result<(), InsertionError> {
 /// let mut triangulation = DelaunayTriangulation::<_, _, _, 2>::default();
 /// let key = triangulation.insert_vertex([0.0, 0.0])?;
 /// assert!(triangulation.contains_vertex(key));

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -116,8 +116,17 @@ use delaunay::prelude::diagnostics::delaunay_violation_report;
 use delaunay::prelude::construction::{
     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
 };
+use delaunay::prelude::DelaunayValidationError;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum DiagnosticsExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Validation(#[from] DelaunayValidationError),
+}
+
+fn main() -> Result<(), DiagnosticsExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -93,9 +93,17 @@ use delaunay::prelude::construction::{
     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
     Vertex, vertex,
 };
-use delaunay::prelude::validation::ValidationPolicy;
+use delaunay::prelude::validation::{ValidationConfigurationError, ValidationPolicy};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum ValidationExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Configuration(#[from] ValidationConfigurationError),
+}
+
+fn main() -> Result<(), ValidationExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -105,9 +105,20 @@ dt.set_delaunay_repair_policy(DelaunayRepairPolicy::Never);
 You can also run a global repair pass manually:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
+use delaunay::prelude::repair::DelaunayRepairError;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum RepairExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Repair(#[from] DelaunayRepairError),
+}
+
+fn main() -> Result<(), RepairExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),
@@ -155,10 +166,18 @@ If repair fails to converge within the flip budget, you get
 detections, etc.).
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
 use delaunay::prelude::repair::DelaunayRepairError;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum RepairExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+}
+
+fn main() -> Result<(), RepairExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),
@@ -199,10 +218,20 @@ You can provide explicit seeds for reproducibility; otherwise deterministic defa
 from the current vertex set.
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
-use delaunay::prelude::repair::DelaunayRepairHeuristicConfig;
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
+use delaunay::prelude::repair::{DelaunayRepairError, DelaunayRepairHeuristicConfig};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum RepairExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Repair(#[from] DelaunayRepairError),
+}
+
+fn main() -> Result<(), RepairExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),
@@ -228,9 +257,20 @@ Toroidal triangulations handle periodic boundary conditions. Use
 `DelaunayTriangulationBuilder` to construct them:
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
+use delaunay::prelude::insertion::InsertionError;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum PeriodicExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Insertion(#[from] InsertionError),
+}
+
+fn main() -> Result<(), PeriodicExampleError> {
     // 2D periodic triangulation with unit square domain
     let vertices = vec![
         vertex!([0.1, 0.1]),
@@ -239,7 +279,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     ];
 
     let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-        .toroidal([1.0, 1.0]) // Phase 1: canonicalized toroidal construction
+        .toroidal([1.0, 1.0]) // canonicalized toroidal construction
         .build::<()>()?;
 
     // Insert more points - they'll be wrapped to [0,1)×[0,1)
@@ -256,8 +296,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 - **Distance computation**: Distances are computed accounting for periodic boundaries (toroidal
   metric)
 - **Construction modes**:
-  - `.toroidal([..])`: Phase 1 canonicalized construction (wrap into fundamental domain)
-  - `.toroidal_periodic([..])`: Phase 2 periodic image-point construction (true toroidal quotient)
+  - `.toroidal([..])`: canonicalized construction (wrap into fundamental domain)
+  - `.toroidal_periodic([..])`: periodic image-point construction (true toroidal quotient)
 
 For more details, see `docs/topology.md` and the toroidal section in the main `README.md`.
 
@@ -332,9 +372,9 @@ want to keep going after skipped vertices, use the explicitly best-effort
 
 ```rust
 use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
-use delaunay::prelude::insertion::InsertionOutcome;
+use delaunay::prelude::insertion::{InsertionError, InsertionOutcome};
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), InsertionError> {
     let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
 
     let (outcome, stats) = dt.insert_best_effort_with_statistics(vertex!([0.5, 0.5, 0.5]))?;
@@ -366,9 +406,20 @@ possible and fan retriangulation otherwise, then runs flip-based Delaunay repair
 the operation rolls back to the pre-removal triangulation.
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
+use delaunay::prelude::tds::InvariantError;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum RemovalExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Invariant(#[from] InvariantError),
+}
+
+fn main() -> Result<(), RemovalExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),
@@ -417,7 +468,15 @@ See [`api_design.md`](api_design.md) for the full Builder vs Edit API design.
 use delaunay::prelude::construction::{DelaunayTriangulationBuilder, vertex};
 use delaunay::prelude::flips::*;
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[derive(Debug, thiserror::Error)]
+enum FlipExampleError {
+    #[error(transparent)]
+    Construction(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Flip(#[from] FlipError),
+}
+
+fn main() -> Result<(), FlipExampleError> {
     let vertices = vec![
         vertex!([0.0, 0.0, 0.0]),
         vertex!([1.0, 0.0, 0.0]),

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -2142,14 +2142,17 @@ where
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::insertion::wire_cavity_neighbors;
+/// use delaunay::prelude::insertion::{InsertionError, wire_cavity_neighbors};
 /// use delaunay::prelude::collections::SimplexKeyBuffer;
 /// use delaunay::prelude::tds::Tds;
 ///
+/// # fn main() -> Result<(), InsertionError> {
 /// let mut tds: Tds<f64, (), (), 3> = Tds::empty();
 /// let new_simplices = SimplexKeyBuffer::new();
 ///
-/// wire_cavity_neighbors(&mut tds, &new_simplices, [], None).unwrap();
+/// wire_cavity_neighbors(&mut tds, &new_simplices, [], None)?;
+/// # Ok(())
+/// # }
 /// ```
 #[expect(
     clippy::too_many_lines,

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -104,25 +104,34 @@ where
     ///
     /// ```
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder, Vertex, vertex,
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, Vertex, vertex,
     /// };
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] DelaunayTriangulationConstructionError),
+    /// #     #[error("triangulation unexpectedly contains no vertices")]
+    /// #     MissingVertex,
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices: [Vertex<f64, i32, 2>; 3] = [
     ///     vertex!([0.0, 0.0], 10i32),
     ///     vertex!([1.0, 0.0], 20),
     ///     vertex!([0.0, 1.0], 30),
     /// ];
-    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .build::<()>()
-    ///     .unwrap();
-    /// let key = dt.vertices().next().unwrap().0;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let key = dt.vertices().next().ok_or(ExampleError::MissingVertex)?.0;
     /// let prev = dt.set_vertex_data(key, Some(99));
     /// assert!(prev.is_some());
     ///
     /// // Clear data
     /// let prev = dt.set_vertex_data(key, None);
     /// assert_eq!(prev, Some(Some(99)));
-    /// assert_eq!(dt.tds().vertex(key).unwrap().data(), None);
+    /// let vertex = dt.tds().vertex(key).ok_or(ExampleError::MissingVertex)?;
+    /// assert_eq!(vertex.data(), None);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn set_vertex_data(&mut self, key: VertexKey, data: Option<U>) -> Option<Option<U>> {
@@ -143,25 +152,34 @@ where
     ///
     /// ```
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder, vertex,
+    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
     /// };
     ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] DelaunayTriangulationConstructionError),
+    /// #     #[error("triangulation unexpectedly contains no simplices")]
+    /// #     MissingSimplex,
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
     ///     vertex!([0.0, 0.0]),
     ///     vertex!([1.0, 0.0]),
     ///     vertex!([0.0, 1.0]),
     /// ];
-    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .build::<i32>()
-    ///     .unwrap();
-    /// let key = dt.simplices().next().unwrap().0;
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<i32>()?;
+    /// let key = dt.simplices().next().ok_or(ExampleError::MissingSimplex)?.0;
     /// let prev = dt.set_simplex_data(key, Some(42));
     /// assert_eq!(prev, Some(None));
     ///
     /// // Clear data
     /// let prev = dt.set_simplex_data(key, None);
     /// assert_eq!(prev, Some(Some(42)));
-    /// assert_eq!(dt.tds().simplex(key).unwrap().data(), None);
+    /// let simplex = dt.tds().simplex(key).ok_or(ExampleError::MissingSimplex)?;
+    /// assert_eq!(simplex.data(), None);
+    /// # Ok(())
+    /// # }
     /// ```
     #[inline]
     pub fn set_simplex_data(&mut self, key: SimplexKey, data: Option<V>) -> Option<Option<V>> {

--- a/src/core/util/deduplication.rs
+++ b/src/core/util/deduplication.rs
@@ -45,16 +45,11 @@ pub enum DeduplicationError {
 ///
 /// ```
 /// use delaunay::prelude::dedup_vertices_exact;
-/// use delaunay::prelude::Vertex;
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::{Vertex, vertex};
 ///
-/// let v1: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([0.0, 0.0])])
-///     .into_iter().next().unwrap();
-/// let v2: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([0.0, 0.0])]) // Duplicate
-///     .into_iter().next().unwrap();
-/// let v3: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([1.0, 1.0])])
-///     .into_iter().next().unwrap();
+/// let v1: Vertex<f64, (), 2> = vertex!([0.0, 0.0]);
+/// let v2: Vertex<f64, (), 2> = vertex!([0.0, 0.0]); // Duplicate
+/// let v3: Vertex<f64, (), 2> = vertex!([1.0, 1.0]);
 ///
 /// let vertices = vec![v1, v2, v3];
 /// let unique = dedup_vertices_exact(&vertices);
@@ -114,16 +109,11 @@ where
 ///
 /// ```
 /// use delaunay::prelude::dedup_vertices_epsilon;
-/// use delaunay::prelude::Vertex;
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::{Vertex, vertex};
 ///
-/// let v1: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([0.0, 0.0])])
-///     .into_iter().next().unwrap();
-/// let v2: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([1e-11, 1e-11])]) // Near duplicate
-///     .into_iter().next().unwrap();
-/// let v3: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([1.0, 1.0])])
-///     .into_iter().next().unwrap();
+/// let v1: Vertex<f64, (), 2> = vertex!([0.0, 0.0]);
+/// let v2: Vertex<f64, (), 2> = vertex!([1e-11, 1e-11]); // Near duplicate
+/// let v3: Vertex<f64, (), 2> = vertex!([1.0, 1.0]);
 ///
 /// let vertices = vec![v1, v2, v3];
 /// let unique = dedup_vertices_epsilon(&vertices, 1e-10);
@@ -248,14 +238,10 @@ where
 ///
 /// ```
 /// use delaunay::prelude::filter_vertices_excluding;
-/// use delaunay::prelude::Vertex;
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::{Vertex, vertex};
 ///
-/// let v1: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([0.0, 0.0])])
-///     .into_iter().next().unwrap();
-/// let v2: Vertex<f64, (), 2> = Vertex::from_points(&[Point::new([1.0, 1.0])])
-///     .into_iter().next().unwrap();
+/// let v1: Vertex<f64, (), 2> = vertex!([0.0, 0.0]);
+/// let v2: Vertex<f64, (), 2> = vertex!([1.0, 1.0]);
 ///
 /// let reference = vec![v1]; // Exclude origin
 /// let vertices = vec![v1, v2];

--- a/src/core/util/facet_utils.rs
+++ b/src/core/util/facet_utils.rs
@@ -110,10 +110,18 @@ where
 /// use delaunay::prelude::tds::facet_view_to_vertices;
 /// use delaunay::prelude::tds::{FacetError, Tds};
 ///
+/// #[derive(Debug, thiserror::Error)]
+/// enum ExampleError {
+///     #[error(transparent)]
+///     Facet(#[from] FacetError),
+///     #[error("triangulation unexpectedly contains no simplices")]
+///     MissingSimplex,
+/// }
+///
 /// fn extract_vertices_example(
 ///     tds: &Tds<f64, (), (), 3>,
-/// ) -> Result<(), FacetError> {
-///     let simplex_key = tds.simplex_keys().next().unwrap();
+/// ) -> Result<(), ExampleError> {
+///     let simplex_key = tds.simplex_keys().next().ok_or(ExampleError::MissingSimplex)?;
 ///     let facet_view = FacetView::new(tds, simplex_key, 0)?;
 ///     
 ///     // Extract owned vertices

--- a/src/core/util/hilbert.rs
+++ b/src/core/util/hilbert.rs
@@ -572,8 +572,8 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
 /// // Quantize once
 /// let quantized: Vec<[u32; 2]> = coords
 ///     .iter()
-///     .map(|c| hilbert_quantize(c, bounds, bits).unwrap())
-///     .collect();
+///     .map(|c| hilbert_quantize(c, bounds, bits))
+///     .collect::<Result<_, _>>()?;
 ///
 /// // Compute all indices in bulk
 /// let indices = hilbert_indices_prequantized(&quantized, bits)?;

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -81,19 +81,22 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashSet;
-/// use delaunay::prelude::query::jaccard_index;
+/// use delaunay::prelude::query::{JaccardComputationError, jaccard_index};
 ///
+/// # fn main() -> Result<(), JaccardComputationError> {
 /// // Identical sets => similarity 1.0
 /// let a: HashSet<_> = [1, 2, 3].into_iter().collect();
-/// assert_eq!(jaccard_index(&a, &a).unwrap(), 1.0);
+/// assert_eq!(jaccard_index(&a, &a)?, 1.0);
 ///
 /// // Partial overlap: {1,2,3} vs {3,4} => |∩|=1, |∪|=4 => 0.25
 /// let b: HashSet<_> = [3, 4].into_iter().collect();
-/// assert!((jaccard_index(&a, &b).unwrap() - 0.25).abs() < 1e-12);
+/// assert!((jaccard_index(&a, &b)? - 0.25).abs() < 1e-12);
 ///
 /// // Empty vs empty => 1.0 by convention
 /// let empty: HashSet<i32> = HashSet::new();
-/// assert_eq!(jaccard_index(&empty, &empty).unwrap(), 1.0);
+/// assert_eq!(jaccard_index(&empty, &empty)?, 1.0);
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors
@@ -146,17 +149,22 @@ where
 /// # Examples
 /// ```
 /// use std::collections::HashSet;
-/// use delaunay::prelude::query::{jaccard_distance, jaccard_index};
+/// use delaunay::prelude::query::{
+///     JaccardComputationError, jaccard_distance, jaccard_index,
+/// };
 ///
+/// # fn main() -> Result<(), JaccardComputationError> {
 /// let a: HashSet<_> = [1, 2, 3].into_iter().collect();
 /// let b: HashSet<_> = [3, 4].into_iter().collect();
 ///
 /// // Distance is 0.0 for identical sets
-/// assert_eq!(jaccard_distance(&a, &a).unwrap(), 0.0);
+/// assert_eq!(jaccard_distance(&a, &a)?, 0.0);
 ///
 /// // Index + distance = 1.0
-/// let sum = jaccard_index(&a, &b).unwrap() + jaccard_distance(&a, &b).unwrap();
+/// let sum = jaccard_index(&a, &b)? + jaccard_distance(&a, &b)?;
 /// assert!((sum - 1.0).abs() < 1e-12);
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors
@@ -490,13 +498,16 @@ where
 ///
 /// ```
 /// use std::collections::HashSet;
-/// use delaunay::prelude::query::format_jaccard_report;
+/// use delaunay::prelude::query::{JaccardComputationError, format_jaccard_report};
 ///
+/// # fn main() -> Result<(), JaccardComputationError> {
 /// let a: HashSet<i32> = [1, 2, 3, 4].into_iter().collect();
 /// let b: HashSet<i32> = [3, 4, 5, 6].into_iter().collect();
 ///
-/// let report = format_jaccard_report(&a, &b, "Set A", "Set B").unwrap();
+/// let report = format_jaccard_report(&a, &b, "Set A", "Set B")?;
 /// assert!(report.contains("Jaccard Index:"));
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Errors

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -131,22 +131,23 @@ pub enum VertexBuilderError {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::{Vertex, VertexBuilder};
+/// use delaunay::prelude::{Vertex, VertexBuilder, VertexBuilderError};
 /// use delaunay::prelude::geometry::Point;
 /// use delaunay::prelude::geometry::Coordinate;
 ///
+/// # fn main() -> Result<(), VertexBuilderError> {
 /// // Build a vertex with just a point
 /// let v: Vertex<f64, (), 3> = VertexBuilder::default()
 ///     .point(Point::new([1.0, 2.0, 3.0]))
-///     .build()
-///     .unwrap();
+///     .build()?;
 ///
 /// // Build a vertex with data
 /// let v: Vertex<f64, i32, 2> = VertexBuilder::default()
 ///     .point(Point::new([0.0, 1.0]))
 ///     .data(42)
-///     .build()
-///     .unwrap();
+///     .build()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct VertexBuilder<T, U, const D: usize> {
     point: Option<Point<T, D>>,

--- a/src/geometry/kernel.rs
+++ b/src/geometry/kernel.rs
@@ -58,10 +58,10 @@ const fn insphere_to_i32(result: InSphere) -> i32 {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::{FastKernel, Kernel};
+/// use delaunay::prelude::geometry::{Coordinate, CoordinateConversionError, FastKernel, Kernel};
 /// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// let kernel = FastKernel::<f64>::new();
 ///
 /// // Test orientation of a 2D triangle
@@ -70,13 +70,15 @@ const fn insphere_to_i32(result: InSphere) -> i32 {
 ///     Point::new([1.0, 0.0]),
 ///     Point::new([0.5, 1.0]),
 /// ];
-/// let orientation = kernel.orientation(&points).unwrap();
+/// let orientation = kernel.orientation(&points)?;
 /// assert!(orientation != 0); // Not degenerate
 ///
 /// // Test if point is inside circumcircle
 /// let test_point = Point::new([0.5, 0.3]);
-/// let result = kernel.in_sphere(&points, &test_point).unwrap();
+/// let result = kernel.in_sphere(&points, &test_point)?;
 /// assert_eq!(result, 1); // Inside
+/// # Ok(())
+/// # }
 /// ```
 pub trait Kernel<const D: usize>: Clone {
     /// The scalar type used for coordinates.
@@ -113,10 +115,11 @@ pub trait Kernel<const D: usize>: Clone {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::geometry::{FastKernel, Kernel};
-    /// use delaunay::prelude::geometry::Point;
-    /// use delaunay::prelude::geometry::Coordinate;
+    /// use delaunay::prelude::geometry::{
+    ///     Coordinate, CoordinateConversionError, FastKernel, Kernel, Point,
+    /// };
     ///
+    /// # fn main() -> Result<(), CoordinateConversionError> {
     /// let kernel = FastKernel::<f64>::new();
     ///
     /// // 3D tetrahedron
@@ -126,8 +129,10 @@ pub trait Kernel<const D: usize>: Clone {
     ///     Point::new([0.0, 1.0, 0.0]),
     ///     Point::new([0.0, 0.0, 1.0]),
     /// ];
-    /// let orientation = kernel.orientation(&points).unwrap();
+    /// let orientation = kernel.orientation(&points)?;
     /// assert!(orientation == -1 || orientation == 1); // Non-degenerate
+    /// # Ok(())
+    /// # }
     /// ```
     fn orientation(
         &self,
@@ -164,10 +169,11 @@ pub trait Kernel<const D: usize>: Clone {
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::geometry::{FastKernel, Kernel};
-    /// use delaunay::prelude::geometry::Point;
-    /// use delaunay::prelude::geometry::Coordinate;
+    /// use delaunay::prelude::geometry::{
+    ///     Coordinate, CoordinateConversionError, FastKernel, Kernel, Point,
+    /// };
     ///
+    /// # fn main() -> Result<(), CoordinateConversionError> {
     /// let kernel = FastKernel::<f64>::new();
     ///
     /// // 3D tetrahedron
@@ -180,11 +186,13 @@ pub trait Kernel<const D: usize>: Clone {
     ///
     /// // Point inside the circumsphere
     /// let inside = Point::new([0.25, 0.25, 0.25]);
-    /// assert_eq!(kernel.in_sphere(&simplex, &inside).unwrap(), 1);
+    /// assert_eq!(kernel.in_sphere(&simplex, &inside)?, 1);
     ///
     /// // Point outside the circumsphere
     /// let outside = Point::new([2.0, 2.0, 2.0]);
-    /// assert_eq!(kernel.in_sphere(&simplex, &outside).unwrap(), -1);
+    /// assert_eq!(kernel.in_sphere(&simplex, &outside)?, -1);
+    /// # Ok(())
+    /// # }
     /// ```
     fn in_sphere(
         &self,
@@ -342,10 +350,10 @@ impl_exact_predicates_for_supported_dims!(0, 1, 2, 3, 4, 5);
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::{FastKernel, Kernel};
+/// use delaunay::prelude::geometry::{Coordinate, CoordinateConversionError, FastKernel, Kernel};
 /// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// // Create a fast kernel for f64 coordinates
 /// let kernel = FastKernel::<f64>::new();
 ///
@@ -357,13 +365,15 @@ impl_exact_predicates_for_supported_dims!(0, 1, 2, 3, 4, 5);
 /// ];
 ///
 /// // Check orientation
-/// let orientation = kernel.orientation(&points).unwrap();
+/// let orientation = kernel.orientation(&points)?;
 /// assert!(orientation != 0);
 ///
 /// // Test insphere predicate
 /// let test_point = Point::new([0.25, 0.25]);
-/// let result = kernel.in_sphere(&points, &test_point).unwrap();
+/// let result = kernel.in_sphere(&points, &test_point)?;
 /// assert_eq!(result, 1); // Inside circumcircle
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Default, Debug)]
 pub struct FastKernel<T> {
@@ -474,10 +484,10 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::{RobustKernel, Kernel};
+/// use delaunay::prelude::geometry::{Coordinate, CoordinateConversionError, Kernel, RobustKernel};
 /// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// let kernel = RobustKernel::<f64>::new();
 ///
 /// let points = [
@@ -487,12 +497,14 @@ where
 ///     Point::new([0.0, 0.0, 1.0]),
 /// ];
 ///
-/// let orientation = kernel.orientation(&points).unwrap();
+/// let orientation = kernel.orientation(&points)?;
 /// assert!(orientation != 0); // Non-degenerate
 ///
 /// let test_point = Point::new([0.25, 0.25, 0.25]);
-/// let result = kernel.in_sphere(&points, &test_point).unwrap();
+/// let result = kernel.in_sphere(&points, &test_point)?;
 /// assert_eq!(result, 1); // Inside circumsphere
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Default, Debug)]
 pub struct RobustKernel<T> {
@@ -590,10 +602,11 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::{AdaptiveKernel, Kernel};
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::{
+///     AdaptiveKernel, Coordinate, CoordinateConversionError, Kernel, Point,
+/// };
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// let kernel = AdaptiveKernel::<f64>::new();
 ///
 /// // Collinear points get a deterministic SoS sign (never 0)
@@ -602,8 +615,10 @@ where
 ///     Point::new([1.0, 0.0]),
 ///     Point::new([2.0, 0.0]),
 /// ];
-/// let orientation = kernel.orientation(&collinear).unwrap();
+/// let orientation = kernel.orientation(&collinear)?;
 /// assert!(orientation == 1 || orientation == -1); // SoS: always non-zero
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone, Default, Debug)]
 pub struct AdaptiveKernel<T> {

--- a/src/geometry/predicates.rs
+++ b/src/geometry/predicates.rs
@@ -452,17 +452,20 @@ impl std::fmt::Display for Orientation {
 /// # Example
 ///
 /// ```
-/// use delaunay::prelude::geometry::Orientation;
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::simplex_orientation;
+/// use delaunay::prelude::geometry::{
+///     Coordinate, CoordinateConversionError, Orientation, Point, simplex_orientation,
+/// };
+///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
 /// let point4 = Point::new([0.0, 0.0, 1.0]);
 /// let simplex_points = vec![point1, point2, point3, point4];
-/// let oriented = simplex_orientation(&simplex_points).unwrap();
+/// let oriented = simplex_orientation(&simplex_points)?;
 /// assert_eq!(oriented, Orientation::NEGATIVE);
+/// # Ok(())
+/// # }
 /// ```
 #[inline]
 pub fn simplex_orientation<T, const D: usize>(
@@ -599,16 +602,20 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::{insphere_distance, InSphere};
+/// use delaunay::prelude::geometry::{
+///     CircumcenterError, Coordinate, InSphere, Point, insphere_distance,
+/// };
+///
+/// # fn main() -> Result<(), CircumcenterError> {
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
 /// let point4 = Point::new([0.0, 0.0, 1.0]);
 /// let simplex_points = vec![point1, point2, point3, point4];
 /// let test_point = Point::new([0.5, 0.5, 0.5]);
-/// assert_eq!(insphere_distance(&simplex_points, test_point).unwrap(), InSphere::INSIDE);
+/// assert_eq!(insphere_distance(&simplex_points, test_point)?, InSphere::INSIDE);
+/// # Ok(())
+/// # }
 /// ```
 pub fn insphere_distance<T, const D: usize>(
     simplex_points: &[Point<T, D>],
@@ -746,10 +753,11 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::insphere;
-/// use delaunay::prelude::geometry::InSphere;
+/// use delaunay::prelude::geometry::{
+///     Coordinate, CoordinateConversionError, InSphere, Point, insphere,
+/// };
+///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
@@ -758,11 +766,13 @@ where
 ///
 /// // Test with a point clearly outside the circumsphere
 /// let outside_point = Point::new([2.0, 2.0, 2.0]);
-/// assert_eq!(insphere(&simplex_points, outside_point).unwrap(), InSphere::OUTSIDE);
+/// assert_eq!(insphere(&simplex_points, outside_point)?, InSphere::OUTSIDE);
 ///
 /// // Test with a point clearly inside the circumsphere
 /// let inside_point = Point::new([0.25, 0.25, 0.25]);
-/// assert_eq!(insphere(&simplex_points, inside_point).unwrap(), InSphere::INSIDE);
+/// assert_eq!(insphere(&simplex_points, inside_point)?, InSphere::INSIDE);
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// See function-level docs above for detailed explanation and references.

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -363,15 +363,18 @@ where
 /// use delaunay::prelude::geometry::Point;
 /// use delaunay::prelude::geometry::Orientation;
 /// use delaunay::prelude::geometry::robust_orientation;
-/// use delaunay::prelude::geometry::Coordinate;
+/// use delaunay::prelude::geometry::{Coordinate, CoordinateConversionError};
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// let tri = vec![
 ///     Point::new([0.0, 0.0]),
 ///     Point::new([1.0, 0.0]),
 ///     Point::new([0.0, 1.0]),
 /// ];
-/// let orientation = robust_orientation(&tri).unwrap();
+/// let orientation = robust_orientation(&tri)?;
 /// assert_eq!(orientation, Orientation::POSITIVE);
+/// # Ok(())
+/// # }
 /// ```
 pub fn robust_orientation<T, const D: usize>(
     simplex_points: &[Point<T, D>],

--- a/src/geometry/util/circumsphere.rs
+++ b/src/geometry/util/circumsphere.rs
@@ -70,16 +70,18 @@ pub use super::CircumcenterError;
 /// # Example
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::circumcenter;
+/// use delaunay::prelude::geometry::{CircumcenterError, Coordinate, Point, circumcenter};
+///
+/// # fn main() -> Result<(), CircumcenterError> {
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
 /// let point4 = Point::new([0.0, 0.0, 1.0]);
 /// let points = vec![point1, point2, point3, point4];
-/// let center = circumcenter(&points).unwrap();
+/// let center = circumcenter(&points)?;
 /// assert_eq!(center, Point::new([0.5, 0.5, 0.5]));
+/// # Ok(())
+/// # }
 /// ```
 pub fn circumcenter<T, const D: usize>(
     points: &[Point<T, D>],
@@ -213,18 +215,20 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::circumradius;
+/// use delaunay::prelude::geometry::{CircumcenterError, Coordinate, Point, circumradius};
 /// use approx::assert_relative_eq;
+///
+/// # fn main() -> Result<(), CircumcenterError> {
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
 /// let point4 = Point::new([0.0, 0.0, 1.0]);
 /// let points = vec![point1, point2, point3, point4];
-/// let radius = circumradius(&points).unwrap();
+/// let radius = circumradius(&points)?;
 /// let expected_radius = (3.0_f64.sqrt() / 2.0);
 /// assert_relative_eq!(radius, expected_radius, epsilon = 1e-9);
+/// # Ok(())
+/// # }
 /// ```
 pub fn circumradius<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where
@@ -258,19 +262,23 @@ where
 /// # Example
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::{circumcenter, circumradius_with_center};
+/// use delaunay::prelude::geometry::{
+///     CircumcenterError, Coordinate, Point, circumcenter, circumradius_with_center,
+/// };
 /// use approx::assert_relative_eq;
+///
+/// # fn main() -> Result<(), CircumcenterError> {
 /// let point1 = Point::new([0.0, 0.0, 0.0]);
 /// let point2 = Point::new([1.0, 0.0, 0.0]);
 /// let point3 = Point::new([0.0, 1.0, 0.0]);
 /// let point4 = Point::new([0.0, 0.0, 1.0]);
 /// let points = vec![point1, point2, point3, point4];
-/// let center = circumcenter(&points).unwrap();
-/// let radius = circumradius_with_center(&points, &center).unwrap();
+/// let center = circumcenter(&points)?;
+/// let radius = circumradius_with_center(&points, &center)?;
 /// let expected_radius = (3.0_f64.sqrt() / 2.0);
 /// assert_relative_eq!(radius, expected_radius, epsilon = 1e-9);
+/// # Ok(())
+/// # }
 /// ```
 pub fn circumradius_with_center<T, const D: usize>(
     points: &[Point<T, D>],

--- a/src/geometry/util/conversions.rs
+++ b/src/geometry/util/conversions.rs
@@ -109,17 +109,20 @@ pub(in crate::geometry::util) fn safe_cast_from_f64<T: CoordinateScalar>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::safe_coords_to_f64;
+/// use delaunay::prelude::geometry::{CoordinateConversionError, safe_coords_to_f64};
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// // Convert f32 coordinates to f64
 /// let coords_f32 = [1.5f32, 2.5f32, 3.5f32];
-/// let coords_f64 = safe_coords_to_f64(&coords_f32).unwrap();
+/// let coords_f64 = safe_coords_to_f64(&coords_f32)?;
 /// assert_eq!(coords_f64, [1.5f64, 2.5f64, 3.5f64]);
 ///
 /// // Works with different array sizes - 4D example
 /// let coords_4d = [1.0f32, 2.0f32, 3.0f32, 4.0f32];
-/// let result_4d = safe_coords_to_f64(&coords_4d).unwrap();
+/// let result_4d = safe_coords_to_f64(&coords_4d)?;
 /// assert_eq!(result_4d, [1.0f64, 2.0f64, 3.0f64, 4.0f64]);
+/// # Ok(())
+/// # }
 /// ```
 pub fn safe_coords_to_f64<T: CoordinateScalar, const D: usize>(
     coords: &[T; D],
@@ -151,17 +154,20 @@ pub fn safe_coords_to_f64<T: CoordinateScalar, const D: usize>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::safe_coords_from_f64;
+/// use delaunay::prelude::geometry::{CoordinateConversionError, safe_coords_from_f64};
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// // Convert f64 coordinates to f32
 /// let coords_f64 = [1.5f64, 2.5f64, 3.5f64];
-/// let coords_f32: [f32; 3] = safe_coords_from_f64(&coords_f64).unwrap();
+/// let coords_f32: [f32; 3] = safe_coords_from_f64(&coords_f64)?;
 /// assert_eq!(coords_f32, [1.5f32, 2.5f32, 3.5f32]);
 ///
 /// // Works with different array sizes - 4D example
 /// let coords_4d = [1.0f64, 2.0f64, 3.0f64, 4.0f64];
-/// let result_4d: [f32; 4] = safe_coords_from_f64(&coords_4d).unwrap();
+/// let result_4d: [f32; 4] = safe_coords_from_f64(&coords_4d)?;
 /// assert_eq!(result_4d, [1.0f32, 2.0f32, 3.0f32, 4.0f32]);
+/// # Ok(())
+/// # }
 /// ```
 pub fn safe_coords_from_f64<T: CoordinateScalar, const D: usize>(
     coords: &[f64; D],
@@ -195,11 +201,14 @@ pub fn safe_coords_from_f64<T: CoordinateScalar, const D: usize>(
 /// # Example
 ///
 /// ```
-/// use delaunay::prelude::geometry::safe_scalar_to_f64;
+/// use delaunay::prelude::geometry::{CoordinateConversionError, safe_scalar_to_f64};
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// let value_f32 = 42.5f32;
-/// let value_f64 = safe_scalar_to_f64(value_f32).unwrap();
+/// let value_f64 = safe_scalar_to_f64(value_f32)?;
 /// assert_eq!(value_f64, 42.5f64);
+/// # Ok(())
+/// # }
 /// ```
 pub fn safe_scalar_to_f64<T: CoordinateScalar>(value: T) -> Result<f64, CoordinateConversionError> {
     safe_cast_to_f64(value, 0)
@@ -224,16 +233,19 @@ pub fn safe_scalar_to_f64<T: CoordinateScalar>(value: T) -> Result<f64, Coordina
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::safe_scalar_from_f64;
+/// use delaunay::prelude::geometry::{CoordinateConversionError, safe_scalar_from_f64};
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// // Convert f64 to f32
 /// let value_f64 = 123.456f64;
-/// let value_f32: f32 = safe_scalar_from_f64(value_f64).unwrap();
+/// let value_f32: f32 = safe_scalar_from_f64(value_f64)?;
 /// assert!((value_f32 - 123.456f32).abs() < 1e-6);
 ///
 /// // Convert f64 to f64 (identity)
-/// let value: f64 = safe_scalar_from_f64(42.0f64).unwrap();
+/// let value: f64 = safe_scalar_from_f64(42.0f64)?;
 /// assert_eq!(value, 42.0f64);
+/// # Ok(())
+/// # }
 /// ```
 pub fn safe_scalar_from_f64<T: CoordinateScalar>(
     value: f64,
@@ -266,11 +278,12 @@ pub fn safe_scalar_from_f64<T: CoordinateScalar>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::safe_usize_to_scalar;
+/// use delaunay::prelude::geometry::{CoordinateConversionError, safe_usize_to_scalar};
 ///
+/// # fn main() -> Result<(), CoordinateConversionError> {
 /// // Normal case - small usize values
 /// let result: Result<f64, _> = safe_usize_to_scalar(42_usize);
-/// assert_eq!(result.unwrap(), 42.0);
+/// assert_eq!(result?, 42.0);
 ///
 /// // Large values that fit within f64 precision
 /// let large_value = (1_u64 << 50) as usize; // 2^50, well within f64 precision
@@ -279,6 +292,8 @@ pub fn safe_scalar_from_f64<T: CoordinateScalar>(
 ///
 /// // Values that would lose precision (if usize is large enough)
 /// // This test may not trigger on all platforms depending on usize size
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Precision Limits

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -72,18 +72,17 @@ fn is_zero_or_roundoff<T: CoordinateScalar>(value: T, scale: T) -> Result<bool, 
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::simplex_volume;
+/// use delaunay::prelude::geometry::{CircumcenterError, Coordinate, Point, simplex_volume};
 /// use approx::assert_relative_eq;
 ///
+/// # fn main() -> Result<(), CircumcenterError> {
 /// // 2D: Triangle area
 /// let triangle = vec![
 ///     Point::new([0.0, 0.0]),
 ///     Point::new([1.0, 0.0]),
 ///     Point::new([0.0, 1.0]),
 /// ];
-/// let area = simplex_volume(&triangle).unwrap();
+/// let area = simplex_volume(&triangle)?;
 /// assert_relative_eq!(area, 0.5, epsilon = 1e-10); // Area = 1*1/2 = 0.5
 ///
 /// // 3D: Tetrahedron volume
@@ -93,8 +92,10 @@ fn is_zero_or_roundoff<T: CoordinateScalar>(value: T, scale: T) -> Result<bool, 
 ///     Point::new([0.0, 1.0, 0.0]),
 ///     Point::new([0.0, 0.0, 1.0]),
 /// ];
-/// let volume = simplex_volume(&tetrahedron).unwrap();
+/// let volume = simplex_volume(&tetrahedron)?;
 /// assert_relative_eq!(volume, 1.0/6.0, epsilon = 1e-10); // Volume = 1/6
+/// # Ok(())
+/// # }
 /// ```
 pub fn simplex_volume<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where
@@ -357,20 +358,21 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::inradius;
+/// use delaunay::prelude::geometry::{CircumcenterError, Coordinate, Point, inradius};
 /// use approx::assert_relative_eq;
 ///
+/// # fn main() -> Result<(), CircumcenterError> {
 /// // 2D: Equilateral triangle with side length 1
 /// let triangle = vec![
 ///     Point::new([0.0, 0.0]),
 ///     Point::new([1.0, 0.0]),
 ///     Point::new([0.5, 0.866025]), // sqrt(3)/2 ≈ 0.866025
 /// ];
-/// let r_in = inradius(&triangle).unwrap();
+/// let r_in = inradius(&triangle)?;
 /// // For equilateral triangle: inradius ≈ 0.2887 (exact: sqrt(3)/6)
 /// assert_relative_eq!(r_in, 0.28867, epsilon = 1e-4);
+/// # Ok(())
+/// # }
 /// ```
 pub fn inradius<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where
@@ -468,17 +470,16 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::geometry::Point;
-/// use delaunay::prelude::geometry::Coordinate;
-/// use delaunay::prelude::geometry::facet_measure;
+/// use delaunay::prelude::geometry::{CircumcenterError, Coordinate, Point, facet_measure};
 /// use approx::assert_relative_eq;
 ///
+/// # fn main() -> Result<(), CircumcenterError> {
 /// // 2D: Line segment length (1D facet in 2D space)
 /// let line_segment = vec![
 ///     Point::new([0.0, 0.0]),
 ///     Point::new([3.0, 4.0]),
 /// ];
-/// let length = facet_measure(&line_segment).unwrap();
+/// let length = facet_measure(&line_segment)?;
 /// assert_relative_eq!(length, 5.0, epsilon = 1e-10); // sqrt(3² + 4²) = 5
 ///
 /// // 3D: Triangle area (2D facet in 3D space)
@@ -487,8 +488,10 @@ where
 ///     Point::new([3.0, 0.0, 0.0]),
 ///     Point::new([0.0, 4.0, 0.0]),
 /// ];
-/// let area = facet_measure(&triangle).unwrap();
+/// let area = facet_measure(&triangle)?;
 /// assert_relative_eq!(area, 6.0, epsilon = 1e-10); // 3*4/2 = 6
+/// # Ok(())
+/// # }
 /// ```
 pub fn facet_measure<T, const D: usize>(points: &[Point<T, D>]) -> Result<T, CircumcenterError>
 where

--- a/src/geometry/util/point_generation.rs
+++ b/src/geometry/util/point_generation.rs
@@ -86,11 +86,16 @@ fn format_bytes(bytes: usize) -> String {
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::scaled_bounds_by_point_count;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, scaled_bounds_by_point_count,
+/// };
 ///
+/// # fn main() -> Result<(), RandomPointGenerationError> {
 /// // 100 points -> side length 100, i.e. [-50, 50]
-/// let bounds = scaled_bounds_by_point_count::<f64>(100).unwrap();
+/// let bounds = scaled_bounds_by_point_count::<f64>(100)?;
 /// assert_eq!(bounds, (-50.0, 50.0));
+/// # Ok(())
+/// # }
 /// ```
 pub fn scaled_bounds_by_point_count<T: CoordinateScalar>(
     n_points: usize,
@@ -134,23 +139,28 @@ pub fn scaled_bounds_by_point_count<T: CoordinateScalar>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::generate_random_points;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, generate_random_points,
+/// };
 ///
+/// # fn main() -> Result<(), RandomPointGenerationError> {
 /// // Generate 100 random 2D points with coordinates in [-10.0, 10.0]
-/// let points_2d = generate_random_points::<f64, 2>(100, (-10.0, 10.0)).unwrap();
+/// let points_2d = generate_random_points::<f64, 2>(100, (-10.0, 10.0))?;
 /// assert_eq!(points_2d.len(), 100);
 ///
 /// // Generate 3D points with coordinates in [0.0, 1.0] (unit cube)
-/// let points_3d = generate_random_points::<f64, 3>(50, (0.0, 1.0)).unwrap();
+/// let points_3d = generate_random_points::<f64, 3>(50, (0.0, 1.0))?;
 /// assert_eq!(points_3d.len(), 50);
 ///
 /// // Generate 4D points centered around origin
-/// let points_4d = generate_random_points::<f32, 4>(25, (-1.0, 1.0)).unwrap();
+/// let points_4d = generate_random_points::<f32, 4>(25, (-1.0, 1.0))?;
 /// assert_eq!(points_4d.len(), 25);
 ///
 /// // Error handling
 /// let result = generate_random_points::<f64, 2>(100, (10.0, -10.0));
 /// assert!(result.is_err()); // Invalid range
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_random_points<T: CoordinateScalar + SampleUniform, const D: usize>(
     n_points: usize,
@@ -206,22 +216,27 @@ pub fn generate_random_points<T: CoordinateScalar + SampleUniform, const D: usiz
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::generate_random_points_seeded;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, generate_random_points_seeded,
+/// };
 ///
+/// # fn main() -> Result<(), RandomPointGenerationError> {
 /// // Generate reproducible random points
-/// let points1 = generate_random_points_seeded::<f64, 3>(100, (-5.0, 5.0), 42).unwrap();
-/// let points2 = generate_random_points_seeded::<f64, 3>(100, (-5.0, 5.0), 42).unwrap();
+/// let points1 = generate_random_points_seeded::<f64, 3>(100, (-5.0, 5.0), 42)?;
+/// let points2 = generate_random_points_seeded::<f64, 3>(100, (-5.0, 5.0), 42)?;
 /// assert_eq!(points1, points2); // Same seed produces identical results
 ///
 /// // Different seeds produce different results
-/// let points3 = generate_random_points_seeded::<f64, 3>(100, (-5.0, 5.0), 123).unwrap();
+/// let points3 = generate_random_points_seeded::<f64, 3>(100, (-5.0, 5.0), 123)?;
 /// assert_ne!(points1, points3);
 ///
 /// // Common ranges - unit cube [0,1]
-/// let unit_points = generate_random_points_seeded::<f64, 3>(50, (0.0, 1.0), 42).unwrap();
+/// let unit_points = generate_random_points_seeded::<f64, 3>(50, (0.0, 1.0), 42)?;
 ///
 /// // Centered around origin [-1,1]
-/// let centered_points = generate_random_points_seeded::<f64, 3>(50, (-1.0, 1.0), 42).unwrap();
+/// let centered_points = generate_random_points_seeded::<f64, 3>(50, (-1.0, 1.0), 42)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_random_points_seeded<T: CoordinateScalar + SampleUniform, const D: usize>(
     n_points: usize,
@@ -279,16 +294,21 @@ pub fn generate_random_points_seeded<T: CoordinateScalar + SampleUniform, const 
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::generate_random_points_periodic;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, generate_random_points_periodic,
+/// };
 ///
+/// # fn main() -> Result<(), RandomPointGenerationError> {
 /// // Generate 100 random 2D points in [0,1) × [0,2)
-/// let points = generate_random_points_periodic::<f64, 2>(100, [1.0, 2.0], 42).unwrap();
+/// let points = generate_random_points_periodic::<f64, 2>(100, [1.0, 2.0], 42)?;
 /// assert_eq!(points.len(), 100);
 ///
 /// // Reproducible generation
-/// let points1 = generate_random_points_periodic::<f64, 3>(50, [1.0, 1.0, 1.0], 123).unwrap();
-/// let points2 = generate_random_points_periodic::<f64, 3>(50, [1.0, 1.0, 1.0], 123).unwrap();
+/// let points1 = generate_random_points_periodic::<f64, 3>(50, [1.0, 1.0, 1.0], 123)?;
+/// let points2 = generate_random_points_periodic::<f64, 3>(50, [1.0, 1.0, 1.0], 123)?;
 /// assert_eq!(points1, points2);
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_random_points_periodic<T: CoordinateScalar + SampleUniform, const D: usize>(
     n_points: usize,
@@ -379,11 +399,16 @@ where
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::generate_random_points_in_ball;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, generate_random_points_in_ball,
+/// };
 ///
+/// # fn main() -> Result<(), RandomPointGenerationError> {
 /// // Generate 100 random 4D points in a radius-10 ball.
-/// let points = generate_random_points_in_ball::<f64, 4>(100, 10.0).unwrap();
+/// let points = generate_random_points_in_ball::<f64, 4>(100, 10.0)?;
 /// assert_eq!(points.len(), 100);
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_random_points_in_ball<T: CoordinateScalar + SampleUniform, const D: usize>(
     n_points: usize,
@@ -410,11 +435,16 @@ pub fn generate_random_points_in_ball<T: CoordinateScalar + SampleUniform, const
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::generate_random_points_in_ball_seeded;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, generate_random_points_in_ball_seeded,
+/// };
 ///
-/// let points1 = generate_random_points_in_ball_seeded::<f64, 4>(10, 1.0, 42).unwrap();
-/// let points2 = generate_random_points_in_ball_seeded::<f64, 4>(10, 1.0, 42).unwrap();
+/// # fn main() -> Result<(), RandomPointGenerationError> {
+/// let points1 = generate_random_points_in_ball_seeded::<f64, 4>(10, 1.0, 42)?;
+/// let points2 = generate_random_points_in_ball_seeded::<f64, 4>(10, 1.0, 42)?;
 /// assert_eq!(points1, points2);
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_random_points_in_ball_seeded<
     T: CoordinateScalar + SampleUniform,
@@ -461,19 +491,24 @@ pub fn generate_random_points_in_ball_seeded<
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::generate_grid_points;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, generate_grid_points,
+/// };
 ///
+/// # fn main() -> Result<(), RandomPointGenerationError> {
 /// // Generate 2D grid: 4x4 = 16 points with unit spacing
-/// let grid_2d = generate_grid_points::<f64, 2>(4, 1.0, [0.0, 0.0]).unwrap();
+/// let grid_2d = generate_grid_points::<f64, 2>(4, 1.0, [0.0, 0.0])?;
 /// assert_eq!(grid_2d.len(), 16);
 ///
 /// // Generate 3D grid: 3x3x3 = 27 points with spacing 2.0
-/// let grid_3d = generate_grid_points::<f64, 3>(3, 2.0, [0.0, 0.0, 0.0]).unwrap();
+/// let grid_3d = generate_grid_points::<f64, 3>(3, 2.0, [0.0, 0.0, 0.0])?;
 /// assert_eq!(grid_3d.len(), 27);
 ///
 /// // Generate 4D grid centered at origin
-/// let grid_4d = generate_grid_points::<f64, 4>(2, 1.0, [-0.5, -0.5, -0.5, -0.5]).unwrap();
+/// let grid_4d = generate_grid_points::<f64, 4>(2, 1.0, [-0.5, -0.5, -0.5, -0.5])?;
 /// assert_eq!(grid_4d.len(), 16); // 2^4 = 16 points
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_grid_points<T: CoordinateScalar, const D: usize>(
     points_per_dim: usize,
@@ -580,14 +615,19 @@ pub fn generate_grid_points<T: CoordinateScalar, const D: usize>(
 /// # Examples
 ///
 /// ```
-/// use delaunay::prelude::generators::generate_poisson_points;
+/// use delaunay::prelude::generators::{
+///     RandomPointGenerationError, generate_poisson_points,
+/// };
 ///
+/// # fn main() -> Result<(), RandomPointGenerationError> {
 /// // Generate ~100 2D points with minimum distance 0.1 in unit square
-/// let poisson_2d = generate_poisson_points::<f64, 2>(100, (0.0, 1.0), 0.1, 42).unwrap();
+/// let poisson_2d = generate_poisson_points::<f64, 2>(100, (0.0, 1.0), 0.1, 42)?;
 /// // Actual count may be less than 100 due to spacing constraints
 ///
 /// // Generate 3D points in a cube
-/// let poisson_3d = generate_poisson_points::<f64, 3>(50, (-1.0, 1.0), 0.2, 123).unwrap();
+/// let poisson_3d = generate_poisson_points::<f64, 3>(50, (-1.0, 1.0), 0.2, 123)?;
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_poisson_points<T: CoordinateScalar + SampleUniform, const D: usize>(
     n_points: usize,

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -219,8 +219,10 @@ where
 /// # Examples
 ///
 /// ```no_run
+/// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::generators::generate_random_triangulation;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// // Generate a 2D triangulation with 50 points, no seed (random each time)
 /// let triangulation_2d = generate_random_triangulation::<f64, (), (), 2>(
 ///     50,
@@ -254,8 +256,10 @@ where
 /// );
 ///
 /// // Access the underlying Tds if needed
-/// let dt = triangulation_3d.unwrap();
+/// let dt = triangulation_3d?;
 /// let vertex_count = dt.tds().number_of_vertices();
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Note on String Data
@@ -331,18 +335,21 @@ where
 /// # Examples
 ///
 /// ```no_run
+/// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::generators::generate_random_triangulation_with_topology_guarantee;
 /// use delaunay::prelude::TopologyGuarantee;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// let dt = generate_random_triangulation_with_topology_guarantee::<f64, (), (), 3>(
 ///     20,
 ///     (-1.0, 1.0),
 ///     None,
 ///     Some(123),
 ///     TopologyGuarantee::Pseudomanifold,
-/// )
-/// .unwrap();
+/// )?;
 /// assert_eq!(dt.dim(), 3);
+/// # Ok(())
+/// # }
 /// ```
 pub fn generate_random_triangulation_with_topology_guarantee<T, U, V, const D: usize>(
     n_points: usize,
@@ -466,23 +473,25 @@ where
 /// # Examples
 ///
 /// ```no_run
+/// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::generators::RandomTriangulationBuilder;
 /// use delaunay::prelude::generators::InsertionOrderStrategy;
 /// use delaunay::prelude::TopologyGuarantee;
 ///
+/// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 /// // Override the default `Hilbert` ordering with `Input` ordering.
 /// let dt = RandomTriangulationBuilder::new(20, (-3.0, 3.0))
 ///     .seed(666)
 ///     .insertion_order(InsertionOrderStrategy::Input)
-///     .build::<(), (), 3>()
-///     .unwrap();
+///     .build::<(), (), 3>()?;
 ///
 /// // Build with PLManifold guarantee
 /// let dt_manifold = RandomTriangulationBuilder::new(100, (-10.0, 10.0))
 ///     .seed(777)
 ///     .topology_guarantee(TopologyGuarantee::PLManifold)
-///     .build::<(), (), 4>()
-///     .unwrap();
+///     .build::<(), (), 4>()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct RandomTriangulationBuilder<T> {
     n_points: usize,
@@ -550,15 +559,18 @@ impl<T> RandomTriangulationBuilder<T> {
     /// # Examples
     ///
     /// ```no_run
+    /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
     /// use delaunay::prelude::generators::RandomTriangulationBuilder;
     /// use delaunay::prelude::generators::InsertionOrderStrategy;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// // Override the default `Hilbert` ordering with `Input` ordering.
     /// let dt = RandomTriangulationBuilder::new(20, (-3.0, 3.0))
     ///     .seed(666)
     ///     .insertion_order(InsertionOrderStrategy::Input)
-    ///     .build::<(), (), 3>()
-    ///     .unwrap();
+    ///     .build::<(), (), 3>()?;
+    /// # Ok(())
+    /// # }
     /// ```
     #[must_use]
     pub const fn insertion_order(mut self, strategy: InsertionOrderStrategy) -> Self {
@@ -599,13 +611,16 @@ where
     /// # Examples
     ///
     /// ```no_run
+    /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
     /// use delaunay::prelude::generators::RandomTriangulationBuilder;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let dt = RandomTriangulationBuilder::new(12, (-2.0, 2.0))
     ///     .seed(7)
-    ///     .build::<(), (), 3>()
-    ///     .unwrap();
+    ///     .build::<(), (), 3>()?;
     /// assert_eq!(dt.dim(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn build<U, V, const D: usize>(
         self,
@@ -633,13 +648,16 @@ where
     /// # Examples
     ///
     /// ```no_run
+    /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
     /// use delaunay::prelude::generators::RandomTriangulationBuilder;
     ///
+    /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
     /// let dt = RandomTriangulationBuilder::new(12, (-2.0, 2.0))
     ///     .seed(7)
-    ///     .build_with_vertex_data::<(), (), 3>(None)
-    ///     .unwrap();
+    ///     .build_with_vertex_data::<(), (), 3>(None)?;
     /// assert_eq!(dt.dim(), 3);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn build_with_vertex_data<U, V, const D: usize>(
         self,


### PR DESCRIPTION
- Replace public doctest unwraps and expects with typed Result examples across core and geometry APIs.
- Use concrete crate errors or small local thiserror enums in guides instead of boxed dynamic errors.
- Clarify toroidal builder wording and point the README at the workflow docs for periodic construction.

Closes #365  