### PR TITLE
fix(periodic): validate compact 3D toroidal quotients

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ complete technical background.
   available as an explicit opt-out
 - [x]  Toroidal (periodic) triangulations via [`DelaunayTriangulationBuilder`]:
   `.toroidal(...)` canonicalizes points into the fundamental domain, while
-  `.toroidal_periodic(...)` builds a true periodic image-point quotient
+  `.toroidal_periodic(...)` builds a validated periodic image-point quotient
+  in 2D and compact 3D
 - [x]  Geometry quality metrics for simplices: radius ratio and normalized
   volume (dimension-agnostic)
 - [x]  Serialization/deserialization of all data structures to/from [JSON]
@@ -258,8 +259,9 @@ fn main() -> Result<(), DelaunayTriangulationConstructionError> {
 ```
 
 For boundary-facet identification and periodic neighbor pointers, use
-`.toroidal_periodic([..])`; see the [toroidal construction workflow] for the
-full recipe.
+`.toroidal_periodic([..])` in 2D or compact 3D; see the
+[toroidal construction workflow] for the full recipe and current 4D/5D
+guardrails.
 
 ### Need more control?
 
@@ -359,7 +361,8 @@ For reproducible checks in CI/local runs, use `just check`, `just test`,
   `(D+2)×(D+2)` determinant exceeds the stack matrix limit.
 - **Periodic domains:** `.toroidal()` canonicalizes coordinates into the
   fundamental domain. `.toroidal_periodic()` uses the periodic image-point
-  method and is strongest in 2D, with compact 3D coverage active.
+  method and is release-validated in 2D and compact 3D. 4D/5D periodic
+  quotients fail fast pending scalable construction work in issue #416.
 - **Large 4D+ batches:** thousands of 4D points can be expensive to
   investigate. Use release mode and the large-scale debug harness for
   characterization.

--- a/docs/ORIENTATION_SPEC.md
+++ b/docs/ORIENTATION_SPEC.md
@@ -201,7 +201,8 @@ drive repair, but replacement-simplex orientation itself uses `robust_orientatio
   structure/topology, rejects geometrically degenerate simplices, and then enforces
   the Delaunay property.
 - `.toroidal_periodic([..])` builds an image-point triangulation and then runs
-  orientation normalization plus lifted geometric orientation validation before
+  orientation normalization, lifted geometric orientation validation, final
+  Levels 1-3 topology validation, and final Level 4 Delaunay validation before
   returning the quotient triangulation.
 
 ## Degenerate Simplices

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -144,7 +144,9 @@ fn main() -> Result<(), ExampleError> {
 **When to use the Builder:**
 
 - **Toroidal/periodic triangulations**: Use `.toroidal()` (Phase 1 canonicalized) or
-  `.toroidal_periodic()` (Phase 2 periodic image-point) with explicit domain periods
+  `.toroidal_periodic()` (Phase 2 periodic image-point) with explicit domain periods.
+  The periodic image-point path is release-validated in 2D and compact 3D; 4D/5D
+  fail fast pending scalable quotient construction in issue #416.
 - **Custom topology guarantees**: Set stricter or more relaxed manifold checks
 - **Custom validation policies**: Configure `ValidationPolicy` via
   `dt.try_set_validation_policy(...)` before or after build when callers need

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -298,8 +298,9 @@ Toroidal workflows are integrated as first-class topology options:
 - `.toroidal()` canonicalizes coordinates into the fundamental domain and uses toroidal topology
   metadata for validation.
 - `.toroidal_periodic(...)` constructs a periodic image-point triangulation over neighboring
-  fundamental domains. This gives the strongest current toroidal behavior, with 2D as the primary
-  supported path and compact 3D coverage active in the test suite.
+  fundamental domains. The 2D and compact 3D paths are validated periodic quotients; 4D/5D
+  periodic construction fails fast until quotient selection scales to routine release validation
+  under issue #416.
 
 Spherical and hyperbolic topology models are present as metadata and validation scaffolding, but
 they do not yet provide full non-Euclidean geometric construction semantics. Treat them as

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -71,14 +71,10 @@ Toroidal support has two modes:
   not identify opposite boundary facets. The 2D and 3D canonical toroidal
   construction paths are part of routine release coverage.
 - `.toroidal_periodic([..])` uses the 3^D image-point method to construct a
-  true periodic quotient with rewired neighbor pointers. This path is strongest
-  in 2D, where periodic triangulation and validation remain in routine release
-  coverage. Compact 3D periodic construction and lifted-predicate smoke coverage
-  are active. Full 3D periodic PL-manifold validation is tested as a known
-  limitation: construction succeeds, but the quotient can still report an
-  unclosed boundary ridge instead of a closed 3-torus. 4D/5D periodic validation
-  is outside routine test coverage because image expansion grows quickly with
-  dimension and high-dimensional quotient selection is not yet robust enough for
+  true periodic quotient with rewired neighbor pointers. This path is release
+  covered in 2D and compact 3D, where periodic triangulations validate as
+  closed tori through Levels 1-4. 4D/5D periodic construction fails fast until
+  issue #416 makes quotient selection scalable and diagnosable enough for
   release validation.
 
 Spherical and hyperbolic topologies are public metadata and behavior-model

--- a/docs/topology.md
+++ b/docs/topology.md
@@ -199,8 +199,10 @@ let dt = DelaunayTriangulationBuilder::new(&vertices)
 
 Toroidal triangulations handle point canonicalization (wrapping coordinates to the
 fundamental domain) and distance computations across periodic boundaries. The
-implementation supports both 2D and 3D toroidal spaces. For true periodic
-image-point construction, use `.toroidal_periodic([..])`.
+implementation supports canonicalized 2D and 3D toroidal spaces. For true
+periodic image-point construction, use `.toroidal_periodic([..])`; the validated
+periodic quotient path currently covers 2D and compact 3D fixtures. 4D/5D
+periodic quotients fail fast pending scalable construction work in issue #416.
 
 For more examples, see the toroidal section in the main `README.md`.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -297,7 +297,8 @@ fn main() -> Result<(), PeriodicExampleError> {
   metric)
 - **Construction modes**:
   - `.toroidal([..])`: canonicalized construction (wrap into fundamental domain)
-  - `.toroidal_periodic([..])`: periodic image-point construction (true toroidal quotient)
+  - `.toroidal_periodic([..])`: periodic image-point construction; currently validated as a true
+    toroidal quotient in 2D and compact 3D; 4D/5D fail fast pending issue #416
 
 For more details, see `docs/topology.md` and the toroidal section in the main `README.md`.
 

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -530,6 +530,19 @@ pub enum InitialSimplexConstructionError {
         attempted: usize,
     },
 
+    /// Periodic quotient construction is not release-validated for this dimension.
+    #[error(
+        "periodic image-point construction is release-validated only up to {max_validated_dimension}D; {dimension}D scalable quotient construction is tracked by issue #{tracking_issue}"
+    )]
+    UnsupportedPeriodicDimension {
+        /// Requested triangulation dimension.
+        dimension: usize,
+        /// Highest dimension with release-validated periodic quotient construction.
+        max_validated_dimension: usize,
+        /// Tracking issue for extending periodic quotient support.
+        tracking_issue: u32,
+    },
+
     /// An insertion-stage-only construction error escaped initial-simplex construction.
     #[error(
         "unexpected insertion-stage construction error while building initial simplex: {message}"
@@ -571,6 +584,15 @@ impl From<TriangulationConstructionError> for InitialSimplexConstructionError {
             TriangulationConstructionError::GeometricDegeneracy { message } => {
                 Self::GeometricDegeneracy { message }
             }
+            TriangulationConstructionError::UnsupportedPeriodicDimension {
+                dimension,
+                max_validated_dimension,
+                tracking_issue,
+            } => Self::UnsupportedPeriodicDimension {
+                dimension,
+                max_validated_dimension,
+                tracking_issue,
+            },
             TriangulationConstructionError::InternalInconsistency { message } => {
                 Self::InternalInconsistency { message }
             }
@@ -1646,6 +1668,7 @@ impl InsertionError {
                 | InitialSimplexConstructionError::InternalInconsistency { .. }
                 | InitialSimplexConstructionError::DuplicateCoordinates { .. }
                 | InitialSimplexConstructionError::LocalRepairBudgetExceeded { .. }
+                | InitialSimplexConstructionError::UnsupportedPeriodicDimension { .. }
                 | InitialSimplexConstructionError::UnexpectedInsertionStage { .. } => false,
             },
             CavityFillingError::NeighborRebuild { reason } => match reason {
@@ -5187,6 +5210,26 @@ mod tests {
             InitialSimplexConstructionError::LocalRepairBudgetExceeded {
                 max_simplices_removed: 2,
                 attempted: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_initial_simplex_construction_error_preserves_unsupported_periodic_dimension() {
+        let source = TriangulationConstructionError::UnsupportedPeriodicDimension {
+            dimension: 4,
+            max_validated_dimension: 3,
+            tracking_issue: 416,
+        };
+
+        let converted = InitialSimplexConstructionError::from(source);
+
+        assert_eq!(
+            converted,
+            InitialSimplexConstructionError::UnsupportedPeriodicDimension {
+                dimension: 4,
+                max_validated_dimension: 3,
+                tracking_issue: 416,
             }
         );
     }

--- a/src/core/construction.rs
+++ b/src/core/construction.rs
@@ -79,6 +79,19 @@ pub enum TriangulationConstructionError {
         message: String,
     },
 
+    /// Periodic quotient construction is not release-validated for this dimension.
+    #[error(
+        "Periodic image-point construction is release-validated only up to {max_validated_dimension}D; {dimension}D scalable quotient construction is tracked by issue #{tracking_issue}"
+    )]
+    UnsupportedPeriodicDimension {
+        /// Requested triangulation dimension.
+        dimension: usize,
+        /// Highest dimension with release-validated periodic quotient construction.
+        max_validated_dimension: usize,
+        /// Tracking issue for extending periodic quotient support.
+        tracking_issue: u32,
+    },
+
     /// Conflict-region extraction failed during incremental construction.
     #[error("Conflict region failed during insertion: {source}")]
     InsertionConflictRegion {

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -6183,6 +6183,16 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
                             ),
                         })?;
 
+                // Periodic-lifted adjacencies do not have a unique bare canonical
+                // mirror facet at this structural layer because the embedding depends
+                // on lattice representative choice. Neighbor/facet-incidence validation
+                // checks lifted facet identity and reciprocal wiring.
+                if simplex.periodic_vertex_offsets().is_some()
+                    || neighbor_simplex.periodic_vertex_offsets().is_some()
+                {
+                    continue;
+                }
+
                 let mirror_idx = simplex
                     .mirror_facet_index(facet_idx, neighbor_simplex)
                     .ok_or_else(|| TdsError::InvalidNeighbors {
@@ -6221,16 +6231,6 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
                             context: "orientation validation".to_string(),
                         },
                     });
-                }
-
-                // Periodic-lifted adjacencies do not have a unique canonical orientation at this
-                // structural layer because the embedding depends on lattice representative choice.
-                // Skip combinatorial orientation checks for these pairs after validating reciprocal
-                // neighbor wiring above.
-                if simplex.periodic_vertex_offsets().is_some()
-                    || neighbor_simplex.periodic_vertex_offsets().is_some()
-                {
-                    continue;
                 }
 
                 let simplex1_facet_vertices =
@@ -7040,6 +7040,12 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
                         },
                     });
                 };
+
+                if simplex.periodic_vertex_offsets().is_some()
+                    || neighbor_simplex.periodic_vertex_offsets().is_some()
+                {
+                    continue;
+                }
 
                 let neighbor_vertices = simplex_vertices.get(&neighbor_key).ok_or_else(|| {
                     TdsError::InconsistentDataStructure {

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -1971,6 +1971,44 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
         Ok(None)
     }
 
+    /// Finds the neighbor facet that matches a source facet in lifted periodic coordinates.
+    fn matching_lifted_mirror_facet_index(
+        simplex: &Simplex<T, U, V, D>,
+        facet_idx: usize,
+        neighbor: &Simplex<T, U, V, D>,
+        context: &str,
+    ) -> Result<usize, TdsError> {
+        let simplex_facet_key =
+            Self::periodic_facet_key_from_simplex_vertices(simplex, simplex.vertices(), facet_idx)?;
+        let mut mirror_idx = None;
+        for neighbor_facet_idx in 0..neighbor.vertices().len() {
+            let neighbor_facet_key = Self::periodic_facet_key_from_simplex_vertices(
+                neighbor,
+                neighbor.vertices(),
+                neighbor_facet_idx,
+            )?;
+            if neighbor_facet_key == simplex_facet_key
+                && mirror_idx.replace(neighbor_facet_idx).is_some()
+            {
+                return Err(TdsError::InvalidNeighbors {
+                    reason: NeighborValidationError::MirrorFacetAmbiguous {
+                        simplex_uuid: simplex.uuid(),
+                        neighbor_uuid: neighbor.uuid(),
+                    },
+                });
+            }
+        }
+
+        mirror_idx.ok_or_else(|| TdsError::InvalidNeighbors {
+            reason: NeighborValidationError::MirrorFacetMissing {
+                simplex_uuid: simplex.uuid(),
+                facet_index: facet_idx,
+                neighbor_uuid: neighbor.uuid(),
+                context: context.to_string(),
+            },
+        })
+    }
+
     pub(crate) fn facet_key_for_simplex_facet(
         &self,
         simplex_key: SimplexKey,
@@ -5507,22 +5545,12 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
                             ),
                         })?;
 
-                if simplex.periodic_vertex_offsets().is_some()
-                    || neighbor_simplex.periodic_vertex_offsets().is_some()
-                {
-                    continue;
-                }
-
-                let mirror_idx = simplex
-                    .mirror_facet_index(facet_idx, neighbor_simplex)
-                    .ok_or_else(|| TdsError::InvalidNeighbors {
-                        reason: NeighborValidationError::MirrorFacetMissing {
-                            simplex_uuid: simplex.uuid(),
-                            facet_index: facet_idx,
-                            neighbor_uuid: neighbor_simplex.uuid(),
-                            context: "local orientation validation".to_string(),
-                        },
-                    })?;
+                let (mirror_idx, uses_periodic_offsets) = Self::orientation_mirror_facet_index(
+                    simplex,
+                    facet_idx,
+                    neighbor_simplex,
+                    "local orientation validation",
+                )?;
                 let observed_back_reference = neighbor_simplex.neighbor_key(mirror_idx).flatten();
                 if observed_back_reference != Some(simplex_key) {
                     return Err(TdsError::InvalidNeighbors {
@@ -5537,6 +5565,9 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
                             context: "local orientation validation".to_string(),
                         },
                     });
+                }
+                if uses_periodic_offsets {
+                    continue;
                 }
 
                 let simplex1_facet_vertices =
@@ -6183,26 +6214,12 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
                             ),
                         })?;
 
-                // Periodic-lifted adjacencies do not have a unique bare canonical
-                // mirror facet at this structural layer because the embedding depends
-                // on lattice representative choice. Neighbor/facet-incidence validation
-                // checks lifted facet identity and reciprocal wiring.
-                if simplex.periodic_vertex_offsets().is_some()
-                    || neighbor_simplex.periodic_vertex_offsets().is_some()
-                {
-                    continue;
-                }
-
-                let mirror_idx = simplex
-                    .mirror_facet_index(facet_idx, neighbor_simplex)
-                    .ok_or_else(|| TdsError::InvalidNeighbors {
-                        reason: NeighborValidationError::MirrorFacetMissing {
-                            simplex_uuid: simplex.uuid(),
-                            facet_index: facet_idx,
-                            neighbor_uuid: neighbor_simplex.uuid(),
-                            context: "orientation validation".to_string(),
-                        },
-                    })?;
+                let (mirror_idx, uses_periodic_offsets) = Self::orientation_mirror_facet_index(
+                    simplex,
+                    facet_idx,
+                    neighbor_simplex,
+                    "orientation validation",
+                )?;
                 let back_neighbor = neighbor_simplex
                     .neighbor_key(mirror_idx)
                     .flatten()
@@ -6231,6 +6248,9 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
                             context: "orientation validation".to_string(),
                         },
                     });
+                }
+                if uses_periodic_offsets {
+                    continue;
                 }
 
                 let simplex1_facet_vertices =
@@ -6263,6 +6283,32 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
         }
 
         Ok(())
+    }
+
+    /// Resolves the mirror facet for orientation validation without forcing periodic parity checks.
+    fn orientation_mirror_facet_index(
+        simplex: &Simplex<T, U, V, D>,
+        facet_idx: usize,
+        neighbor_simplex: &Simplex<T, U, V, D>,
+        context: &str,
+    ) -> Result<(usize, bool), TdsError> {
+        let uses_periodic_offsets = simplex.periodic_vertex_offsets().is_some()
+            || neighbor_simplex.periodic_vertex_offsets().is_some();
+        let mirror_idx = if uses_periodic_offsets {
+            Self::matching_lifted_mirror_facet_index(simplex, facet_idx, neighbor_simplex, context)?
+        } else {
+            simplex
+                .mirror_facet_index(facet_idx, neighbor_simplex)
+                .ok_or_else(|| TdsError::InvalidNeighbors {
+                    reason: NeighborValidationError::MirrorFacetMissing {
+                        simplex_uuid: simplex.uuid(),
+                        facet_index: facet_idx,
+                        neighbor_uuid: neighbor_simplex.uuid(),
+                        context: context.to_string(),
+                    },
+                })?
+        };
+        Ok((mirror_idx, uses_periodic_offsets))
     }
 
     fn facet_vertices_in_simplex_order(
@@ -9676,6 +9722,61 @@ mod tests {
         assert!(tds.validate_coherent_orientation().is_ok());
         assert!(tds.is_coherently_oriented());
         assert!(tds.normalize_coherent_orientation().is_ok());
+    }
+
+    #[test]
+    fn test_orientation_validation_rejects_one_sided_periodic_neighbor() {
+        let mut tds: Tds<f64, (), (), 2> = Tds::empty();
+
+        let v_a = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
+        let v_b = tds.insert_vertex_with_mapping(vertex!([1.0, 0.0])).unwrap();
+        let v_c = tds.insert_vertex_with_mapping(vertex!([0.0, 1.0])).unwrap();
+        let v_d = tds.insert_vertex_with_mapping(vertex!([1.0, 1.0])).unwrap();
+
+        let simplex1_key = tds
+            .insert_simplex_with_mapping(Simplex::new(vec![v_a, v_b, v_c], None).unwrap())
+            .unwrap();
+        let simplex2_key = tds
+            .insert_simplex_with_mapping(Simplex::new(vec![v_a, v_b, v_d], None).unwrap())
+            .unwrap();
+
+        {
+            let simplex1 = tds.simplex_mut(simplex1_key).unwrap();
+            simplex1
+                .set_neighbors_from_keys(vec![None, None, Some(simplex2_key)])
+                .unwrap();
+            simplex1
+                .set_periodic_vertex_offsets(vec![[0, 0], [0, 0], [0, 0]])
+                .unwrap();
+        }
+        {
+            let simplex2 = tds.simplex_mut(simplex2_key).unwrap();
+            simplex2
+                .set_neighbors_from_keys(vec![None, None, None])
+                .unwrap();
+            simplex2
+                .set_periodic_vertex_offsets(vec![[0, 0], [0, 0], [0, 0]])
+                .unwrap();
+        }
+
+        let err = tds.validate_coherent_orientation().unwrap_err();
+        assert!(matches!(
+            err,
+            TdsError::InvalidNeighbors {
+                reason: NeighborValidationError::BackReferenceMismatch { observed: None, .. },
+            }
+        ));
+        assert!(!tds.is_coherently_oriented());
+
+        let err = tds
+            .validate_coherent_orientation_for_simplices(&[simplex1_key])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            TdsError::InvalidNeighbors {
+                reason: NeighborValidationError::BackReferenceMismatch { observed: None, .. },
+            }
+        ));
     }
 
     #[test]

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -21,12 +21,14 @@
 //! constructor. The resulting triangulation is a valid Euclidean Delaunay triangulation
 //! of the canonicalized point set; it does **not** identify opposite boundary facets.
 //!
-//! **Phase 2 (`.toroidal_periodic()`, issue #210):** Full periodic construction using
+//! **Phase 2 (`.toroidal_periodic()`, issue #210):** Periodic construction using
 //! the 3^D image-point method — generating copies of each point shifted by ±L in each
 //! dimension, building the full Euclidean DT on the expanded set, normalizing lifted
 //! simplices, searching a closed quotient candidate subset, and rebuilding quotient
-//! representatives with periodic neighbor pointers. Produces a true toroidal
-//! (χ = 0) triangulation. See `REFERENCES.md`, "Periodic and Toroidal
+//! representatives with periodic neighbor pointers. The 2D and compact 3D paths
+//! are release-covered as true toroidal (χ = 0) triangulations. 4D/5D periodic
+//! quotients fail fast until issue #416 makes quotient selection scalable enough
+//! for routine validation. See `REFERENCES.md`, "Periodic and Toroidal
 //! Triangulations", first entry.
 //!
 //! # Examples
@@ -115,7 +117,10 @@ use crate::construction::{
 use crate::core::algorithms::incremental_insertion::{
     DelaunayRepairErrorKind, InsertionError, InsertionErrorSourceKind,
 };
-use crate::core::collections::{FastHashMap, PeriodicOffsetBuffer, Uuid, VertexKeySet};
+use crate::core::collections::{
+    FastHashMap, MAX_PRACTICAL_DIMENSION_SIZE, PeriodicOffsetBuffer, SmallBuffer, Uuid,
+    VertexKeySet,
+};
 use crate::core::construction::TriangulationConstructionError;
 use crate::core::operations::InsertionOutcome;
 use crate::core::simplex::{Simplex, SimplexValidationError};
@@ -131,6 +136,7 @@ use crate::core::vertex::Vertex;
 use crate::geometry::kernel::{AdaptiveKernel, Kernel};
 use crate::geometry::point::Point;
 use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
+use crate::geometry::util::circumcenter;
 use crate::repair::DelaunayRepairPolicy;
 use crate::topology::spaces::toroidal::ToroidalSpace;
 use crate::topology::traits::global_topology_model::{
@@ -1250,8 +1256,10 @@ impl<'v, T, U, const D: usize> DelaunayTriangulationBuilder<'v, T, U, D> {
     /// Euclidean Delaunay triangulation is built on the expanded set, the fundamental domain
     /// is extracted, and boundary facets are rewired with periodic neighbor pointers.
     ///
-    /// The result is a valid toroidal triangulation with Euler characteristic χ = 0 (2D),
-    /// χ = 0 (3D), etc.
+    /// The 2D and compact 3D results validate as toroidal triangulations with
+    /// Euler characteristic χ = 0. Higher-dimensional periodic quotients fail
+    /// fast until issue #416 makes quotient selection scalable enough for
+    /// routine validation.
     ///
     /// **Requires at least `2*D + 1` input points** after canonicalization.
     ///
@@ -1749,6 +1757,20 @@ where
                             "Periodic geometric orientation validation failed after build: {e}",
                         ),
                     })?;
+                dt.as_triangulation().validate().map_err(|e| {
+                    TriangulationConstructionError::FinalTopologyValidation {
+                        message: "Periodic quotient failed final Levels 1-3 topology validation"
+                            .to_string(),
+                        source: e.into(),
+                    }
+                })?;
+                dt.is_valid().map_err(|e| {
+                    TriangulationConstructionError::FinalTopologyValidation {
+                        message: "Periodic quotient failed final Level 4 Delaunay validation"
+                            .to_string(),
+                        source: InvariantError::Delaunay(e).into(),
+                    }
+                })?;
                 Ok(dt)
             }
         }
@@ -2049,6 +2071,16 @@ where
                 ),
             }
         })?;
+        if D > 3 {
+            return Err(
+                TriangulationConstructionError::UnsupportedPeriodicDimension {
+                    dimension: D,
+                    max_validated_dimension: 3,
+                    tracking_issue: 416,
+                }
+                .into(),
+            );
+        }
         let n = canonical_vertices.len();
         let min_points = 2 * D + 1;
         if n < min_points {
@@ -2086,7 +2118,6 @@ where
             let span = u64::try_from(2 * IMAGE_JITTER_UNITS + 1).expect("span fits in u64");
             i64::try_from(h % span).expect("residue fits in i64") - IMAGE_JITTER_UNITS
         };
-
         let canonical_f64: Vec<[f64; D]> = canonical_vertices
             .iter()
             .enumerate()
@@ -2362,22 +2393,19 @@ where
 
                 Some(lifted)
             };
-        let simplex_barycenter_in_fundamental_domain = |simplex_key: SimplexKey| -> Option<bool> {
+        let simplex_circumcenter_in_fundamental_domain = |simplex_key: SimplexKey| -> Option<bool> {
             let simplex = tds_ref.simplex(simplex_key)?;
-            let mut sums = [0.0_f64; D];
+            let mut points: SmallBuffer<Point<T, D>, MAX_PRACTICAL_DIMENSION_SIZE> =
+                SmallBuffer::with_capacity(D + 1);
             for vk in simplex.vertices() {
                 let vertex = tds_ref.vertex(*vk)?;
-                let coords = vertex.point().coords();
-                for (axis, sum) in sums.iter_mut().enumerate() {
-                    *sum += coords[axis].to_f64()?;
-                }
+                points.push(*vertex.point());
             }
-            let denom = <f64 as num_traits::NumCast>::from(D + 1)
-                .expect("simplex vertex count fits in f64 for D");
-            for (axis, sum) in sums.iter().enumerate() {
-                let bary = *sum / denom;
+            let center = circumcenter(&points).ok()?;
+            for (axis, coord) in center.coords().iter().enumerate() {
+                let center_coord = coord.to_f64()?;
                 let period = domain[axis];
-                if !(bary >= 0.0 && bary < period) {
+                if !(center_coord >= 0.0 && center_coord < period) {
                     return Some(false);
                 }
             }
@@ -2395,7 +2423,7 @@ where
             let Some(lifted_vertices) = normalize_simplex_lifted(ck) else {
                 continue;
             };
-            let in_domain = simplex_barycenter_in_fundamental_domain(ck).unwrap_or(false);
+            let in_domain = simplex_circumcenter_in_fundamental_domain(ck).unwrap_or(false);
             let mut symbolic_signature = lifted_vertices.clone();
             symbolic_signature.sort_unstable();
             let lifted_ordered = lifted_vertices.clone();
@@ -2454,7 +2482,31 @@ where
         let mut best_selected_count = 0_usize;
         let mut best_coverage_count = 0_usize;
         let mut best_abs_chi = i64::MAX;
-        if D == 2 {
+        if D > 2 {
+            let selected: Vec<bool> = candidates.iter().map(|candidate| candidate.3).collect();
+            let mut facet_counts: FastHashMap<PeriodicFacetKey, u8> = FastHashMap::default();
+            let mut covered: VertexKeySet = VertexKeySet::default();
+            for (idx, is_selected) in selected.iter().copied().enumerate() {
+                if !is_selected {
+                    continue;
+                }
+                for facet in &candidates[idx].2 {
+                    *facet_counts.entry(*facet).or_insert(0) += 1;
+                }
+                for (vertex_key, _) in &candidates[idx].1 {
+                    covered.insert(*vertex_key);
+                }
+            }
+            if facet_counts.values().all(|&count| count <= 2)
+                && covered.len() == central_key_set.len()
+            {
+                best_boundary_count = facet_counts.values().filter(|&&count| count == 1).count();
+                best_selected_count = selected.iter().filter(|&&is_selected| is_selected).count();
+                best_coverage_count = covered.len();
+                best_abs_chi = 0;
+                best_selected = selected;
+            }
+        } else if D == 2 {
             let target_faces = central_key_set.len().saturating_mul(2);
             let mut edge_to_index: FastHashMap<PeriodicFacetKey, usize> = FastHashMap::default();
             let mut candidate_edges: Vec<[usize; 3]> = Vec::with_capacity(candidates.len());
@@ -2674,11 +2726,7 @@ where
                     best_abs_chi = abs_chi;
                     best_selected = selected;
                 }
-                let best_has_full_canonical_coverage = best_coverage_count == central_key_set.len();
-                if best_boundary_count == 0
-                    && ((D == 2 && best_abs_chi == 0)
-                        || (D > 2 && best_has_full_canonical_coverage))
-                {
+                if D == 2 && best_boundary_count == 0 && best_abs_chi == 0 {
                     break;
                 }
             }
@@ -2723,45 +2771,6 @@ where
             }
             .into());
         }
-        if D > 2 {
-            // In the quotient TDS, simplices that collapse to the same canonical vertex set cannot
-            // be distinct facet-neighbors: they would share all D+1 vertices and violate the
-            // mirror-facet invariant enforced by `set_neighbors_by_key`.
-            //
-            // Keep at most one selected representative per canonical simplex. Prefer in-domain
-            // representatives, then deterministic symbolic ordering.
-            let mut selected_by_canonical: FastHashMap<Vec<VertexKey>, usize> =
-                FastHashMap::default();
-            let mut dedup_selected = vec![false; candidates.len()];
-
-            for (idx, is_selected) in best_selected.iter().copied().enumerate() {
-                if !is_selected {
-                    continue;
-                }
-                let mut canonical_keys: Vec<VertexKey> =
-                    candidates[idx].1.iter().map(|(vk, _)| *vk).collect();
-                canonical_keys.sort_unstable();
-
-                if let Some(existing_idx) = selected_by_canonical.get(&canonical_keys).copied() {
-                    let existing_in_domain = candidates[existing_idx].3;
-                    let candidate_in_domain = candidates[idx].3;
-                    let should_replace = (!existing_in_domain && candidate_in_domain)
-                        || (existing_in_domain == candidate_in_domain
-                            && candidates[idx].0 < candidates[existing_idx].0);
-                    if should_replace {
-                        dedup_selected[existing_idx] = false;
-                        dedup_selected[idx] = true;
-                        selected_by_canonical.insert(canonical_keys, idx);
-                    }
-                } else {
-                    dedup_selected[idx] = true;
-                    selected_by_canonical.insert(canonical_keys, idx);
-                }
-            }
-
-            best_selected = dedup_selected;
-        }
-
         let mut representative_lifted_by_symbolic: FastHashMap<
             SymbolicSignature<D>,
             SymbolicSignature<D>,
@@ -2890,33 +2899,6 @@ where
         for (_facet_sig, occurrences) in facet_occurrences {
             match occurrences.as_slice() {
                 [(a_ck, a_idx), (b_ck, b_idx)] => {
-                    let a_lifted = rep_lifted_by_key.get(a_ck).ok_or_else(|| {
-                        TriangulationConstructionError::InternalInconsistency {
-                            message: format!(
-                                "missing lifted representative for quotient simplex {a_ck:?}"
-                            ),
-                        }
-                    })?;
-                    let b_lifted = rep_lifted_by_key.get(b_ck).ok_or_else(|| {
-                        TriangulationConstructionError::InternalInconsistency {
-                            message: format!(
-                                "missing lifted representative for quotient simplex {b_ck:?}"
-                            ),
-                        }
-                    })?;
-                    let shares_all_canonical_vertices = a_lifted
-                        .iter()
-                        .zip(b_lifted.iter())
-                        .all(|((a_vk, _), (b_vk, _))| a_vk == b_vk);
-
-                    if shares_all_canonical_vertices {
-                        return Err(TriangulationConstructionError::GeometricDegeneracy {
-                            message: format!(
-                                "Periodic quotient produced distinct simplices with identical canonical vertices across a shared facet: {a_ck:?}[{a_idx}] <-> {b_ck:?}[{b_idx}]",
-                            ),
-                        }
-                        .into());
-                    }
                     neighbor_updates.get_mut(a_ck).ok_or_else(|| {
                         TriangulationConstructionError::InternalInconsistency {
                             message: format!(

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -2497,10 +2497,10 @@ where
                     covered.insert(*vertex_key);
                 }
             }
-            if facet_counts.values().all(|&count| count <= 2)
+            if facet_counts.values().all(|&count| count == 2)
                 && covered.len() == central_key_set.len()
             {
-                best_boundary_count = facet_counts.values().filter(|&&count| count == 1).count();
+                best_boundary_count = 0;
                 best_selected_count = selected.iter().filter(|&&is_selected| is_selected).count();
                 best_coverage_count = covered.len();
                 best_abs_chi = 0;

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -273,6 +273,19 @@ pub enum DelaunayConstructionFailure {
         message: String,
     },
 
+    /// Periodic quotient construction is not release-validated for this dimension.
+    #[error(
+        "periodic image-point construction is release-validated only up to {max_validated_dimension}D; {dimension}D scalable quotient construction is tracked by issue #{tracking_issue}"
+    )]
+    UnsupportedPeriodicDimension {
+        /// Requested triangulation dimension.
+        dimension: usize,
+        /// Highest dimension with release-validated periodic quotient construction.
+        max_validated_dimension: usize,
+        /// Tracking issue for extending periodic quotient support.
+        tracking_issue: u32,
+    },
+
     /// Internal construction invariant failed.
     #[error("internal inconsistency during construction: {message}")]
     InternalInconsistency {
@@ -384,6 +397,15 @@ impl From<TriangulationConstructionError> for DelaunayConstructionFailure {
             TriangulationConstructionError::GeometricDegeneracy { message } => {
                 Self::GeometricDegeneracy { message }
             }
+            TriangulationConstructionError::UnsupportedPeriodicDimension {
+                dimension,
+                max_validated_dimension,
+                tracking_issue,
+            } => Self::UnsupportedPeriodicDimension {
+                dimension,
+                max_validated_dimension,
+                tracking_issue,
+            },
             TriangulationConstructionError::InternalInconsistency { message } => {
                 Self::InternalInconsistency { message }
             }
@@ -4347,6 +4369,7 @@ where
                     reason: TdsConstructionFailure::DuplicateUuid { .. }
                         | TdsConstructionFailure::Validation { .. },
                 } | DelaunayConstructionFailure::InternalInconsistency { .. }
+                    | DelaunayConstructionFailure::UnsupportedPeriodicDimension { .. }
                     | DelaunayConstructionFailure::DelaunayRepair { .. }
                     | DelaunayConstructionFailure::InsertionTopologyValidation { .. }
                     | DelaunayConstructionFailure::LocalRepairBudgetExceeded { .. }
@@ -7101,6 +7124,21 @@ mod tests {
         assert!(
             !TestDelaunay::<3>::is_non_retryable_construction_error(&err),
             "GeometricDegeneracy should NOT be non-retryable"
+        );
+    }
+
+    #[test]
+    fn test_is_non_retryable_construction_error_true_for_unsupported_periodic_dimension() {
+        let err: DelaunayTriangulationConstructionError =
+            TriangulationConstructionError::UnsupportedPeriodicDimension {
+                dimension: 4,
+                max_validated_dimension: 3,
+                tracking_issue: 416,
+            }
+            .into();
+        assert!(
+            TestDelaunay::<4>::is_non_retryable_construction_error(&err),
+            "UnsupportedPeriodicDimension should be non-retryable"
         );
     }
 

--- a/src/topology/characteristics/euler.rs
+++ b/src/topology/characteristics/euler.rs
@@ -45,6 +45,9 @@ use crate::core::{
 };
 use crate::topology::traits::topological_space::TopologyError;
 
+type LiftedCellVertex = (VertexKey, SmallBuffer<i16, MAX_PRACTICAL_DIMENSION_SIZE>);
+type LiftedCellKey = SmallBuffer<LiftedCellVertex, MAX_PRACTICAL_DIMENSION_SIZE>;
+
 /// Counts of k-simplices for all dimensions 0 ≤ k ≤ D.
 ///
 /// Stores the f-vector (f₀, f₁, ..., `f_D`) where `f_k` is the number of
@@ -276,25 +279,20 @@ pub(crate) fn count_simplices_with_facet_to_simplices_map<T, U, V, const D: usiz
     // re-iterating all simplices once per k.
     // Skip if D <= 2 (no intermediate dimensions)
     if D > 2 {
-        let mut intermediate_simplex_sets: Vec<
-            FastHashSet<SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
-        > = (0..(D - 2)).map(|_| FastHashSet::default()).collect();
-
-        // Pre-sort each simplex's vertex keys once so every generated combination is already
-        // in canonical (sorted) order, avoiding per-combination sorting.
-        let mut sorted_vertex_keys: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE> =
-            SmallBuffer::new();
+        let mut intermediate_simplex_sets: Vec<FastHashSet<LiftedCellKey>> =
+            (0..(D - 2)).map(|_| FastHashSet::default()).collect();
 
         for (_simplex_key, simplex) in tds.simplices() {
-            sorted_vertex_keys.clear();
-            sorted_vertex_keys.extend(simplex.vertices().iter().copied());
-            sorted_vertex_keys.sort();
-
             for simplex_dimension in 1..=D - 2 {
                 let simplex_set =
                     &mut intermediate_simplex_sets[simplex_dimension.saturating_sub(1)];
                 let simplex_size = simplex_dimension + 1; // k-simplex has k+1 vertices
-                insert_simplices_of_size(&sorted_vertex_keys, simplex_size, simplex_set);
+                insert_lifted_simplices_of_size(
+                    simplex.vertices(),
+                    simplex.periodic_vertex_offsets(),
+                    simplex_size,
+                    simplex_set,
+                );
             }
         }
 
@@ -307,21 +305,16 @@ pub(crate) fn count_simplices_with_facet_to_simplices_map<T, U, V, const D: usiz
     FVector { by_dim }
 }
 
-fn insert_simplices_of_size(
+fn insert_lifted_simplices_of_size<const D: usize>(
     vertex_keys: &[VertexKey],
+    periodic_offsets: Option<&[[i8; D]]>,
     simplex_size: usize,
-    simplex_set: &mut FastHashSet<SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
+    simplex_set: &mut FastHashSet<LiftedCellKey>,
 ) {
     let n = vertex_keys.len();
     if n < simplex_size {
         return;
     }
-
-    // We expect `vertex_keys` to be in sorted (canonical) order.
-    //
-    // With sorted input, each combination produced by increasing indices is already sorted, so we
-    // can insert it directly without per-combination sorting.
-    debug_assert!(vertex_keys.windows(2).all(|w| w[0] <= w[1]));
 
     // Generate all C(n, simplex_size) combinations using the standard lexicographic algorithm.
     //
@@ -333,7 +326,85 @@ fn insert_simplices_of_size(
     let mut indices: SmallBuffer<usize, MAX_PRACTICAL_DIMENSION_SIZE> = (0..simplex_size).collect();
 
     'outer: loop {
-        // Extract current combination (already sorted due to sorted input + increasing indices).
+        let mut simplex_vertices: LiftedCellKey = SmallBuffer::new();
+        for &vertex_index in &indices {
+            let offset: SmallBuffer<i16, MAX_PRACTICAL_DIMENSION_SIZE> = periodic_offsets
+                .map_or_else(SmallBuffer::new, |offsets| {
+                    offsets[vertex_index]
+                        .iter()
+                        .map(|&component| i16::from(component))
+                        .collect()
+                });
+            simplex_vertices.push((vertex_keys[vertex_index], offset));
+        }
+        normalize_lifted_cell_key(&mut simplex_vertices);
+        simplex_set.insert(simplex_vertices);
+
+        // Generate next combination.
+        // The maximum valid value at position `i` is `i + n - simplex_size`.
+        //
+        // Find the rightmost index that can be incremented.
+        let mut pivot = simplex_size;
+        loop {
+            if pivot == 0 {
+                break 'outer;
+            }
+            pivot -= 1;
+            if indices[pivot] < pivot + n - simplex_size {
+                break;
+            }
+        }
+
+        indices[pivot] += 1;
+        for position in (pivot + 1)..simplex_size {
+            indices[position] = indices[position - 1] + 1;
+        }
+    }
+}
+
+fn normalize_lifted_cell_key(simplex_vertices: &mut LiftedCellKey) {
+    simplex_vertices.sort_unstable_by(|(vertex_a, offset_a), (vertex_b, offset_b)| {
+        vertex_a.cmp(vertex_b).then_with(|| offset_a.cmp(offset_b))
+    });
+    let anchor_offset = simplex_vertices
+        .first()
+        .map_or_else(SmallBuffer::new, |(_, offset)| offset.clone());
+    let axes = simplex_vertices
+        .iter()
+        .map(|(_, offset)| offset.len())
+        .max()
+        .unwrap_or(0)
+        .max(anchor_offset.len());
+    for (_, offset) in simplex_vertices.iter_mut() {
+        let mut normalized: SmallBuffer<i16, MAX_PRACTICAL_DIMENSION_SIZE> =
+            SmallBuffer::with_capacity(axes);
+        for axis in 0..axes {
+            let component = offset.get(axis).copied().unwrap_or(0)
+                - anchor_offset.get(axis).copied().unwrap_or(0);
+            normalized.push(component);
+        }
+        *offset = normalized;
+    }
+    simplex_vertices.sort_unstable_by(|(vertex_a, offset_a), (vertex_b, offset_b)| {
+        vertex_a.cmp(vertex_b).then_with(|| offset_a.cmp(offset_b))
+    });
+}
+
+fn insert_simplices_of_size(
+    vertex_keys: &[VertexKey],
+    simplex_size: usize,
+    simplex_set: &mut FastHashSet<SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
+) {
+    let n = vertex_keys.len();
+    if n < simplex_size {
+        return;
+    }
+
+    debug_assert!(vertex_keys.windows(2).all(|w| w[0] <= w[1]));
+
+    let mut indices: SmallBuffer<usize, MAX_PRACTICAL_DIMENSION_SIZE> = (0..simplex_size).collect();
+
+    'outer: loop {
         let mut simplex_vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE> =
             SmallBuffer::new();
         for &vertex_index in &indices {
@@ -341,10 +412,6 @@ fn insert_simplices_of_size(
         }
         simplex_set.insert(simplex_vertices);
 
-        // Generate next combination.
-        // The maximum valid value at position `i` is `i + n - simplex_size`.
-        //
-        // Find the rightmost index that can be incremented.
         let mut pivot = simplex_size;
         loop {
             if pivot == 0 {

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -114,7 +114,7 @@ use thiserror::Error;
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct LiftedVertexId {
     vertex_key: VertexKey,
-    offset: SmallBuffer<i8, 8>,
+    offset: SmallBuffer<i16, 8>,
 }
 
 type LiftedVertexBuffer = SmallBuffer<LiftedVertexId, 8>;
@@ -158,18 +158,41 @@ impl Hash for LiftedVertexId {
 
 /// Creates a lifted vertex identity from a real TDS vertex key and periodic
 /// lattice offset.
-fn lifted_vertex_id(vk: VertexKey, offset: &[i8]) -> LiftedVertexId {
-    if offset.is_empty() || offset.iter().all(|&o| o == 0) {
+fn lifted_vertex_id<O>(vk: VertexKey, offset: &[O]) -> LiftedVertexId
+where
+    O: Copy + Into<i16>,
+{
+    if offset.is_empty() || offset.iter().all(|&o| o.into() == 0) {
         return LiftedVertexId::base(vk);
     }
     LiftedVertexId {
         vertex_key: vk,
-        offset: offset.iter().copied().collect(),
+        offset: offset.iter().map(|&component| component.into()).collect(),
     }
 }
 
 /// Computes a periodic-aware simplex key from lifted vertex IDs.
 fn periodic_simplex_key(lifted_vertices: &[LiftedVertexId]) -> u64 {
+    if lifted_vertices.iter().all(LiftedVertexId::is_base) {
+        let bare_vertices: VertexKeyBuffer =
+            lifted_vertices.iter().map(|id| id.vertex_key).collect();
+        return facet_key_from_vertices(&bare_vertices);
+    }
+
+    let keys = normalize_lifted_vertices(lifted_vertices);
+    let mut hasher = FastHasher::default();
+    for key in &keys {
+        key.hash(&mut hasher);
+    }
+    hasher.finish()
+}
+
+/// Computes an exact lifted simplex key without quotient translation normalization.
+///
+/// Vertex links already express every lifted vertex relative to the linked
+/// anchor vertex, so applying an additional global translation quotient can
+/// collapse distinct link simplices.
+fn anchored_lifted_simplex_key(lifted_vertices: &[LiftedVertexId]) -> u64 {
     if lifted_vertices.iter().all(LiftedVertexId::is_base) {
         let bare_vertices: VertexKeyBuffer =
             lifted_vertices.iter().map(|id| id.vertex_key).collect();
@@ -183,6 +206,34 @@ fn periodic_simplex_key(lifted_vertices: &[LiftedVertexId]) -> u64 {
         key.hash(&mut hasher);
     }
     hasher.finish()
+}
+
+/// Normalizes lifted vertices by subtracting the offset of the first sorted
+/// lifted vertex, making periodic simplex identities translation invariant.
+fn normalize_lifted_vertices(lifted_vertices: &[LiftedVertexId]) -> LiftedVertexBuffer {
+    let mut keys: LiftedVertexBuffer = lifted_vertices.iter().cloned().collect();
+    keys.sort_unstable();
+    let anchor_offset: SmallBuffer<i16, 8> = keys
+        .first()
+        .map_or_else(SmallBuffer::new, |key| key.offset.clone());
+    let axes = keys
+        .iter()
+        .map(|key| key.offset.len())
+        .max()
+        .unwrap_or(0)
+        .max(anchor_offset.len());
+
+    let mut normalized = LiftedVertexBuffer::with_capacity(keys.len());
+    for key in keys {
+        let mut offset: SmallBuffer<i16, 8> = SmallBuffer::with_capacity(axes);
+        for axis in 0..axes {
+            let component = key.offset.get(axis).copied().unwrap_or(0)
+                - anchor_offset.get(axis).copied().unwrap_or(0);
+            offset.push(component);
+        }
+        normalized.push(lifted_vertex_id(key.vertex_key, &offset));
+    }
+    normalized
 }
 
 fn ordered_lifted_edge(a: &LiftedVertexId, b: &LiftedVertexId) -> (LiftedVertexId, LiftedVertexId) {
@@ -392,11 +443,17 @@ pub fn validate_closed_boundary<T, U, V, const D: usize>(
         return Ok(());
     }
 
-    // First count boundary facets so we can reserve reasonably.
-    let boundary_facet_count = facet_to_simplices
-        .values()
-        .filter(|handles| matches!(handles.as_slice(), [_]))
-        .count();
+    // First count boundary facets so we can reserve reasonably. Periodic
+    // self-neighbor facets are closed quotient identifications, not boundary.
+    let mut boundary_facet_count = 0usize;
+    for simplex_facet_pairs in facet_to_simplices.values() {
+        let [handle] = simplex_facet_pairs.as_slice() else {
+            continue;
+        };
+        if is_boundary_facet_handle(tds, *handle)? {
+            boundary_facet_count = boundary_facet_count.saturating_add(1);
+        }
+    }
 
     if boundary_facet_count == 0 {
         return Ok(());
@@ -423,6 +480,9 @@ pub fn validate_closed_boundary<T, U, V, const D: usize>(
 
         let simplex_key = handle.simplex_key();
         let facet_index = handle.facet_index() as usize;
+        if !is_boundary_facet_handle(tds, *handle)? {
+            continue;
+        }
 
         // Derive the facet's vertex keys from the owning simplex.
         let simplex_vertices = tds.simplex_vertices(simplex_key)?;
@@ -615,6 +675,9 @@ fn validate_closed_boundary_for_local_facets<T, U, V, const D: usize>(
         let [handle] = simplex_facet_pairs.as_slice() else {
             continue;
         };
+        if !is_boundary_facet_handle(tds, *handle)? {
+            continue;
+        }
 
         let (facet_vertices, facet_vertices_bare) =
             simplex_facet_vertex_ids(tds, handle.simplex_key(), handle.facet_index() as usize)?;
@@ -705,7 +768,11 @@ fn boundary_facet_count_for_ridge<T, U, V, const D: usize>(
             }
             let handles = facet_incident_handles(tds, facet_key, &facet_vertices_bare)?;
             match handles.len() {
-                1 => count = count.saturating_add(1),
+                1 => {
+                    if is_boundary_facet_handle(tds, handles[0])? {
+                        count = count.saturating_add(1);
+                    }
+                }
                 2 => {}
                 other => {
                     return Err(ManifoldError::ManifoldFacetMultiplicity {
@@ -718,6 +785,34 @@ fn boundary_facet_count_for_ridge<T, U, V, const D: usize>(
     }
 
     Ok(count)
+}
+
+/// Returns true when a one-sided facet occurrence is an actual boundary facet.
+///
+/// Periodic quotient TDSs may encode a closed facet identification as a single
+/// facet occurrence whose neighbor slot points back to the owning simplex. That
+/// is valid closed-topology metadata, not a boundary facet.
+fn is_boundary_facet_handle<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    handle: FacetHandle,
+) -> Result<bool, ManifoldError> {
+    let simplex_key = handle.simplex_key();
+    let facet_index = handle.facet_index() as usize;
+    let simplex = tds
+        .simplex(simplex_key)
+        .ok_or_else(|| TdsError::SimplexNotFound {
+            simplex_key,
+            context: "boundary facet classification".to_string(),
+        })?;
+
+    let is_periodic_self_identified = simplex
+        .neighbor_key(facet_index)
+        .is_some_and(|neighbor| neighbor == Some(simplex_key))
+        && simplex.periodic_vertex_offsets().is_some_and(|offsets| {
+            !offsets.is_empty() && offsets.len() == simplex.number_of_vertices()
+        });
+
+    Ok(!is_periodic_self_identified)
 }
 
 /// Computes the star of a simplex (a set of vertices) as the set of incident D-simplices.
@@ -792,6 +887,8 @@ fn simplex_link_simplices_from_star<T, U, V, const D: usize>(
     let expected_link_vertices = (D + 1).saturating_sub(simplex_vertices.len());
 
     let mut link_simplices: LinkSimplexBuffer = SmallBuffer::with_capacity(star_simplices.len());
+    let mut seen_link_simplices: FastHashSet<u64> =
+        fast_hash_set_with_capacity(star_simplices.len().max(1));
 
     for &simplex_key in star_simplices {
         let candidate_vertices = tds.simplex_vertices(simplex_key)?;
@@ -819,10 +916,10 @@ fn simplex_link_simplices_from_star<T, U, V, const D: usize>(
                 // Lift with *relative* offset so adjacent simplices agree.
                 let lifted = match (offsets, ref_slot) {
                     (Some(offs), Some(r)) => {
-                        let rel: SmallBuffer<i8, 8> = offs[i]
+                        let rel: SmallBuffer<i16, 8> = offs[i]
                             .iter()
                             .zip(offs[r].iter())
-                            .map(|(&a, &b)| a - b)
+                            .map(|(&a, &b)| i16::from(a) - i16::from(b))
                             .collect();
                         lifted_vertex_id(vk, &rel)
                     }
@@ -843,7 +940,10 @@ fn simplex_link_simplices_from_star<T, U, V, const D: usize>(
             .into());
         }
 
-        link_simplices.push(link_vertices);
+        let link_key = anchored_lifted_simplex_key(&link_vertices);
+        if seen_link_simplices.insert(link_key) {
+            link_simplices.push(link_vertices);
+        }
     }
 
     Ok(link_simplices)
@@ -911,48 +1011,22 @@ fn ridge_link_edges_from_star<T, U, V, const D: usize>(
     let mut link_vertices: LiftedVertexBuffer = LiftedVertexBuffer::with_capacity(2);
 
     for &simplex_key in star_simplices {
-        let simplex_vertices = tds.simplex_vertices(simplex_key)?;
-        let offsets = tds
-            .simplex(simplex_key)
-            .and_then(|c| c.periodic_vertex_offsets());
-
-        // Find the reference offset from the first ridge vertex's slot.
-        let ref_slot = offsets.and_then(|offs| {
-            simplex_vertices
-                .iter()
-                .enumerate()
-                .find(|(idx, cv)| {
-                    // Match simplex vertex against lifted ridge vertices.
-                    let lv = lifted_vertex_id(**cv, &offs[*idx]);
-                    ridge_vertices.contains(&lv)
-                })
-                .map(|(idx, _)| idx)
-        });
+        let Some(simplex_vertices) =
+            normalized_simplex_vertices_for_lifted_target(tds, simplex_key, ridge_vertices)?
+        else {
+            return Err(TdsError::InconsistentDataStructure {
+                message: format!(
+                    "ridge star simplex {simplex_key:?} does not contain normalized ridge vertices \
+                     {ridge_vertices:?}"
+                ),
+            }
+            .into());
+        };
 
         link_vertices.clear();
-        for (i, &vk) in simplex_vertices.iter().enumerate() {
-            // Lift with absolute offsets for ridge membership test (ridge
-            // vertices in `ridge_vertices` use absolute lifted IDs).
-            let abs_lifted = offsets.map_or_else(
-                || LiftedVertexId::base(vk),
-                |offs| lifted_vertex_id(vk, &offs[i]),
-            );
-            if !ridge_vertices.contains(&abs_lifted) {
-                // Lift link vertices with *relative* offsets so adjacent
-                // simplices agree on shared vertex identity.
-                let rel_lifted = match (offsets, ref_slot) {
-                    (Some(offs), Some(r)) => {
-                        let simplex_offs: &[[i8; D]] = offs;
-                        let rel: SmallBuffer<i8, 8> = simplex_offs[i]
-                            .iter()
-                            .zip(simplex_offs[r].iter())
-                            .map(|(&a, &b)| a - b)
-                            .collect();
-                        lifted_vertex_id(vk, &rel)
-                    }
-                    _ => LiftedVertexId::base(vk),
-                };
-                link_vertices.push(rel_lifted);
+        for lifted in simplex_vertices {
+            if !ridge_vertices.contains(&lifted) {
+                link_vertices.push(lifted);
             }
         }
 
@@ -1059,11 +1133,10 @@ fn build_ridge_star_map<T, U, V, const D: usize>(
                     .into());
                 }
 
-                // Periodic-aware key: lifted vertex IDs produce distinct
-                // ridge keys for different offset images.
-                let ridge_key = periodic_simplex_key(&ridge_vertices);
+                let normalized_ridge_vertices = normalize_lifted_vertices(&ridge_vertices);
+                let ridge_key = periodic_simplex_key(&normalized_ridge_vertices);
                 let star = ridge_to_star.entry(ridge_key).or_insert_with(|| RidgeStar {
-                    ridge_vertices: ridge_vertices.clone(),
+                    ridge_vertices: normalized_ridge_vertices.clone(),
                     star_simplices: SmallBuffer::new(),
                 });
                 star.star_simplices.push(simplex_key);
@@ -1148,12 +1221,11 @@ fn build_ridge_star_map_for_simplices<T, U, V, const D: usize>(
                     .into());
                 }
 
-                // Periodic-aware key: lifted vertex IDs produce distinct
-                // ridge keys for different offset images.
-                let ridge_key = periodic_simplex_key(&ridge_vertices_lifted);
-                ridge_to_vertices.entry(ridge_key).or_insert_with(|| {
-                    (ridge_vertices_lifted.clone(), ridge_vertices_bare.clone())
-                });
+                let normalized_ridge_vertices = normalize_lifted_vertices(&ridge_vertices_lifted);
+                let ridge_key = periodic_simplex_key(&normalized_ridge_vertices);
+                ridge_to_vertices
+                    .entry(ridge_key)
+                    .or_insert_with(|| (normalized_ridge_vertices, ridge_vertices_bare.clone()));
             }
         }
     }
@@ -1179,6 +1251,46 @@ fn build_ridge_star_map_for_simplices<T, U, V, const D: usize>(
     }
 
     Ok(ridge_to_star)
+}
+
+fn normalized_simplex_vertices_for_lifted_target<T, U, V, const D: usize>(
+    tds: &Tds<T, U, V, D>,
+    simplex_key: SimplexKey,
+    target_vertices: &[LiftedVertexId],
+) -> Result<Option<LiftedVertexBuffer>, ManifoldError> {
+    let simplex_vertices = tds.simplex_vertices(simplex_key)?;
+    let offsets = tds
+        .simplex(simplex_key)
+        .and_then(|simplex| simplex.periodic_vertex_offsets());
+
+    let Some(offsets) = offsets else {
+        let vertices: LiftedVertexBuffer = simplex_vertices
+            .iter()
+            .copied()
+            .map(LiftedVertexId::base)
+            .collect();
+        return Ok(Some(vertices));
+    };
+
+    let Some(anchor) = target_vertices.first() else {
+        return Ok(Some(LiftedVertexBuffer::new()));
+    };
+    let Some(anchor_index) = simplex_vertices
+        .iter()
+        .position(|&vertex_key| vertex_key == anchor.vertex_key)
+    else {
+        return Ok(None);
+    };
+    let anchor_offset = offsets[anchor_index];
+    let mut normalized = LiftedVertexBuffer::with_capacity(simplex_vertices.len());
+    for (idx, &vertex_key) in simplex_vertices.iter().enumerate() {
+        let mut relative_offset: SmallBuffer<i16, 8> = SmallBuffer::with_capacity(D);
+        for axis in 0..D {
+            relative_offset.push(i16::from(offsets[idx][axis]) - i16::from(anchor_offset[axis]));
+        }
+        normalized.push(lifted_vertex_id(vertex_key, &relative_offset));
+    }
+    Ok(Some(normalized))
 }
 
 /// Computes the periodic-aware star of a ridge from its lifted and bare vertex
@@ -1210,20 +1322,15 @@ fn periodic_aware_ridge_star<T, U, V, const D: usize>(
     let mut star_simplices: SmallBuffer<SimplexKey, 8> =
         SmallBuffer::with_capacity(all_star_simplices.len());
     for &ck in &all_star_simplices {
-        let simplex_offsets = tds.simplex(ck).and_then(|c| c.periodic_vertex_offsets());
-        let matches = match simplex_offsets {
-            None => true,
-            Some(offs) => {
-                let cv = tds.simplex_vertices(ck)?;
-                lifted_vertices.iter().all(|lv| {
-                    cv.iter().enumerate().any(|(i, &vk)| {
-                        let lifted = lifted_vertex_id(vk, &offs[i]);
-                        &lifted == lv
-                    })
-                })
-            }
+        let Some(normalized_vertices) =
+            normalized_simplex_vertices_for_lifted_target(tds, ck, lifted_vertices)?
+        else {
+            continue;
         };
-        if matches {
+        if lifted_vertices
+            .iter()
+            .all(|lv| normalized_vertices.contains(lv))
+        {
             star_simplices.push(ck);
         }
     }
@@ -1921,7 +2028,7 @@ fn validate_link_facets_and_boundary<const D: usize>(
                 return (0, false);
             }
 
-            let key = periodic_simplex_key(&facet_vertices);
+            let key = anchored_lifted_simplex_key(&facet_vertices);
             let entry = facet_map.entry(key).or_insert_with(|| FacetInfo {
                 vertices: facet_vertices.clone(),
                 count: 0,
@@ -1974,7 +2081,7 @@ fn validate_link_facets_and_boundary<const D: usize>(
                 if ridge_vertices.len() != D.saturating_sub(2) {
                     return (boundary_facet_count, false);
                 }
-                let ridge_key = periodic_simplex_key(&ridge_vertices);
+                let ridge_key = anchored_lifted_simplex_key(&ridge_vertices);
                 *ridge_map.entry(ridge_key).or_insert(0) += 1;
             }
         }
@@ -3751,9 +3858,9 @@ mod tests {
     }
 
     #[test]
-    fn test_build_ridge_star_map_for_simplices_separates_periodic_images() {
+    fn test_build_ridge_star_map_for_simplices_identifies_translated_periodic_images() {
         // Two 2D simplices share bare vertex keys but differ in periodic offsets.
-        // The ridge map must produce distinct ridges for different offset images.
+        // The ridge map identifies globally translated quotient ridges.
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
 
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
@@ -3776,21 +3883,55 @@ mod tests {
 
         let map = build_ridge_star_map_for_simplices(&tds, &[c1, c2]).unwrap();
 
-        // In 2D, ridges have D-1 = 1 vertex.  Each triangle contributes 3 ridges.
-        // c1 produces: {v0}, {v1}, {v2}    (all at base image)
-        // c2 produces: {lifted_v0'}, {v1}, {v2}  (v0 at [1,0] image)
-        //
-        // Shared ridges: {v1} and {v2} (same lifted ID in both simplices).
-        // Distinct ridges: {v0} from c1, {lifted_v0'} from c2.
-        assert_eq!(map.len(), 4, "expected 4 distinct periodic-aware ridges");
+        // In 2D, ridges have D-1 = 1 vertex. Single-vertex ridges are identified
+        // modulo global periodic translation, so v0@base and v0@[1,0] represent
+        // the same quotient ridge.
+        assert_eq!(map.len(), 3, "expected 3 quotient-aware ridges");
 
-        // Ridges {v1} and {v2} should have a 2-simplex star (both c1 and c2).
+        // All quotient ridges should have a 2-simplex star (both c1 and c2).
         let shared_count = map.values().filter(|s| s.star_simplices.len() == 2).count();
-        assert_eq!(shared_count, 2, "two ridges should be shared");
+        assert_eq!(shared_count, 3, "three ridges should be shared");
+    }
 
-        // Ridges {v0@base} and {v0@[1,0]} should each have a 1-simplex star.
-        let unique_count = map.values().filter(|s| s.star_simplices.len() == 1).count();
-        assert_eq!(unique_count, 2, "two ridges should be unique per image");
+    #[test]
+    fn test_anchored_lifted_simplex_key_preserves_vertex_link_offsets() {
+        let mut tds: Tds<f64, (), (), 3> = Tds::empty();
+
+        let v0 = tds
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]))
+            .unwrap();
+        let v1 = tds
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]))
+            .unwrap();
+        let v2 = tds
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]))
+            .unwrap();
+
+        let first_link_triangle: LiftedVertexBuffer = [
+            lifted_vertex_id(v0, &[1_i16, 0, 0]),
+            lifted_vertex_id(v1, &[1_i16, 0, 0]),
+            lifted_vertex_id(v2, &[1_i16, 0, 0]),
+        ]
+        .into_iter()
+        .collect();
+        let shifted_link_triangle: LiftedVertexBuffer = [
+            lifted_vertex_id(v0, &[2_i16, 0, 0]),
+            lifted_vertex_id(v1, &[2_i16, 0, 0]),
+            lifted_vertex_id(v2, &[2_i16, 0, 0]),
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(
+            periodic_simplex_key(&first_link_triangle),
+            periodic_simplex_key(&shifted_link_triangle),
+            "quotient simplex keys intentionally identify global translations"
+        );
+        assert_ne!(
+            anchored_lifted_simplex_key(&first_link_triangle),
+            anchored_lifted_simplex_key(&shifted_link_triangle),
+            "vertex-link keys must preserve offsets relative to the linked vertex"
+        );
     }
 
     #[test]
@@ -3813,7 +3954,7 @@ mod tests {
 
         // Bare [v0] finds c1, but lifted_vertex_id(v0, [99,99]) won't match
         // c1's lifted v0 (which is bare v0 since offset is [0,0]).
-        let synthetic = lifted_vertex_id(v0, &[99, 99]);
+        let synthetic = lifted_vertex_id(v0, &[99_i16, 99_i16]);
         let bare: VertexKeyBuffer = std::iter::once(v0).collect();
         let lifted: LiftedVertexBuffer = std::iter::once(synthetic).collect();
 
@@ -3829,8 +3970,9 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_ridge_links_for_simplices_ok_with_periodic_offsets() {
-        // Two 2D simplices with periodic offsets form valid ridge link paths.
+    fn test_validate_ridge_links_for_simplices_rejects_split_periodic_link() {
+        // These two lifted triangles share quotient ridge vertices but leave a split
+        // periodic link, so quotient-aware ridge-link validation must reject them.
         let mut tds: Tds<f64, (), (), 2> = Tds::empty();
 
         let v0 = tds.insert_vertex_with_mapping(vertex!([0.0, 0.0])).unwrap();
@@ -3849,8 +3991,10 @@ mod tests {
             .unwrap();
         let c2 = tds.insert_simplex_with_mapping(simplex2).unwrap();
 
-        // All ridge links should be valid paths (boundary ridges with 2 degree-1 vertices).
-        validate_ridge_links_for_simplices(&tds, &[c1, c2]).unwrap();
+        match validate_ridge_links_for_simplices(&tds, &[c1, c2]) {
+            Err(ManifoldError::RidgeLinkNotManifold { .. }) => {}
+            other => panic!("Expected RidgeLinkNotManifold, got {other:?}"),
+        }
     }
 
     #[test]

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -209,6 +209,23 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
         },
         DelaunayConstructionFailure::GeometricDegeneracy { .. }
     ));
+    let unsupported_periodic_dimension =
+        DelaunayConstructionFailure::UnsupportedPeriodicDimension {
+            dimension: 4,
+            max_validated_dimension: 3,
+            tracking_issue: 416,
+        };
+    let DelaunayConstructionFailure::UnsupportedPeriodicDimension {
+        dimension,
+        max_validated_dimension,
+        tracking_issue,
+    } = unsupported_periodic_dimension
+    else {
+        unreachable!("constructed unsupported periodic dimension variant should match");
+    };
+    assert_eq!(dimension, 4);
+    assert_eq!(max_validated_dimension, 3);
+    assert_eq!(tracking_issue, 416);
     let cavity_failure = DelaunayConstructionFailure::InsertionCavityFilling {
         source: CavityFillingError::EmptyFanTriangulation,
     };

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -9,21 +9,17 @@ use std::collections::HashMap;
 use std::f64::consts::TAU;
 
 use delaunay::prelude::construction::{
-    ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationBuilder,
-    DelaunayTriangulationConstructionError, ExplicitConstructionError, ExplicitInsertionError,
-    ExplicitInsertionErrorKind, ExplicitInvariantError, ExplicitInvariantErrorKind,
-    ExplicitTdsErrorKind, InsertionOrderStrategy, TopologyGuarantee, Vertex, VertexBuilder, vertex,
+    ConstructionOptions, DelaunayConstructionFailure, DelaunayTriangulation,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
+    ExplicitConstructionError, ExplicitInsertionError, ExplicitInsertionErrorKind,
+    ExplicitInvariantError, ExplicitInvariantErrorKind, ExplicitTdsErrorKind,
+    InsertionOrderStrategy, TopologyGuarantee, Vertex, VertexBuilder, vertex,
 };
 use delaunay::prelude::geometry::{Coordinate, Point, RobustKernel};
 use delaunay::prelude::insertion::InsertionErrorSourceKind;
-use delaunay::prelude::repair::DelaunayRepairError;
-#[cfg(feature = "slow-tests")]
-use delaunay::prelude::tds::InvariantError;
 use delaunay::prelude::tds::{InvariantErrorSummaryDetail, TriangulationValidationErrorKind};
 use delaunay::prelude::topology::spaces::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
 use delaunay::prelude::topology::validation::{count_simplices, euler_characteristic};
-#[cfg(feature = "slow-tests")]
-use delaunay::prelude::triangulation::TriangulationValidationError;
 use delaunay::prelude::validation::ValidationPolicy;
 
 // =============================================================================
@@ -445,7 +441,7 @@ macro_rules! gen_toroidal_periodic_validation_test {
 
 gen_toroidal_periodic_validation_test!(2, levels_1_to_4, true);
 #[test]
-fn test_builder_periodic_topology_level4_smoke_3d() {
+fn test_builder_toroidal_periodic_3d_validates_level_1_to_4() {
     let vertices = vec![
         vertex!([0.2_f64, 0.3, 0.4]),
         vertex!([0.8, 0.1, 0.2]),
@@ -459,60 +455,63 @@ fn test_builder_periodic_topology_level4_smoke_3d() {
     let dt = DelaunayTriangulationBuilder::new(&vertices)
         .toroidal_periodic([1.0_f64; 3])
         .build_with_kernel::<_, ()>(&kernel)
-        .expect("compact periodic 3D build should succeed");
+        .expect("compact periodic 3D quotient should validate after #413");
 
     assert_eq!(dt.number_of_vertices(), vertices.len());
-    assert!(
-        dt.tds().is_valid().is_ok(),
-        "TDS structural validity should pass for compact periodic 3D"
-    );
     assert!(
         dt.global_topology().is_periodic(),
         "global_topology should use periodic image-point construction"
     );
     assert!(
-        dt.number_of_simplices() > 0,
-        "periodic image-point construction should produce at least one simplex"
+        dt.tds().is_valid().is_ok(),
+        "TDS structural validity should pass for periodic 3D"
     );
     assert!(
-        dt.simplices().all(|(_, simplex)| {
-            simplex
-                .periodic_vertex_offsets()
-                .is_some_and(|offsets| offsets.len() == simplex.number_of_vertices())
-        }),
-        "periodic image-point construction should populate per-simplex periodic offsets"
+        dt.as_triangulation().validate().is_ok(),
+        "Levels 1-3 topology validation should pass for periodic 3D"
     );
-    // The compact 3D quotient is a smoke fixture for lifted predicate evaluation,
-    // not a full periodic-Delaunay quality fixture. A local violation is a valid
-    // Level 4 result; malformed periodic-offset plumbing is not.
-    match dt.is_delaunay_via_flips() {
-        Ok(()) => {}
-        Err(DelaunayRepairError::PostconditionFailed { message }) => {
-            assert!(
-                !message.contains("predicate failed in strict mode")
-                    && !message.contains("periodic offset")
-                    && !message.contains("cannot align periodic vertex"),
-                "periodic Level 4 should evaluate lifted predicates with populated offsets: {message}"
-            );
-        }
-        Err(err) => panic!("periodic Level 4 validation returned an unexpected error: {err:?}"),
-    }
+    assert!(
+        dt.validate().is_ok(),
+        "Levels 1-4 validation should pass for periodic 3D"
+    );
 }
-#[test]
-#[cfg(feature = "slow-tests")]
-fn test_builder_toroidal_periodic_validate_levels_1_to_4_3d_known_limitation() {
-    let dt = build_toroidal_periodic_triangulation::<3>();
 
-    match dt.as_triangulation().validate() {
-        Err(InvariantError::Triangulation(
-            TriangulationValidationError::BoundaryRidgeMultiplicity {
-                boundary_facet_count,
-                ..
-            },
-        )) => assert_eq!(boundary_facet_count, 4),
-        other => panic!("expected periodic 3D ridge-multiplicity limitation, got {other:?}"),
-    }
+macro_rules! gen_toroidal_periodic_high_dim_guardrail_test {
+    ($dim:literal) => {
+        pastey::paste! {
+            #[test]
+            fn [<test_builder_toroidal_periodic_ $dim d_fails_fast_until_scalable_quotient>]() {
+                let vertices = toroidal_periodic_vertices::<$dim>();
+                let kernel = RobustKernel::new();
+                let err = DelaunayTriangulationBuilder::new(&vertices)
+                    .toroidal_periodic([1.0_f64; $dim])
+                    .build_with_kernel::<_, ()>(&kernel)
+                    .expect_err(concat!(
+                        stringify!($dim),
+                        "D periodic quotient construction should fail fast pending #416"
+                    ));
+
+                match err {
+                    DelaunayTriangulationConstructionError::Triangulation(
+                        DelaunayConstructionFailure::UnsupportedPeriodicDimension {
+                            dimension,
+                            max_validated_dimension,
+                            tracking_issue,
+                        },
+                    ) => {
+                        assert_eq!(dimension, $dim);
+                        assert_eq!(max_validated_dimension, 3);
+                        assert_eq!(tracking_issue, 416);
+                    }
+                    other => panic!("expected high-dimensional periodic guardrail, got {other:?}"),
+                }
+            }
+        }
+    };
 }
+
+gen_toroidal_periodic_high_dim_guardrail_test!(4);
+gen_toroidal_periodic_high_dim_guardrail_test!(5);
 
 /// Explicit 7-vertex torus (Heawood triangulation) with `GlobalTopology::Toroidal`
 /// is rejected until explicit non-Euclidean construction has Level 4 validation.
@@ -608,40 +607,6 @@ fn test_explicit_toroidal_torus_euler_mismatch_without_override() {
             panic!("expected explicit topology or orientation-normalization failure, got {other:?}")
         }
     }
-}
-
-/// `toroidal_periodic` in 3D builds a valid periodic triangulation.
-///
-/// For a 3D periodic triangulation on the 3-torus the Euler characteristic is
-/// also 0, so we verify TDS structural validity rather than the full `validate()`
-/// check (which would expect χ = 2 for a sphere).
-#[test]
-fn test_builder_toroidal_periodic_3d_success() {
-    // Keep this fixture compact: the periodic 3D pipeline expands to 3^D image
-    // points internally.
-
-    let vertices = vec![
-        vertex!([0.1_f64, 0.2, 0.3]),
-        vertex!([0.4, 0.7, 0.1]),
-        vertex!([0.7, 0.3, 0.8]),
-        vertex!([0.2, 0.9, 0.5]),
-        vertex!([0.8, 0.6, 0.2]),
-        vertex!([0.5, 0.1, 0.7]),
-        vertex!([0.3, 0.5, 0.9]),
-        vertex!([0.6, 0.8, 0.4]),
-        vertex!([0.9, 0.2, 0.6]),
-    ];
-    let n = vertices.len();
-    let kernel = RobustKernel::new();
-    let dt = DelaunayTriangulationBuilder::new(&vertices)
-        .toroidal_periodic([1.0_f64, 1.0, 1.0])
-        .build_with_kernel::<_, ()>(&kernel)
-        .expect("periodic 3D build should succeed");
-    assert_eq!(dt.number_of_vertices(), n);
-    assert!(
-        dt.tds().is_valid().is_ok(),
-        "TDS structural validity should pass for 3D periodic triangulation"
-    );
 }
 
 // =============================================================================


### PR DESCRIPTION
- Validate periodic image-point quotients through final Levels 1-3 topology and Level 4 Delaunay checks before returning them.
- Preserve lifted periodic vertex identity in Euler and manifold validation so 3D quotient links and ridges are checked in the correct lattice frame.
- Select periodic quotient candidates by circumcenter ownership instead of barycenter ownership.
- Add a typed UnsupportedPeriodicDimension guardrail so 4D/5D periodic quotient construction fails fast pending scalable follow-up work in #416.
- Refresh toroidal periodic docs to state the 2D/compact 3D release boundary and high-dimensional guardrails.

Closes #413