### PR TITLE
test(geometry): isolate strict insphere consistency control (#383)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -10,14 +10,15 @@
 # - bandit: Python security linting for production scripts, excluding tests
 # - markdownlint: Codacy Markdown review, threshold configured in Codacy UI
 # - shellcheck: shell-script linting
-# - duplication: advisory duplicate-code metric
-# - lizard: advisory complexity feedback
 #
 # Recommended disabled tools:
 # - prospector, pylintpython3: redundant with Ruff and ty type checking
 # - trivy: dependency vulnerability scanning is handled by cargo-audit and
 #   Dependabot unless this repository adds containers or IaC
 # - jacksonlinter, spectral: not relevant to the current project surface
+# - lizard and any duplicate-code metric, if exposed by the Codacy UI: useful
+#   for occasional baseline exploration, but too broad and noisy for PR quality
+#   gates on this invariant-heavy Rust crate
 
 engines:
   bandit:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### ⚠️ Breaking Changes
 
 - Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
+- Split strict and best-effort insertion statistics [#405](https://github.com/acgetchell/delaunay/pull/405)
 - Replace public core module with focused facades [#392](https://github.com/acgetchell/delaunay/pull/392)
 - Rename public cell APIs to simplex nomenclature [#393](https://github.com/acgetchell/delaunay/pull/393)
+- Flatten triangulation modules into focused APIs [#399](https://github.com/acgetchell/delaunay/pull/399)
+- Reconcile topology validation policy [#385](https://github.com/acgetchell/delaunay/pull/385) [#404](https://github.com/acgetchell/delaunay/pull/404)
+- Box Delaunay repair flip errors [#407](https://github.com/acgetchell/delaunay/pull/407)
 
 ### Merged Pull Requests
 
+- Use typed errors in public examples [#365](https://github.com/acgetchell/delaunay/pull/365) [#410](https://github.com/acgetchell/delaunay/pull/410)
+- Prefer builder-based fallible examples [#214](https://github.com/acgetchell/delaunay/pull/214) [#409](https://github.com/acgetchell/delaunay/pull/409)
+- Box Delaunay repair flip errors [#407](https://github.com/acgetchell/delaunay/pull/407)
+- Split strict and best-effort insertion statistics [#405](https://github.com/acgetchell/delaunay/pull/405)
+- Reconcile topology validation policy [#385](https://github.com/acgetchell/delaunay/pull/385) [#404](https://github.com/acgetchell/delaunay/pull/404)
+- Localize remove_vertex repair [#401](https://github.com/acgetchell/delaunay/pull/401)
+- Bump idna in the uv group across 1 directory [#400](https://github.com/acgetchell/delaunay/pull/400)
+- Flatten triangulation modules into focused APIs [#399](https://github.com/acgetchell/delaunay/pull/399)
+- Bump codecov/codecov-action from 6.0.0 to 6.0.1 [#398](https://github.com/acgetchell/delaunay/pull/398)
+- Bump sysinfo in the dependencies group across 1 directory [#397](https://github.com/acgetchell/delaunay/pull/397)
+- Bump taiki-e/install-action from 2.77.5 to 2.79.1 [#396](https://github.com/acgetchell/delaunay/pull/396)
+- Surface squash-body commit entries [#395](https://github.com/acgetchell/delaunay/pull/395)
 - Replace Node markdown tooling with rumdl [#394](https://github.com/acgetchell/delaunay/pull/394)
 - Rename public cell APIs to simplex nomenclature [#393](https://github.com/acgetchell/delaunay/pull/393)
 - Replace public core module with focused facades [#392](https://github.com/acgetchell/delaunay/pull/392)
 - Support periodic flip parity for external cells [#391](https://github.com/acgetchell/delaunay/pull/391)
 - Refactor/387 tds mutation boundaries [#390](https://github.com/acgetchell/delaunay/pull/390)
 - Refresh release docs and benchmark guidance [#389](https://github.com/acgetchell/delaunay/pull/389)
+- Isolate strict insphere consistency control [#383](https://github.com/acgetchell/delaunay/pull/383)
 
 ### Added
 
@@ -30,12 +47,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Preserve periodic vertex offsets when bistellar flips build replacement cells.
   - Align external-facet parity checks across periodic cell frames instead of rejecting periodic external cells.
   - Surface replacement periodic-offset shape and frame conflicts with typed flip-context errors.
+- [**breaking**] Split strict and best-effort insertion statistics [#405](https://github.com/acgetchell/delaunay/pull/405)
+  [`71336b5`](https://github.com/acgetchell/delaunay/commit/71336b52ffad7ad6923ea0268928a700e37c43e3)
+
+  - Make insert_with_statistics return typed insertion errors for skipped
+    duplicate or retry-exhausted vertices so callers using ? cannot silently
+    ignore skipped inputs.
+
+  - Add insert_best_effort_with_statistics for diagnostic and bulk-ingestion
+    workflows that intentionally preserve skipped insertions as outcomes with
+    telemetry.
+
+  - Derive the default validation policy from the active topology guarantee so
+    PLManifold starts in ExplicitOnly mode while Pseudomanifold keeps
+    OnSuspicion.
+
+  - Document skipped-input observability across construction, workflows, and
+    robustness guidance.
 
 ### Changed
 
 - Refactor/387 tds mutation boundaries [#390](https://github.com/acgetchell/delaunay/pull/390)
   [`da30293`](https://github.com/acgetchell/delaunay/commit/da3029302e8484d26d2a88d1291050c332e6b822)
-
 - [**breaking**] Replace public core module with focused facades [#392](https://github.com/acgetchell/delaunay/pull/392)
   [`655ff4c`](https://github.com/acgetchell/delaunay/commit/655ff4c944ac918c1a88ab70b26908bd1ebd329f)
 
@@ -45,7 +78,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add focused prelude/docs coverage for the new public import paths.
   - Update downstream-style tests and doctests to stop relying on
     `delaunay::core`.
-
 - [**breaking**] Rename public cell APIs to simplex nomenclature [#393](https://github.com/acgetchell/delaunay/pull/393)
   [`48935d5`](https://github.com/acgetchell/delaunay/commit/48935d5c1ecbeef1b9b833b1de0d1cbcc2e72938)
 
@@ -57,6 +89,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   - Remove redundant integration tests whose coverage is now exercised by unit, property, and public API tests.
   - Move Codacy SARIF filtering into a tested support script and simplify Cargo package metadata.
+- [**breaking**] Flatten triangulation modules into focused APIs [#399](https://github.com/acgetchell/delaunay/pull/399)
+  [`774fd1b`](https://github.com/acgetchell/delaunay/commit/774fd1b92756a070d945061eff203fbc80563dbe)
+
+  - Move Delaunay-facing APIs from the old triangulation facade to crate-root
+    modules and focused preludes such as construction, insertion, flips,
+    repair, validation, and delaunayize.
+
+  - Split generic Triangulation behavior into construction, insertion, query,
+    orientation, repair, and validation modules with colocated tests and errors.
+
+  - Keep the broad prelude for exploratory use while making focused preludes
+    orthogonal and workflow-specific.
+
+  - Refresh docs, examples, benchmarks, and API export tests for the new module
+    layout and 7,500-vertex 3D debug-scale default.
+- [**breaking**] Reconcile topology validation policy [#385](https://github.com/acgetchell/delaunay/pull/385)
+  [#404](https://github.com/acgetchell/delaunay/pull/404) [`e5a74a1`](https://github.com/acgetchell/delaunay/commit/e5a74a10586b162fad56d7f227ab194997f7a87c)
+
+  - Add explicit caller-owned validation mode for PL-manifold topology guarantees.
+  - Reject incoherent topology guarantee and validation policy pairings through typed fallible setters.
+  - Keep compatibility setters non-committal when a requested pairing is invalid.
+  - Derive builder validation policy from the selected topology guarantee and document the compatibility matrix.
+- [**breaking**] Box Delaunay repair flip errors [#407](https://github.com/acgetchell/delaunay/pull/407)
+  [`1789ceb`](https://github.com/acgetchell/delaunay/commit/1789cebd4f56b4dc09e014482d8d90176fdaeffc)
+
+  - Box `DelaunayRepairError::Flip` sources while preserving typed `FlipError`
+    inspection through `From&lt;FlipError&gt;` and `Error::source`.
+
+  - Update repair and construction mappings for the named boxed variant.
+  - Cover clone and source behavior for wrapped linear-algebra errors.
+- Isolate strict insphere consistency control [#383](https://github.com/acgetchell/delaunay/pull/383)
+  [`54a08b7`](https://github.com/acgetchell/delaunay/commit/54a08b7a9e773cfee4747ee8efc5ac59e73e064e)
+
+  - Document the strict insphere consistency environment knob as a process-wide
+    once-per-process snapshot.
+
+  - Add a thread-local test override guard so strict diagnostic paths can be
+    exercised without mutating global environment state.
+
+  - Mark the production review checklist item complete.
 
 ### Documentation
 
@@ -75,26 +147,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   - Update generated benchmark-summary guidance to surface `just bench-perf-summary`,
     current Criterion metadata, and large-scale characterization defaults.
+- Prefer builder-based fallible examples [#214](https://github.com/acgetchell/delaunay/pull/214) [#409](https://github.com/acgetchell/delaunay/pull/409)
+  [`238dc12`](https://github.com/acgetchell/delaunay/commit/238dc124f6fb930cbeee31ea07c16d017f1822bd)
+
+  - Present `DelaunayTriangulationBuilder` as the primary construction path while retaining `DelaunayTriangulation::new` as a legacy convenience constructor.
+  - Replace doctest `unwrap()` patterns with typed `?` propagation and explicit optional guards across construction, validation, repair, geometry, and topology
+    examples.
+
+  - Re-export `DelaunayTriangulationBuilder` from `prelude::delaunayize` so single-prelude delaunayize examples can use the builder directly.
+- Use typed errors in public examples [#365](https://github.com/acgetchell/delaunay/pull/365) [#410](https://github.com/acgetchell/delaunay/pull/410)
+  [`15633e2`](https://github.com/acgetchell/delaunay/commit/15633e2c03d2b2b9af1532676f0ce2c1292a538c)
+
+  - Replace public doctest unwraps and expects with typed Result examples across core and geometry APIs.
+  - Use concrete crate errors or small local thiserror enums in guides instead of boxed dynamic errors.
+  - Clarify toroidal builder wording and point the README at the workflow docs for periodic construction.
 
 ### Fixed
 
-- Surface squash-body commit entries [`27116dd`](https://github.com/acgetchell/delaunay/commit/27116ddc1b292ef2f361491a2454a66f126dcaca)
+- Surface squash-body commit entries [#395](https://github.com/acgetchell/delaunay/pull/395)
+  [`44dc3ed`](https://github.com/acgetchell/delaunay/commit/44dc3ede1012ed4b1f3a560b3c724e2e21d5169e)
 
   - Mirror conventional pseudo-commit headings from squash merge bodies into their matching changelog sections while preserving the primary PR entry.
   - Regenerate active and archived changelogs so historical squash-body fixes, docs, maintenance, and performance notes appear under the right headings.
   - Resolve production-review hygiene by clarifying Cargo feature gates, relabeling TDS UUID-map invariants, and recording UUID panic paths as test-only.
-- Preserve squash-body release notes [`8d36b92`](https://github.com/acgetchell/delaunay/commit/8d36b92b364bdfcf123c99798b252828acb297b6)
-
-  - Mirror isolated conventional squash-body headings from any changelog section while keeping the source commit-body detail intact.
-  - Skip only exact parent/summary duplicates so generated archives retain distinct fix, docs, maintenance, and performance notes.
-  - Canonicalize renamed diagnostics feature wording before mirror/dedupe so pre-rename wording cannot be reintroduced.
-- Deduplicate contextual squash entries [`792bb48`](https://github.com/acgetchell/delaunay/commit/792bb4865e7d449942ff7d42fd00366413f49796)
-
-  - Collapse standalone generated entries only when the same commit, normalized title, and body are already preserved under a contextual squash-body heading.
-  - Canonicalize renamed diagnostics wording before dedupe so pre-rename feature names do not reappear in generated release notes.
-  - Preserve legitimate follow-up headings unless they belong to a contextual duplicate that replaced a standalone entry.
-  - Regenerate active and archived changelogs from the updated postprocessing pipeline.
-  - Align CI and local tooling pins for cargo-llvm-cov, cargo-nextest, and uv.
 
 ### Maintenance
 
@@ -105,6 +180,131 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add dprint/pretty_yaml YAML formatting and wire yaml-check/yaml-fix through dprint plus yamllint.
   - Format generated changelog archives with rumdl after git-cliff postprocessing.
   - Add Semgrep guards for check-before-fix docs and pinned, allowlisted GitHub Actions.
+- Bump codecov/codecov-action from 6.0.0 to 6.0.1 [#398](https://github.com/acgetchell/delaunay/pull/398)
+  [`325aa94`](https://github.com/acgetchell/delaunay/commit/325aa941ba9adaca7973c1f2a3f623c88b9a5d27)
+
+  Bumps [codecov/codecov-action](https://github.com/codecov/codecov-action) from 6.0.0 to 6.0.1.
+
+  - [Release notes](https://github.com/codecov/codecov-action/releases)
+  - [Changelog](https://github.com/codecov/codecov-action/blob/main/CHANGELOG.md)
+  - [Commits](https://github.com/codecov/codecov-action/compare/57e3a136b779b570ffcdbf80b3bdc90e7fab3de2...e79a6962e0d4c0c17b229090214935d2e33f8354)
+
+---
+
+  updated-dependencies:
+
+- dependency-name: codecov/codecov-action
+  dependency-version: 6.0.1
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+  ...
+
+- Bump sysinfo in the dependencies group across 1 directory [#397](https://github.com/acgetchell/delaunay/pull/397)
+  [`8800150`](https://github.com/acgetchell/delaunay/commit/88001505822ed949c5075f9000a7f2e114bcf089)
+
+  Bumps the dependencies group with 1 update in the / directory: [sysinfo](https://github.com/GuillaumeGomez/sysinfo).
+
+  Updates `sysinfo` from 0.39.1 to 0.39.2
+
+  - [Changelog](https://github.com/GuillaumeGomez/sysinfo/blob/main/CHANGELOG.md)
+  - [Commits](https://github.com/GuillaumeGomez/sysinfo/compare/v0.39.1...v0.39.2)
+
+---
+
+  updated-dependencies:
+
+- dependency-name: sysinfo
+  dependency-version: 0.39.2
+  dependency-type: direct:production
+  update-type: version-update:semver-patch
+  dependency-group: dependencies
+  ...
+
+- Bump taiki-e/install-action from 2.77.5 to 2.79.1 [#396](https://github.com/acgetchell/delaunay/pull/396)
+  [`d89961c`](https://github.com/acgetchell/delaunay/commit/d89961cfdc4af5c354c78f4e5fe008f1f273c6e2)
+
+  Bumps [taiki-e/install-action](https://github.com/taiki-e/install-action) from 2.77.5 to 2.79.1.
+
+  - [Release notes](https://github.com/taiki-e/install-action/releases)
+  - [Changelog](https://github.com/taiki-e/install-action/blob/main/CHANGELOG.md)
+  - [Commits](https://github.com/taiki-e/install-action/compare/fa0dd4cd0a40696e6f9766370614a5ce482e6aa8...b550161ef8a7bc4f2a671c0b03a18ac9ccedea1e)
+
+---
+
+  updated-dependencies:
+
+- dependency-name: taiki-e/install-action
+  dependency-version: 2.79.1
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+  ...
+
+- Bump idna in the uv group across 1 directory [#400](https://github.com/acgetchell/delaunay/pull/400)
+  [`dadb724`](https://github.com/acgetchell/delaunay/commit/dadb7248243e2b320095c647d8314fd952c116e0)
+
+  Bumps the uv group with 1 update in the / directory: [idna](https://github.com/kjd/idna).
+
+  Updates `idna` from 3.13 to 3.15
+
+  - [Release notes](https://github.com/kjd/idna/releases)
+  - [Changelog](https://github.com/kjd/idna/blob/master/HISTORY.md)
+  - [Commits](https://github.com/kjd/idna/compare/v3.13...v3.15)
+
+---
+
+  updated-dependencies:
+
+- dependency-name: idna
+  dependency-version: '3.15'
+  dependency-type: indirect
+  dependency-group: uv
+  ...
+
+- Run Windows tests with cargo-nextest [`bc5d48f`](https://github.com/acgetchell/delaunay/commit/bc5d48f61012d49224d783f6c49f88024948959c)
+
+  - Install and verify the pinned cargo-nextest version across the CI build matrix.
+  - Run Windows library and release integration tests through nextest while keeping doctests on cargo test.
+  - Document the Windows nextest alignment in the tooling notes.
+
+### Performance
+
+- Localize remove_vertex repair [#401](https://github.com/acgetchell/delaunay/pull/401)
+  [`382f9e1`](https://github.com/acgetchell/delaunay/commit/382f9e13cff0f4a325361c056ea1d59be18003c5)
+
+  - Avoid global simplex scans and incident-simplex rebuilds on successful
+    vertex removal by using the affected vertex star and scoped repair.
+
+  - Promote and validate orientation over the touched removal scope, with the
+    full global orientation path retained as a fallback.
+
+  - Add a Criterion remove_vertex benchmark covering successful removals and
+    invalid-remnant rollback across 2D through 5D.
+
+#### Performance: Stress remove_vertex cases
+
+- Add adversarial remove_vertex benchmark fixtures for near-boundary,
+  cospherical, near-degenerate, and large-coordinate point sets.
+
+- Include the selected fixture kind in Criterion case names so benchmark
+  output shows which geometry each run exercises.
+
+- Name the vertex-removal orientation normalization budget.
+
+#### Changed: Cover vertex-removal helper invariants
+
+  Add focused regression coverage for vertex-removal helper behavior:
+
+- affected-vertex collection and missing-simplex error preservation
+- local validation-scope deduplication and live-simplex filtering
+- incident-simplex repair, isolated-vertex reporting, and postcondition failure
+- fan-boundary filtering for facets that already contain the apex
+
+#### Fixed: Bound local facet repair removals
+
+- Preserve local repair removal budgets before mutating the TDS.
+- Reuse scoped neighbor repair after vertex-removal facet cleanup.
+- Install and verify cargo-nextest for faster CI test recipes.
+- Build examples once before running their compiled binaries.
 
 ## [0.7.7] - 2026-05-15
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ Before you begin, ensure you have:
    - **Ubuntu/Debian**: `sudo apt-get install findutils coreutils`
    - **Other systems**: Install equivalent packages for `find` and `sort`
 
-**Note**: Many development tasks now use Python utilities (managed by uv) instead of traditional shell tools, reducing the number of required system dependencies.
+**Note**: Many development tasks now use Python utilities (managed by uv)
+instead of traditional shell tools, reducing the number of required system
+dependencies.
 
 ### Quick Start
 

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Downloads](https://img.shields.io/crates/d/delaunay.svg)](https://crates.io/crates/delaunay)
 [![License](https://img.shields.io/crates/l/delaunay.svg)](https://github.com/acgetchell/delaunay/blob/main/LICENSE)
 [![Docs.rs](https://docs.rs/delaunay/badge.svg)](https://docs.rs/delaunay)
-[![CI](https://github.com/acgetchell/delaunay/actions/workflows/ci.yml/badge.svg)](https://github.com/acgetchell/delaunay/actions/workflows/ci.yml)
-[![CodeQL](https://github.com/acgetchell/delaunay/actions/workflows/codeql.yml/badge.svg)](https://github.com/acgetchell/delaunay/actions/workflows/codeql.yml)
-[![rust-clippy analyze](https://github.com/acgetchell/delaunay/actions/workflows/rust-clippy.yml/badge.svg)](https://github.com/acgetchell/delaunay/actions/workflows/rust-clippy.yml)
+[![CI][ci-badge]][ci-workflow]
+[![CodeQL][codeql-badge]][codeql-workflow]
+[![rust-clippy analyze][clippy-badge]][clippy-workflow]
 [![codecov](https://codecov.io/gh/acgetchell/delaunay/graph/badge.svg?token=WT7qZGT9bO)](https://codecov.io/gh/acgetchell/delaunay)
-[![Audit dependencies](https://github.com/acgetchell/delaunay/actions/workflows/audit.yml/badge.svg)](https://github.com/acgetchell/delaunay/actions/workflows/audit.yml)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/3cad94f994f5434d877ae77f0daee692)](https://app.codacy.com/gh/acgetchell/delaunay/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Audit dependencies][audit-badge]][audit-workflow]
+[![Codacy Badge][codacy-badge]][codacy-dashboard]
 
 [Rust] crate providing D-dimensional [Delaunay triangulations] and
 [convex hulls][Convex hulls] (2D through 5D explicitly tested) constructed with
@@ -532,6 +532,16 @@ Portions of this library were developed with the assistance of these AI tools:
 > All code was written and/or reviewed and validated by the author.
 
 [Rust]: https://rust-lang.org
+[audit-badge]: https://github.com/acgetchell/delaunay/actions/workflows/audit.yml/badge.svg
+[audit-workflow]: https://github.com/acgetchell/delaunay/actions/workflows/audit.yml
+[ci-badge]: https://github.com/acgetchell/delaunay/actions/workflows/ci.yml/badge.svg
+[ci-workflow]: https://github.com/acgetchell/delaunay/actions/workflows/ci.yml
+[clippy-badge]: https://github.com/acgetchell/delaunay/actions/workflows/rust-clippy.yml/badge.svg
+[clippy-workflow]: https://github.com/acgetchell/delaunay/actions/workflows/rust-clippy.yml
+[codacy-badge]: https://app.codacy.com/project/badge/Grade/3cad94f994f5434d877ae77f0daee692
+[codacy-dashboard]: https://app.codacy.com/gh/acgetchell/delaunay/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade
+[codeql-badge]: https://github.com/acgetchell/delaunay/actions/workflows/codeql.yml/badge.svg
+[codeql-workflow]: https://github.com/acgetchell/delaunay/actions/workflows/codeql.yml
 [CGAL]: https://www.cgal.org/
 [C++]: https://isocpp.org
 [Spade]: https://crates.io/crates/spade

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -1,6 +1,8 @@
 # Code Organization Guide
 
-This document provides a comprehensive guide to the delaunay project's code organization, from the overall project architecture to detailed individual module patterns.
+This document provides a comprehensive guide to the delaunay project's code
+organization, from the overall project architecture to detailed individual
+module patterns.
 
 ## Table of Contents
 

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -103,7 +103,7 @@ This matters for large-scale investigations that need to run under
 
 | Variable | Activation | Module | Description |
 |---|---|---|---|
-| `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` | presence | `geometry/robust_predicates.rs` | Cross-validates exact insphere results |
+| `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` | presence | `geometry/robust_predicates.rs` | Process-wide, once-per-process snapshot that cross-validates exact insphere results |
 | `DELAUNAY_DEBUG_LU_FALLBACK` | presence | `circumsphere.rs` | Logs when circumsphere computation falls back to LU decomposition |
 
 ## Point Generation

--- a/docs/dev/debug_env_vars.md
+++ b/docs/dev/debug_env_vars.md
@@ -103,7 +103,7 @@ This matters for large-scale investigations that need to run under
 
 | Variable | Activation | Module | Description |
 |---|---|---|---|
-| `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` | presence | `geometry/robust_predicates.rs` | Process-wide, once-per-process snapshot that cross-validates exact insphere results |
+| `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` | presence | `geometry/robust_predicates.rs` | Process-wide snapshot; cross-validates exact insphere results |
 | `DELAUNAY_DEBUG_LU_FALLBACK` | presence | `circumsphere.rs` | Logs when circumsphere computation falls back to LU decomposition |
 
 ## Point Generation

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -95,6 +95,11 @@ The useful updates ported in this pass are:
   Scanning. Codacy's default maintainability patterns can still run in Codacy,
   but they must not create broad Code Scanning alerts for test-only paths such
   as `scripts/tests/**`.
+- Codacy Code Patterns should stay aligned with local validators rather than
+  acting as an independent style regime. Keep repository-owned Rust feedback on
+  Opengrep/Semgrep rules; keep broad advisory engines such as Lizard disabled
+  for PR gating unless a specific baseline audit requests them. If the Codacy
+  UI exposes a separate duplicate-code metric, treat it the same way.
 - CI and local setup pins should track the same supported tool versions when
   practical. The current workflow pins align coverage and test tooling on
   `cargo-llvm-cov` 0.8.7 and `cargo-nextest` 0.9.136. Both CI and Codecov

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -38,6 +38,11 @@ Both repositories now share the same core Rust and Python support-tooling loop:
 The useful updates ported in this pass are:
 
 - `just check-fast` for a cheap compile-only check.
+- `just markdown-check` keeps `rumdl` as the Markdown linter and adds a raw
+  active-doc line-length guard so table rows and other Markdown constructs that
+  `rumdl` exempts from MD013 still respect the repository's 160-column limit.
+  The guard excludes generated changelog files and archived historical docs,
+  which remain governed by their regeneration/archive workflows.
 - `just changelog-unreleased <version>`, implemented with
   `GIT_CLIFF_OFFLINE=true git-cliff --tag`, so release PR changelogs no longer
   need temporary local release tags.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -72,7 +72,9 @@ Key combinatorial objects:
 
 - **Vertices**: 0-simplices. In the implementation, a vertex has coordinates plus an internal key
   and a UUID (used for stable referencing, e.g. serialization to files).
-- **Simplices**: maximal `D`-simplices. Each simplex stores an ordered list of `D+1` vertex keys, and also has an internal key and an externally accessible UUID.
+- **Simplices**: maximal `D`-simplices. Each simplex stores an ordered list of
+  `D+1` vertex keys, and also has an internal key and an externally accessible
+  UUID.
 - **Facets**: codimension-1 faces of a simplex. A `D`-simplex has `D+1` facets, each missing exactly one
   vertex.
 - **Adjacency / neighbors**: two simplices are neighbors if they share a facet. The triangulation data
@@ -328,7 +330,8 @@ At a high level:
 
 The crate’s incremental construction follows the standard cavity-based approach (CGAL-style; see
 [CGAL Triangulation_3](https://doc.cgal.org/latest/Triangulation_3/index.html) and
-[`src/core/algorithms/incremental_insertion.rs`](../src/core/algorithms/incremental_insertion.rs)):[^bowyer1981][^watson1981][^cgal-triangulation3][^impl-incremental-insertion]
+[`src/core/algorithms/incremental_insertion.rs`](../src/core/algorithms/incremental_insertion.rs)):
+[^bowyer1981][^watson1981][^cgal-triangulation3][^impl-incremental-insertion]
 
 1. **Locate** the simplex containing the query point (facet walking / scan fallback;
    [`src/core/algorithms/locate.rs`](../src/core/algorithms/locate.rs)).[^devillers-walking][^impl-locate]

--- a/docs/production_review_remediation_checklist.md
+++ b/docs/production_review_remediation_checklist.md
@@ -51,9 +51,10 @@ Treat partial items as still open until their acceptance notes are satisfied.
 - [ ] **12. Confirm clone semantics for linear-algebra error variants.**
   Verify `LaError: Clone` and keep parent error enums honestly cloneable.
   Tracked for v0.7.8 in #384.
-- [ ] **13. Make strict insphere consistency test control isolated.**
-  Rename the once-init env flag for process-wide semantics or use an atomic
-  test hook. Tracked for v0.7.8 in #383.
+- [x] **13. Make strict insphere consistency test control isolated.**
+  The once-init strict-insphere env snapshot is now named and documented as
+  process-wide, while unit tests use a thread-local override guard instead of
+  mutating process environment state. Tracked for v0.7.8 in #383.
 - [x] **14. Consolidate focused preludes.**
   Delaunay-facing workflow preludes now live directly under
   `delaunay::prelude::{construction,insertion,flips,repair,delaunayize,diagnostics,validation}`,

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -431,7 +431,9 @@ Validates the geometric optimality of the triangulation.
 
 ### What It Checks
 
-- **Delaunay property**: Verified via local flip predicates (k=2/k=3 and inverses), equivalent to the empty-circumsphere condition for properly constructed triangulations
+- **Delaunay property**: Verified via local flip predicates (k=2/k=3 and
+  inverses), equivalent to the empty-circumsphere condition for properly
+  constructed triangulations
 - Uses geometric predicates from the kernel (`insphere` test)
 - **Independent of Levels 1-3**: Checks geometric property, not structural/topological
 - **Flip-based repair**: Insertions run k=2/k=3 flip repairs with inverse edge/triangle queues in

--- a/justfile
+++ b/justfile
@@ -344,6 +344,24 @@ markdown-check: _ensure-rumdl
     done < <(git ls-files -z '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n100 rumdl check
+        violations=0
+        for file in "${files[@]}"; do
+            case "$file" in
+                CHANGELOG.md|docs/archive/*) continue ;;
+            esac
+            line_number=0
+            while IFS= read -r line || [[ -n "$line" ]]; do
+                line_number=$((line_number + 1))
+                if [ "${#line}" -gt 160 ]; then
+                    printf '%s:%d: line length %d exceeds 160\n' "$file" "$line_number" "${#line}" >&2
+                    violations=$((violations + 1))
+                fi
+            done < "$file"
+        done
+        if [ "$violations" -gt 0 ]; then
+            echo "Markdown raw line-length check failed." >&2
+            exit 1
+        fi
     else
         echo "No markdown files found to check."
     fi

--- a/src/geometry/kernel.rs
+++ b/src/geometry/kernel.rs
@@ -474,8 +474,8 @@ where
 ///   instead of forcing a decision, useful when your application needs to
 ///   detect and handle cospherical or coplanar configurations directly
 /// - **Opt-in diagnostic consistency checks** — cross-validates insphere results
-///   against a distance-based check when `DELAUNAY_STRICT_INSPHERE_CONSISTENCY`
-///   is set
+///   against a distance-based check when the process-wide
+///   `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` snapshot is set
 ///
 /// For standard Delaunay triangulation, [`AdaptiveKernel`] is the better
 /// default: zero configuration, provable error bounds, and `SoS`

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -1303,7 +1303,9 @@ mod tests {
 
         if let Some((simplex, test_point, det, dist)) = witness {
             panic!(
-                "Found periodic-3D determinant-vs-distance inconsistency: determinant={det:?}, distance={dist:?}, simplex={simplex:?}, test_point={test_point:?}"
+                "Found periodic-3D determinant-vs-distance inconsistency: \
+                 determinant={det:?}, distance={dist:?}, simplex={simplex:?}, \
+                 test_point={test_point:?}"
             );
         }
     }

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -20,10 +20,59 @@ use crate::geometry::traits::coordinate::{
     Coordinate, CoordinateConversionError, CoordinateScalar,
 };
 use core::{cmp::Ordering, hint::cold_path};
+#[cfg(test)]
+use std::cell::Cell;
 use std::sync::LazyLock;
 
-static STRICT_INSPHERE_CONSISTENCY: LazyLock<bool> =
+static PROCESS_WIDE_STRICT_INSPHERE_CONSISTENCY: LazyLock<bool> =
     LazyLock::new(|| std::env::var_os("DELAUNAY_STRICT_INSPHERE_CONSISTENCY").is_some());
+
+#[cfg(test)]
+thread_local! {
+    static STRICT_INSPHERE_CONSISTENCY_TEST_OVERRIDE: Cell<Option<bool>> =
+        const { Cell::new(None) };
+}
+
+#[cfg(test)]
+struct StrictInsphereConsistencyOverrideGuard {
+    previous: Option<bool>,
+}
+
+#[cfg(test)]
+impl Drop for StrictInsphereConsistencyOverrideGuard {
+    fn drop(&mut self) {
+        STRICT_INSPHERE_CONSISTENCY_TEST_OVERRIDE.with(|override_value| {
+            override_value.set(self.previous);
+        });
+    }
+}
+
+/// Returns whether strict insphere consistency diagnostics are active.
+///
+/// Production code reads `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` once per
+/// process. Unit tests can override the value for the current test thread so
+/// branch coverage does not depend on process-wide environment mutation.
+fn strict_insphere_consistency_enabled() -> bool {
+    #[cfg(test)]
+    if let Some(enabled) = STRICT_INSPHERE_CONSISTENCY_TEST_OVERRIDE.with(Cell::get) {
+        return enabled;
+    }
+
+    *PROCESS_WIDE_STRICT_INSPHERE_CONSISTENCY
+}
+
+/// Overrides strict insphere consistency diagnostics for the current test thread.
+#[cfg(test)]
+fn set_strict_insphere_consistency_for_current_test(
+    enabled: bool,
+) -> StrictInsphereConsistencyOverrideGuard {
+    let previous = STRICT_INSPHERE_CONSISTENCY_TEST_OVERRIDE.with(|override_value| {
+        let previous = override_value.get();
+        override_value.set(Some(enabled));
+        previous
+    });
+    StrictInsphereConsistencyOverrideGuard { previous }
+}
 
 /// Result of consistency verification between different insphere methods.
 ///
@@ -91,9 +140,10 @@ pub enum InsphereConsistencyError {
 ///
 /// 1. Exact-sign determinant evaluation using relative coordinates for the
 ///    supported exact-insphere dimensions.
-/// 2. If `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` is set, a diagnostic consistency
-///    check against a distance-based insphere. This does not override the exact
-///    result; it only hard-fails for deterministic witness capture.
+/// 2. If the process-wide `DELAUNAY_STRICT_INSPHERE_CONSISTENCY` snapshot is
+///    set, a diagnostic consistency check against a distance-based insphere.
+///    This does not override the exact result; it only hard-fails for
+///    deterministic witness capture.
 /// 3. A [`Simulation of Simplicity`](crate::geometry::sos) fallback. This is
 ///    only reached when the exact-sign computation itself is unsupported, such
 ///    as D ≥ 6 where the insphere matrix exceeds the stack-matrix limit.
@@ -183,7 +233,7 @@ where
     // Strategy 1: Exact-sign determinant approach with adaptive tolerance.
     match relative_exact_insphere(simplex_points, test_point) {
         Ok(result) => {
-            if *STRICT_INSPHERE_CONSISTENCY {
+            if strict_insphere_consistency_enabled() {
                 // Strategy 2: Diagnostic consistency check against distance-based insphere.
                 // The exact-sign result is provably correct for finite inputs; a disagreement
                 // from insphere_distance reflects f64 rounding in the distance-based check,
@@ -294,7 +344,7 @@ where
         Ordering::Equal => InSphere::BOUNDARY,
     };
 
-    if *STRICT_INSPHERE_CONSISTENCY
+    if strict_insphere_consistency_enabled()
         && let ConsistencyResult::Inconsistent(error) =
             verify_insphere_consistency(simplex_points, test_point, result)
     {
@@ -489,6 +539,7 @@ mod tests {
     use crate::geometry::util::squared_norm;
     use num_traits::NumCast;
     use rand::{RngExt, SeedableRng};
+    use std::thread;
 
     fn matrix_block_is_finite<const N: usize>(matrix: &Matrix<N>, k: usize) -> bool {
         (0..k).all(|row| (0..k).all(|column| matrix_get(matrix, row, column).unwrap().is_finite()))
@@ -657,6 +708,55 @@ mod tests {
                 determinant_result: InSphere::OUTSIDE,
                 distance_result: InSphere::INSIDE,
             })
+        );
+    }
+
+    #[test]
+    fn test_strict_insphere_consistency_override_is_thread_local() {
+        let process_wide_setting = *PROCESS_WIDE_STRICT_INSPHERE_CONSISTENCY;
+        assert_eq!(strict_insphere_consistency_enabled(), process_wide_setting);
+
+        {
+            let _guard = set_strict_insphere_consistency_for_current_test(!process_wide_setting);
+            assert_eq!(strict_insphere_consistency_enabled(), !process_wide_setting);
+
+            {
+                let _nested_guard =
+                    set_strict_insphere_consistency_for_current_test(process_wide_setting);
+                assert_eq!(strict_insphere_consistency_enabled(), process_wide_setting);
+            }
+            assert_eq!(strict_insphere_consistency_enabled(), !process_wide_setting);
+
+            let child_setting = thread::spawn(strict_insphere_consistency_enabled)
+                .join()
+                .expect("strict insphere consistency check thread should not panic");
+            assert_eq!(child_setting, process_wide_setting);
+        }
+
+        assert_eq!(strict_insphere_consistency_enabled(), process_wide_setting);
+    }
+
+    #[test]
+    fn test_strict_insphere_consistency_override_exercises_error_path() {
+        let _guard = set_strict_insphere_consistency_for_current_test(true);
+        let simplex = vec![
+            Point::new([0.0, 0.0, 0.0]),
+            Point::new([1.0, 0.0, 0.0]),
+            Point::new([0.0, 1.0, 0.0]),
+            Point::new([0.0, 0.0, 1.0]),
+        ];
+        let test_point = Point::new([0.25, 0.25, 0.25]);
+
+        assert_eq!(
+            robust_insphere(&simplex, &test_point).unwrap(),
+            InSphere::INSIDE
+        );
+        assert!(
+            matches!(
+                robust_insphere_positive_oriented(&simplex, &test_point),
+                Err(CoordinateConversionError::InsphereInconsistency { .. })
+            ),
+            "strict consistency override should exercise the positive-oriented diagnostic error path"
         );
     }
 


### PR DESCRIPTION
- Document the strict insphere consistency environment knob as a process-wide once-per-process snapshot.
- Add a thread-local test override guard so strict diagnostic paths can be exercised without mutating global environment state.
- Mark the production review checklist item complete.

Closes #383