### PR TITLE
build!: update tooling to Rust 1.96.0 (#430)

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -3,9 +3,9 @@ coverage:
   status:
     project:
       default:
-        target: 60%
+        target: 90%
         removed_code_behavior: removals_only
-        threshold: 5%
+        threshold: 1%
     patch:
       default:
         target: 50%

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"
@@ -15,6 +17,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     labels:
       - "dependencies"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -33,6 +33,8 @@ jobs:
       CARGO_AUDIT_VERSION: "0.22.1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -49,7 +51,9 @@ jobs:
           restore-keys: advisory-db-
 
       - name: Install cargo-audit
-        run: cargo install --locked cargo-audit --version "${CARGO_AUDIT_VERSION}"
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: cargo-audit@${{ env.CARGO_AUDIT_VERSION }}
 
       - name: Run cargo audit
         run: |

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # required to diff against BASELINE_COMMIT
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -201,13 +202,15 @@ jobs:
             --dev
       - name: Classify benchmark comparison outcome
         if: env.BASELINE_EXISTS == 'true' && env.SKIP_BENCHMARKS == 'false'
+        env:
+          COMPARE_REGRESSION_OUTCOME: ${{ steps.compare_regression.outcome }}
         run: |
           set -euo pipefail
 
           results_file="benches/main_vs_release_compare_results.txt"
 
           # Successful compare step => no regressions beyond configured threshold.
-          if [ "${{ steps.compare_regression.outcome }}" = "success" ]; then
+          if [ "$COMPARE_REGRESSION_OUTCOME" = "success" ]; then
             echo "BENCHMARK_REGRESSION_DETECTED=false" >> "$GITHUB_ENV"
             exit 0
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ env:
   ACTIONLINT_VERSION: "1.7.12"
   DPRINT_VERSION: "0.54.0"
   JUST_VERSION: "1.51.0"
-  NEXTEST_VERSION: "0.9.136"
-  RUMDL_VERSION: "0.1.94"
+  NEXTEST_VERSION: "0.9.137"
+  RUMDL_VERSION: "0.2.6"
   SHFMT_VERSION: "3.13.1"
   SHFMT_SHA256_DARWIN_AMD64: "6feedafc72915794163114f512348e2437d080d0047ef8b8fa2ec63b575f12af"
   SHFMT_SHA256_DARWIN_ARM64: "9680526be4a66ea1ffe988ed08af58e1400fe1e4f4aef5bd88b20bb9b3da33f8"
   SHFMT_SHA256_LINUX_AMD64: "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1"
   TAPLO_VERSION: "0.10.0"
-  TYPOS_VERSION: "1.46.1"
+  TYPOS_VERSION: "1.47.1"
   UV_VERSION: "0.11.15"
 
 jobs:
@@ -54,6 +54,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -65,14 +67,14 @@ jobs:
 
       - name: Install just
         if: matrix.os != 'windows-latest'
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: just@${{ env.JUST_VERSION }}
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: nextest@${{ env.NEXTEST_VERSION }}
+          tool: cargo-nextest@${{ env.NEXTEST_VERSION }}
 
       - name: Verify cargo-nextest
         run: cargo nextest --version
@@ -85,25 +87,25 @@ jobs:
 
       - name: Install rumdl (for Markdown linting)
         if: matrix.os != 'windows-latest'
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: rumdl@${{ env.RUMDL_VERSION }}
 
       - name: Install dprint (for YAML formatting)
         if: matrix.os != 'windows-latest'
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: dprint@${{ env.DPRINT_VERSION }}
 
       - name: Install typos-cli
         if: matrix.os != 'windows-latest'
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: typos-cli@${{ env.TYPOS_VERSION }}
 
       - name: Install taplo (for TOML formatting and linting)
         if: matrix.os != 'windows-latest'
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: taplo-cli@${{ env.TAPLO_VERSION }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,19 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  ACTIONLINT_VERSION: "1.7.12"
+  CARGO_NEXTEST_VERSION: "0.9.137"
   DPRINT_VERSION: "0.54.0"
   JUST_VERSION: "1.51.0"
-  NEXTEST_VERSION: "0.9.137"
   RUMDL_VERSION: "0.2.6"
-  SHFMT_VERSION: "3.13.1"
-  SHFMT_SHA256_DARWIN_AMD64: "6feedafc72915794163114f512348e2437d080d0047ef8b8fa2ec63b575f12af"
-  SHFMT_SHA256_DARWIN_ARM64: "9680526be4a66ea1ffe988ed08af58e1400fe1e4f4aef5bd88b20bb9b3da33f8"
-  SHFMT_SHA256_LINUX_AMD64: "fb096c5d1ac6beabbdbaa2874d025badb03ee07929f0c9ff67563ce8c75398b1"
   TAPLO_VERSION: "0.10.0"
   TYPOS_VERSION: "1.47.1"
   UV_VERSION: "0.11.15"
+  ZIZMOR_VERSION: "1.25.2"
 
 jobs:
   build:
@@ -53,6 +50,13 @@ jobs:
             target: x86_64-pc-windows-msvc
 
     steps:
+      - name: Disable Git autocrlf on Windows
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -65,8 +69,21 @@ jobs:
           cache-bin: false # Avoid restoring stale rustup/cargo shims from cache.
       # toolchain, components, etc. are specified in rust-toolchain.toml
 
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version-file: ".python-version"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: ${{ env.UV_VERSION }}
+          enable-cache: true
+
+      - name: Sync Python tooling
+        run: uv sync --locked --group dev
+
       - name: Install just
-        if: matrix.os != 'windows-latest'
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: just@${{ env.JUST_VERSION }}
@@ -74,183 +91,39 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: cargo-nextest@${{ env.NEXTEST_VERSION }}
-
-      - name: Verify cargo-nextest
-        run: cargo nextest --version
-
-      - name: Install uv (for Python scripts and pytest)
-        if: matrix.os != 'windows-latest'
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
-        with:
-          version: ${{ env.UV_VERSION }}
+          tool: cargo-nextest@${{ env.CARGO_NEXTEST_VERSION }}
 
       - name: Install rumdl (for Markdown linting)
-        if: matrix.os != 'windows-latest'
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: rumdl@${{ env.RUMDL_VERSION }}
 
       - name: Install dprint (for YAML formatting)
-        if: matrix.os != 'windows-latest'
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: dprint@${{ env.DPRINT_VERSION }}
 
       - name: Install typos-cli
-        if: matrix.os != 'windows-latest'
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: typos-cli@${{ env.TYPOS_VERSION }}
 
       - name: Install taplo (for TOML formatting and linting)
-        if: matrix.os != 'windows-latest'
+        id: install-taplo
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: taplo-cli@${{ env.TAPLO_VERSION }}
 
-      - name: Install actionlint (Linux/macOS)
-        if: matrix.os != 'windows-latest'
-        run: |
-          set -euo pipefail
+      - name: Install taplo on Windows after cached install failure
+        if: matrix.os == 'windows-latest' && steps.install-taplo.outcome == 'failure'
+        shell: pwsh
+        run: cargo install --locked taplo-cli --version $env:TAPLO_VERSION
 
-          # actionlint is published as prebuilt binaries (Go), not a Rust crate.
-          # Install directly from rhysd/actionlint releases to avoid cargo-binstall fallback failures.
-          # Verify SHA256 checksums from the upstream release for supply-chain hardening.
-          OS="$(uname -s)"
-          ARCH="$(uname -m)"
+      - name: Install zizmor
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: zizmor@${{ env.ZIZMOR_VERSION }}
 
-          case "$OS" in
-            Linux) ACTIONLINT_OS="linux" ;;
-            Darwin) ACTIONLINT_OS="darwin" ;;
-            *)
-              echo "Unsupported OS for actionlint: $OS" >&2
-              exit 1
-              ;;
-          esac
-
-          case "$ARCH" in
-            x86_64|amd64) ACTIONLINT_ARCH="amd64" ;;
-            arm64|aarch64) ACTIONLINT_ARCH="arm64" ;;
-            *)
-              echo "Unsupported architecture for actionlint: $ARCH" >&2
-              exit 1
-              ;;
-          esac
-
-          verify_sha256() {
-            local checksum_file="$1"
-            if command -v sha256sum >/dev/null 2>&1; then
-              sha256sum -c "$checksum_file"
-            else
-              shasum -a 256 -c "$checksum_file"
-            fi
-          }
-
-          VERSION="${ACTIONLINT_VERSION}"
-          TARBALL="actionlint_${VERSION}_${ACTIONLINT_OS}_${ACTIONLINT_ARCH}.tar.gz"
-          CHECKSUMS_FILE="actionlint_${VERSION}_checksums.txt"
-          BASE_URL="https://github.com/rhysd/actionlint/releases/download/v${VERSION}"
-
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "$tmpdir"' EXIT
-
-          curl -fsSL "${BASE_URL}/${TARBALL}" -o "$tmpdir/$TARBALL"
-          curl -fsSL "${BASE_URL}/${CHECKSUMS_FILE}" -o "$tmpdir/$CHECKSUMS_FILE"
-
-          orig_dir="$PWD"
-          cd "$tmpdir"
-          grep -F "  $TARBALL" "$CHECKSUMS_FILE" > checksum.txt
-          verify_sha256 checksum.txt
-          cd "$orig_dir"
-
-          tar -xzf "$tmpdir/$TARBALL" -C "$tmpdir"
-
-          actionlint_path="$(find "$tmpdir" -type f -name actionlint | head -n 1)"
-          if [[ -z "$actionlint_path" ]]; then
-            echo "actionlint binary not found in $TARBALL" >&2
-            exit 1
-          fi
-
-          sudo install -m 0755 "$actionlint_path" /usr/local/bin/actionlint
-
-      - name: actionlint -version
-        if: matrix.os != 'windows-latest'
-        run: actionlint -version
-
-      - name: Install additional tools (Linux)
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          # Install shellcheck, jq, and yamllint
-          sudo apt-get update
-          sudo apt-get install -y shellcheck jq yamllint
-
-          # Install shfmt (pinned for CI consistency)
-          SHFMT_ASSET="shfmt_v${SHFMT_VERSION}_linux_amd64"
-          SHFMT_BASE_URL="https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}"
-          SHFMT_SHA256="${SHFMT_SHA256_LINUX_AMD64}"
-
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "$tmpdir"' EXIT
-
-          curl -fsSL \
-            "${SHFMT_BASE_URL}/${SHFMT_ASSET}" \
-            -o "$tmpdir/${SHFMT_ASSET}"
-
-          (
-            cd "$tmpdir"
-            printf '%s  %s\n' "$SHFMT_SHA256" "$SHFMT_ASSET" > checksum.txt
-            sha256sum -c checksum.txt
-          )
-
-          sudo install -m 0755 "$tmpdir/${SHFMT_ASSET}" /usr/local/bin/shfmt
-
-      - name: Install additional tools (macOS)
-        if: matrix.os == 'macos-latest'
-        run: |
-          # Install shellcheck, jq, and yamllint via Homebrew
-          brew install shellcheck jq yamllint
-
-          # Install shfmt (pinned for CI consistency with Linux)
-          SHFMT_ARCH="amd64"
-          if [[ "$(uname -m)" == "arm64" ]]; then
-            SHFMT_ARCH="arm64"
-          fi
-
-          SHFMT_ASSET="shfmt_v${SHFMT_VERSION}_darwin_${SHFMT_ARCH}"
-          SHFMT_BASE_URL="https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}"
-          case "$SHFMT_ARCH" in
-            amd64) SHFMT_SHA256="${SHFMT_SHA256_DARWIN_AMD64}" ;;
-            arm64) SHFMT_SHA256="${SHFMT_SHA256_DARWIN_ARM64}" ;;
-            *)
-              echo "Unsupported shfmt architecture: $SHFMT_ARCH" >&2
-              exit 1
-              ;;
-          esac
-
-          tmpdir="$(mktemp -d)"
-          trap 'rm -rf "$tmpdir"' EXIT
-
-          curl -fsSL \
-            "${SHFMT_BASE_URL}/${SHFMT_ASSET}" \
-            -o "$tmpdir/${SHFMT_ASSET}"
-
-          (
-            cd "$tmpdir"
-            printf '%s  %s\n' "$SHFMT_SHA256" "$SHFMT_ASSET" > checksum.txt
-            shasum -a 256 -c checksum.txt
-          )
-
-          sudo install -m 0755 "$tmpdir/${SHFMT_ASSET}" /usr/local/bin/shfmt
-
-      - name: Run CI checks (Linux/macOS)
-        if: matrix.os != 'windows-latest'
+      - name: Run CI checks
         run: just ci
-
-      - name: Build and test (Windows)
-        if: matrix.os == 'windows-latest'
-        run: |
-          cargo build --verbose --all-targets
-          cargo nextest run --profile ci --lib
-          cargo test --doc --verbose
-          cargo nextest run --release --profile ci --tests

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -54,6 +54,8 @@ jobs:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set Codacy paths
         run: |

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,12 +23,13 @@ jobs:
     env:
       CARGO_LLVM_COV_VERSION: "0.8.7"
       JUST_VERSION: "1.51.0"
-      NEXTEST_VERSION: "0.9.136"
+      NEXTEST_VERSION: "0.9.137"
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Needed for codecov to analyze diff
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -40,35 +41,20 @@ jobs:
       - name: Install LLVM coverage tools
         run: rustup component add llvm-tools-preview
 
-      - name: Cache cargo-llvm-cov
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cargo/bin/cargo-llvm-cov
-          key: cargo-llvm-cov-${{ runner.os }}-${{ env.CARGO_LLVM_COV_VERSION }}
-          restore-keys: |
-            cargo-llvm-cov-${{ runner.os }}-
-
       - name: Install cargo-llvm-cov
-        run: |
-          installed_version=""
-          if command -v cargo-llvm-cov &> /dev/null; then
-            installed_version="$(cargo llvm-cov --version)"
-            installed_version="${installed_version#cargo-llvm-cov }"
-          fi
-
-          if [ "${installed_version}" != "${CARGO_LLVM_COV_VERSION}" ]; then
-            cargo install cargo-llvm-cov --locked --force --version "${CARGO_LLVM_COV_VERSION}"
-          fi
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
+        with:
+          tool: cargo-llvm-cov@${{ env.CARGO_LLVM_COV_VERSION }}
 
       - name: Install just
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
           tool: just@${{ env.JUST_VERSION }}
 
       - name: Install cargo-nextest
-        uses: taiki-e/install-action@e49978b799e49ff429d162b7a30601a569ab6538 # v2.81.1
+        uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7
         with:
-          tool: nextest@${{ env.NEXTEST_VERSION }}
+          tool: cargo-nextest@${{ env.NEXTEST_VERSION }}
 
       - name: Verify cargo-nextest
         run: cargo nextest --version

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         if: matrix.language == 'rust'

--- a/.github/workflows/generate-baseline.yml
+++ b/.github/workflows/generate-baseline.yml
@@ -54,11 +54,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # Full history for tag operations
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
-          cache: true
+          cache: false
           cache-bin: false
           # Toolchain from rust-toolchain.toml
 
@@ -66,6 +67,7 @@ jobs:
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: ${{ env.UV_VERSION }}
+          enable-cache: false
 
       - name: Verify uv installation
         run: uv --version
@@ -112,6 +114,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
           ref: ${{ steps.ref_info.outputs.ref_name }}
           path: bench-target
 
@@ -204,6 +207,7 @@ jobs:
       - name: Display next steps
         env:
           BASELINE_REF: ${{ steps.ref_info.outputs.ref_name }}
+          BASELINE_ARTIFACT_NAME: ${{ steps.safe_name.outputs.artifact_name }}
           SAFE_REF_TYPE: ${{ github.ref_type }}
         run: |
           set -euo pipefail
@@ -213,7 +217,7 @@ jobs:
           echo "📋 Summary:"
           echo "  Ref: $BASELINE_REF"
           echo "  Commit: ${BASELINE_COMMIT:-unknown}"
-          echo "  Artifact: ${{ steps.safe_name.outputs.artifact_name }}"
+          echo "  Artifact: $BASELINE_ARTIFACT_NAME"
           echo ""
           echo "🔄 The benchmark workflow will now use this baseline for:"
           echo "  • Pull request performance testing"

--- a/.github/workflows/profiling-benchmarks.yml
+++ b/.github/workflows/profiling-benchmarks.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
@@ -57,28 +59,15 @@ jobs:
           cache: false
           rustflags: ""
 
-      - name: Cache Cargo dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-profiling-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-profiling-
-            ${{ runner.os }}-cargo-
-
       - name: Install system dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y build-essential
 
       - name: Set profiling mode
+        env:
+          INPUT_MODE: ${{ github.event.inputs.mode || 'development' }}
         run: |
-          INPUT_MODE="${{ github.event.inputs.mode || 'development' }}"
           # Profiling mode determination:
           # 1. Tag pushes (github.event_name == "push"): Always use development mode
           #    - Avoids CI timeout issues on release tag creation
@@ -88,7 +77,7 @@ jobs:
           # 3. Scheduled runs and manual dispatch with mode="production": Use production mode
           #    - Full large-scale profiling counts, including opt-in 4D 5K/10K
           #    - May take 4-6 hours
-          if [[ "$INPUT_MODE" == "development" ]] || [[ "${{ github.event_name }}" == "push" ]]; then
+          if [[ "$INPUT_MODE" == "development" ]] || [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             echo "PROFILING_DEV_MODE=1" >> "$GITHUB_ENV"
             echo "Running in development mode (reduced scale)"
             # Smaller, faster dev runs
@@ -121,13 +110,14 @@ jobs:
           cargo build --profile perf --bench profiling_suite
 
       - name: Run comprehensive profiling benchmarks
+        env:
+          BENCH_FILTER_VALUE: ${{ github.event.inputs.benchmark_filter || '' }}
         run: |
           # Create results directory
           mkdir -p profiling-results
 
           # Set benchmark filter if provided. Keep the Criterion separator and
           # filter as separate argv tokens for cargo bench.
-          BENCH_FILTER_VALUE="${{ github.event.inputs.benchmark_filter || '' }}"
           BENCH_FILTER_ARGS=()
           if [[ -n "$BENCH_FILTER_VALUE" ]]; then
             BENCH_FILTER_ARGS=("--" "$BENCH_FILTER_VALUE")
@@ -159,28 +149,43 @@ jobs:
             2>&1 | tee profiling-results/memory_profiling_detailed.log
 
       - name: Generate profiling summary
+        env:
+          BENCH_FILTER_VALUE: ${{ github.event.inputs.benchmark_filter || '' }}
+          SUMMARY_BRANCH: ${{ github.ref_name }}
+          SUMMARY_COMMIT: ${{ github.sha }}
+          SUMMARY_RUNNER_OS: ${{ runner.os }}
+          SUMMARY_TRIGGER: ${{ github.event_name }}
         run: |
+          if [[ "${PROFILING_DEV_MODE:-}" == "1" ]]; then
+            summary_mode="Development"
+            summary_mode_detail="Development (reduced auxiliary profiling for faster iteration)"
+          else
+            summary_mode="Production"
+            summary_mode_detail="Production (large-scale counts plus auxiliary profiling)"
+          fi
+          if [[ "$BENCH_FILTER_VALUE" == *memory* ]]; then
+            summary_memory_tracking="Enabled for memory benchmarks (count-allocations feature)"
+          else
+            summary_memory_tracking="Enabled only for memory-specific runs"
+          fi
+          summary_benchmark_filter="${BENCH_FILTER_VALUE:-All benchmarks}"
+
           # Create a summary of the profiling run
           cat > profiling-results/profiling_summary.md << EOF
           # Comprehensive Profiling Results
 
           **Date**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
-          **Commit**: ${{ github.sha }}
-          **Branch**: ${{ github.ref_name }}
-          **Trigger**: ${{ github.event_name }}
-          **Mode**: ${{ env.PROFILING_DEV_MODE == '1' && 'Development' || 'Production' }}
-          **Runner**: ${{ runner.os }}
+          **Commit**: ${SUMMARY_COMMIT}
+          **Branch**: ${SUMMARY_BRANCH}
+          **Trigger**: ${SUMMARY_TRIGGER}
+          **Mode**: ${summary_mode}
+          **Runner**: ${SUMMARY_RUNNER_OS}
 
           ## Configuration
 
-          - **Profiling Mode**: ${{ env.PROFILING_DEV_MODE == '1' &&
-            'Development (reduced auxiliary profiling for faster iteration)' ||
-            'Production (large-scale counts plus auxiliary profiling)' }}
-          - **Memory Tracking**: ${{ contains(github.event.inputs.benchmark_filter || '', 'memory') &&
-            'Enabled for memory benchmarks (count-allocations feature)' ||
-            'Enabled only for memory-specific runs' }}
-          - **Benchmark Filter**: ${{ (github.event.inputs.benchmark_filter || '') != '' &&
-            github.event.inputs.benchmark_filter || 'All benchmarks' }}
+          - **Profiling Mode**: ${summary_mode_detail}
+          - **Memory Tracking**: ${summary_memory_tracking}
+          - **Benchmark Filter**: ${summary_benchmark_filter}
 
           ## Benchmark Categories Run
 
@@ -208,10 +213,13 @@ jobs:
 
       - name: Save profiling baseline for tagged release
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          SAFE_REF_NAME: ${{ github.ref_name }}
         run: |
           # For tagged releases, save as new baseline
           echo "Tagged release detected - this will serve as new profiling baseline"
-          cp -r target/criterion profiling-results/criterion-baseline-${{ github.ref_name }}
+          safe_ref_name="$(printf '%s' "$SAFE_REF_NAME" | tr -c 'A-Za-z0-9._-' '_')"
+          cp -r target/criterion "profiling-results/criterion-baseline-${safe_ref_name}"
 
       - name: Upload profiling results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -232,8 +240,10 @@ jobs:
 
       - name: Log completion (if triggered manually)
         if: github.event_name == 'workflow_dispatch'
+        env:
+          SUMMARY_COMMIT: ${{ github.sha }}
         run: |
-          echo "Manual profiling run completed for commit ${{ github.sha }}"
+          echo "Manual profiling run completed for commit $SUMMARY_COMMIT"
           echo "Check the Actions tab for detailed results and artifacts"
 
   memory-stress-test:
@@ -251,23 +261,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
         with:
           cache: false
           rustflags: ""
-
-      - name: Cache Cargo dependencies
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-cargo-memory-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Run allocation API tests
         run: |

--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1

--- a/.github/workflows/semgrep-sarif.yml
+++ b/.github/workflows/semgrep-sarif.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,38 @@
+name: zizmor
+
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.ref_name }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "42 18 * * 5"
+  workflow_dispatch:
+
+jobs:
+  analyze:
+    name: GitHub Actions Security Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          inputs: .github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ repository-rule files.
 
 - **Language**: Rust
 - **Project**: d‑dimensional Delaunay triangulation library
-- **MSRV**: 1.95
+- **MSRV**: 1.96.0
 - **Edition**: 2024
 - **Unsafe code**: forbidden (`#![forbid(unsafe_code)]`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,7 +154,7 @@ dependencies.
 The project uses:
 
 - **Edition**: Rust 2024
-- **MSRV**: Rust 1.95.0
+- **MSRV**: Rust 1.96.0
 - **Linting**: Strict clippy pedantic mode
 - **Testing**: Standard `#[test]` with comprehensive coverage
 - **Benchmarking**: Criterion with allocation tracking
@@ -165,7 +165,7 @@ The project uses:
 
 When you enter the project directory, `rustup` will automatically:
 
-- **Install the correct Rust version** (1.95.0) if you don't have it
+- **Install the correct Rust version** (1.96.0) if you don't have it
 - **Switch to the pinned version** for this project
 - **Install required components** (clippy, rustfmt, rust-src)
 - **Keep the host toolchain lean**; workflows install cross-compilation
@@ -181,7 +181,7 @@ When you enter the project directory, `rustup` will automatically:
 **First time in the project?** You'll see:
 
 ```text
-info: syncing channel updates for '1.95.0-<your-platform>'
+info: syncing channel updates for '1.96.0-<your-platform>'
 info: downloading component 'cargo'
 info: downloading component 'clippy'
 ...
@@ -193,7 +193,7 @@ This is normal and only happens once. After that, the correct toolchain is used 
 
 ```bash
 rustup show
-# Should show: active toolchain: 1.95.0-<platform> (overridden by '/path/to/delaunay/rust-toolchain.toml')
+# Should show: active toolchain: 1.96.0-<platform> (overridden by '/path/to/delaunay/rust-toolchain.toml')
 ```
 
 ### Python Development Environment

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "delaunay"
 version = "0.7.8"
 edition = "2024"
-rust-version = "1.95"
+rust-version = "1.96.0"
 authors = [ "Adam Getchell <adam@adamgetchell.org>" ]
 homepage = "https://github.com/acgetchell/delaunay"
 documentation = "https://docs.rs/delaunay"

--- a/benches/allocation_hot_paths.rs
+++ b/benches/allocation_hot_paths.rs
@@ -12,7 +12,6 @@
 //! placeholder so workspace benchmark compile checks remain feature-neutral.
 
 use criterion::{criterion_group, criterion_main};
-
 #[cfg(feature = "count-allocations")]
 #[path = "common/bench_utils.rs"]
 mod bench_utils;
@@ -31,6 +30,7 @@ mod allocation_contracts {
     };
     use delaunay::prelude::query::measure_with_result;
     use delaunay::prelude::tds::{SimplexKey, TdsError, VertexKey, facet_key_from_vertices};
+    use std::assert_matches;
     use std::{hint::black_box, num::NonZeroUsize, time::Duration};
     use thiserror::Error;
 
@@ -417,7 +417,7 @@ mod allocation_contracts {
                     let (location, stats) =
                         bench_result(locate_result, "hinted locate_with_stats should succeed");
 
-                    assert!(matches!(location, LocateResult::InsideSimplex(found) if found == simplex_key));
+                    assert_matches!(location, LocateResult::InsideSimplex(found) if found == simplex_key);
                     assert!(stats.used_hint);
                     assert!(!stats.fell_back_to_scan());
                     assert_allocation_budget(

--- a/benches/remove_vertex.rs
+++ b/benches/remove_vertex.rs
@@ -301,7 +301,7 @@ fn centered_unit_direction<const D: usize>(point: &Point<f64, D>) -> [f64; D] {
 
     for (direction_coord, coordinate) in direction.iter_mut().zip(point.coords()) {
         *direction_coord = coordinate - COSPHERICAL_CENTER;
-        norm_squared += *direction_coord * *direction_coord;
+        norm_squared = (*direction_coord).mul_add(*direction_coord, norm_squared);
     }
 
     if norm_squared <= f64::EPSILON {

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,7 +2,7 @@
 # This ensures consistent configuration across all developers and IDEs
 
 # Minimum Supported Rust Version - matches Cargo.toml and rust-toolchain.toml
-msrv = "1.95"
+msrv = "1.96.0"
 
 # Note: Lint levels are controlled via command-line flags in AGENTS.md:
 # cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -37,6 +37,40 @@ Both repositories now share the same core Rust and Python support-tooling loop:
 
 The useful updates ported in this pass are:
 
+- Rust MSRV metadata now follows `causal-triangulations` and `la-stack` at
+  Rust 1.96.0. `Cargo.toml`, `rust-toolchain.toml`, `clippy.toml`, contributor
+  docs, and agent guidance all use the same baseline so the upcoming
+  `la-stack` 0.4.2 dependency update in #424 has no MSRV conflict.
+- The local `cargo-nextest` pin and CI workflow environment variables now use
+  0.9.137, matching both sibling repositories. `cargo-llvm-cov` stays on 0.8.7,
+  which is still shared across the repositories.
+- CI Markdown and spelling tool pins now track the newer sibling-repository
+  versions used by `la-stack`: `rumdl` 0.2.6 and `typos-cli` 1.47.1.
+- Local just helpers now version-check the pinned `cargo-nextest`, `rumdl`,
+  `typos-cli`, and `zizmor` tools instead of accepting any installed version.
+  Delaunay does not currently pin or invoke `cargo-instruments`; no
+  `cargo-instruments` alignment was needed in this pass.
+- GitHub Actions Cargo tool installation now uses
+  `taiki-e/cache-cargo-install-action` where Delaunay previously used
+  `taiki-e/install-action`, matching the sibling workflow pattern for pinned
+  Rust CLI tools while preserving Delaunay's existing matrix shape and
+  platform-specific validation split.
+- `.github/workflows/audit.yml` now installs `cargo-audit` 0.22.1 through the
+  same cached Cargo-tool installer, and `.github/workflows/zizmor.yml` imports
+  the dedicated GitHub Actions security scan from `la-stack`.
+- `semgrep.yaml` now carries the low-noise hardening rules already proven useful
+  in sibling repositories: checkout credential persistence, `pull_request_target`
+  avoidance, `github-script` expression interpolation, locked `uv sync`, direct
+  `subprocess.run` outside the wrapper, public `_unchecked` API exposure,
+  prefixed panic macros, doctest unwrap/expect usage, and erased dynamic-error
+  doctest examples. It also ports the sibling `assert!(matches!(...))` doctest
+  rule and rewrites public documentation examples to `std::assert_matches!` so
+  failing examples show the unmatched value instead of a bare boolean.
+- Delaunay intentionally keeps its lean `rust-toolchain.toml` profile instead
+  of copying the heavier sibling toolchain component and target lists. The
+  minimal profile plus `clippy`, `rustfmt`, and `rust-src` remains the better
+  default for this larger crate because workflows already install additional
+  targets or components when they need them.
 - `just check-fast` for a cheap compile-only check.
 - `just markdown-check` keeps `rumdl` as the Markdown linter and adds a raw
   active-doc line-length guard so table rows and other Markdown constructs that
@@ -102,15 +136,16 @@ The useful updates ported in this pass are:
   UI exposes a separate duplicate-code metric, treat it the same way.
 - CI and local setup pins should track the same supported tool versions when
   practical. The current workflow pins align coverage and test tooling on
-  `cargo-llvm-cov` 0.8.7 and `cargo-nextest` 0.9.136. Both CI and Codecov
-  install the same `cargo-nextest` pin with the repository's pinned binary-tool
-  installer and verify `cargo nextest --version` before nextest-backed recipes
-  run. The CI build matrix also installs and verifies that pin on Windows, where
-  the lightweight direct-Cargo job runs library and integration tests through
-  `cargo nextest run` while keeping doctests on `cargo test --doc`. Local
-  `just setup-tools` uses `cargo install --locked cargo-nextest` and verifies
-  the command is available for developer machines. All uv-backed workflows use
-  uv 0.11.15 to match the local Python tooling bootstrap.
+  `cargo-llvm-cov` 0.8.7 and `cargo-nextest` 0.9.137. Both CI and Codecov
+  install the same `cargo-nextest` pin with the sibling repositories'
+  `taiki-e/cache-cargo-install-action` pattern and verify
+  `cargo nextest --version` before nextest-backed recipes run. The CI build
+  matrix also installs and verifies that pin on Windows, where the lightweight
+  direct-Cargo job runs library and integration tests through `cargo nextest
+  run` while keeping doctests on `cargo test --doc`. Local `just setup-tools`
+  uses `cargo install --locked cargo-nextest` and verifies the pinned version is
+  available for developer machines. All uv-backed workflows use uv 0.11.15 to
+  match the local Python tooling bootstrap.
 - `.config/nextest.toml` keeps `profile.ci` bounded for normal CI while
   `profile.slow` raises the per-test watchdog for `just test-slow`, allowing
   intentional multi-minute correctness regressions to run without making the

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -53,8 +53,13 @@ The useful updates ported in this pass are:
 - GitHub Actions Cargo tool installation now uses
   `taiki-e/cache-cargo-install-action` where Delaunay previously used
   `taiki-e/install-action`, matching the sibling workflow pattern for pinned
-  Rust CLI tools while preserving Delaunay's existing matrix shape and
-  platform-specific validation split.
+  Rust CLI tools while preserving Delaunay's existing matrix shape.
+- `.github/workflows/ci.yml` now follows the sibling repository pattern on all
+  three operating systems: set up Python and uv, sync the locked dev tool group,
+  install pinned Cargo tools, and run `just ci` for Linux, macOS, and Windows.
+  uv-managed wrappers provide `actionlint`, `shellcheck`, `shfmt`, and
+  `yamllint`, avoiding platform-specific apt/Homebrew/curl installation paths in
+  the CI job.
 - `.github/workflows/audit.yml` now installs `cargo-audit` 0.22.1 through the
   same cached Cargo-tool installer, and `.github/workflows/zizmor.yml` imports
   the dedicated GitHub Actions security scan from `la-stack`.
@@ -136,16 +141,23 @@ The useful updates ported in this pass are:
   UI exposes a separate duplicate-code metric, treat it the same way.
 - CI and local setup pins should track the same supported tool versions when
   practical. The current workflow pins align coverage and test tooling on
-  `cargo-llvm-cov` 0.8.7 and `cargo-nextest` 0.9.137. Both CI and Codecov
-  install the same `cargo-nextest` pin with the sibling repositories'
-  `taiki-e/cache-cargo-install-action` pattern and verify
-  `cargo nextest --version` before nextest-backed recipes run. The CI build
-  matrix also installs and verifies that pin on Windows, where the lightweight
-  direct-Cargo job runs library and integration tests through `cargo nextest
-  run` while keeping doctests on `cargo test --doc`. Local `just setup-tools`
-  uses `cargo install --locked cargo-nextest` and verifies the pinned version is
-  available for developer machines. All uv-backed workflows use uv 0.11.15 to
-  match the local Python tooling bootstrap.
+  `cargo-llvm-cov` 0.8.7 and `cargo-nextest` 0.9.137. CI, Codecov, and local
+  setup install the same `cargo-nextest` pin with the sibling repositories'
+  `taiki-e/cache-cargo-install-action`/`cargo install --locked` pattern before
+  nextest-backed recipes run. The CI build matrix runs `just ci` on Linux,
+  macOS, and Windows after syncing the locked uv dev group and installing the
+  pinned Cargo tools. All uv-backed workflows use uv 0.11.15 to match the local
+  Python tooling bootstrap.
+- `.codecov.yml` now ratchets Delaunay's coverage policy above the older
+  causal-triangulations baseline without copying la-stack's near-total
+  threshold. Project coverage targets the current 90% line with only 1%
+  tolerated drift. Patch coverage remains at 50% for this cleanup because
+  Codecov attributes the `assert_matches!` test-quality migration as uncovered
+  macro-invocation churn; once that lands, the next coverage-only ratchet should
+  raise the patch target toward 70% without forcing superficial tests.
+- Semgrep now ports the sibling repositories' Rust examples/benchmarks hygiene
+  checks: examples and benchmarks should avoid panic-only `unwrap`/`expect`
+  paths and dynamic error erasure so public usage remains explicit and typed.
 - `.config/nextest.toml` keeps `profile.ci` bounded for normal CI while
   `profile.slow` raises the per-test watchdog for `just test-slow`, allowing
   intentional multi-minute correctness regressions to run without making the
@@ -157,6 +169,9 @@ Some causal-triangulations tooling remains project-specific and was not ported:
 
 - CDT-specific Semgrep rules for geometry-backend isolation, foliation
   validation, CDT error variants, and `causal_triangulations::prelude` imports.
+- CDT's Python test `Path.read_text`/`write_text` encoding rule is deferred to
+  #429 because Delaunay has existing Python fixture cleanup to do before that
+  rule can become low-noise.
 - CDT's `examples-validate` recipe and output-marker checks; Delaunay examples
   are currently validated through `just examples`.
 - CDT's `performance-analysis` script; Delaunay keeps its benchmark helpers and

--- a/justfile
+++ b/justfile
@@ -23,7 +23,8 @@ _coverage_base_args := '''--ignore-filename-regex '(^|/)(benches|examples)/' \
 _ensure-actionlint:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v actionlint >/dev/null || { echo "❌ 'actionlint' not found. See 'just setup' or https://github.com/rhysd/actionlint"; exit 1; }
+    command -v uv >/dev/null || { echo "❌ 'uv' not found. See 'just setup' or https://github.com/astral-sh/uv"; exit 1; }
+    uv run actionlint -version >/dev/null
 
 _ensure-cargo-llvm-cov:
     #!/usr/bin/env bash
@@ -96,12 +97,14 @@ _ensure-rumdl:
 _ensure-shellcheck:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v shellcheck >/dev/null || { echo "❌ 'shellcheck' not found. See 'just setup' or https://www.shellcheck.net"; exit 1; }
+    command -v uv >/dev/null || { echo "❌ 'uv' not found. See 'just setup' or https://github.com/astral-sh/uv"; exit 1; }
+    uv run shellcheck --version >/dev/null
 
 _ensure-shfmt:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v shfmt >/dev/null || { echo "❌ 'shfmt' not found. See 'just setup' or install: brew install shfmt"; exit 1; }
+    command -v uv >/dev/null || { echo "❌ 'uv' not found. See 'just setup' or https://github.com/astral-sh/uv"; exit 1; }
+    uv run shfmt --version >/dev/null
 
 # Internal helper: ensure taplo is installed
 _ensure-taplo:
@@ -132,7 +135,8 @@ _ensure-uv:
 _ensure-yamllint:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v yamllint >/dev/null || { echo "❌ 'yamllint' not found. See 'just setup' or install: brew install yamllint"; exit 1; }
+    command -v uv >/dev/null || { echo "❌ 'uv' not found. See 'just setup' or https://github.com/astral-sh/uv"; exit 1; }
+    uv run yamllint --version >/dev/null
 
 _ensure-zizmor:
     #!/usr/bin/env bash
@@ -156,7 +160,7 @@ action-lint: _ensure-actionlint
         files+=("$file")
     done < <(git ls-files -z '.github/workflows/*.yml' '.github/workflows/*.yaml')
     if [ "${#files[@]}" -gt 0 ]; then
-        printf '%s\0' "${files[@]}" | xargs -0 actionlint
+        printf '%s\0' "${files[@]}" | xargs -0 uv run actionlint
     else
         echo "No workflow files found to lint."
     fi
@@ -795,10 +799,6 @@ setup-tools:
         install_with_brew taplo
         install_with_brew dprint
         install_with_brew rumdl
-        install_with_brew yamllint
-        install_with_brew shfmt
-        install_with_brew shellcheck
-        install_with_brew actionlint
         echo ""
     else
         echo "⚠️  'brew' not found. Skipping Homebrew installs."
@@ -807,9 +807,17 @@ setup-tools:
         else
             echo "Install required tools via your system package manager, or ensure they are on PATH."
         fi
-        echo "Required tools: uv, jq, taplo, dprint, rumdl, yamllint, shfmt, shellcheck, actionlint, git-cliff, typos, zizmor"
+        echo "Required standalone tools: uv, jq, taplo, dprint, rumdl, git-cliff, typos, zizmor"
         echo ""
     fi
+
+    echo "Ensuring uv-managed Python tooling..."
+    if ! have uv; then
+        echo "❌ 'uv' not found. Install uv from https://github.com/astral-sh/uv and re-run: just setup-tools"
+        exit 1
+    fi
+    uv sync --group dev
+    echo ""
 
     echo "Ensuring Rust toolchain + components..."
     if ! have rustup; then
@@ -889,7 +897,7 @@ setup-tools:
     echo "Verifying required commands are available..."
     missing=0
 
-    cmds=(uv jq taplo dprint rumdl yamllint shfmt shellcheck actionlint git-cliff typos zizmor)
+    cmds=(uv jq taplo dprint rumdl git-cliff typos zizmor)
     cmds+=(cargo-nextest cargo-llvm-cov)
 
     for cmd in "${cmds[@]}"; do
@@ -897,6 +905,15 @@ setup-tools:
             echo "  ✓ $cmd"
         else
             echo "  ✗ $cmd"
+            missing=1
+        fi
+    done
+
+    for cmd in actionlint shellcheck shfmt yamllint; do
+        if uv run "$cmd" --version >/dev/null 2>&1 || uv run "$cmd" -version >/dev/null 2>&1; then
+            echo "  ✓ $cmd (uv)"
+        else
+            echo "  ✗ $cmd (uv)"
             missing=1
         fi
     done
@@ -927,8 +944,8 @@ shell-check: _ensure-shellcheck _ensure-shfmt
         files+=("$file")
     done < <(git ls-files -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then
-        printf '%s\0' "${files[@]}" | xargs -0 -n4 shellcheck -x
-        printf '%s\0' "${files[@]}" | xargs -0 shfmt -d
+        printf '%s\0' "${files[@]}" | xargs -0 -n4 uv run shellcheck -x
+        printf '%s\0' "${files[@]}" | xargs -0 uv run shfmt -d
     else
         echo "No shell files found to check."
     fi
@@ -943,7 +960,7 @@ shell-fmt: _ensure-shfmt
     done < <(git ls-files -z '*.sh')
     if [ "${#files[@]}" -gt 0 ]; then
         echo "🧹 shfmt -w (${#files[@]} files)"
-        printf '%s\0' "${files[@]}" | xargs -0 shfmt -w
+        printf '%s\0' "${files[@]}" | xargs -0 uv run shfmt -w
     else
         echo "No shell files found to format."
     fi
@@ -1169,7 +1186,7 @@ yaml-lint: _ensure-yamllint
     done < <(git ls-files -z '*.yml' '*.yaml' 'CITATION.cff')
     if [ "${#files[@]}" -gt 0 ]; then
         echo "🔍 yamllint (${#files[@]} YAML/CFF files)"
-        yamllint --strict -c .yamllint "${files[@]}"
+        uv run yamllint --strict -c .yamllint "${files[@]}"
     else
         echo "No YAML files found to lint."
     fi

--- a/justfile
+++ b/justfile
@@ -735,8 +735,7 @@ semgrep-test: _ensure-uv
     set -euo pipefail
     config_dir="$(mktemp -d "${TMPDIR:-/tmp}/delaunay-semgrep-config.XXXXXX")"
     cleanup() {
-        find "$config_dir" -type l -exec unlink {} \;
-        find "$config_dir" -depth -type d -exec rmdir {} +
+        rm -rf "$config_dir"
     }
     trap cleanup EXIT
 

--- a/justfile
+++ b/justfile
@@ -7,7 +7,10 @@
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
 cargo_llvm_cov_version := "0.8.7"
-nextest_version := "0.9.136"
+nextest_version := "0.9.137"
+rumdl_version := "0.2.6"
+typos_version := "1.47.1"
+zizmor_version := "1.25.2"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes benches/examples from reports while allowing integration tests to
@@ -25,8 +28,12 @@ _ensure-actionlint:
 _ensure-cargo-llvm-cov:
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! command -v cargo-llvm-cov >/dev/null; then
-        echo "❌ 'cargo-llvm-cov' not found. See 'just setup-tools' or install:"
+    installed_version=""
+    if command -v cargo-llvm-cov >/dev/null; then
+        installed_version="$(cargo llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_version" != "{{ cargo_llvm_cov_version }}" ]]; then
+        echo "❌ 'cargo-llvm-cov' {{ cargo_llvm_cov_version }} not found. See 'just setup-tools' or install:"
         echo "   cargo install --locked cargo-llvm-cov --version {{ cargo_llvm_cov_version }}"
         exit 1
     fi
@@ -34,8 +41,12 @@ _ensure-cargo-llvm-cov:
 _ensure-nextest:
     #!/usr/bin/env bash
     set -euo pipefail
-    if ! command -v cargo-nextest >/dev/null; then
-        echo "❌ 'cargo-nextest' not found. See 'just setup-tools' or install:"
+    installed_version=""
+    if cargo nextest --version >/dev/null 2>&1; then
+        installed_version="$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_version" != "{{ nextest_version }}" ]]; then
+        echo "❌ 'cargo-nextest' {{ nextest_version }} not found. See 'just setup-tools' or install:"
         echo "   cargo install --locked cargo-nextest --version {{ nextest_version }}"
         exit 1
     fi
@@ -72,7 +83,15 @@ _ensure-dprint:
 _ensure-rumdl:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v rumdl >/dev/null || { echo "❌ 'rumdl' not found. See 'just setup' or install: cargo install rumdl"; exit 1; }
+    installed_version=""
+    if command -v rumdl >/dev/null; then
+        installed_version="$(rumdl --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_version" != "{{ rumdl_version }}" ]]; then
+        echo "❌ 'rumdl' {{ rumdl_version }} not found. See 'just setup-tools' or install:"
+        echo "   cargo install --locked rumdl --version {{ rumdl_version }}"
+        exit 1
+    fi
 
 _ensure-shellcheck:
     #!/usr/bin/env bash
@@ -94,7 +113,15 @@ _ensure-taplo:
 _ensure-typos:
     #!/usr/bin/env bash
     set -euo pipefail
-    command -v typos >/dev/null || { echo "❌ 'typos' not found. See 'just setup-tools' or install: cargo install typos-cli"; exit 1; }
+    installed_version=""
+    if command -v typos >/dev/null; then
+        installed_version="$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_version" != "{{ typos_version }}" ]]; then
+        echo "❌ 'typos' {{ typos_version }} not found. See 'just setup-tools' or install:"
+        echo "   cargo install --locked typos-cli --version {{ typos_version }}"
+        exit 1
+    fi
 
 # Internal helper: ensure uv is installed
 _ensure-uv:
@@ -106,6 +133,19 @@ _ensure-yamllint:
     #!/usr/bin/env bash
     set -euo pipefail
     command -v yamllint >/dev/null || { echo "❌ 'yamllint' not found. See 'just setup' or install: brew install yamllint"; exit 1; }
+
+_ensure-zizmor:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    installed_version=""
+    if command -v zizmor >/dev/null; then
+        installed_version="$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_version" != "{{ zizmor_version }}" ]]; then
+        echo "❌ 'zizmor' {{ zizmor_version }} not found. See 'just setup-tools' or install:"
+        echo "   cargo install --locked zizmor --version {{ zizmor_version }}"
+        exit 1
+    fi
 
 # GitHub Actions workflow validation
 action-lint: _ensure-actionlint
@@ -334,7 +374,7 @@ lint: lint-code lint-docs lint-config
 lint-code: fmt-check clippy doc-check semgrep semgrep-test python-lint shell-lint
 
 # Configuration checks: JSON, TOML, YAML/CFF, GitHub Actions workflows
-lint-config: json-check toml-check toml-lint toml-fmt-check yaml-check citation-check action-lint
+lint-config: json-check toml-check toml-lint toml-fmt-check yaml-check citation-check action-lint zizmor
 
 # Documentation linting: Markdown + spell checking
 lint-docs: markdown-check spell-check
@@ -344,15 +384,15 @@ markdown-check: _ensure-rumdl
     set -euo pipefail
     files=()
     while IFS= read -r -d '' file; do
+        case "$file" in
+            CHANGELOG.md|docs/archive/*) continue ;;
+        esac
         files+=("$file")
     done < <(git ls-files -z '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
         printf '%s\0' "${files[@]}" | xargs -0 -n100 rumdl check
         violations=0
         for file in "${files[@]}"; do
-            case "$file" in
-                CHANGELOG.md|docs/archive/*) continue ;;
-            esac
             line_number=0
             while IFS= read -r line || [[ -n "$line" ]]; do
                 line_number=$((line_number + 1))
@@ -376,6 +416,9 @@ markdown-fix: _ensure-rumdl
     set -euo pipefail
     files=()
     while IFS= read -r -d '' file; do
+        case "$file" in
+            CHANGELOG.md|docs/archive/*) continue ;;
+        esac
         files+=("$file")
     done < <(git ls-files -z '*.md')
     if [ "${#files[@]}" -gt 0 ]; then
@@ -445,8 +488,8 @@ perf-help:
     @echo "  CRIT_SAMPLE_SIZE=100 just bench  # Custom sample size"
     @echo "  just bench-ci              # Final optimized CI-suite benchmark run"
     @echo "  just profile v0.7.5        # v0.7.5 code on its declared Rust toolchain"
-    @echo "  just profile 1.95          # Current tree on Rust 1.95"
-    @echo "  just profile 1.95 v0.7.5   # v0.7.5 code on Rust 1.95"
+    @echo "  just profile 1.96.0        # Current tree on Rust 1.96.0"
+    @echo "  just profile 1.96.0 v0.7.5 # v0.7.5 code on Rust 1.96.0"
 
 # Quick pre-push 2D-5D large-scale wall-clock smoke guard.
 perf-large-scale-smoke max_secs="60": _ensure-nextest
@@ -764,7 +807,7 @@ setup-tools:
         else
             echo "Install required tools via your system package manager, or ensure they are on PATH."
         fi
-        echo "Required tools: uv, jq, taplo, dprint, rumdl, yamllint, shfmt, shellcheck, actionlint, git-cliff, typos"
+        echo "Required tools: uv, jq, taplo, dprint, rumdl, yamllint, shfmt, shellcheck, actionlint, git-cliff, typos, zizmor"
         echo ""
     fi
 
@@ -784,11 +827,15 @@ setup-tools:
         echo "  ✓ samply"
     fi
 
-    if ! have typos; then
-        echo "  ⏳ Installing typos-cli (cargo)..."
-        cargo install --locked typos-cli
+    installed_typos_version=""
+    if command -v typos >/dev/null; then
+        installed_typos_version="$(typos --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_typos_version" != "{{ typos_version }}" ]]; then
+        echo "  ⏳ Installing typos-cli {{ typos_version }} (cargo)..."
+        cargo install --locked typos-cli --version {{ typos_version }}
     else
-        echo "  ✓ typos"
+        echo "  ✓ typos {{ typos_version }}"
     fi
 
     if ! have git-cliff; then
@@ -805,25 +852,44 @@ setup-tools:
         echo "  ✓ llvm-tools-preview"
     fi
 
-    if ! have cargo-nextest; then
+    installed_nextest_version=""
+    if cargo nextest --version >/dev/null 2>&1; then
+        installed_nextest_version="$(cargo nextest --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_nextest_version" != "{{ nextest_version }}" ]]; then
         echo "  ⏳ Installing cargo-nextest {{ nextest_version }} (cargo)..."
         cargo install --locked cargo-nextest --version {{ nextest_version }}
     else
-        echo "  ✓ cargo-nextest"
+        echo "  ✓ cargo-nextest {{ nextest_version }}"
     fi
 
-    if ! have cargo-llvm-cov; then
+    installed_llvm_cov_version=""
+    if command -v cargo-llvm-cov >/dev/null; then
+        installed_llvm_cov_version="$(cargo llvm-cov --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_llvm_cov_version" != "{{ cargo_llvm_cov_version }}" ]]; then
         echo "  ⏳ Installing cargo-llvm-cov {{ cargo_llvm_cov_version }} (cargo)..."
         cargo install --locked cargo-llvm-cov --version {{ cargo_llvm_cov_version }}
     else
-        echo "  ✓ cargo-llvm-cov"
+        echo "  ✓ cargo-llvm-cov {{ cargo_llvm_cov_version }}"
+    fi
+
+    installed_zizmor_version=""
+    if command -v zizmor >/dev/null; then
+        installed_zizmor_version="$(zizmor --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)"
+    fi
+    if [[ "$installed_zizmor_version" != "{{ zizmor_version }}" ]]; then
+        echo "  ⏳ Installing zizmor {{ zizmor_version }} (cargo)..."
+        cargo install --locked zizmor --version {{ zizmor_version }}
+    else
+        echo "  ✓ zizmor {{ zizmor_version }}"
     fi
 
     echo ""
     echo "Verifying required commands are available..."
     missing=0
 
-    cmds=(uv jq taplo dprint rumdl yamllint shfmt shellcheck actionlint git-cliff typos)
+    cmds=(uv jq taplo dprint rumdl yamllint shfmt shellcheck actionlint git-cliff typos zizmor)
     cmds+=(cargo-nextest cargo-llvm-cov)
 
     for cmd in "${cmds[@]}"; do
@@ -1107,3 +1173,6 @@ yaml-lint: _ensure-yamllint
     else
         echo "No YAML files found to lint."
     fi
+
+zizmor: _ensure-zizmor
+    zizmor .github

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -223,4 +223,13 @@ disable = [
 line-length = 160
 
 [dependency-groups]
-dev = [ "pytest>=9.0.3", "ruff>=0.12.11", "semgrep>=1.152.0", "ty>=0.0.8" ]
+dev = [
+    "actionlint-py==1.7.12.24",
+    "pytest>=9.0.3",
+    "ruff>=0.12.11",
+    "semgrep>=1.152.0",
+    "shellcheck-py==0.11.0.1",
+    "shfmt-py==4.0.0",
+    "ty>=0.0.8",
+    "yamllint==1.38.0",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # Pin to MSRV as specified in Cargo.toml
-channel = "1.95"
+channel = "1.96.0"
 
 # Essential repository components. Keep this lean so checkout and CI setup do
 # not install IDE-only or cross-target components unless a workflow asks for

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -2553,7 +2553,8 @@ Hardware Information:
                 # Should detect error and report failure, not "no regressions"
                 assert "Result:" in captured.out
                 assert "Benchmark comparison failed" in captured.out
-                assert f"(see benches/{MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE} for details)" in captured.out
+                expected_path = str(Path("benches") / MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE)
+                assert f"(see {expected_path} for details)" in captured.out
                 # Should NOT say "no regressions" when there was an error
                 assert "No significant performance regressions" not in captured.out
 

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -2531,7 +2531,8 @@ Hardware Information:
                 "❌ Error: Benchmark execution timeout\n\n"
                 "Details: Command timed out after 1800 seconds\n\n"
                 "This error prevented the benchmark comparison from completing successfully.\n"
-                "Please check the CI logs for more information.\n"
+                "Please check the CI logs for more information.\n",
+                encoding=UTF8,
             )
 
             env_vars = {

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -73,6 +73,7 @@ PUBLIC_API_TITLE = "### Public API Performance Contract (`ci_performance_suite`)
 CIRCUMSPHERE_TITLE = "### Circumsphere Predicate Performance"
 TDS_TITLE = "## Triangulation Data Structure Performance"
 PERFORMANCE_UPDATES_TITLE = "## Performance Data Updates"
+UTF8 = "utf-8"
 
 
 def completed_process(
@@ -473,9 +474,9 @@ malformed api_benchmark_metric benchmark_id=ignored vertices=x simplices=y
             criterion_dir = Path(temp_dir) / "target" / "criterion"
             criterion_dir.mkdir(parents=True)
             metrics_path = criterion_dir / _CI_PERFORMANCE_SUITE_METRICS_FILE
-            metrics_path.write_text("{ invalid json", encoding="utf-8")
+            metrics_path.write_text("{ invalid json", encoding=UTF8)
 
-            with pytest.raises(ValueError, match=str(metrics_path)):
+            with pytest.raises(ValueError, match=re.escape(str(metrics_path))):
                 _load_ci_performance_metrics(criterion_dir)
 
     def test_find_criterion_results_preserves_ci_suite_ids(self) -> None:
@@ -889,7 +890,7 @@ Git commit: abc123
 === 10 Points (2D) ===
 Time: [1.0, 1.0, 1.0] µs
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             # Mock successful cargo command
             mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
@@ -1126,7 +1127,7 @@ Time: [1.0, 1.0, 1.0] µs
             comparator._write_error_file(output_file, "Baseline file not found", baseline_file)
 
             assert output_file.exists()
-            content = output_file.read_text()
+            content = output_file.read_text(encoding=UTF8)
             assert "Comparison Results" in content
             assert "❌ Error: Baseline file not found" in content
             assert str(baseline_file) in content
@@ -1141,7 +1142,7 @@ Time: [1.0, 1.0, 1.0] µs
             comparator._write_error_file(output_file, "Benchmark execution error", error_message)
 
             assert output_file.exists()
-            content = output_file.read_text()
+            content = output_file.read_text(encoding=UTF8)
             assert "❌ Error: Benchmark execution error" in content
             assert error_message in content
             assert "Please check the CI logs for more information" in content
@@ -1155,7 +1156,7 @@ Time: [1.0, 1.0, 1.0] µs
 
             assert output_file.exists()
             assert output_file.parent.exists()
-            content = output_file.read_text()
+            content = output_file.read_text(encoding=UTF8)
             assert "❌ Error: Test error" in content
 
     def test_write_error_file_handles_write_failure(self, comparator) -> None:
@@ -1999,7 +2000,7 @@ Hardware Information:
 === 1000 Points (2D) ===
 Time: [95.0, 100.0, 105.0] µs
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -2035,7 +2036,7 @@ Time: [95.0, 100.0, 105.0] µs
 Git commit: abc123def456
 Tag: v1.0.0
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
             # Do NOT create baseline_results.txt - this ensures the copy path is taken
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
@@ -2082,7 +2083,7 @@ Hardware Information:
 === 1000 Points (2D) ===
 Time: [95.0, 100.0, 105.0] µs
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -2181,7 +2182,7 @@ Git commit: abc123def456
 Hardware Information:
   OS: macOS
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -2660,7 +2661,7 @@ class TestTimeoutHandling:
         with tempfile.TemporaryDirectory() as temp_dir:
             project_root = Path(temp_dir)
             baseline_file = Path(temp_dir) / "baseline.txt"
-            baseline_file.write_text("mock baseline")
+            baseline_file.write_text("mock baseline", encoding=UTF8)
 
             comparator = PerformanceComparator(project_root)
 
@@ -2680,7 +2681,7 @@ class TestTimeoutHandling:
                 # Verify error file contains full exception message with command context
                 error_file = project_root / "benches" / MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE
                 assert error_file.exists()
-                error_content = error_file.read_text()
+                error_content = error_file.read_text(encoding=UTF8)
                 assert "❌ Error: Benchmark execution timeout" in error_content
                 assert "cargo bench" in error_content  # Command from exception
                 assert "timeout after 1800 seconds" in error_content  # Explicit timeout value
@@ -2979,7 +2980,7 @@ Throughput: [8333.3, 9090.9, 10000.0] Kelem/s
             baseline_dir = project_root / "baseline-artifact"
             baseline_dir.mkdir(parents=True)
             baseline_file = baseline_dir / "baseline_results.txt"
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             generator = PerformanceSummaryGenerator(project_root)
             lines = generator._parse_baseline_results()
@@ -3484,7 +3485,7 @@ Benchmark completed.""",
             assert output_file.exists()
 
             # Check file contains expected content
-            content = output_file.read_text()
+            content = output_file.read_text(encoding=UTF8)
             assert "# Delaunay Library Performance Results" in content
             assert "## Performance Results Summary" in content
 
@@ -3644,7 +3645,7 @@ Benchmark completed.""",
                 # Should still succeed
                 assert success
 
-                content = output_file.read_text()
+                content = output_file.read_text(encoding=UTF8)
                 assert "Version unknown" in content
 
     def test_baseline_fallback_behavior_edge_case(self) -> None:
@@ -3663,6 +3664,7 @@ Benchmark completed.""",
                 "=== 1000 Points (3D) ===\n"
                 "Time: [805.0, 810.0, 815.0] µs\n"
                 "Throughput: [1200.0, 1235.0, 1245.0] Kelem/s\n",
+                encoding=UTF8,
             )
 
             # Do NOT create primary baseline file (baseline-artifact/baseline_results.txt)
@@ -3682,7 +3684,7 @@ Benchmark completed.""",
                 success = generator.generate_summary(output_file)
                 assert success
 
-                content = output_file.read_text()
+                content = output_file.read_text(encoding=UTF8)
 
                 # Verify that baseline data was included (meaning fallback worked)
                 assert "Triangulation Data Structure Performance" in content
@@ -3711,11 +3713,12 @@ Benchmark completed.""",
                 "=== 10 Points (2D) ===\n"
                 "Time: [100.0, 110.0, 120.0] µs\n"
                 "Throughput: [8000.0, 9000.0, 10000.0] Kelem/s\n",
+                encoding=UTF8,
             )
 
             # Mock comparison file
             comparison_file = baseline_dir / MAIN_VS_RELEASE_COMPARISON_RESULTS_FILE
-            comparison_file.write_text("✅ OK: All benchmarks within acceptable range\n")
+            comparison_file.write_text("✅ OK: All benchmarks within acceptable range\n", encoding=UTF8)
 
             with (
                 patch("benchmark_utils.get_git_commit_hash") as mock_commit,
@@ -3727,7 +3730,7 @@ Benchmark completed.""",
 
                 assert success
 
-                content = output_file.read_text()
+                content = output_file.read_text(encoding=UTF8)
 
                 # Verify all major sections are present
                 assert "# Delaunay Library Performance Results" in content
@@ -3805,7 +3808,7 @@ Hardware Information:
 === 1000 Points (2D) ===
 Time: [95.0, 100.0, 105.0] µs
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             generator = PerformanceSummaryGenerator(project_root)
             lines = generator._parse_baseline_results()
@@ -3877,7 +3880,7 @@ Hardware Information:
 === 10 Points (2D) ===
 Time: [160.1, 168.18, 177.67] µs
 """
-            tag_baseline_file.write_text(baseline_content)
+            tag_baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -3889,7 +3892,7 @@ Time: [160.1, 168.18, 177.67] µs
                     assert success
 
                     # Check that environment variables were set
-                    with open(env_path, encoding="utf-8") as f:
+                    with open(env_path, encoding=UTF8) as f:
                         env_content = f.read()
                         assert "BASELINE_EXISTS=true" in env_content
                         assert "BASELINE_SOURCE=artifact" in env_content
@@ -3907,7 +3910,7 @@ Time: [160.1, 168.18, 177.67] µs
                     # Check that baseline_results.txt was created
                     standard_file = baseline_dir / "baseline_results.txt"
                     assert standard_file.exists()
-                    assert "Tag: v0.4.3" in standard_file.read_text(encoding="utf-8")
+                    assert "Tag: v0.4.3" in standard_file.read_text(encoding=UTF8)
 
             finally:
                 Path(env_path).unlink(missing_ok=True)
@@ -3928,7 +3931,7 @@ Hardware Information:
 === 100 Points (2D) ===
 Time: [95.0, 100.0, 105.0] µs
 """
-            generic_baseline_file.write_text(baseline_content)
+            generic_baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -3940,7 +3943,7 @@ Time: [95.0, 100.0, 105.0] µs
                     assert success
 
                     # Check that environment variables were set
-                    with open(env_path, encoding="utf-8") as f:
+                    with open(env_path, encoding=UTF8) as f:
                         env_content = f.read()
                         assert "BASELINE_EXISTS=true" in env_content
                         assert "BASELINE_SOURCE=artifact" in env_content
@@ -3954,7 +3957,7 @@ Time: [95.0, 100.0, 105.0] µs
                     # Check that baseline_results.txt was created
                     standard_file = baseline_dir / "baseline_results.txt"
                     assert standard_file.exists()
-                    assert "Test CPU" in standard_file.read_text(encoding="utf-8")
+                    assert "Test CPU" in standard_file.read_text(encoding=UTF8)
 
             finally:
                 Path(env_path).unlink(missing_ok=True)
@@ -3996,7 +3999,7 @@ Time: [95.0, 100.0, 105.0] µs
                     assert " → " not in captured.out  # No conversion arrow
 
                     # Standard file should remain unchanged
-                    assert standard_file.read_text(encoding="utf-8") == standard_content
+                    assert standard_file.read_text(encoding=UTF8) == standard_content
 
             finally:
                 Path(env_path).unlink(missing_ok=True)
@@ -4046,7 +4049,7 @@ Tag: v0.4.3
 Hardware Information:
   OS: macOS
 """
-            tag_baseline_file.write_text(baseline_content)
+            tag_baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -4079,7 +4082,7 @@ Tag: v0.4.3
 Hardware Information:
   OS: macOS
 """
-            tag_baseline_file.write_text(baseline_content)
+            tag_baseline_file.write_text(baseline_content, encoding=UTF8)
 
             # Metadata with commit info
             metadata = {"tag": "v0.4.3", "commit": "fedcba987654321", "generated_at": "2025-09-13T00:00:36Z"}
@@ -4209,7 +4212,7 @@ Git commit: abc123def456
 Hardware Information:
   OS: macOS
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -4413,7 +4416,7 @@ Tag: v1.0.0; echo "injected"; rm -rf /tmp/test
 Hardware Information:
   OS: macOS
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -4455,7 +4458,7 @@ Tag: {long_tag}
 Hardware Information:
   OS: macOS
 """
-            baseline_file.write_text(baseline_content)
+            baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name
@@ -4613,7 +4616,7 @@ Hardware Information:
 === 10 Points (2D) ===
 Time: [160.1, 168.18, 177.67] µs
 """
-            tag_baseline_file.write_text(baseline_content)
+            tag_baseline_file.write_text(baseline_content, encoding=UTF8)
 
             with tempfile.NamedTemporaryFile(mode="w", delete=False) as env_file:
                 env_path = env_file.name

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -176,6 +176,10 @@ rules:
           - pattern: NumCast::from($VALUE).unwrap_or_else($FALLBACK)
           - pattern: num_traits::NumCast::from($VALUE).unwrap_or($FALLBACK)
           - pattern: num_traits::NumCast::from($VALUE).unwrap_or_else($FALLBACK)
+          - pattern: cast::<$FROM, $TO>($VALUE).unwrap_or($FALLBACK)
+          - pattern: cast::<$FROM, $TO>($VALUE).unwrap_or_else($FALLBACK)
+          - pattern: num_traits::cast::<$FROM, $TO>($VALUE).unwrap_or($FALLBACK)
+          - pattern: num_traits::cast::<$FROM, $TO>($VALUE).unwrap_or_else($FALLBACK)
           - patterns:
               - pattern: $SAFE(...).unwrap_or($FALLBACK)
               - metavariable-regex:
@@ -336,6 +340,8 @@ rules:
       - pattern-either:
           - pattern: $VALUE.unwrap()
           - pattern: panic!(...)
+          - pattern: std::panic!(...)
+          - pattern: core::panic!(...)
           - patterns:
               - pattern: $VALUE.expect($MESSAGE)
               - metavariable-regex:
@@ -395,6 +401,79 @@ rules:
       exclude:
         - "/tests/semgrep/**"
     pattern-regex: '(?m)(?<!#\[non_exhaustive\]\n)^\s*pub\s+enum\s+[A-Za-z0-9_]*Error\b'
+
+  - id: delaunay.rust.no-public-unchecked-apis
+    languages:
+      - generic
+    severity: WARNING
+    message: "Keep *_unchecked APIs private so invalid-state escape hatches do not become public contracts."
+    metadata:
+      category: correctness
+      rationale: >-
+        Unchecked helpers should stay behind validated constructors, parsers, or
+        setters rather than becoming public API contracts.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/src/project_rules/**/*.rs"
+      exclude:
+        - "/tests/semgrep/**"
+    pattern-regex: '^\s*pub(?:\([^)]*\))?\s+(?:const\s+|async\s+|unsafe\s+)?fn\s+[A-Za-z_][A-Za-z0-9_]*_unchecked\s*\(' # yamllint disable-line rule:line-length
+
+  - id: delaunay.rust.no-unwrap-expect-in-doctests
+    languages:
+      - generic
+    severity: WARNING
+    message: "Use fallible doctest flow instead of unwrap() or expect() in public documentation examples."
+    metadata:
+      category: correctness
+      rationale: >-
+        Public Rust documentation examples should model typed error handling
+        with DelaunayResult and ? rather than teaching panic-based control flow.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/doctests/**/*.txt"
+      exclude:
+        - "/tests/semgrep/**"
+    pattern-regex: '^\s*//[!/]\s*(?:#\s*)?.*(?:\b[\w:]+|[\]\)])\.(unwrap|expect)\s*\('
+
+  - id: delaunay.rust.no-box-dyn-error-in-doctests
+    languages:
+      - generic
+    severity: WARNING
+    message: "Use DelaunayResult or a typed error in doctests instead of erased dynamic errors."
+    metadata:
+      category: maintainability
+      rationale: >-
+        Public documentation should model the crate's typed error surface rather
+        than Box<dyn Error>, &dyn Error, or anyhow::Error.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/doctests/**/*.txt"
+      exclude:
+        - "/tests/semgrep/**"
+    pattern-regex: '^\s*//[!/].*(?:Box\s*<\s*dyn\s+(?:std::error::Error|Error)|&\s*dyn\s+(?:std::error::Error|Error)|anyhow::Error|anyhow::Result)' # yamllint disable-line rule:line-length
+
+  - id: delaunay.rust.prefer-assert-matches-in-doctests
+    languages:
+      - generic
+    severity: WARNING
+    message: "Use std::assert_matches! instead of assert!(matches!(...)) in public documentation examples."
+    metadata:
+      category: maintainability
+      rationale: >-
+        Public Rust documentation examples should teach std::assert_matches!,
+        which reports the unmatched value on failure instead of the bare boolean
+        that assert!(matches!(...)) produces.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/doctests/**/*.txt"
+      exclude:
+        - "/tests/semgrep/**"
+    pattern-regex: '^\s*//[!/].*\bassert!\s*\(\s*matches!\s*\('
 
   - id: delaunay.rust.no-env-gated-stdio-diagnostics
     languages:
@@ -661,7 +740,7 @@ rules:
       exclude:
         - "/tests/semgrep/**"
     patterns:
-      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/upload-artifact|actions/download-artifact|actions/github-script|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|taiki-e/install-action|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|codacy/codacy-coverage-reporter-action|codacy/codacy-analysis-cli-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@' # yamllint disable-line rule:line-length
+      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/upload-artifact|actions/download-artifact|actions/github-script|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|taiki-e/cache-cargo-install-action|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|codacy/codacy-coverage-reporter-action|codacy/codacy-analysis-cli-action|zizmorcore/zizmor-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@' # yamllint disable-line rule:line-length
 
   - id: delaunay.github-actions.external-action-version-comment
     languages:
@@ -680,6 +759,87 @@ rules:
         - "/tests/semgrep/**"
     patterns:
       - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@[a-fA-F0-9]{40}\s*$' # yamllint disable-line rule:line-length
+
+  - id: delaunay.github-actions.checkout-persist-credentials-false
+    languages:
+      - regex
+    severity: WARNING
+    message: "Set persist-credentials: false on actions/checkout steps."
+    metadata:
+      category: security
+      rationale: >-
+        Checkout credentials should not remain available to later workflow steps
+        unless a job explicitly needs them.
+    paths:
+      include:
+        - "/.github/workflows/**/*.yml"
+        - "/.github/workflows/**/*.yaml"
+        - "/tests/semgrep/.github/workflows/**/*.yml"
+        - "/tests/semgrep/.github/workflows/**/*.yaml"
+      exclude:
+        - "/tests/semgrep/**"
+    patterns:
+      - pattern-regex: '(?m)^[ \t]*(?:-[ \t]*)?uses:[ \t]*actions/checkout@[a-fA-F0-9]{40}[^\n]*\n(?!(?:[ \t]*with:\n)?(?:[ \t]{10,}\S[^\n]*\n){0,8}[ \t]{10,}persist-credentials:[ \t]*false\b)' # yamllint disable-line rule:line-length
+
+  - id: delaunay.github-actions.no-pull-request-target
+    languages:
+      - regex
+    severity: WARNING
+    message: "Avoid pull_request_target; use pull_request unless a workflow has a documented security review."
+    metadata:
+      category: security
+      rationale: >-
+        pull_request_target runs with base-repository privileges and is risky
+        for workflows that touch untrusted PR content.
+    paths:
+      include:
+        - "/.github/workflows/**/*.yml"
+        - "/.github/workflows/**/*.yaml"
+        - "/tests/semgrep/.github/workflows/**/*.yml"
+        - "/tests/semgrep/.github/workflows/**/*.yaml"
+      exclude:
+        - "/tests/semgrep/**"
+    pattern-regex: '(?m)^\s*pull_request_target\s*:'
+
+  - id: delaunay.github-actions.github-script-no-expression-interpolation
+    languages:
+      - regex
+    severity: WARNING
+    message: "Pass GitHub expression values to actions/github-script through env instead of interpolating inside script blocks."
+    metadata:
+      category: security
+      rationale: >-
+        Interpolating ${{ ... }} directly into JavaScript can turn workflow
+        context strings into executable code.
+    paths:
+      include:
+        - "/.github/workflows/**/*.yml"
+        - "/.github/workflows/**/*.yaml"
+        - "/tests/semgrep/.github/workflows/**/*.yml"
+        - "/tests/semgrep/.github/workflows/**/*.yaml"
+      exclude:
+        - "/tests/semgrep/**"
+    patterns:
+      - pattern-regex: '(?ms)^\s*script:\s*\|\n(?:(?!^\s*-\s+(?:name|uses):).)*\$\{\{' # yamllint disable-line rule:line-length
+
+  - id: delaunay.github-actions.uv-sync-locked-in-workflows
+    languages:
+      - regex
+    severity: WARNING
+    message: "Use uv sync --locked in GitHub Actions workflows."
+    metadata:
+      category: reproducibility
+      rationale: "Workflow dependency installs should fail on lockfile drift instead of silently resolving new versions."
+    paths:
+      include:
+        - "/.github/workflows/**/*.yml"
+        - "/.github/workflows/**/*.yaml"
+        - "/tests/semgrep/.github/workflows/**/*.yml"
+        - "/tests/semgrep/.github/workflows/**/*.yaml"
+      exclude:
+        - "/tests/semgrep/**"
+    patterns:
+      - pattern-regex: '(?m)^\s*(?:run:\s*)?uv\s+sync\b(?![^\n]*\s--locked\b)[^\n]*$' # yamllint disable-line rule:line-length
 
   - id: delaunay.python.no-broad-exception
     languages:
@@ -793,6 +953,26 @@ rules:
       - pattern: MagicMock(..., returncode=..., ...)
       - pattern: unittest.mock.MagicMock(..., returncode=..., ...)
       - pattern: mock.MagicMock(..., returncode=..., ...)
+
+  - id: delaunay.python.no-direct-subprocess-run-outside-wrapper
+    languages:
+      - python
+    severity: WARNING
+    message: "Use subprocess_utils command wrappers instead of calling subprocess.run directly."
+    metadata:
+      category: security
+      rationale: >-
+        Support scripts should inherit the repository's subprocess hardening for
+        executable resolution, shell rejection, text output, and timeouts.
+    paths:
+      include:
+        - "/scripts/**/*.py"
+        - "/tests/semgrep/scripts/tests/**/*.py"
+      exclude:
+        - "/scripts/subprocess_utils.py"
+        - "/scripts/tests/**/*.py"
+        - "/tests/semgrep/**"
+    pattern: subprocess.run(...)
 
   - id: delaunay.python.no-untyped-defs-in-scripts
     languages:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -376,8 +376,6 @@ rules:
         - "/tests/prelude_exports.rs"
         - "/tests/public_*.rs"
         - "/tests/semgrep/src/project_rules/**/*.rs"
-      exclude:
-        - "/tests/semgrep/**"
     pattern-either:
       - pattern: $VALUE.unwrap()
       - pattern: $VALUE.expect(...)
@@ -434,8 +432,6 @@ rules:
       include:
         - "/src/**/*.rs"
         - "/tests/semgrep/doctests/**/*.txt"
-      exclude:
-        - "/tests/semgrep/**"
     pattern-regex: '^\s*//[!/]\s*(?:#\s*)?.*(?:\b[\w:]+|[\]\)])\.(unwrap|expect)\s*\('
 
   - id: delaunay.rust.no-box-dyn-error-in-doctests
@@ -452,8 +448,6 @@ rules:
       include:
         - "/src/**/*.rs"
         - "/tests/semgrep/doctests/**/*.txt"
-      exclude:
-        - "/tests/semgrep/**"
     pattern-regex: '^\s*//[!/].*(?:Box\s*<\s*dyn\s+(?:std::error::Error|Error)|&\s*dyn\s+(?:std::error::Error|Error)|anyhow::Error|anyhow::Result)' # yamllint disable-line rule:line-length
 
   - id: delaunay.rust.prefer-assert-matches-in-doctests
@@ -471,8 +465,6 @@ rules:
       include:
         - "/src/**/*.rs"
         - "/tests/semgrep/doctests/**/*.txt"
-      exclude:
-        - "/tests/semgrep/**"
     pattern-regex: '^\s*//[!/].*\bassert!\s*\(\s*matches!\s*\('
 
   - id: delaunay.rust.no-env-gated-stdio-diagnostics
@@ -525,8 +517,6 @@ rules:
     paths:
       include:
         - "/src/**/*.rs"
-        - "/examples/**/*.rs"
-        - "/benches/**/*.rs"
         - "/tests/allocation_api.rs"
         - "/tests/delaunay_public_api_coverage.rs"
         - "/tests/prelude_exports.rs"
@@ -574,6 +564,48 @@ rules:
           impl $TYPE {
               ...
           }
+
+  - id: delaunay.rust.no-unwrap-expect-in-benches-examples
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use explicit fixture error handling instead of unwrap() or expect() in benchmarks and examples."
+    metadata:
+      category: correctness
+      rationale: >-
+        Benchmarks and public examples should keep failure modes explicit so
+        users and CI see the operation that failed instead of a panic-only
+        unwrap/expect path.
+      ported_from: "la-stack.rust.no-unwrap-expect-in-benches-examples"
+    paths:
+      include:
+        - "/benches/**/*.rs"
+        - "/examples/**/*.rs"
+        - "/tests/semgrep/src/project_rules/rust_style.rs"
+    pattern-either:
+      - pattern: $VALUE.unwrap()
+      - pattern: $VALUE.expect(...)
+
+  - id: delaunay.rust.no-box-dyn-error-in-examples-benches
+    languages:
+      - rust
+    severity: WARNING
+    message: "Use concrete crate errors in examples and benchmarks instead of dynamic error erasure."
+    metadata:
+      category: maintainability
+      rationale: >-
+        Examples and benchmarks should model typed error handling that users
+        can copy into their own code.
+      ported_from: "causal-triangulations.rust.no-box-dyn-error-in-examples-benches"
+    paths:
+      include:
+        - "/examples/**/*.rs"
+        - "/benches/**/*.rs"
+        - "/tests/semgrep/src/project_rules/rust_style.rs"
+    patterns:
+      - pattern-regex: >-
+          ^[ \t]*[^\n]*(\bBox\s*<\s*dyn\s+(std::error::)?Error\b|&\s*dyn\s+(std::error::)?Error\b|\banyhow::Error\b)
+      - pattern-not-regex: '^[ \t]*(//|///|/\*|\*)'
 
   - id: delaunay.rust.no-clippy-allow-lints
     languages:
@@ -740,7 +772,7 @@ rules:
       exclude:
         - "/tests/semgrep/**"
     patterns:
-      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/upload-artifact|actions/download-artifact|actions/github-script|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|taiki-e/cache-cargo-install-action|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|codacy/codacy-coverage-reporter-action|codacy/codacy-analysis-cli-action|zizmorcore/zizmor-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@' # yamllint disable-line rule:line-length
+      - pattern-regex: '(?m)^\s*uses:\s*(?!\./)(?!docker://)(?!(?:actions/checkout|actions/cache|actions/upload-artifact|actions/download-artifact|actions/github-script|actions/setup-python|actions-rust-lang/setup-rust-toolchain|astral-sh/setup-uv|taiki-e/cache-cargo-install-action|github/codeql-action/(?:upload-sarif|init|analyze)|codecov/codecov-action|codacy/codacy-coverage-reporter-action|codacy/codacy-analysis-cli-action|zizmorcore/zizmor-action)@)[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?@' # yamllint disable-line rule:line-length
 
   - id: delaunay.github-actions.external-action-version-comment
     languages:
@@ -776,8 +808,6 @@ rules:
         - "/.github/workflows/**/*.yaml"
         - "/tests/semgrep/.github/workflows/**/*.yml"
         - "/tests/semgrep/.github/workflows/**/*.yaml"
-      exclude:
-        - "/tests/semgrep/**"
     patterns:
       - pattern-regex: '(?m)^[ \t]*(?:-[ \t]*)?uses:[ \t]*actions/checkout@[a-fA-F0-9]{40}[^\n]*\n(?!(?:[ \t]*with:\n)?(?:[ \t]{10,}\S[^\n]*\n){0,8}[ \t]{10,}persist-credentials:[ \t]*false\b)' # yamllint disable-line rule:line-length
 
@@ -797,8 +827,6 @@ rules:
         - "/.github/workflows/**/*.yaml"
         - "/tests/semgrep/.github/workflows/**/*.yml"
         - "/tests/semgrep/.github/workflows/**/*.yaml"
-      exclude:
-        - "/tests/semgrep/**"
     pattern-regex: '(?m)^\s*pull_request_target\s*:'
 
   - id: delaunay.github-actions.github-script-no-expression-interpolation
@@ -817,8 +845,6 @@ rules:
         - "/.github/workflows/**/*.yaml"
         - "/tests/semgrep/.github/workflows/**/*.yml"
         - "/tests/semgrep/.github/workflows/**/*.yaml"
-      exclude:
-        - "/tests/semgrep/**"
     patterns:
       - pattern-regex: '(?ms)^\s*script:\s*\|\n(?:(?!^\s*-\s+(?:name|uses):).)*\$\{\{' # yamllint disable-line rule:line-length
 
@@ -836,8 +862,6 @@ rules:
         - "/.github/workflows/**/*.yaml"
         - "/tests/semgrep/.github/workflows/**/*.yml"
         - "/tests/semgrep/.github/workflows/**/*.yaml"
-      exclude:
-        - "/tests/semgrep/**"
     patterns:
       - pattern-regex: '(?m)^\s*(?:run:\s*)?uv\s+sync\b(?![^\n]*\s--locked\b)[^\n]*$' # yamllint disable-line rule:line-length
 
@@ -971,7 +995,6 @@ rules:
       exclude:
         - "/scripts/subprocess_utils.py"
         - "/scripts/tests/**/*.py"
-        - "/tests/semgrep/**"
     pattern: subprocess.run(...)
 
   - id: delaunay.python.no-untyped-defs-in-scripts

--- a/src/core/adjacency.rs
+++ b/src/core/adjacency.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 /// let simplex_key = SimplexKey::from(KeyData::from_ffi(1));
 /// let vertex_key = VertexKey::from(KeyData::from_ffi(2));
 /// let err = AdjacencyIndexBuildError::MissingVertexKey { simplex_key, vertex_key };
-/// assert!(matches!(err, AdjacencyIndexBuildError::MissingVertexKey { .. }));
+/// std::assert_matches!(err, AdjacencyIndexBuildError::MissingVertexKey { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -2615,7 +2615,7 @@ impl FlipPredicateError {
 ///     offset_count: 1,
 /// };
 /// let err: FlipError = reason.into();
-/// assert!(matches!(err, FlipError::InvalidFlipContext { .. }));
+/// std::assert_matches!(err, FlipError::InvalidFlipContext { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -3473,7 +3473,7 @@ pub enum FlipVertexAdjacencyError {
 /// use delaunay::prelude::flips::FlipError;
 ///
 /// let err = FlipError::UnsupportedDimension { dimension: 1 };
-/// assert!(matches!(err, FlipError::UnsupportedDimension { .. }));
+/// std::assert_matches!(err, FlipError::UnsupportedDimension { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -4253,13 +4253,13 @@ impl fmt::Display for DelaunayRepairDiagnostics {
 ///     source: Box::new(FlipError::DegenerateSimplex),
 /// };
 ///
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     err,
 ///     DelaunayRepairError::VerificationFailed {
 ///         context: DelaunayRepairVerificationContext::StrictValidation,
 ///         ..
 ///     },
-/// ));
+/// );
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[non_exhaustive]
@@ -4325,14 +4325,14 @@ impl fmt::Display for DelaunayRepairVerificationContext {
 ///     found: TopologyGuarantee::Pseudomanifold,
 ///     message: "requires manifold",
 /// };
-/// assert!(matches!(err, DelaunayRepairError::InvalidTopology { .. }));
+/// std::assert_matches!(err, DelaunayRepairError::InvalidTopology { .. });
 ///
 /// let flip_err = DelaunayRepairError::from(FlipError::DegenerateSimplex);
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     flip_err,
 ///     DelaunayRepairError::Flip { source }
 ///         if matches!(source.as_ref(), FlipError::DegenerateSimplex)
-/// ));
+/// );
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -9544,6 +9544,7 @@ mod tests {
     use proptest::prelude::*;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::{error::Error as _, iter::once, sync::Once};
 
     fn init_tracing() {
@@ -9677,7 +9678,7 @@ mod tests {
         let mut coords = [offset; D];
         for (i, coord) in coords.iter_mut().enumerate().take(D) {
             let idx = f64::from(u32::try_from(i + 1).expect("index fits in u32"));
-            *coord += scale * 0.11 * idx;
+            *coord = (scale * 0.11).mul_add(idx, *coord);
         }
         coords
     }
@@ -9725,10 +9726,10 @@ mod tests {
                     let missing_simplex = SimplexKey::from(KeyData::from_ffi(999_999 + $dim));
                     let missing_simplices: SimplexKeyBuffer = std::iter::once(missing_simplex).collect();
                     let err = snapshot_removed_simplex_vertices(&tds, &missing_simplices).unwrap_err();
-                    assert!(matches!(
+                    assert_matches!(
                         err,
                         FlipError::MissingSimplex { simplex_key } if simplex_key == missing_simplex
-                    ));
+                    );
                 }
 
                 #[test]
@@ -11304,12 +11305,12 @@ mod tests {
         let err =
             validate_flip_trial_simplex_neighbors(&tds, simplex_key, simplex, &[]).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsValidationFailure::InvalidNeighbors {
                 reason: NeighborValidationError::UnassignedNeighborSlot { facet_index: 0, .. },
             }
-        ));
+        );
     }
 
     /// Checks that a k=2 flip and its inverse preserve topology in dimension `D`.
@@ -11934,7 +11935,7 @@ mod tests {
             direction: FlipDirection::Forward,
         };
 
-        assert!(matches!(
+        assert_matches!(
             apply_bistellar_flip_dynamic(&mut tds, 0, &valid_shape),
             Err(FlipError::InvalidFlipContext {
                 reason: FlipContextError::InvalidMoveSize {
@@ -11942,8 +11943,8 @@ mod tests {
                     dimension,
                 }
             }) if dimension == D
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             apply_bistellar_flip_dynamic(&mut tds, D + 2, &valid_shape),
             Err(FlipError::InvalidFlipContext {
                 reason: FlipContextError::InvalidMoveSize {
@@ -11951,13 +11952,13 @@ mod tests {
                     dimension,
                 }
             }) if k_move == D + 2 && dimension == D
-        ));
+        );
 
         let wrong_removed_face = FlipContextDyn {
             removed_face_vertices: vertices[..D - 1].iter().copied().collect(),
             ..valid_shape.clone()
         };
-        assert!(matches!(
+        assert_matches!(
             apply_bistellar_flip_dynamic(&mut tds, 2, &wrong_removed_face),
             Err(FlipError::InvalidFlipContext {
                 reason: FlipContextError::WrongRemovedFaceArity {
@@ -11965,13 +11966,13 @@ mod tests {
                     found,
                 }
             }) if expected == D && found == D - 1
-        ));
+        );
 
         let wrong_inserted_face = FlipContextDyn {
             inserted_face_vertices: once(vertices[D]).collect(),
             ..valid_shape.clone()
         };
-        assert!(matches!(
+        assert_matches!(
             apply_bistellar_flip_dynamic(&mut tds, 2, &wrong_inserted_face),
             Err(FlipError::InvalidFlipContext {
                 reason: FlipContextError::WrongInsertedFaceArity {
@@ -11980,13 +11981,13 @@ mod tests {
                     found: 1,
                 }
             })
-        ));
+        );
 
         let wrong_removed_simplices = FlipContextDyn {
             removed_simplices: once(c0).collect(),
             ..valid_shape.clone()
         };
-        assert!(matches!(
+        assert_matches!(
             apply_bistellar_flip_dynamic(&mut tds, 2, &wrong_removed_simplices),
             Err(FlipError::InvalidFlipContext {
                 reason: FlipContextError::WrongRemovedSimplexCount {
@@ -11994,18 +11995,18 @@ mod tests {
                     found: 1,
                 }
             })
-        ));
+        );
 
         let overlapping_faces = FlipContextDyn {
             inserted_face_vertices: [vertices[D - 1], vertices[D]].into_iter().collect(),
             ..valid_shape
         };
-        assert!(matches!(
+        assert_matches!(
             apply_bistellar_flip_dynamic(&mut tds, 2, &overlapping_faces),
             Err(FlipError::InvalidFlipContext {
                 reason: FlipContextError::OverlappingFaces,
             })
-        ));
+        );
         assert_eq!(tds.number_of_vertices(), 0);
         assert_eq!(tds.number_of_simplices(), 0);
     }
@@ -12091,7 +12092,7 @@ mod tests {
         let context = build_k2_flip_context(&tds, facet).unwrap();
         let result = apply_bistellar_flip_k2(&mut tds, &context);
 
-        assert!(matches!(result, Err(FlipError::DuplicateSimplex)));
+        assert_matches!(result, Err(FlipError::DuplicateSimplex));
         assert!(tds.is_valid().is_ok());
     }
 
@@ -12150,10 +12151,7 @@ mod tests {
 
         let result = apply_bistellar_flip_k2(&mut tds, &ctx);
 
-        assert!(matches!(
-            result,
-            Err(FlipError::InsertedSimplexAlreadyExists { .. })
-        ));
+        assert_matches!(result, Err(FlipError::InsertedSimplexAlreadyExists { .. }));
         assert!(tds.is_valid().is_ok());
     }
 
@@ -12185,7 +12183,7 @@ mod tests {
         let context = build_k2_flip_context(&tds, facet).unwrap();
         let result = apply_bistellar_flip_k2(&mut tds, &context);
 
-        assert!(matches!(result, Err(FlipError::NonManifoldFacet)));
+        assert_matches!(result, Err(FlipError::NonManifoldFacet));
         assert!(tds.is_valid().is_ok());
     }
 
@@ -12375,7 +12373,7 @@ mod tests {
         let before = snapshot_topology(&tds);
         let facet = FacetHandle::new(simplex, 0);
         let err = build_k2_flip_context(&tds, facet).unwrap_err();
-        assert!(matches!(err, FlipError::BoundaryFacet { .. }));
+        assert_matches!(err, FlipError::BoundaryFacet { .. });
         assert_eq!(snapshot_topology(&tds), before);
     }
 
@@ -12401,10 +12399,7 @@ mod tests {
 
         let ridge = RidgeHandle::new(simplex, 0, 1);
         let err = build_k3_flip_context(&tds, ridge).unwrap_err();
-        assert!(matches!(
-            err,
-            FlipError::InvalidRidgeMultiplicity { found: 1 }
-        ));
+        assert_matches!(err, FlipError::InvalidRidgeMultiplicity { found: 1 });
     }
 
     #[test]
@@ -12491,7 +12486,7 @@ mod tests {
 
         let edge = EdgeKey::new(opposite_a, opposite_b);
         let err = build_k2_flip_context_from_edge(&tds, edge).unwrap_err();
-        assert!(matches!(err, FlipError::InvalidEdgeMultiplicity { .. }));
+        assert_matches!(err, FlipError::InvalidEdgeMultiplicity { .. });
     }
 
     #[test]
@@ -12513,13 +12508,13 @@ mod tests {
 
         let triangle = TriangleHandle::new(vertices[0], vertices[1], vertices[2]);
         let err = build_k3_flip_context_from_triangle(&tds, triangle).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             FlipError::InvalidTriangleMultiplicity {
                 found: 1,
                 expected: 4,
             }
-        ));
+        );
     }
 
     #[test]
@@ -12536,7 +12531,7 @@ mod tests {
         let before = snapshot_topology(&tds);
         let err = apply_bistellar_flip_k1(&mut tds, simplex_key, vertex!([0.5, 0.0])).unwrap_err();
 
-        assert!(matches!(err, FlipError::DegenerateSimplex));
+        assert_matches!(err, FlipError::DegenerateSimplex);
         assert_eq!(snapshot_topology(&tds), before);
         assert!(tds.is_valid().is_ok());
     }
@@ -12923,10 +12918,7 @@ mod tests {
         let tds = tds.expect("expected a non-Delaunay configuration from candidates");
         let result = verify_delaunay_via_flip_predicates(&tds, &kernel);
 
-        assert!(matches!(
-            result,
-            Err(DelaunayRepairError::PostconditionFailed { .. })
-        ));
+        assert_matches!(result, Err(DelaunayRepairError::PostconditionFailed { .. }));
     }
 
     #[test]
@@ -12943,14 +12935,14 @@ mod tests {
             None,
         );
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelaunayRepairError::Flip { source })
                 if matches!(
                     source.as_ref(),
                     FlipError::UnsupportedDimension { dimension: 1 }
                 )
-        ));
+        );
     }
 
     #[test]
@@ -13697,12 +13689,12 @@ mod tests {
         let source = source
             .downcast_ref::<Box<FlipError>>()
             .expect("source should remain a typed boxed FlipError");
-        assert!(matches!(source.as_ref(), FlipError::DegenerateSimplex));
+        assert_matches!(source.as_ref(), FlipError::DegenerateSimplex);
 
         let DelaunayRepairError::Flip { source } = err else {
             panic!("expected boxed flip source");
         };
-        assert!(matches!(source.as_ref(), FlipError::DegenerateSimplex));
+        assert_matches!(source.as_ref(), FlipError::DegenerateSimplex);
     }
 
     #[test]
@@ -13900,8 +13892,11 @@ mod tests {
                 let mut coords = [0.0; D];
                 coords[index % D] =
                     0.05 * f64::from(u32::try_from(index + 1).expect("test index fits in u32"));
-                coords[(index + 1) % D] +=
-                    0.01 * f64::from(u32::try_from(index + 2).expect("test index fits in u32"));
+                let next_index = (index + 1) % D;
+                coords[next_index] = 0.01_f64.mul_add(
+                    f64::from(u32::try_from(index + 2).expect("test index fits in u32")),
+                    coords[next_index],
+                );
                 tds.insert_vertex_with_mapping(vertex!(coords)).unwrap()
             })
             .collect()
@@ -14057,7 +14052,7 @@ mod tests {
                 #[test]
                 fn [<test_removed_simplex_frame_requires_source_simplex_ $dim d>]() {
                     let result = removed_simplex_frame(&[]);
-                    assert!(matches!(result, Err(FlipError::InvalidFlipContext { .. })));
+                    assert_matches!(result, Err(FlipError::InvalidFlipContext { .. }));
                 }
             }
         };
@@ -14312,10 +14307,7 @@ mod tests {
             Some(frame_simplex),
             &truncated_removed_simplices,
         );
-        assert!(matches!(
-            lift_result,
-            Err(FlipError::InvalidFlipContext { .. })
-        ));
+        assert_matches!(lift_result, Err(FlipError::InvalidFlipContext { .. }));
 
         let kernel = AdaptiveKernel::<f64>::new();
         let config = RepairAttemptConfig {

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -62,7 +62,7 @@ use std::hash::{Hash, Hasher};
 /// use delaunay::prelude::insertion::HullExtensionReason;
 ///
 /// let reason = HullExtensionReason::NoVisibleFacets;
-/// assert!(matches!(reason, HullExtensionReason::NoVisibleFacets));
+/// std::assert_matches!(reason, HullExtensionReason::NoVisibleFacets);
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -988,7 +988,7 @@ impl fmt::Display for DelaunayRepairFailureContext {
 /// let err = NeighborRebuildError::Wiring {
 ///     reason: NeighborWiringError::MissingSimplex { simplex_key },
 /// };
-/// assert!(matches!(err, NeighborRebuildError::Wiring { .. }));
+/// std::assert_matches!(err, NeighborRebuildError::Wiring { .. });
 /// ```
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1048,7 +1048,7 @@ pub enum NeighborRebuildError {
 ///     facet_index: 4,
 ///     vertex_count: 3,
 /// };
-/// assert!(matches!(err, CavityFillingError::InvalidFacetIndex { .. }));
+/// std::assert_matches!(err, CavityFillingError::InvalidFacetIndex { .. });
 /// ```
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1215,7 +1215,7 @@ impl fmt::Display for CavityRepairStage {
 ///
 /// let simplex_key = SimplexKey::from(KeyData::from_ffi(11));
 /// let err = NeighborWiringError::MissingSimplex { simplex_key };
-/// assert!(matches!(err, NeighborWiringError::MissingSimplex { .. }));
+/// std::assert_matches!(err, NeighborWiringError::MissingSimplex { .. });
 /// ```
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1344,7 +1344,7 @@ pub enum NeighborWiringError {
 /// let err = InsertionError::DuplicateCoordinates {
 ///     coordinates: "[0.0, 0.0, 0.0]".to_string(),
 /// };
-/// assert!(matches!(err, InsertionError::DuplicateCoordinates { .. }));
+/// std::assert_matches!(err, InsertionError::DuplicateCoordinates { .. });
 /// ```
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -4279,6 +4279,7 @@ mod tests {
     use crate::topology::characteristics::euler::TopologyClassification;
     use crate::vertex;
     use slotmap::KeyData;
+    use std::assert_matches;
 
     /// Return one mutual neighbor pair from a test TDS.
     fn first_neighbor_pair<T, U, V, const D: usize>(
@@ -4466,12 +4467,12 @@ mod tests {
 
         let result = fill_cavity(tds, new_vkey, &invalid_boundary_facets);
         assert!(result.is_err());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InsertionError::CavityFilling {
                 reason: CavityFillingError::MissingBoundarySimplex { .. },
             })
-        ));
+        );
     }
 
     #[test]
@@ -4491,12 +4492,12 @@ mod tests {
 
         let result = fill_cavity(tds, new_vkey, &invalid_boundary_facets);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InsertionError::CavityFilling {
                 reason: CavityFillingError::InvalidFacetIndex { .. },
             })
-        ));
+        );
         assert_eq!(
             tds.number_of_simplices(),
             original_simplex_count,
@@ -4520,12 +4521,12 @@ mod tests {
 
         let result = wire_cavity_neighbors(tds, &invalid_simplices, [], None);
         assert!(result.is_err());
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InsertionError::NeighborWiring {
                 reason: NeighborWiringError::MissingSimplex { .. },
             })
-        ));
+        );
     }
 
     #[test]
@@ -4557,7 +4558,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NeighborWiring {
                 reason: NeighborWiringError::ExternalFacetNotFound {
@@ -4566,7 +4567,7 @@ mod tests {
                     ..
                 },
             } if simplex_key == external_simplex
-        ));
+        );
     }
 
     #[test]
@@ -4605,7 +4606,7 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NeighborWiring {
                 reason: NeighborWiringError::ExternalFacetAlreadyShared {
@@ -4615,7 +4616,7 @@ mod tests {
                     ..
                 },
             } if simplex_key == external_simplex
-        ));
+        );
     }
 
     #[test]
@@ -4629,12 +4630,12 @@ mod tests {
         let err =
             external_facets_for_boundary(&tds, &internal_simplices, &boundary_facets).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NeighborWiring {
                 reason: NeighborWiringError::MissingSimplex { simplex_key },
             } if simplex_key == missing_simplex
-        ));
+        );
     }
 
     #[test]
@@ -4660,12 +4661,12 @@ mod tests {
         let err =
             external_facets_for_boundary(&tds, &internal_simplices, &boundary_facets).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NeighborWiring {
                 reason: NeighborWiringError::MissingSimplex { simplex_key },
             } if simplex_key == missing_neighbor
-        ));
+        );
     }
 
     #[test]
@@ -4755,12 +4756,12 @@ mod tests {
         let boundary_facets = vec![FacetHandle::new(simplex_key, 0)];
         let err = fill_cavity(tds, new_vkey, &boundary_facets).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::CavityFilling {
                 reason: CavityFillingError::WrongSimplexArity { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -4794,13 +4795,13 @@ mod tests {
         new_simplices.push(c3);
 
         let err = wire_cavity_neighbors(&mut tds, &new_simplices, [], None).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NonManifoldTopology {
                 simplex_count: 3,
                 ..
             }
-        ));
+        );
     }
 
     #[test]
@@ -4826,7 +4827,7 @@ mod tests {
         new_simplices.push(simplex_key);
 
         let err = wire_cavity_neighbors(tds, &new_simplices, [], None).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NeighborWiring {
                 reason: NeighborWiringError::WrongSimplexArity {
@@ -4835,7 +4836,7 @@ mod tests {
                     found: 4,
                 },
             } if key == simplex_key
-        ));
+        );
     }
 
     #[test]
@@ -4845,13 +4846,13 @@ mod tests {
             max: u8::MAX,
         };
 
-        assert!(matches!(
+        assert_matches!(
             err,
             NeighborWiringError::FacetIndexOverflow {
                 facet_index,
                 max: u8::MAX,
             } if facet_index == usize::from(u8::MAX) + 1
-        ));
+        );
     }
 
     #[test]
@@ -4863,14 +4864,14 @@ mod tests {
             found: 2,
         };
 
-        assert!(matches!(
+        assert_matches!(
             err,
             NeighborWiringError::WrongSimplexArity {
                 simplex_key: key,
                 expected: 3,
                 found: 2,
             } if key == simplex_key
-        ));
+        );
         assert!(err.to_string().contains("expected 3"));
         assert!(err.to_string().contains("has 2 vertices"));
     }
@@ -5777,10 +5778,10 @@ mod tests {
 
                     let err = repair_neighbor_pointers_local(&mut tds, &simplex_keys, None).unwrap_err();
 
-                    assert!(matches!(
+                    assert_matches!(
                         err,
                         InsertionError::NonManifoldTopology { simplex_count: 3, .. }
-                    ));
+                    );
                 }
             }
         };
@@ -6005,12 +6006,12 @@ mod tests {
             .unwrap();
 
         let err = extend_hull(tds, &kernel, new_vkey, &p).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::HullExtension {
                 reason: HullExtensionReason::NoVisibleFacets
             }
-        ));
+        );
     }
 
     #[test]
@@ -6078,12 +6079,12 @@ mod tests {
         let missing = SimplexKey::from(KeyData::from_ffi(u64::MAX));
 
         let err = set_neighbor(&mut tds, missing, 0, None).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NeighborWiring {
                 reason: NeighborWiringError::MissingSimplex { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -6097,7 +6098,7 @@ mod tests {
             .unwrap();
 
         let err = set_neighbor(&mut tds, simplex_key, 3, None).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             InsertionError::NeighborWiring {
                 reason: NeighborWiringError::InvalidFacetIndex {
@@ -6106,7 +6107,7 @@ mod tests {
                     ..
                 },
             }
-        ));
+        );
     }
 
     #[test]

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -4865,12 +4865,12 @@ mod tests {
         };
 
         assert_matches!(
-            err,
+            &err,
             NeighborWiringError::WrongSimplexArity {
                 simplex_key: key,
                 expected: 3,
                 found: 2,
-            } if key == simplex_key
+            } if *key == simplex_key
         );
         assert!(err.to_string().contains("expected 3"));
         assert!(err.to_string().contains("has 2 vertices"));

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -77,7 +77,7 @@ fn ridge_fan_dump_enabled() -> bool {
 ///
 /// let vertex = VertexKey::from(KeyData::from_ffi(2));
 /// let result = LocateResult::OnVertex(vertex);
-/// assert!(matches!(result, LocateResult::OnVertex(_)));
+/// std::assert_matches!(result, LocateResult::OnVertex(_));
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LocateResult {
@@ -101,7 +101,7 @@ pub enum LocateResult {
 /// use delaunay::prelude::algorithms::LocateError;
 ///
 /// let err = LocateError::EmptyTriangulation;
-/// assert!(matches!(err, LocateError::EmptyTriangulation));
+/// std::assert_matches!(err, LocateError::EmptyTriangulation);
 /// ```
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -137,7 +137,7 @@ pub enum LocateError {
 ///
 /// let simplex_key = SimplexKey::from(KeyData::from_ffi(5));
 /// let err = ConflictError::InvalidStartSimplex { simplex_key };
-/// assert!(matches!(err, ConflictError::InvalidStartSimplex { .. }));
+/// std::assert_matches!(err, ConflictError::InvalidStartSimplex { .. });
 /// ```
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -306,12 +306,12 @@ pub enum ConflictError {
 ///     extra_facets_len: 3,
 /// };
 /// let err = ConflictError::InternalInconsistency { site: site.clone() };
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     err,
 ///     ConflictError::InternalInconsistency {
 ///         site: InternalInconsistencySite::RidgeFanExtraFacetOutOfBounds { .. }
 ///     }
-/// ));
+/// );
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
@@ -741,15 +741,15 @@ pub(crate) struct LocateTrace {
 /// // Point inside the 4-simplex
 /// let inside_point = Point::new([0.2, 0.2, 0.2, 0.2]);
 /// let inside = locate(dt.tds(), &kernel, &inside_point, None)?;
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     inside,
 ///     LocateResult::InsideSimplex(simplex_key) if dt.tds().contains_simplex(simplex_key)
-/// ));
+/// );
 ///
 /// // Point outside the convex hull
 /// let outside_point = Point::new([2.0, 2.0, 2.0, 2.0]);
 /// let outside = locate(dt.tds(), &kernel, &outside_point, None)?;
-/// assert!(matches!(outside, LocateResult::Outside));
+/// std::assert_matches!(outside, LocateResult::Outside);
 /// # Ok(())
 /// # }
 /// ```
@@ -789,7 +789,7 @@ pub(crate) struct LocateTrace {
 /// let query_point = Point::new([0.15, 0.15, 0.15, 0.15]);
 ///
 /// let located = locate(dt.tds(), &kernel, &query_point, Some(hint_simplex))?;
-/// assert!(matches!(located, LocateResult::InsideSimplex(_)));
+/// std::assert_matches!(located, LocateResult::InsideSimplex(_));
 /// # Ok(())
 /// # }
 /// ```
@@ -2032,6 +2032,7 @@ mod tests {
     use crate::prelude::DelaunayTriangulation;
     use crate::vertex;
     use slotmap::KeyData;
+    use std::assert_matches;
 
     #[test]
     fn test_internal_inconsistency_site_display_variants() {
@@ -2296,7 +2297,7 @@ mod tests {
         let point = Point::new([0.0, 0.0, 0.0]);
 
         let result = locate(&tds, &kernel, &point, None);
-        assert!(matches!(result, Err(LocateError::EmptyTriangulation)));
+        assert_matches!(result, Err(LocateError::EmptyTriangulation));
     }
 
     #[test]
@@ -2358,7 +2359,7 @@ mod tests {
         let point = Point::new([10.0, 10.0]);
         let result = locate(dt.tds(), &kernel, &point, None);
 
-        assert!(matches!(result, Ok(LocateResult::Outside)));
+        assert_matches!(result, Ok(LocateResult::Outside));
     }
 
     #[test]
@@ -2376,7 +2377,7 @@ mod tests {
         let point = Point::new([2.0, 2.0, 2.0]);
         let result = locate(dt.tds(), &kernel, &point, None);
 
-        assert!(matches!(result, Ok(LocateResult::Outside)));
+        assert_matches!(result, Ok(LocateResult::Outside));
     }
 
     #[test]
@@ -2395,7 +2396,7 @@ mod tests {
         let point = Point::new([0.25, 0.25, 0.25]);
 
         let result = locate(dt.tds(), &kernel, &point, Some(hint_simplex));
-        assert!(matches!(result, Ok(LocateResult::InsideSimplex(_))));
+        assert_matches!(result, Ok(LocateResult::InsideSimplex(_)));
     }
 
     #[test]
@@ -2411,7 +2412,7 @@ mod tests {
         let point = Point::new([0.3, 0.3]);
         let result = locate(dt.tds(), &kernel, &point, None);
 
-        assert!(matches!(result, Ok(LocateResult::InsideSimplex(_))));
+        assert_matches!(result, Ok(LocateResult::InsideSimplex(_)));
     }
 
     #[test]
@@ -2441,18 +2442,18 @@ mod tests {
         let point = Point::new([10.0, 10.0]);
         let (result, stats) = locate_with_stats(dt.tds(), &kernel, &point, None).unwrap();
 
-        assert!(matches!(result, LocateResult::Outside));
+        assert_matches!(result, LocateResult::Outside);
         assert!(stats.fell_back_to_scan());
         assert!(!stats.used_hint);
         assert_eq!(stats.start_simplex, simplex_key);
         assert_eq!(stats.walk_steps, 2);
-        assert!(matches!(
+        assert_matches!(
             stats.fallback,
             Some(LocateFallback {
                 reason: LocateFallbackReason::CycleDetected,
                 steps: 2,
             })
-        ));
+        );
     }
 
     #[test]
@@ -2472,7 +2473,7 @@ mod tests {
         // Test all facets - point should not be outside any of them
         for facet_idx in 0..4 {
             let result = is_point_outside_facet(dt.tds(), &kernel, simplex_key, facet_idx, &point);
-            assert!(matches!(result, Ok(Some(false) | None)));
+            assert_matches!(result, Ok(Some(false) | None));
         }
     }
 
@@ -2840,7 +2841,7 @@ mod tests {
         let (result, stats) =
             locate_with_stats(dt.tds(), &kernel, &point, Some(invalid_hint)).unwrap();
 
-        assert!(matches!(result, LocateResult::InsideSimplex(_)));
+        assert_matches!(result, LocateResult::InsideSimplex(_));
         assert_eq!(stats.start_simplex, expected_start);
         assert!(!stats.used_hint);
         assert!(!stats.fell_back_to_scan());
@@ -2899,13 +2900,13 @@ mod tests {
         conflict_simplices.push(third_simplex);
 
         let err = extract_cavity_boundary(&tds, &conflict_simplices).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             ConflictError::NonManifoldFacet {
                 simplex_count: 3,
                 ..
             }
-        ));
+        );
     }
 
     #[test]
@@ -2971,7 +2972,7 @@ mod tests {
 
         let (result, stats) = locate_with_stats(dt.tds(), &kernel, &point, Some(hint)).unwrap();
 
-        assert!(matches!(result, LocateResult::InsideSimplex(_)));
+        assert_matches!(result, LocateResult::InsideSimplex(_));
         assert_eq!(stats.start_simplex, hint);
         assert!(stats.used_hint);
         assert!(!stats.fell_back_to_scan());
@@ -3003,10 +3004,10 @@ mod tests {
         conflict_simplices.push(invalid);
 
         let err = extract_cavity_boundary(dt.tds(), &conflict_simplices).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             ConflictError::InvalidStartSimplex { simplex_key } if simplex_key == invalid
-        ));
+        );
     }
 
     /// A simplex with fewer than D+1 vertex keys is detected early by the
@@ -3231,7 +3232,7 @@ mod tests {
 
         let (result, stats) = locate_with_stats(dt.tds(), &kernel, &point, None).unwrap();
 
-        assert!(matches!(result, LocateResult::InsideSimplex(_)));
+        assert_matches!(result, LocateResult::InsideSimplex(_));
         assert!(!stats.used_hint, "None hint should set used_hint = false");
         assert!(!stats.fell_back_to_scan());
     }

--- a/src/core/boundary.rs
+++ b/src/core/boundary.rs
@@ -306,6 +306,7 @@ mod tests {
     use crate::core::vertex::Vertex;
     use crate::geometry::{point::Point, traits::coordinate::Coordinate};
     use crate::triangulation::DelaunayTriangulation;
+    use std::assert_matches;
 
     // =============================================================================
     // SINGLE SIMPLEX TESTS
@@ -664,10 +665,10 @@ mod tests {
             .is_boundary_facet_with_map(&facet, &facet_to_simplices)
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::FacetError(FacetError::InvalidFacetMultiplicity { found: 3, .. })
-        ));
+        );
     }
 
     #[test]
@@ -686,13 +687,13 @@ mod tests {
 
         let err = number_of_boundary_facets_in_map(&facet_to_simplices).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::FacetError(FacetError::InvalidFacetMultiplicity {
                 facet_key: 0xCAFE,
                 found: 3
             })
-        ));
+        );
     }
 
     #[test]

--- a/src/core/construction.rs
+++ b/src/core/construction.rs
@@ -340,6 +340,7 @@ mod tests {
     use crate::geometry::kernel::FastKernel;
     use crate::geometry::traits::coordinate::Coordinate;
     use crate::vertex;
+    use std::assert_matches;
     use uuid::Uuid;
 
     #[test]
@@ -429,10 +430,10 @@ mod tests {
 
         let result = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(TriangulationConstructionError::InsufficientVertices { dimension: 3, .. })
-        ));
+        );
     }
 
     #[test]
@@ -446,10 +447,10 @@ mod tests {
 
         let result = Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(TriangulationConstructionError::InsufficientVertices { .. })
-        ));
+        );
     }
 
     fn invalid_initial_simplex_vertices<const D: usize>() -> Vec<Vertex<f64, (), D>> {
@@ -484,12 +485,12 @@ mod tests {
 
                         let result = Triangulation::<FastKernel<f64>, (), (), $dim>::build_initial_simplex(&vertices);
 
-                        assert!(matches!(
+                        assert_matches!(
                             result,
                             Err(TriangulationConstructionError::Tds(
                                 TdsConstructionError::ValidationError(TdsError::InvalidVertex { .. })
                             ))
-                        ));
+                        );
                     }
                 )+
             }
@@ -544,10 +545,10 @@ mod tests {
 
         let result = Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(TriangulationConstructionError::GeometricDegeneracy { .. })
-        ));
+        );
     }
 
     #[test]
@@ -561,9 +562,9 @@ mod tests {
 
         let result = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(TriangulationConstructionError::GeometricDegeneracy { .. })
-        ));
+        );
     }
 }

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -95,7 +95,7 @@ use thiserror::Error;
 /// use delaunay::prelude::tds::FacetError;
 ///
 /// let err = FacetError::FacetNotFoundInTriangulation;
-/// assert!(matches!(err, FacetError::FacetNotFoundInTriangulation));
+/// std::assert_matches!(err, FacetError::FacetNotFoundInTriangulation);
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1229,6 +1229,7 @@ mod tests {
     use crate::triangulation::DelaunayTriangulation;
     use crate::vertex;
     use slotmap::SlotMap;
+    use std::assert_matches;
     use std::{collections::HashSet, mem};
 
     // =============================================================================
@@ -1286,10 +1287,10 @@ mod tests {
         let simplex_key = dt.simplices().next().unwrap().0;
 
         // Test invalid facet index (should be 0 or 1 for 1D, facet_index >= 2 is invalid)
-        assert!(matches!(
+        assert_matches!(
             FacetView::new(dt.tds(), simplex_key, 99),
             Err(FacetError::InvalidFacetIndex { .. })
-        ));
+        );
     }
 
     #[test]
@@ -1868,7 +1869,7 @@ mod tests {
 
         // Test invalid facet index
         let result = FacetView::new(dt.tds(), simplex_key, 10);
-        assert!(matches!(result, Err(FacetError::InvalidFacetIndex { .. })));
+        assert_matches!(result, Err(FacetError::InvalidFacetIndex { .. }));
     }
 
     #[test]

--- a/src/core/insertion.rs
+++ b/src/core/insertion.rs
@@ -2697,6 +2697,7 @@ mod tests {
     };
     use crate::triangulation::DelaunayTriangulation;
     use crate::vertex;
+    use std::assert_matches;
 
     use slotmap::KeyData;
     use std::cell::Cell;
@@ -3093,10 +3094,7 @@ mod tests {
 
         let tol = 1e-10_f64;
         let err = tri.duplicate_coordinates_error(&[0.0, 0.0], tol, Some(&index));
-        assert!(matches!(
-            err,
-            Some(InsertionError::DuplicateCoordinates { .. })
-        ));
+        assert_matches!(err, Some(InsertionError::DuplicateCoordinates { .. }));
     }
 
     #[test]
@@ -3111,10 +3109,7 @@ mod tests {
         let index: HashGridIndex<f64, 2> = HashGridIndex::new(0.0); // unusable
         let tol = 1e-10_f64;
         let err = tri.duplicate_coordinates_error(&[0.0, 0.0], tol, Some(&index));
-        assert!(matches!(
-            err,
-            Some(InsertionError::DuplicateCoordinates { .. })
-        ));
+        assert_matches!(err, Some(InsertionError::DuplicateCoordinates { .. }));
     }
 
     fn duplicate_coordinate_tolerance_scales_down_for_small_features<const D: usize>() {
@@ -3152,10 +3147,10 @@ mod tests {
             tolerance > 1.0e-10,
             "unit-scale hint simplices should preserve near-duplicate filtering"
         );
-        assert!(matches!(
+        assert_matches!(
             tri.duplicate_coordinates_error(&candidate, tolerance, None),
             Some(InsertionError::DuplicateCoordinates { .. })
-        ));
+        );
     }
 
     fn duplicate_index_rebuilds_when_tolerance_exceeds_cell_size<const D: usize>() {
@@ -3264,12 +3259,12 @@ mod tests {
         // Second insertion at same coordinates: insert() returns Err; the internal
         // statistics helper reports Skipped so telemetry can classify the no-op.
         let err = insert(&mut tri, vertex!([0.0, 0.0, 0.0]), None, None).unwrap_err();
-        assert!(matches!(err, InsertionError::DuplicateCoordinates { .. }));
+        assert_matches!(err, InsertionError::DuplicateCoordinates { .. });
 
         let (outcome, stats) =
             insert_with_statistics(&mut tri, vertex!([0.0, 0.0, 0.0]), None, None).unwrap();
         assert!(stats.skipped());
-        assert!(matches!(outcome, InsertionOutcome::Skipped { .. }));
+        assert_matches!(outcome, InsertionOutcome::Skipped { .. });
 
         // No new vertex should have been inserted.
         assert_eq!(tri.number_of_vertices(), 1);
@@ -3312,10 +3307,7 @@ mod tests {
         let (outcome, stats) = insert_with_statistics(&mut tri, vertex!([0.0, 0.0]), None, None)
             .expect("insertion should succeed");
 
-        assert!(matches!(
-            outcome,
-            InsertionOutcome::Inserted { hint: None, .. }
-        ));
+        assert_matches!(outcome, InsertionOutcome::Inserted { hint: None, .. });
         assert_eq!(stats.attempts, 1);
         assert!(!stats.used_perturbation());
         assert!(!stats.skipped());
@@ -3339,21 +3331,15 @@ mod tests {
         for (i, v) in vertices.into_iter().enumerate() {
             let (outcome, stats) = insert_with_statistics(&mut tri, v, None, None).unwrap();
 
-            assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+            assert_matches!(outcome, InsertionOutcome::Inserted { .. });
             assert_eq!(stats.attempts, 1);
 
             if i < 3 {
                 // Bootstrap phase - no hint yet
-                assert!(matches!(
-                    outcome,
-                    InsertionOutcome::Inserted { hint: None, .. }
-                ));
+                assert_matches!(outcome, InsertionOutcome::Inserted { hint: None, .. });
             } else {
                 // After D+1 vertices, hint should be available
-                assert!(matches!(
-                    outcome,
-                    InsertionOutcome::Inserted { hint: Some(_), .. }
-                ));
+                assert_matches!(outcome, InsertionOutcome::Inserted { hint: Some(_), .. });
             }
         }
 
@@ -3387,7 +3373,7 @@ mod tests {
             )
             .unwrap();
 
-        assert!(matches!(detail.outcome, InsertionOutcome::Inserted { .. }));
+        assert_matches!(detail.outcome, InsertionOutcome::Inserted { .. });
         assert_eq!(detail.telemetry.global_conflict_scans, 0);
         assert_eq!(detail.telemetry.global_conflict_simplices_scanned, 0);
         assert_eq!(detail.telemetry.global_conflict_simplices_found_total, 0);
@@ -3437,7 +3423,7 @@ mod tests {
             )
             .unwrap();
 
-        assert!(matches!(detail.outcome, InsertionOutcome::Inserted { .. }));
+        assert_matches!(detail.outcome, InsertionOutcome::Inserted { .. });
         assert_eq!(detail.telemetry.global_conflict_scans, 0);
         assert_eq!(detail.telemetry.conflict_region_calls, 1);
         assert_eq!(detail.telemetry.conflict_region_simplices_total, 0);
@@ -3487,7 +3473,7 @@ mod tests {
             )
             .unwrap();
 
-        assert!(matches!(detail.outcome, InsertionOutcome::Inserted { .. }));
+        assert_matches!(detail.outcome, InsertionOutcome::Inserted { .. });
         assert!(
             !detail.delaunay_repair_required,
             "caller-provided conflict simplices should preserve the cavity insertion repair flag"
@@ -3515,10 +3501,7 @@ mod tests {
             insert_with_statistics(&mut tri, vertex!([0.2, 0.2, 0.2, 0.2]), None, hint_simplex)
                 .unwrap();
 
-        assert!(matches!(
-            outcome,
-            InsertionOutcome::Inserted { hint: Some(_), .. }
-        ));
+        assert_matches!(outcome, InsertionOutcome::Inserted { hint: Some(_), .. });
         assert_eq!(stats.attempts, 1);
         assert!(stats.success());
     }
@@ -3534,7 +3517,7 @@ mod tests {
         // Try duplicate - should be skipped
         let result = insert_with_statistics(&mut tri, vertex!([1.0, 2.0, 3.0]), None, None);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Ok((
                 InsertionOutcome::Skipped {
@@ -3542,7 +3525,7 @@ mod tests {
                 },
                 _
             ))
-        ));
+        );
     }
 
     #[test]
@@ -3612,7 +3595,7 @@ mod tests {
             let (outcome, stats) =
                 insert_with_statistics(&mut tri, vertex!(coords), None, None).unwrap();
 
-            assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+            assert_matches!(outcome, InsertionOutcome::Inserted { .. });
             assert_eq!(stats.attempts, 1);
             assert!(stats.success());
         }
@@ -4184,7 +4167,7 @@ mod tests {
             let (outcome, stats) =
                 insert_with_statistics(&mut tri, vertex!(*coords), None, None).unwrap();
             assert!(stats.success());
-            assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+            assert_matches!(outcome, InsertionOutcome::Inserted { .. });
             assert_eq!(stats.attempts, 1);
         }
         assert_eq!(tri.number_of_vertices(), 4);
@@ -4207,10 +4190,7 @@ mod tests {
         let tol = 1e-10_f64;
         // No index provided: should fall back to linear scan.
         let err = tri.duplicate_coordinates_error(&[3.0, 4.0], tol, None);
-        assert!(matches!(
-            err,
-            Some(InsertionError::DuplicateCoordinates { .. })
-        ));
+        assert_matches!(err, Some(InsertionError::DuplicateCoordinates { .. }));
 
         // Non-duplicate should return None.
         let no_err = tri.duplicate_coordinates_error(&[99.0, 99.0], tol, None);

--- a/src/core/operations.rs
+++ b/src/core/operations.rs
@@ -55,7 +55,7 @@ pub enum TopologicalOperation {
 ///         found: TopologyGuarantee::Pseudomanifold,
 ///     },
 /// };
-/// assert!(matches!(decision, RepairDecision::Skip { .. }));
+/// std::assert_matches!(decision, RepairDecision::Skip { .. });
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepairDecision {
@@ -76,7 +76,7 @@ pub enum RepairDecision {
 /// use delaunay::prelude::operations::RepairSkipReason;
 ///
 /// let reason = RepairSkipReason::PolicyDisabled;
-/// assert!(matches!(reason, RepairSkipReason::PolicyDisabled));
+/// std::assert_matches!(reason, RepairSkipReason::PolicyDisabled);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum RepairSkipReason {
@@ -374,7 +374,7 @@ impl DelaunayInsertionState {
 ///         coordinates: "[0.0, 0.0, 0.0]".to_string(),
 ///     },
 /// };
-/// assert!(matches!(outcome, InsertionOutcome::Skipped { .. }));
+/// std::assert_matches!(outcome, InsertionOutcome::Skipped { .. });
 /// ```
 #[derive(Debug, Clone)]
 pub enum InsertionOutcome {
@@ -458,6 +458,7 @@ impl SuspicionFlags {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     #[test]
     fn test_topological_operation_admissibility() {
@@ -487,28 +488,28 @@ mod tests {
 
         let decision =
             DelaunayRepairPolicy::EveryInsertion.decide(1, TopologyGuarantee::PLManifold, op);
-        assert!(matches!(decision, RepairDecision::Proceed));
+        assert_matches!(decision, RepairDecision::Proceed);
 
         let decision =
             DelaunayRepairPolicy::EveryInsertion.decide(0, TopologyGuarantee::PLManifold, op);
-        assert!(matches!(
+        assert_matches!(
             decision,
             RepairDecision::Skip {
                 reason: RepairSkipReason::PolicyDisabled
             }
-        ));
+        );
 
         let decision =
             DelaunayRepairPolicy::EveryInsertion.decide(1, TopologyGuarantee::Pseudomanifold, op);
-        assert!(matches!(decision, RepairDecision::Proceed));
+        assert_matches!(decision, RepairDecision::Proceed);
 
         let decision = DelaunayRepairPolicy::Never.decide(1, TopologyGuarantee::PLManifold, op);
-        assert!(matches!(
+        assert_matches!(
             decision,
             RepairDecision::Skip {
                 reason: RepairSkipReason::PolicyDisabled
             }
-        ));
+        );
     }
 
     #[test]
@@ -517,7 +518,7 @@ mod tests {
         let op = TopologicalOperation::CavityFlip;
         let decision =
             DelaunayRepairPolicy::EveryInsertion.decide(1, TopologyGuarantee::Pseudomanifold, op);
-        assert!(matches!(
+        assert_matches!(
             decision,
             RepairDecision::Skip {
                 reason: RepairSkipReason::Inadmissible {
@@ -526,7 +527,7 @@ mod tests {
                     found: TopologyGuarantee::Pseudomanifold,
                 }
             }
-        ));
+        );
     }
 
     #[test]

--- a/src/core/orientation.rs
+++ b/src/core/orientation.rs
@@ -509,6 +509,7 @@ mod tests {
     use crate::geometry::kernel::FastKernel;
     use crate::topology::traits::topological_space::{GlobalTopology, ToroidalConstructionMode};
     use crate::vertex;
+    use std::assert_matches;
 
     /// Regression test: a negatively oriented but topologically valid simplex
     /// passes topology-only validation while failing full validation.
@@ -578,11 +579,11 @@ mod tests {
 
         let tri = Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
         let err = tri.is_valid().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             InvariantError::Tds(TdsError::Geometric(GeometricError::NegativeOrientation { message }))
                 if message.contains("negative geometric orientation")
-        ));
+        );
     }
 
     #[test]
@@ -691,11 +692,11 @@ mod tests {
             .unwrap()
             .swap_vertex_slots(0, 1);
         let err = tri.validate_geometric_simplex_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::Geometric(GeometricError::NegativeOrientation { message })
                 if message.contains("negative geometric orientation")
-        ));
+        );
     }
 
     #[test]
@@ -715,12 +716,12 @@ mod tests {
 
         let tri = Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
         let err = tri.validate_geometric_simplex_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InconsistentDataStructure { message }
                 if message.contains("has periodic offsets")
                     && message.contains("expected periodic-orientation-offset-capable topology")
-        ));
+        );
     }
 
     #[test]
@@ -739,14 +740,14 @@ mod tests {
 
         let tri = Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
         let err = tri.validate_geometric_simplex_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::DimensionMismatch {
                 expected: 3,
                 actual: 2,
                 ..
             }
-        ));
+        );
     }
 
     #[test]
@@ -772,11 +773,11 @@ mod tests {
         });
 
         let err = tri.validate_geometric_simplex_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InconsistentDataStructure { message }
                 if message.contains("Failed to lift coordinates")
                     && message.contains("Invalid toroidal period")
-        ));
+        );
     }
 }

--- a/src/core/repair.rs
+++ b/src/core/repair.rs
@@ -85,6 +85,7 @@ fn quality_error_to_tds_error(simplex_key: SimplexKey, error: QualityError) -> T
 
 /// Internal result from over-shared-facet repair, including the surviving frontier
 /// that should seed local neighbor-pointer repair.
+#[derive(Debug)]
 pub(crate) struct LocalFacetRepairOutcome {
     /// Number of simplices actually removed from the TDS.
     pub(crate) removed_count: usize,
@@ -1232,6 +1233,7 @@ mod tests {
     use crate::core::vertex::Vertex;
     use crate::geometry::kernel::FastKernel;
     use crate::vertex;
+    use std::assert_matches;
 
     use slotmap::KeyData;
 
@@ -1662,14 +1664,14 @@ mod tests {
     #[test]
     fn test_pick_fan_apex_errors_for_empty_facets() {
         let (tri, _, _) = build_single_tet();
-        assert!(matches!(
+        assert_matches!(
             tri.pick_fan_apex(&[]),
             Err(TdsError::DimensionMismatch {
                 expected: 1,
                 actual: 0,
                 ..
             })
-        ));
+        );
     }
 
     #[test]
@@ -1678,13 +1680,13 @@ mod tests {
         let missing_simplex = SimplexKey::from(KeyData::from_ffi(0xBAD));
         let facets = [FacetHandle::new(missing_simplex, 0)];
 
-        assert!(matches!(
+        assert_matches!(
             tri.pick_fan_apex(&facets),
             Err(TdsError::SimplexNotFound {
                 simplex_key,
                 ..
             }) if simplex_key == missing_simplex
-        ));
+        );
     }
 
     #[test]
@@ -1709,13 +1711,13 @@ mod tests {
 
         let result = tri.affected_vertices_for_vertex_removal(&[missing_simplex], v0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InvariantError::Tds(TdsError::SimplexNotFound {
                 simplex_key,
                 ..
             })) if simplex_key == missing_simplex
-        ));
+        );
     }
 
     #[test]
@@ -1788,12 +1790,12 @@ mod tests {
         let result =
             tri.repair_affected_vertex_incidence_from_scope(&affected_vertices, &validation_scope);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InvariantError::Triangulation(
                 TriangulationValidationError::IsolatedVertex { vertex_key, .. }
             )) if vertex_key == v3
-        ));
+        );
     }
 
     #[test]
@@ -1812,12 +1814,12 @@ mod tests {
             &validation_scope,
         );
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InvariantError::Tds(
                 TdsError::InconsistentDataStructure { .. }
             ))
-        ));
+        );
     }
 
     #[test]
@@ -1845,16 +1847,16 @@ mod tests {
                 context: "quality lookup".to_string(),
             },
         };
-        assert!(matches!(
+        assert_matches!(
             quality_error_to_tds_error(simplex_key, simplex_error),
             TdsError::SimplexNotFound { simplex_key: key, .. } if key == simplex_key
-        ));
+        );
 
         let vertex_error = QualityError::VertexNotFound { vertex_key };
-        assert!(matches!(
+        assert_matches!(
             quality_error_to_tds_error(simplex_key, vertex_error),
             TdsError::VertexNotFound { vertex_key: key, .. } if key == vertex_key
-        ));
+        );
     }
 
     #[test]
@@ -1866,14 +1868,14 @@ mod tests {
             dimension: 3,
         };
 
-        assert!(matches!(
+        assert_matches!(
             quality_error_to_tds_error(simplex_key, error),
             TdsError::DimensionMismatch {
                 expected: 4,
                 actual: 3,
                 ..
             }
-        ));
+        );
     }
 
     // =========================================================================
@@ -2108,13 +2110,13 @@ mod tests {
 
         let result = tri.repair_local_facet_issues_with_frontier(&issues, 0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InsertionError::MaxSimplicesRemovedExceeded {
                 max_simplices_removed: 0,
                 attempted
             }) if attempted > 0
-        ));
+        );
         assert_eq!(tri.tds.number_of_simplices(), original_simplex_count);
         for simplex_key in original_simplices {
             assert!(
@@ -2140,12 +2142,12 @@ mod tests {
             0,
         );
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InvariantError::Tds(TdsError::InconsistentDataStructure { ref message }))
                 if message.contains("Local facet repair after vertex removal failed")
                     && message.contains("Local facet repair removal budget exceeded")
-        ));
+        );
         assert_eq!(simplices_removed, 0);
         assert!(post_repair_frontier.is_empty());
         assert_eq!(tri.tds.number_of_simplices(), original_simplex_count);
@@ -2221,13 +2223,13 @@ mod tests {
 
         let result = tri.repair_local_facet_issues(&issues, 0);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InsertionError::MaxSimplicesRemovedExceeded {
                 max_simplices_removed: 0,
                 attempted
             }) if attempted > 0
-        ));
+        );
         assert_eq!(tri.tds.number_of_simplices(), original_simplex_count);
     }
 }

--- a/src/core/simplex.rs
+++ b/src/core/simplex.rs
@@ -88,7 +88,7 @@ use uuid::Uuid;
 /// use delaunay::prelude::tds::SimplexValidationError;
 ///
 /// let err = SimplexValidationError::DuplicateVertices;
-/// assert!(matches!(err, SimplexValidationError::DuplicateVertices));
+/// std::assert_matches!(err, SimplexValidationError::DuplicateVertices);
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -2127,6 +2127,7 @@ mod tests {
     use crate::geometry::util::{circumcenter, circumradius, circumradius_with_center};
     use crate::prelude::DelaunayTriangulation;
     use approx::assert_relative_eq;
+    use std::assert_matches;
     use std::{
         cmp,
         collections::{HashSet, hash_map::DefaultHasher},
@@ -3901,20 +3902,20 @@ mod tests {
         // Too few vertices for a 3D simplex (D+1 = 4)
         let err =
             Simplex::<f64, (), (), 3>::new(vec![vkeys[0], vkeys[1], vkeys[2]], None).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             SimplexValidationError::InsufficientVertices {
                 actual: 3,
                 expected: 4,
                 dimension: 3,
             }
-        ));
+        );
 
         // Duplicate vertex keys are rejected
         let err =
             Simplex::<f64, (), (), 3>::new(vec![vkeys[0], vkeys[1], vkeys[2], vkeys[0]], None)
                 .unwrap_err();
-        assert!(matches!(err, SimplexValidationError::DuplicateVertices));
+        assert_matches!(err, SimplexValidationError::DuplicateVertices);
     }
 
     #[test]
@@ -3931,18 +3932,18 @@ mod tests {
         // Insufficient vertices (wrong vertex buffer length)
         let mut wrong_len = simplex_ref.clone();
         wrong_len.vertices.pop();
-        assert!(matches!(
+        assert_matches!(
             wrong_len.is_valid(),
             Err(SimplexValidationError::InsufficientVertices { .. })
-        ));
+        );
 
         // Duplicate vertices
         let mut dup = simplex_ref.clone();
         dup.vertices[1] = dup.vertices[0];
-        assert!(matches!(
+        assert_matches!(
             dup.is_valid(),
             Err(SimplexValidationError::DuplicateVertices)
-        ));
+        );
     }
 
     #[test]
@@ -4017,10 +4018,10 @@ mod tests {
         let slots = simplex.ensure_neighbors_buffer_mut();
         slots[0] = NeighborSlot::Unassigned;
 
-        assert!(matches!(
+        assert_matches!(
             simplex.is_valid(),
             Err(SimplexValidationError::UnassignedNeighborSlot { facet_index: 0 })
-        ));
+        );
     }
 
     #[test]
@@ -4107,24 +4108,24 @@ mod tests {
 
         // Both helpers should fail early (before attempting to build individual FacetViews).
         let err = Simplex::facet_views_from_tds(dt.tds(), simplex_key).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             FacetError::InvalidFacetIndex {
                 index: u8::MAX,
                 facet_count,
             } if u8::try_from(facet_count).is_err()
-        ));
+        );
 
         let err = Simplex::facet_view_iter(dt.tds(), simplex_key)
             .err()
             .expect("Expected facet_view_iter to fail on vertex_count overflow");
-        assert!(matches!(
+        assert_matches!(
             err,
             FacetError::InvalidFacetIndex {
                 index: u8::MAX,
                 facet_count,
             } if u8::try_from(facet_count).is_err()
-        ));
+        );
     }
 
     #[test]
@@ -4175,10 +4176,10 @@ mod tests {
         };
         let simplex_err: SimplexValidationError = err.into();
 
-        assert!(matches!(
+        assert_matches!(
             simplex_err,
             SimplexValidationError::CoordinateConversion { .. }
-        ));
+        );
     }
 
     // =============================================================================

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -367,13 +367,13 @@ use uuid::Uuid;
 /// use delaunay::prelude::tds::TriangulationConstructionState;
 ///
 /// let state = TriangulationConstructionState::Incomplete(2);
-/// assert!(matches!(state, TriangulationConstructionState::Incomplete(2)));
+/// std::assert_matches!(state, TriangulationConstructionState::Incomplete(2));
 ///
 /// let default_state = TriangulationConstructionState::default();
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     default_state,
 ///     TriangulationConstructionState::Incomplete(0)
-/// ));
+/// );
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TriangulationConstructionState {
@@ -406,7 +406,7 @@ impl Default for TriangulationConstructionState {
 ///     entity: EntityKind::Vertex,
 ///     uuid: Uuid::nil(),
 /// };
-/// assert!(matches!(err, TdsConstructionError::DuplicateUuid { .. }));
+/// std::assert_matches!(err, TdsConstructionError::DuplicateUuid { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -457,7 +457,7 @@ pub enum EntityKind {
 /// let err = GeometricError::DegenerateOrientation {
 ///     message: "det=0".to_string(),
 /// };
-/// assert!(matches!(err, GeometricError::DegenerateOrientation { .. }));
+/// std::assert_matches!(err, GeometricError::DegenerateOrientation { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1288,7 +1288,7 @@ pub enum InvariantKind {
 ///         message: "bad neighbors".to_string(),
 ///     },
 /// });
-/// assert!(matches!(err, InvariantError::Tds(_)));
+/// std::assert_matches!(err, InvariantError::Tds(_));
 /// ```
 ///
 /// This is used by [`TriangulationValidationReport`] so that diagnostic reporting can
@@ -5296,7 +5296,7 @@ impl<T, U, V, const D: usize> Tds<T, U, V, D> {
     /// assert_eq!(tds.number_of_vertices(), 0);
     /// assert_eq!(tds.number_of_simplices(), 0);
     /// assert_eq!(tds.dim(), -1);
-    /// assert!(matches!(tds.construction_state, TriangulationConstructionState::Incomplete(0)));
+    /// std::assert_matches!(tds.construction_state, TriangulationConstructionState::Incomplete(0));
     /// ```
     #[must_use]
     pub fn empty() -> Self {
@@ -7683,6 +7683,7 @@ mod tests {
     use crate::validation::DelaunayTriangulationValidationError;
     use crate::vertex;
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::sync::Arc;
 
     // =============================================================================
@@ -8023,12 +8024,12 @@ mod tests {
             .unwrap();
 
         let err = tds.facet_key_for_simplex_facet(simplex_key, 2).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InconsistentDataStructure { message }
                 if message.contains("Failed to derive periodic facet key")
                     && message.contains("facet 2")
-        ));
+        );
     }
 
     #[test]
@@ -8735,7 +8736,7 @@ mod tests {
             .push_vertex_key(invalid_vkey);
 
         let err = tds.assign_neighbors().unwrap_err();
-        assert!(matches!(err, TdsError::VertexKeyRetrievalFailed { .. }));
+        assert_matches!(err, TdsError::VertexKeyRetrievalFailed { .. });
     }
 
     #[test]
@@ -8760,7 +8761,7 @@ mod tests {
         .unwrap();
 
         let err = tds.assign_neighbors().unwrap_err();
-        assert!(matches!(err, TdsError::InconsistentDataStructure { .. }));
+        assert_matches!(err, TdsError::InconsistentDataStructure { .. });
     }
 
     #[test]
@@ -9029,7 +9030,7 @@ mod tests {
             .set_neighbors_by_key(simplex1, &[Some(simplex_far), None, None])
             .unwrap_err()
             .0;
-        assert!(matches!(err, TdsError::InvalidNeighbors { .. }));
+        assert_matches!(err, TdsError::InvalidNeighbors { .. });
 
         // A true facet-neighbor (shares {v_a,v_b}) placed at the wrong facet index.
         let simplex2 = tds
@@ -9039,7 +9040,7 @@ mod tests {
             .set_neighbors_by_key(simplex1, &[Some(simplex2), None, None])
             .unwrap_err()
             .0;
-        assert!(matches!(err, TdsError::InvalidNeighbors { .. }));
+        assert_matches!(err, TdsError::InvalidNeighbors { .. });
     }
 
     #[test]
@@ -9094,7 +9095,7 @@ mod tests {
             .set_neighbors_by_key(simplex1, &[None, None, None])
             .unwrap_err()
             .0;
-        assert!(matches!(err, TdsError::InvalidNeighbors { .. }));
+        assert_matches!(err, TdsError::InvalidNeighbors { .. });
         assert!(tds.is_valid().is_ok());
     }
 
@@ -9147,7 +9148,7 @@ mod tests {
             .push_vertex_key(invalid_vkey);
 
         let err = tds.build_simplex_vertex_sets().unwrap_err();
-        assert!(matches!(err, TdsError::VertexNotFound { .. }));
+        assert_matches!(err, TdsError::VertexNotFound { .. });
     }
 
     #[test]
@@ -9213,11 +9214,11 @@ mod tests {
             Tds::validate_shared_facet_count(simplex1, simplex_far, &this_vertices, &far_vertices)
                 .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::NotNeighbors { simplex1: c1, simplex2: c2 }
                 if c1 == simplex1_uuid && c2 == simplex_far_uuid
-        ));
+        );
     }
 
     #[test]
@@ -9271,12 +9272,12 @@ mod tests {
 
         let err = Tds::expected_mirror_facet_index(simplex1, simplex2, &this_vertices).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::MirrorFacetAmbiguous { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9304,12 +9305,12 @@ mod tests {
 
         let err = Tds::expected_mirror_facet_index(simplex1, simplex2, &this_vertices).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::MirrorFacetDuplicateSimplices { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9364,12 +9365,12 @@ mod tests {
         let err =
             Tds::verified_mirror_facet_index(simplex1, 0, simplex2, &this_vertices).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::MirrorFacetMissing { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9398,12 +9399,12 @@ mod tests {
         let err = Tds::verified_mirror_facet_index(simplex1, 2, simplex2, &this_vertices_wrong)
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::MirrorFacetIndexMismatch { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9447,12 +9448,12 @@ mod tests {
             .validate_neighbors_with_precomputed_vertex_sets(&simplex_vertices)
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::MirrorFacetIndexMismatch { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9524,12 +9525,12 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::SharedFacetMissingVertex { .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9597,12 +9598,12 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::BackReferenceMismatch { observed: None, .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9646,12 +9647,12 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::BackReferenceMismatch { observed: None, .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9677,22 +9678,22 @@ mod tests {
         assert!(!Tds::allows_periodic_self_neighbor(simplex));
 
         let err = tds.validate_coherent_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::OrientationViolation {
                 simplex1_key,
                 simplex2_key,
                 ..
             } if simplex1_key == simplex_key && simplex2_key == simplex_key
-        ));
+        );
         assert!(!tds.is_coherently_oriented());
 
         let err = tds.normalize_coherent_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InconsistentDataStructure { message }
                 if message.contains("Contradictory orientation constraints")
-        ));
+        );
     }
 
     #[test]
@@ -9760,23 +9761,23 @@ mod tests {
         }
 
         let err = tds.validate_coherent_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::BackReferenceMismatch { observed: None, .. },
             }
-        ));
+        );
         assert!(!tds.is_coherently_oriented());
 
         let err = tds
             .validate_coherent_orientation_for_simplices(&[simplex1_key])
             .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::BackReferenceMismatch { observed: None, .. },
             }
-        ));
+        );
     }
 
     #[test]
@@ -9801,7 +9802,7 @@ mod tests {
             .validate_neighbor_pointers_match_facet_to_simplices_map(&facet_to_simplices)
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::UnassignedNeighborSlot {
@@ -9810,7 +9811,7 @@ mod tests {
                     ..
                 },
             } if key == simplex_key
-        ));
+        );
     }
 
     #[test]
@@ -9835,7 +9836,7 @@ mod tests {
             .validate_neighbor_pointers_match_facet_to_simplices_map(&facet_to_simplices)
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::BoundaryFacetHasNonPeriodicSelfNeighbor {
@@ -9844,7 +9845,7 @@ mod tests {
                     ..
                 },
             } if key == simplex_key
-        ));
+        );
     }
 
     #[test]
@@ -9888,12 +9889,12 @@ mod tests {
         }
 
         let err = tds.validate_coherent_orientation().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::BackReferenceMismatch { observed: None, .. },
             }
-        ));
+        );
         assert!(!tds.is_coherently_oriented());
     }
 
@@ -9917,7 +9918,7 @@ mod tests {
         let err = tds
             .validate_coherent_orientation_for_simplices(&[simplex1_key])
             .unwrap_err();
-        assert!(matches!(err, TdsError::OrientationViolation { .. }));
+        assert_matches!(err, TdsError::OrientationViolation { .. });
     }
 
     #[test]
@@ -9936,13 +9937,13 @@ mod tests {
         let err = tds
             .validate_coherent_orientation_for_simplices(&[simplex_key])
             .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsError::SimplexNotFound {
                 simplex_key: missing_key,
                 ..
             } if missing_key == simplex_key
-        ));
+        );
     }
 
     macro_rules! test_normalize_repairs_incoherent_adjacent_pair {
@@ -9985,7 +9986,7 @@ mod tests {
                 tds.assign_neighbors().unwrap();
 
                 let err = tds.validate_coherent_orientation().unwrap_err();
-                assert!(matches!(err, TdsError::OrientationViolation { .. }));
+                assert_matches!(err, TdsError::OrientationViolation { .. });
                 assert!(!tds.is_coherently_oriented());
 
                 tds.normalize_coherent_orientation().unwrap();
@@ -10056,7 +10057,7 @@ mod tests {
         }
 
         let err = tds.build_facet_to_simplices_map().unwrap_err();
-        assert!(matches!(err, TdsError::IndexOutOfBounds { .. }));
+        assert_matches!(err, TdsError::IndexOutOfBounds { .. });
     }
 
     #[test]
@@ -10076,34 +10077,34 @@ mod tests {
         // Break vertex mapping: remove one uuid entry (len mismatch).
         let uuid_a = tds.vertex(a).unwrap().uuid();
         tds.uuid_to_vertex_key.remove(&uuid_a);
-        assert!(matches!(
+        assert_matches!(
             tds.validate_vertex_mappings(),
             Err(TdsError::MappingInconsistency {
                 entity: EntityKind::Vertex,
                 ..
             })
-        ));
+        );
 
         // Restore length but make the UUID map point at the wrong key.
         tds.uuid_to_vertex_key.insert(uuid_a, b);
-        assert!(matches!(
+        assert_matches!(
             tds.validate_vertex_mappings(),
             Err(TdsError::MappingInconsistency {
                 entity: EntityKind::Vertex,
                 ..
             })
-        ));
+        );
 
         // Break simplex mapping similarly.
         let uuid_simplex = tds.simplex(simplex_key).unwrap().uuid();
         tds.uuid_to_simplex_key.remove(&uuid_simplex);
-        assert!(matches!(
+        assert_matches!(
             tds.validate_simplex_mappings(),
             Err(TdsError::MappingInconsistency {
                 entity: EntityKind::Simplex,
                 ..
             })
-        ));
+        );
     }
 
     #[test]
@@ -10123,12 +10124,12 @@ mod tests {
             .push_vertex_key(invalid_vkey);
 
         let err = tds.validate_simplex_vertex_keys().unwrap_err();
-        assert!(matches!(err, TdsError::VertexNotFound { .. }));
+        assert_matches!(err, TdsError::VertexNotFound { .. });
 
         // Now wired into structural validation: is_valid() should fail early with the
         // more precise "missing vertex key" diagnostic.
         let err = tds.is_valid().unwrap_err();
-        assert!(matches!(err, TdsError::VertexNotFound { .. }));
+        assert_matches!(err, TdsError::VertexNotFound { .. });
     }
 
     // ---- Error variant Display / construction coverage ----
@@ -10215,7 +10216,7 @@ mod tests {
             message: "test".to_string(),
         };
         let inv = InvariantError::from(tds_err);
-        assert!(matches!(inv, InvariantError::Tds(_)));
+        assert_matches!(inv, InvariantError::Tds(_));
 
         let tri_err = TriangulationValidationError::EulerCharacteristicMismatch {
             computed: 1,
@@ -10223,7 +10224,7 @@ mod tests {
             classification: TopologyClassification::Ball(3),
         };
         let inv = InvariantError::from(tri_err);
-        assert!(matches!(inv, InvariantError::Triangulation(_)));
+        assert_matches!(inv, InvariantError::Triangulation(_));
     }
 
     #[test]
@@ -10232,7 +10233,7 @@ mod tests {
             message: "test".to_string(),
         };
         let inv = InvariantError::from(dt_err);
-        assert!(matches!(inv, InvariantError::Delaunay(_)));
+        assert_matches!(inv, InvariantError::Delaunay(_));
     }
 
     #[test]
@@ -10312,7 +10313,7 @@ mod tests {
             }),
         };
         assert_eq!(violation.kind, InvariantKind::NeighborConsistency);
-        assert!(matches!(violation.error, InvariantError::Tds(_)));
+        assert_matches!(violation.error, InvariantError::Tds(_));
     }
 
     #[test]
@@ -10341,10 +10342,10 @@ mod tests {
             message: "det<0".to_string(),
         };
         let tds_err: TdsError = geo.into();
-        assert!(matches!(
+        assert_matches!(
             tds_err,
             TdsError::Geometric(GeometricError::NegativeOrientation { .. })
-        ));
+        );
         // Display propagates via #[error(transparent)].
         assert!(tds_err.to_string().contains("det<0"));
     }
@@ -10619,10 +10620,10 @@ mod tests {
 
         let error = tds.remove_duplicate_simplices().unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             error.into_inner(),
             TdsError::InconsistentDataStructure { .. }
-        ));
+        );
         assert_eq!(tds.number_of_simplices(), 4);
         assert_eq!(tds.generation(), generation_before);
         assert_eq!(tds, before);
@@ -10648,7 +10649,7 @@ mod tests {
         tds.simplices.remove(ck);
 
         let err = tds.validate_vertex_incidence().unwrap_err();
-        assert!(matches!(err, TdsError::SimplexNotFound { .. }));
+        assert_matches!(err, TdsError::SimplexNotFound { .. });
     }
 
     #[test]
@@ -10743,7 +10744,7 @@ mod tests {
         .unwrap();
 
         let err = tds.validate_no_duplicate_simplices().unwrap_err();
-        assert!(matches!(err, TdsError::DuplicateSimplices { .. }));
+        assert_matches!(err, TdsError::DuplicateSimplices { .. });
     }
 
     #[test]
@@ -10901,10 +10902,10 @@ mod tests {
 
         let simplex = Simplex::new(vec![v0, v1, stale], None).unwrap();
         let err = tds.insert_simplex_with_mapping(simplex).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsConstructionError::ValidationError(TdsError::VertexNotFound { .. })
-        ));
+        );
     }
 
     #[test]
@@ -10918,10 +10919,10 @@ mod tests {
         let err = tds
             .insert_simplex_with_mapping_trusted_vertices(simplex)
             .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsConstructionError::ValidationError(TdsError::VertexNotFound { .. })
-        ));
+        );
     }
 
     #[test]
@@ -10939,7 +10940,7 @@ mod tests {
         let mut simplex_b = Simplex::new(vec![v0, v1, v2], None).unwrap();
         simplex_b.set_uuid(uuid_a).unwrap();
         let err = tds.insert_simplex_with_mapping(simplex_b).unwrap_err();
-        assert!(matches!(err, TdsConstructionError::DuplicateUuid { .. }));
+        assert_matches!(err, TdsConstructionError::DuplicateUuid { .. });
     }
 
     #[test]
@@ -10956,14 +10957,14 @@ mod tests {
 
         let err = tds.insert_simplex_with_mapping(candidate).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsConstructionError::ValidationError(TdsError::DimensionMismatch {
                 expected: 3,
                 actual: 2,
                 ..
             })
-        ));
+        );
         assert_eq!(tds.number_of_simplices(), 0);
         assert_eq!(tds.generation(), generation_before);
         assert_eq!(tds.simplex_key_from_uuid(&candidate_uuid), None);
@@ -10991,12 +10992,12 @@ mod tests {
 
         let err = tds.insert_simplex_with_mapping(candidate).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsConstructionError::ValidationError(TdsError::InconsistentDataStructure {
                 message
             }) if message.contains("Failed to derive periodic facet key")
-        ));
+        );
         assert_eq!(tds.number_of_simplices(), 1);
         assert_eq!(tds.generation(), generation_before);
         assert_eq!(tds.simplex_key_from_uuid(&candidate_uuid), None);
@@ -11017,10 +11018,10 @@ mod tests {
 
         let err = tds.insert_simplex_with_mapping(candidate).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             TdsConstructionError::ValidationError(TdsError::DuplicateSimplices { .. })
-        ));
+        );
         assert_eq!(tds.number_of_simplices(), 1);
         assert_eq!(tds.generation(), generation_before);
         assert_eq!(tds.simplex_key_from_uuid(&candidate_uuid), None);
@@ -11117,7 +11118,7 @@ mod tests {
         tds.uuid_to_vertex_key.retain(|_, &mut vk| vk != v2);
 
         let err = tds.simplex_vertices(ck).unwrap_err();
-        assert!(matches!(err, TdsError::VertexNotFound { .. }));
+        assert_matches!(err, TdsError::VertexNotFound { .. });
     }
 
     // =========================================================================
@@ -11144,7 +11145,7 @@ mod tests {
         tds.vertex_mut(v0).unwrap().set_incident_simplex(Some(ck2));
 
         let err = tds.validate_vertex_incidence().unwrap_err();
-        assert!(matches!(err, TdsError::InconsistentDataStructure { .. }));
+        assert_matches!(err, TdsError::InconsistentDataStructure { .. });
     }
 
     #[test]
@@ -11165,7 +11166,7 @@ mod tests {
             .set_incident_simplex(Some(dangling));
 
         let err = tds.validate_vertex_incidence().unwrap_err();
-        assert!(matches!(err, TdsError::SimplexNotFound { .. }));
+        assert_matches!(err, TdsError::SimplexNotFound { .. });
     }
 
     // =========================================================================
@@ -11282,10 +11283,7 @@ mod tests {
         tds.uuid_to_vertex_key.retain(|_, &mut vk| vk != v2);
 
         let err = tds.assign_incident_simplices().unwrap_err();
-        assert!(matches!(
-            err.as_tds_error(),
-            TdsError::VertexNotFound { .. }
-        ));
+        assert_matches!(err.as_tds_error(), TdsError::VertexNotFound { .. });
     }
 
     // =========================================================================
@@ -11463,7 +11461,7 @@ mod tests {
         let err = tds
             .validate_neighbor_topology(ck, &[None, None])
             .unwrap_err();
-        assert!(matches!(err, TdsError::InvalidNeighbors { .. }));
+        assert_matches!(err, TdsError::InvalidNeighbors { .. });
     }
 
     // =========================================================================

--- a/src/core/util/delaunay_validation.rs
+++ b/src/core/util/delaunay_validation.rs
@@ -29,7 +29,7 @@ use thiserror::Error;
 ///
 /// let simplex_key = SimplexKey::from(KeyData::from_ffi(1));
 /// let err = DelaunayValidationError::DelaunayViolation { simplex_key };
-/// assert!(matches!(err, DelaunayValidationError::DelaunayViolation { .. }));
+/// std::assert_matches!(err, DelaunayValidationError::DelaunayViolation { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -809,6 +809,7 @@ mod tests {
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::{Coordinate, CoordinateConversionError};
     use crate::triangulation::DelaunayTriangulation;
+    use std::assert_matches;
 
     use crate::vertex;
 
@@ -1144,10 +1145,7 @@ mod tests {
         }
 
         let err = is_delaunay_property_only(&tds).unwrap_err();
-        assert!(matches!(
-            err,
-            DelaunayValidationError::TriangulationState { .. }
-        ));
+        assert_matches!(err, DelaunayValidationError::TriangulationState { .. });
     }
 
     #[test]
@@ -1166,9 +1164,6 @@ mod tests {
         simplex.ensure_neighbors_buffer_mut().truncate(2); // wrong length (expected 3)
 
         let err = is_delaunay_property_only(&tds).unwrap_err();
-        assert!(matches!(
-            err,
-            DelaunayValidationError::InvalidSimplex { .. }
-        ));
+        assert_matches!(err, DelaunayValidationError::InvalidSimplex { .. });
     }
 }

--- a/src/core/util/facet_keys.rs
+++ b/src/core/util/facet_keys.rs
@@ -360,6 +360,7 @@ pub fn usize_to_u8(idx: usize, facet_count: usize) -> Result<u8, FacetError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     use crate::core::simplex::Simplex;
     use crate::core::util::measure_with_result;
@@ -376,13 +377,13 @@ mod tests {
             (VertexKey::null(), [0_i8; 2]),
         ];
         let err = periodic_facet_key_from_lifted_vertices::<2>(&lifted_vertices, 0).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             PeriodicFacetKeyDerivationError::InvalidLiftedSimplexArity {
                 expected: 3,
                 actual: 2
             }
-        ));
+        );
     }
 
     #[test]
@@ -393,10 +394,10 @@ mod tests {
             (VertexKey::null(), [127_i8, 0_i8]),
         ];
         let err = periodic_facet_key_from_lifted_vertices::<2>(&lifted_vertices, 1).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             PeriodicFacetKeyDerivationError::RelativeOffsetOutOfRange { axis: 0, .. }
-        ));
+        );
     }
     #[test]
     fn periodic_facet_key_happy_path_translation_invariance_and_distinctness() {
@@ -447,13 +448,13 @@ mod tests {
             (VertexKey::null(), [0_i8; 2]),
         ];
         let err = periodic_facet_key_from_lifted_vertices::<2>(&lifted_vertices, 3).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             PeriodicFacetKeyDerivationError::FacetIndexOutOfBounds {
                 facet_index: 3,
                 vertex_count: 3
             }
-        ));
+        );
     }
 
     #[test]
@@ -618,16 +619,13 @@ mod tests {
 
         // Error case: facet index out of bounds.
         let err = verify_facet_index_consistency(tds, simplex_key, simplex_key, 99).unwrap_err();
-        assert!(matches!(err, FacetError::InvalidFacetIndex { .. }));
+        assert_matches!(err, FacetError::InvalidFacetIndex { .. });
 
         // Logging: demonstrate behavior for large out-of-bounds facet index
         let err_large =
             verify_facet_index_consistency(tds, simplex_key, simplex_key, 300).unwrap_err();
         println!("    Large facet_idx=300 error: {err_large:?}");
-        assert!(matches!(
-            err_large,
-            FacetError::InvalidFacetIndexOverflow { .. }
-        ));
+        assert_matches!(err_large, FacetError::InvalidFacetIndexOverflow { .. });
 
         // False case: two disjoint triangles in the same TDS share no facet keys.
         let mut tds2: Tds<f64, (), (), 2> = Tds::empty();

--- a/src/core/util/hilbert.rs
+++ b/src/core/util/hilbert.rs
@@ -590,12 +590,12 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
 ///
 /// // Invalid bits parameter
 /// let result = hilbert_indices_prequantized(&quantized, 0);
-/// assert!(matches!(result, Err(HilbertError::InvalidBitsParameter { bits: 0 })));
+/// std::assert_matches!(result, Err(HilbertError::InvalidBitsParameter { bits: 0 }));
 ///
 /// // Overflow (D=5, bits=26 => 130 > 128)
 /// let quantized_5d = vec![[1_u32, 2, 3, 4, 5]];
 /// let result = hilbert_indices_prequantized(&quantized_5d, 26);
-/// assert!(matches!(result, Err(HilbertError::IndexOverflow { .. })));
+/// std::assert_matches!(result, Err(HilbertError::IndexOverflow { .. }));
 /// ```
 pub fn hilbert_indices_prequantized<const D: usize>(
     quantized: &[[u32; D]],
@@ -680,6 +680,7 @@ pub fn hilbert_sorted_indices<T: CoordinateScalar, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::Coordinate;
@@ -751,14 +752,14 @@ mod tests {
     fn test_scaled_quantize_reports_conversion_error() {
         let result = quantize_with_scale(&[1.0_f64], (0.0, 1.0), 31, u32::MAX, f64::INFINITY);
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(HilbertError::QuantizedCoordinateConversionFailed {
                 bits: 31,
                 max_grid_value: u32::MAX,
                 coordinate_index: 0
             })
-        ));
+        );
     }
 
     #[test]
@@ -1019,20 +1020,14 @@ mod tests {
     fn test_hilbert_indices_prequantized_validates_bits_zero() {
         let quantized = vec![[1_u32, 2]];
         let result = hilbert_indices_prequantized(&quantized, 0);
-        assert!(matches!(
-            result,
-            Err(HilbertError::InvalidBitsParameter { bits: 0 })
-        ));
+        assert_matches!(result, Err(HilbertError::InvalidBitsParameter { bits: 0 }));
     }
 
     #[test]
     fn test_hilbert_indices_prequantized_validates_bits_too_large() {
         let quantized = vec![[1_u32, 2]];
         let result = hilbert_indices_prequantized(&quantized, 32);
-        assert!(matches!(
-            result,
-            Err(HilbertError::InvalidBitsParameter { bits: 32 })
-        ));
+        assert_matches!(result, Err(HilbertError::InvalidBitsParameter { bits: 32 }));
     }
 
     #[test]
@@ -1040,14 +1035,14 @@ mod tests {
         // With D=5 and bits=26, total_bits = 130 > 128
         let quantized = vec![[1_u32, 2, 3, 4, 5]];
         let result = hilbert_indices_prequantized(&quantized, 26);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(HilbertError::IndexOverflow {
                 dimension: 5,
                 bits: 26,
                 total_bits: 130
             })
-        ));
+        );
     }
 
     #[test]

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -27,7 +27,7 @@ use thiserror::Error;
 ///     intersection: 1,
 ///     union: 2,
 /// };
-/// assert!(matches!(err, JaccardComputationError::SetSizeTooLarge { .. }));
+/// std::assert_matches!(err, JaccardComputationError::SetSizeTooLarge { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -645,6 +645,7 @@ macro_rules! assert_jaccard_gte {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     use crate::core::tds::{Tds, VertexKey};
     use crate::geometry::traits::coordinate::Coordinate;
@@ -756,10 +757,10 @@ mod tests {
             .push_vertex_key(invalid_vkey);
 
         let err = extract_edge_set(&dt.as_triangulation().tds).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             FacetError::VertexKeyNotFoundInTriangulation { key } if key == invalid_vkey
-        ));
+        );
     }
 
     #[test]
@@ -781,10 +782,7 @@ mod tests {
             .push_vertex_key(invalid_vkey);
 
         let err = extract_facet_identifier_set(&dt.as_triangulation().tds).unwrap_err();
-        assert!(matches!(
-            err,
-            FacetError::BoundaryFacetRetrievalFailed { .. }
-        ));
+        assert_matches!(err, FacetError::BoundaryFacetRetrievalFailed { .. });
     }
 
     #[test]

--- a/src/core/util/uuid.rs
+++ b/src/core/util/uuid.rs
@@ -13,7 +13,7 @@ use uuid::Uuid;
 /// use delaunay::prelude::tds::UuidValidationError;
 ///
 /// let err = UuidValidationError::NilUuid;
-/// assert!(matches!(err, UuidValidationError::NilUuid));
+/// std::assert_matches!(err, UuidValidationError::NilUuid);
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -607,13 +607,13 @@ impl TopologyGuarantee {
 /// let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
 ///     Triangulation::new_empty(FastKernel::new());
 ///
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     tri.try_set_validation_policy(ValidationPolicy::Never),
 ///     Err(ValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
 ///         topology_guarantee: TopologyGuarantee::PLManifold,
 ///         validation_policy: ValidationPolicy::Never,
 ///     })
-/// ));
+/// );
 /// ```
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1568,6 +1568,7 @@ mod tests {
     use crate::validation::DelaunayTriangulationValidationError;
     use crate::vertex;
     use slotmap::KeyData;
+    use std::assert_matches;
 
     fn insert_test_vertex_with_coords<const D: usize>(
         tds: &mut Tds<f64, (), (), D>,
@@ -1753,7 +1754,7 @@ mod tests {
             InvariantError::Tds(tds_err)
         );
 
-        assert!(matches!(
+        assert_matches!(
             TriangulationValidationError::try_from(ManifoldError::ManifoldFacetMultiplicity {
                 facet_key: 123,
                 simplex_count: 3
@@ -1763,9 +1764,9 @@ mod tests {
                 facet_key: 123,
                 simplex_count: 3
             }
-        ));
+        );
 
-        assert!(matches!(
+        assert_matches!(
             TriangulationValidationError::try_from(ManifoldError::BoundaryRidgeMultiplicity {
                 ridge_key: 0x00ab_cdef,
                 boundary_facet_count: 4
@@ -1775,9 +1776,9 @@ mod tests {
                 ridge_key: 0x00ab_cdef,
                 boundary_facet_count: 4
             }
-        ));
+        );
 
-        assert!(matches!(
+        assert_matches!(
             TriangulationValidationError::try_from(ManifoldError::RidgeLinkNotManifold {
                 ridge_key: 0x00ab_cdef,
                 link_vertex_count: 7,
@@ -1795,9 +1796,9 @@ mod tests {
                 degree_one_vertices: 2,
                 connected: false
             }
-        ));
+        );
 
-        assert!(matches!(
+        assert_matches!(
             TriangulationValidationError::try_from(ManifoldError::VertexLinkNotManifold {
                 vertex_key: VertexKey::from(KeyData::from_ffi(1)),
                 link_vertex_count: 3,
@@ -1817,7 +1818,7 @@ mod tests {
                 interior_vertex: true,
                 ..
             }
-        ));
+        );
     }
 
     #[test]
@@ -2029,12 +2030,12 @@ mod tests {
                         let mut tri =
                             Triangulation::<FastKernel<f64>, (), (), $dim>::new_with_tds(FastKernel::new(), tds);
 
-                        assert!(matches!(
+                        assert_matches!(
                             tri.validate_at_completion(),
                             Err(InvariantError::Triangulation(
                                 TriangulationValidationError::VertexLinkNotManifold { .. }
                             ))
-                        ));
+                        );
                         assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
                         assert_eq!(
                             tri.try_set_validation_policy(ValidationPolicy::Never),
@@ -2183,7 +2184,7 @@ mod tests {
         });
         let ins =
             Triangulation::<FastKernel<f64>, (), (), 3>::invariant_error_to_insertion_error(inv);
-        assert!(matches!(ins, InsertionError::TopologyValidation(_)));
+        assert_matches!(ins, InsertionError::TopologyValidation(_));
 
         let inv = InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex {
             vertex_key: VertexKey::from(KeyData::from_ffi(1)),
@@ -2191,10 +2192,7 @@ mod tests {
         });
         let ins =
             Triangulation::<FastKernel<f64>, (), (), 3>::invariant_error_to_insertion_error(inv);
-        assert!(matches!(
-            ins,
-            InsertionError::TopologyValidationFailed { .. }
-        ));
+        assert_matches!(ins, InsertionError::TopologyValidationFailed { .. });
 
         let inv =
             InvariantError::Delaunay(DelaunayTriangulationValidationError::VerificationFailed {
@@ -2202,10 +2200,7 @@ mod tests {
             });
         let ins =
             Triangulation::<FastKernel<f64>, (), (), 3>::invariant_error_to_insertion_error(inv);
-        assert!(matches!(
-            ins,
-            InsertionError::DelaunayValidationFailed { .. }
-        ));
+        assert_matches!(ins, InsertionError::DelaunayValidationFailed { .. });
     }
 
     #[test]
@@ -2224,7 +2219,7 @@ mod tests {
             simplex_count: 5,
         };
         let inv = InvariantError::from(err);
-        assert!(matches!(
+        assert_matches!(
             inv,
             InvariantError::Triangulation(
                 TriangulationValidationError::ManifoldFacetMultiplicity {
@@ -2232,7 +2227,7 @@ mod tests {
                     simplex_count: 5
                 }
             )
-        ));
+        );
     }
 
     #[test]
@@ -2471,12 +2466,12 @@ mod tests {
             Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
         tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
 
-        assert!(matches!(
+        assert_matches!(
             tri.is_valid(),
             Err(InvariantError::Triangulation(
                 TriangulationValidationError::Disconnected { .. }
             ))
-        ));
+        );
 
         tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
 
@@ -2661,12 +2656,12 @@ mod tests {
             .insert_vertex_with_mapping(vertex!([10.0, 10.0, 10.0]))
             .unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             tri.is_valid(),
             Err(InvariantError::Triangulation(
                 TriangulationValidationError::IsolatedVertex { .. }
             ))
-        ));
+        );
     }
 
     #[test]
@@ -2801,12 +2796,12 @@ mod tests {
             .insert_simplex_with_mapping(Simplex::new(vec![v0, v1, v2, v4], None).unwrap())
             .unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             tds.is_valid(),
             Err(TdsError::InvalidNeighbors {
                 reason: NeighborValidationError::InteriorFacetNeighborMismatch { .. },
             })
-        ));
+        );
     }
 
     #[test]
@@ -3070,7 +3065,7 @@ mod tests {
 
         let empty: SimplexKeyBuffer = SimplexKeyBuffer::new();
         let err = tri.validate_connectedness(&empty).unwrap_err();
-        assert!(matches!(err, InsertionError::TopologyValidation(_)));
+        assert_matches!(err, InsertionError::TopologyValidation(_));
     }
 
     #[test]
@@ -3181,7 +3176,7 @@ mod tests {
                 )
                 .unwrap();
 
-            assert!(matches!(detail.outcome, InsertionOutcome::Inserted { .. }));
+            assert_matches!(detail.outcome, InsertionOutcome::Inserted { .. });
             assert!(
                 detail.telemetry.topology_validation_calls > 0,
                 "{guarantee:?} insertion should record required topology validation"

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -71,7 +71,7 @@ use uuid::Uuid;
 /// let err = VertexValidationError::InvalidUuid {
 ///     source: UuidValidationError::NilUuid,
 /// };
-/// assert!(matches!(err, VertexValidationError::InvalidUuid { .. }));
+/// std::assert_matches!(err, VertexValidationError::InvalidUuid { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -943,6 +943,7 @@ mod tests {
     use approx::{assert_abs_diff_eq, assert_relative_eq};
     use serde::{Deserialize, Serialize};
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::collections::hash_map::DefaultHasher;
     use std::hash::Hasher;
 
@@ -1610,22 +1611,22 @@ mod tests {
         // Test that equal points result in equal ordering
         assert!(vertex1.partial_cmp(&vertex2) != Some(Ordering::Less));
         assert!(vertex2.partial_cmp(&vertex1) != Some(Ordering::Less));
-        assert!(matches!(
+        assert_matches!(
             vertex1.partial_cmp(&vertex2),
             Some(Ordering::Less | Ordering::Equal)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             vertex2.partial_cmp(&vertex1),
             Some(Ordering::Less | Ordering::Equal)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             vertex1.partial_cmp(&vertex2),
             Some(Ordering::Greater | Ordering::Equal)
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             vertex2.partial_cmp(&vertex1),
             Some(Ordering::Greater | Ordering::Equal)
-        ));
+        );
     }
 
     #[test]

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -772,12 +772,12 @@ impl From<DelaunayTriangulationValidationError> for ExplicitDelaunayValidationEr
 /// let vertices = vec![vertex!([0.0, 0.0]), vertex!([1.0, 0.0]), vertex!([0.0, 1.0])];
 /// let simplices = vec![vec![0, 1]]; // Wrong arity for 2D (needs 3 vertices)
 ///
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     DelaunayTriangulationBuilder::from_vertices_and_simplices(&vertices, &simplices).build::<()>(),
 ///     Err(DelaunayTriangulationConstructionError::ExplicitConstruction(
 ///         ExplicitConstructionError::InvalidSimplexArity { simplex_index: 0, actual: 2, expected: 3 },
 ///     ))
-/// ));
+/// );
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1073,12 +1073,12 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, f64, U, D> {
     /// assert_eq!(dt.number_of_simplices(), 2);
     ///
     /// let bad_simplices = vec![vec![0, 1]]; // Wrong arity for a 2D simplex.
-    /// assert!(matches!(
+    /// std::assert_matches!(
     ///     DelaunayTriangulationBuilder::from_vertices_and_simplices(&vertices, &bad_simplices).build::<()>(),
     ///     Err(DelaunayTriangulationConstructionError::ExplicitConstruction(
     ///         ExplicitConstructionError::InvalidSimplexArity { .. },
     ///     ))
-    /// ));
+    /// );
     /// # Ok(())
     /// # }
     /// ```
@@ -3034,6 +3034,7 @@ mod tests {
     use crate::vertex;
     use approx::assert_relative_eq;
     use slotmap::{Key, KeyData};
+    use std::assert_matches;
 
     #[derive(Clone, Copy, Debug)]
     struct ValidationFailureModel;
@@ -3705,13 +3706,13 @@ mod tests {
         assert_eq!(dt.number_of_vertices(), 4);
         assert_eq!(dt.dim(), 2);
         assert!(dt.as_triangulation().validate().is_ok());
-        assert!(matches!(
+        assert_matches!(
             dt.global_topology(),
             GlobalTopology::Toroidal {
                 mode: ToroidalConstructionMode::Canonicalized,
                 ..
             }
-        ));
+        );
     }
 
     #[test]
@@ -3807,13 +3808,13 @@ mod tests {
             .unwrap();
         assert_eq!(dt.number_of_vertices(), n);
         assert!(dt.tds().is_valid().is_ok());
-        assert!(matches!(
+        assert_matches!(
             dt.global_topology(),
             GlobalTopology::Toroidal {
                 mode: ToroidalConstructionMode::PeriodicImagePoint,
                 ..
             }
-        ));
+        );
     }
 
     #[test]

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -971,10 +971,23 @@ pub(crate) fn batch_local_repair_trigger<const D: usize>(
 
 type VertexBuffer<T, U, const D: usize> = Vec<Vertex<T, U, D>>;
 
+/// Preprocessed vertex ordering state used by batch construction to preserve
+/// deterministic insertion order, retry fallback order, and deduplication-grid
+/// reuse across public construction entry points.
 pub(crate) struct PreprocessVertices<T, U, const D: usize> {
     primary: Option<VertexBuffer<T, U, D>>,
     fallback: Option<VertexBuffer<T, U, D>>,
     grid_cell_size: Option<T>,
+}
+
+impl<T, U, const D: usize> fmt::Debug for PreprocessVertices<T, U, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PreprocessVertices")
+            .field("primary_len", &self.primary.as_ref().map(Vec::len))
+            .field("fallback_len", &self.fallback.as_ref().map(Vec::len))
+            .field("has_grid_cell_size", &self.grid_cell_size.is_some())
+            .finish()
+    }
 }
 
 impl<T, U, const D: usize> PreprocessVertices<T, U, D> {
@@ -4795,6 +4808,7 @@ mod tests {
     use crate::validation::DelaunayTriangulationValidationError;
     use crate::vertex;
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::num::NonZeroUsize;
     use std::sync::Once;
     use std::time::Instant;
@@ -4864,12 +4878,12 @@ mod tests {
             )
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DelaunayTriangulationConstructionError::Triangulation(
                 DelaunayConstructionFailure::FinalTopologyValidation { .. }
             )
-        ));
+        );
     }
 
     macro_rules! test_incremental_insertion {
@@ -5303,7 +5317,7 @@ mod tests {
         assert_eq!(summary.simplices_removed_total, 4);
         assert_eq!(summary.simplices_removed_max, 4);
         assert_eq!(stats.attempts, 3);
-        assert!(matches!(stats.result, InsertionResult::Inserted));
+        assert_matches!(stats.result, InsertionResult::Inserted);
     }
 
     #[test]
@@ -5978,12 +5992,12 @@ mod tests {
             InitialSimplexStrategy::First,
         );
 
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(DelaunayTriangulationConstructionError::Triangulation(
                 DelaunayConstructionFailure::GeometricDegeneracy { .. }
             ))
-        ));
+        );
     }
 
     #[test]
@@ -6012,10 +6026,10 @@ mod tests {
         assert_eq!(error.statistics.total_skipped(), 0);
         assert_eq!(error.statistics.total_attempts, 0);
         assert!(error.statistics.skip_samples.is_empty());
-        assert!(matches!(
+        assert_matches!(
             error.error,
             DelaunayTriangulationConstructionError::Triangulation(_)
-        ));
+        );
     }
 
     fn vertices_from_coords_permutation_3d(
@@ -6677,10 +6691,10 @@ mod tests {
             reason: CavityFillingError::EmptyFanTriangulation,
         };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InternalInconsistency { .. }
-        ));
+        );
     }
 
     #[test]
@@ -6691,10 +6705,10 @@ mod tests {
             },
         };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InternalInconsistency { .. }
-        ));
+        );
     }
 
     #[test]
@@ -6704,13 +6718,13 @@ mod tests {
             attempted: 3,
         };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::LocalRepairBudgetExceeded {
                 max_simplices_removed: 2,
                 attempted: 3,
             }
-        ));
+        );
     }
 
     #[test]
@@ -6720,10 +6734,10 @@ mod tests {
             uuid: Uuid::nil(),
         };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InternalInconsistency { .. }
-        ));
+        );
     }
 
     #[test]
@@ -6870,45 +6884,45 @@ mod tests {
             open_simplex: SimplexKey::from(KeyData::from_ffi(1)),
         });
         let mapped = TestDelaunay::<3>::map_insertion_error(conflict);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InsertionConflictRegion {
                 source: ConflictError::OpenBoundary { .. },
             }
-        ));
+        );
 
         let location = InsertionError::Location(LocateError::EmptyTriangulation);
         let mapped = TestDelaunay::<3>::map_insertion_error(location);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InsertionLocation {
                 source: LocateError::EmptyTriangulation,
             }
-        ));
+        );
 
         let non_manifold = InsertionError::NonManifoldTopology {
             facet_hash: 0xab,
             simplex_count: 3,
         };
         let mapped = TestDelaunay::<3>::map_insertion_error(non_manifold);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InsertionNonManifoldTopology {
                 facet_hash: 0xab,
                 simplex_count: 3,
             }
-        ));
+        );
 
         let hull = InsertionError::HullExtension {
             reason: HullExtensionReason::NoVisibleFacets,
         };
         let mapped = TestDelaunay::<3>::map_insertion_error(hull);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InsertionHullExtension {
                 reason: HullExtensionReason::NoVisibleFacets,
             }
-        ));
+        );
 
         let delaunay = InsertionError::DelaunayValidationFailed {
             source: DelaunayTriangulationValidationError::VerificationFailed {
@@ -6916,10 +6930,10 @@ mod tests {
             },
         };
         let mapped = TestDelaunay::<3>::map_insertion_error(delaunay);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InsertionDelaunayValidation { .. }
-        ));
+        );
 
         let topology = InsertionError::TopologyValidationFailed {
             message: "test".to_string(),
@@ -6930,10 +6944,10 @@ mod tests {
             },
         };
         let mapped = TestDelaunay::<3>::map_insertion_error(topology);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::InsertionTopologyValidation { .. }
-        ));
+        );
     }
 
     #[test]
@@ -6963,16 +6977,16 @@ mod tests {
             attempted: 3,
         };
         let mapped = TestDelaunay::<3>::map_insertion_error(error);
-        assert!(matches!(
+        assert_matches!(
             mapped,
             TriangulationConstructionError::LocalRepairBudgetExceeded {
                 max_simplices_removed: 2,
                 attempted: 3,
             }
-        ));
+        );
 
         let public_error: DelaunayTriangulationConstructionError = mapped.into();
-        assert!(matches!(
+        assert_matches!(
             public_error,
             DelaunayTriangulationConstructionError::Triangulation(
                 DelaunayConstructionFailure::LocalRepairBudgetExceeded {
@@ -6980,7 +6994,7 @@ mod tests {
                     attempted: 3,
                 }
             )
-        ));
+        );
     }
 
     #[test]

--- a/src/delaunay/delaunayize.rs
+++ b/src/delaunay/delaunayize.rs
@@ -763,6 +763,7 @@ mod tests {
     use crate::vertex;
     use crate::{DelaunayTriangulationBuilder, TriangulationConstructionError};
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::error::Error as StdError;
 
     // =============================================================================
@@ -869,12 +870,12 @@ mod tests {
         )
         .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             DelaunayizeError::TopologyRepairFailed {
                 source: PlManifoldRepairError::BudgetExhausted { .. }
             }
-        ));
+        );
         assert_eq!(dt.number_of_simplices(), before_simplex_count);
 
         let mut after_simplex_uuids = dt

--- a/src/delaunay/flips.rs
+++ b/src/delaunay/flips.rs
@@ -377,6 +377,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     use crate::TopologyGuarantee;
     use crate::core::collections::spatial_hash_grid::HashGridIndex;
@@ -461,14 +462,14 @@ mod tests {
             .flip_k2(FacetHandle::new(simplex_key, u8::MAX))
             .unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             FlipError::InvalidFacetIndex {
                 simplex_key: key,
                 facet_index: u8::MAX,
                 vertex_count: 4,
             } if key == simplex_key
-        ));
+        );
     }
 
     #[test]
@@ -483,10 +484,7 @@ mod tests {
             .flip_k3_inverse_from_triangle(TriangleHandle::new(a, b, c))
             .unwrap_err();
 
-        assert!(matches!(
-            err,
-            FlipError::UnsupportedDimension { dimension: 3 }
-        ));
+        assert_matches!(err, FlipError::UnsupportedDimension { dimension: 3 });
     }
 
     #[test]
@@ -501,9 +499,6 @@ mod tests {
             .flip_k3_inverse_from_triangle(TriangleHandle::new(a, b, c))
             .unwrap_err();
 
-        assert!(matches!(
-            err,
-            FlipError::UnsupportedDimension { dimension: 0 }
-        ));
+        assert_matches!(err, FlipError::UnsupportedDimension { dimension: 0 });
     }
 }

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -291,13 +291,13 @@ where
     ///     .insert_with_statistics(vertex!([0.0, 0.0, 0.0]))?;
     ///
     /// assert!(stats.success());
-    /// assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+    /// std::assert_matches!(outcome, InsertionOutcome::Inserted { .. });
     ///
     /// let duplicate = dt.insert_with_statistics(vertex!([0.0, 0.0, 0.0]));
-    /// assert!(matches!(
+    /// std::assert_matches!(
     ///     duplicate,
     ///     Err(InsertionError::DuplicateCoordinates { .. })
-    /// ));
+    /// );
     /// # Ok(())
     /// # }
     /// ```
@@ -337,13 +337,13 @@ where
     ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))?;
     ///
     /// assert!(stats.success());
-    /// assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+    /// std::assert_matches!(outcome, InsertionOutcome::Inserted { .. });
     ///
     /// let vertices_before_duplicate = dt.number_of_vertices();
     /// let (duplicate_outcome, duplicate_stats) = dt
     ///     .insert_best_effort_with_statistics(vertex!([0.0, 0.0, 0.0]))?;
     ///
-    /// assert!(matches!(duplicate_outcome, InsertionOutcome::Skipped { .. }));
+    /// std::assert_matches!(duplicate_outcome, InsertionOutcome::Skipped { .. });
     /// assert!(duplicate_stats.skipped_duplicate());
     /// assert_eq!(dt.number_of_vertices(), vertices_before_duplicate);
     /// # Ok(())
@@ -746,10 +746,10 @@ where
     /// let err = dt
     ///     .remove_vertex(vertex_key)
     ///     .expect_err("removal should leave an isolated vertex");
-    /// assert!(matches!(
+    /// std::assert_matches!(
     ///     err,
     ///     InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex { .. })
-    /// ));
+    /// );
     /// assert_eq!(dt.number_of_vertices(), 3);
     /// assert_eq!(dt.number_of_simplices(), 1);
     /// # Ok(())
@@ -851,6 +851,7 @@ mod tests {
     use crate::geometry::util::safe_usize_to_scalar;
     use crate::vertex;
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::sync::Once;
     use uuid::Uuid;
 
@@ -1087,13 +1088,13 @@ mod tests {
         match error {
             InsertionError::TopologyValidationFailed { message, source } => {
                 assert_eq!(message, RIDGE_LINK_REPAIR_VALIDATION_MESSAGE);
-                assert!(matches!(
+                assert_matches!(
                     source,
                     TriangulationValidationError::BoundaryRidgeMultiplicity {
                         ridge_key: observed_ridge_key,
                         boundary_facet_count: 3
                     } if observed_ridge_key == ridge_key
-                ));
+                );
             }
             other => panic!("expected TopologyValidationFailed, got {other:?}"),
         }

--- a/src/delaunay/validation.rs
+++ b/src/delaunay/validation.rs
@@ -171,10 +171,10 @@ impl ValidationCadence {
     /// ```rust
     /// use delaunay::prelude::validation::ValidationCadence;
     ///
-    /// assert!(matches!(
+    /// std::assert_matches!(
     ///     ValidationCadence::from_optional_every(Some(32)),
     ///     ValidationCadence::EveryN(every) if every.get() == 32,
-    /// ));
+    /// );
     /// assert_eq!(
     ///     ValidationCadence::from_optional_every(None),
     ///     ValidationCadence::Never,

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -93,16 +93,16 @@ use num_traits::NumCast;
 ///     hull_generation: 1,
 ///     tds_generation: 2,
 /// };
-/// assert!(matches!(err, ConvexHullValidationError::StaleHull { .. }));
+/// std::assert_matches!(err, ConvexHullValidationError::StaleHull { .. });
 ///
 /// let mismatch = ConvexHullValidationError::IdentityMismatch {
 ///     hull_identity: Uuid::nil(),
 ///     tds_identity: Uuid::new_v4(),
 /// };
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     mismatch,
 ///     ConvexHullValidationError::IdentityMismatch { .. }
-/// ));
+/// );
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -160,16 +160,16 @@ pub enum ConvexHullValidationError {
 /// let err = ConvexHullConstructionError::InvalidTriangulation {
 ///     message: "empty".to_string(),
 /// };
-/// assert!(matches!(err, ConvexHullConstructionError::InvalidTriangulation { .. }));
+/// std::assert_matches!(err, ConvexHullConstructionError::InvalidTriangulation { .. });
 ///
 /// let mismatch = ConvexHullConstructionError::IdentityMismatch {
 ///     hull_identity: Uuid::nil(),
 ///     tds_identity: Uuid::new_v4(),
 /// };
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     mismatch,
 ///     ConvexHullConstructionError::IdentityMismatch { .. }
-/// ));
+/// );
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -1978,6 +1978,7 @@ mod tests {
     use crate::geometry::traits::coordinate::CoordinateConversionError;
     use crate::triangulation::DelaunayTriangulation;
     use crate::vertex;
+    use std::assert_matches;
     use std::error::Error;
     use std::sync::atomic::Ordering;
     use std::thread;
@@ -3600,12 +3601,12 @@ mod tests {
             _ => panic!("Expected InsufficientData error for no vertices"),
         }
 
-        // Also test with matches! macro (alternative assertion style)
+        // Also test with assert_matches! for variant diagnostics.
         let result2 = ConvexHull::from_triangulation(empty_dt.as_triangulation());
-        assert!(matches!(
+        assert_matches!(
             result2,
             Err(ConvexHullConstructionError::InsufficientData { .. })
-        ));
+        );
     }
 
     #[test]
@@ -7079,14 +7080,14 @@ mod tests {
             &Point::new([2.0, 2.0, 2.0]),
             dt2.as_triangulation(),
         );
-        assert!(matches!(
+        assert_matches!(
             visibility,
             Err(ConvexHullConstructionError::IdentityMismatch { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             hull.validate(dt2.as_triangulation()),
             Err(ConvexHullValidationError::IdentityMismatch { .. })
-        ));
+        );
     }
 
     #[test]
@@ -7119,14 +7120,14 @@ mod tests {
             &Point::new([2.0, 2.0, 2.0]),
             dt2.as_triangulation(),
         );
-        assert!(matches!(
+        assert_matches!(
             visibility,
             Err(ConvexHullConstructionError::IdentityMismatch { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             hull.validate(dt2.as_triangulation()),
             Err(ConvexHullValidationError::IdentityMismatch { .. })
-        ));
+        );
     }
 
     #[test]
@@ -7174,10 +7175,10 @@ mod tests {
             Vertex::new_with_uuid(Point::new([0.25, 0.25, 0.125]), duplicate_uuid, None);
 
         let result = dt.insert(duplicate_uuid_vertex);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(InsertionError::DuplicateUuid { uuid, .. }) if uuid == duplicate_uuid
-        ));
+        );
 
         assert_eq!(
             dt.as_triangulation().tds.generation(),

--- a/src/geometry/matrix.rs
+++ b/src/geometry/matrix.rs
@@ -28,7 +28,7 @@ pub type Matrix<const D: usize> = LaMatrix<D>;
 /// use delaunay::prelude::geometry::MatrixError;
 ///
 /// let err = MatrixError::SingularMatrix;
-/// assert!(matches!(err, MatrixError::SingularMatrix));
+/// std::assert_matches!(err, MatrixError::SingularMatrix);
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -244,6 +244,7 @@ pub fn determinant<const D: usize>(m: &Matrix<D>) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     use approx::assert_relative_eq;
 
@@ -252,10 +253,7 @@ mod tests {
         let k = MAX_STACK_MATRIX_DIM + 1;
         let res: Result<(), StackMatrixDispatchError> =
             try_with_la_stack_matrix!(k, |_m| { Ok(()) });
-        assert!(matches!(
-            res,
-            Err(StackMatrixDispatchError::UnsupportedDim { .. })
-        ));
+        assert_matches!(res, Err(StackMatrixDispatchError::UnsupportedDim { .. }));
     }
 
     #[test]

--- a/src/geometry/predicates.rs
+++ b/src/geometry/predicates.rs
@@ -1009,6 +1009,7 @@ mod tests {
     use crate::geometry::traits::coordinate::Coordinate;
     use crate::prelude::circumradius;
     use approx::assert_relative_eq;
+    use std::assert_matches;
     use std::collections::HashMap;
 
     /// Populate a test matrix while keeping production matrix errors loud.
@@ -2255,10 +2256,10 @@ mod tests {
         let matrix = Matrix::<3>::zero();
         let err = try_orientation_from_matrix(&matrix, 4).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             StackMatrixDispatchError::ActiveBlockDimensionMismatch { k: 4, dim: 3 }
-        ));
+        );
     }
 
     #[test]
@@ -2397,10 +2398,10 @@ mod tests {
         let matrix = Matrix::<3>::zero();
         let err = try_insphere_from_matrix(&matrix, 2, 1).unwrap_err();
 
-        assert!(matches!(
+        assert_matches!(
             err,
             StackMatrixDispatchError::ActiveBlockDimensionMismatch { k: 2, dim: 3 }
-        ));
+        );
     }
 
     // =======================================================================

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -142,7 +142,7 @@ impl From<TdsError> for QualitySimplexVerticesError {
 /// let err = QualityError::NumericConversion {
 ///     operation: QualityNumericOperation::EdgeCountConversion,
 /// };
-/// assert!(matches!(err, QualityError::NumericConversion { .. }));
+/// std::assert_matches!(err, QualityError::NumericConversion { .. });
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 #[non_exhaustive]
@@ -563,6 +563,7 @@ mod tests {
     use crate::triangulation::DelaunayTriangulation;
     use crate::vertex;
     use approx::assert_relative_eq;
+    use std::assert_matches;
 
     // sqrt(3) constant computed at compile time
     // const SQRT_3: f64 = 1.732_050_807_568_877_3;
@@ -750,10 +751,7 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
         if let Ok(ratio) = ratio_result {
             assert!(ratio > 10.0);
         } else {
-            assert!(matches!(
-                ratio_result,
-                Err(QualityError::DegenerateSimplex { .. })
-            ));
+            assert_matches!(ratio_result, Err(QualityError::DegenerateSimplex { .. }));
         }
 
         // Test normalized_volume
@@ -761,10 +759,7 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
         if let Ok(norm_vol) = vol_result {
             assert!(norm_vol < 0.01);
         } else {
-            assert!(matches!(
-                vol_result,
-                Err(QualityError::DegenerateSimplex { .. })
-            ));
+            assert_matches!(vol_result, Err(QualityError::DegenerateSimplex { .. }));
         }
     }
 
@@ -781,35 +776,35 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
             simplex_key,
             context: "quality metric simplex lookup".to_string(),
         });
-        assert!(matches!(
+        assert_matches!(
             missing_simplex,
             QualitySimplexVerticesError::SimplexNotFound {
                 simplex_key: observed,
                 context
             } if observed == simplex_key && context == "quality metric simplex lookup"
-        ));
+        );
 
         let missing_vertex = QualitySimplexVerticesError::from(TdsError::VertexNotFound {
             vertex_key,
             context: "quality metric vertex lookup".to_string(),
         });
-        assert!(matches!(
+        assert_matches!(
             missing_vertex,
             QualitySimplexVerticesError::ReferencedVertexNotFound {
                 vertex_key: observed,
                 context
             } if observed == vertex_key && context == "quality metric vertex lookup"
-        ));
+        );
 
         let unexpected = QualitySimplexVerticesError::from(TdsError::DuplicateSimplices {
             message: "same vertex set appears twice".to_string(),
         });
-        assert!(matches!(
+        assert_matches!(
             unexpected,
             QualitySimplexVerticesError::UnexpectedTdsFailure { message }
                 if message.contains("Duplicate simplices")
                     && message.contains("same vertex set appears twice")
-        ));
+        );
     }
 
     #[test]
@@ -1114,10 +1109,10 @@ let simplex_key = dt.simplices().next().unwrap().0;
         let invalid_key = SimplexKey::from(KeyData::from_ffi(u64::MAX));
 
         let result = radius_ratio(dt.as_triangulation(), invalid_key);
-        assert!(matches!(result, Err(QualityError::SimplexVertices { .. })));
+        assert_matches!(result, Err(QualityError::SimplexVertices { .. }));
 
         let result = normalized_volume(dt.as_triangulation(), invalid_key);
-        assert!(matches!(result, Err(QualityError::SimplexVertices { .. })));
+        assert_matches!(result, Err(QualityError::SimplexVertices { .. }));
     }
 
     #[test]
@@ -1308,7 +1303,7 @@ let simplex_key = dt.simplices().next().unwrap().0;
         let invalid_key = SimplexKey::from(KeyData::from_ffi(u64::MAX));
 
         let result = simplex_points(dt.as_triangulation(), invalid_key);
-        assert!(matches!(result, Err(QualityError::SimplexVertices { .. })));
+        assert_matches!(result, Err(QualityError::SimplexVertices { .. }));
     }
 
     #[test]
@@ -1558,13 +1553,13 @@ let simplex_key = dt.simplices().next().unwrap().0;
                 }) = result
                 {
                     // Should include numeric information when we surface a degenerate simplex
-                    assert!(matches!(
+                    assert_matches!(
                         measure,
                         QualityDegeneracyMeasure::Inradius
                             | QualityDegeneracyMeasure::Volume
                             | QualityDegeneracyMeasure::AverageEdgeLength
                             | QualityDegeneracyMeasure::EdgeLengthPower
-                    ));
+                    );
                     assert!(!observed.is_empty());
                 }
             }

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -539,6 +539,7 @@ mod tests {
     use crate::geometry::util::squared_norm;
     use num_traits::NumCast;
     use rand::{RngExt, SeedableRng};
+    use std::assert_matches;
     use std::thread;
 
     fn matrix_block_is_finite<const N: usize>(matrix: &Matrix<N>, k: usize) -> bool {
@@ -772,10 +773,7 @@ mod tests {
         let result = robust_orientation(&points).unwrap();
 
         // Should detect orientation (exact result depends on coordinate system)
-        assert!(matches!(
-            result,
-            Orientation::POSITIVE | Orientation::NEGATIVE
-        ));
+        assert_matches!(result, Orientation::POSITIVE | Orientation::NEGATIVE);
     }
 
     #[test]
@@ -1429,10 +1427,10 @@ mod tests {
         assert!(result.is_ok());
 
         let insphere_result = result.unwrap();
-        assert!(matches!(
+        assert_matches!(
             insphere_result,
             InSphere::INSIDE | InSphere::BOUNDARY | InSphere::OUTSIDE
-        ));
+        );
     }
 
     #[test]
@@ -1713,10 +1711,10 @@ mod tests {
 
         // Verify we get a sensible InSphere result
         let insphere_result = result.unwrap();
-        assert!(matches!(
+        assert_matches!(
             insphere_result,
             InSphere::INSIDE | InSphere::BOUNDARY | InSphere::OUTSIDE
-        ));
+        );
     }
 
     #[test]

--- a/src/geometry/traits/coordinate.rs
+++ b/src/geometry/traits/coordinate.rs
@@ -120,7 +120,7 @@ impl fmt::Display for DegenerateSimplexReason {
 ///     from_type: "f64",
 ///     to_type: "f32",
 /// };
-/// assert!(matches!(err, CoordinateConversionError::ConversionFailed { .. }));
+/// std::assert_matches!(err, CoordinateConversionError::ConversionFailed { .. });
 /// ```
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -247,7 +247,7 @@ impl From<StackMatrixDispatchError> for CoordinateConversionError {
 ///     coordinate_value: "NaN".to_string(),
 ///     dimension: 3,
 /// };
-/// assert!(matches!(err, CoordinateValidationError::InvalidCoordinate { .. }));
+/// std::assert_matches!(err, CoordinateValidationError::InvalidCoordinate { .. });
 /// ```
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
 #[non_exhaustive]

--- a/src/geometry/util/circumsphere.rs
+++ b/src/geometry/util/circumsphere.rs
@@ -308,6 +308,7 @@ mod tests {
     use super::*;
     use crate::geometry::point::Point;
     use approx::assert_relative_eq;
+    use std::assert_matches;
 
     #[test]
     fn predicates_circumcenter() {
@@ -773,7 +774,7 @@ mod tests {
         let empty_points: Vec<Point<f64, 3>> = vec![];
         let result = circumcenter(&empty_points);
 
-        assert!(matches!(result, Err(CircumcenterError::EmptyPointSet)));
+        assert_matches!(result, Err(CircumcenterError::EmptyPointSet));
     }
 
     #[test]
@@ -786,10 +787,7 @@ mod tests {
         ];
 
         let result = circumcenter(&points_2d);
-        assert!(matches!(
-            result,
-            Err(CircumcenterError::InvalidSimplex { .. })
-        ));
+        assert_matches!(result, Err(CircumcenterError::InvalidSimplex { .. }));
 
         // Test too many points
         let points_extra = vec![
@@ -800,10 +798,7 @@ mod tests {
         ];
 
         let result = circumcenter(&points_extra);
-        assert!(matches!(
-            result,
-            Err(CircumcenterError::InvalidSimplex { .. })
-        ));
+        assert_matches!(result, Err(CircumcenterError::InvalidSimplex { .. }));
     }
 
     #[test]
@@ -816,10 +811,7 @@ mod tests {
         ];
 
         let result = circumcenter(&collinear_points);
-        assert!(matches!(
-            result,
-            Err(CircumcenterError::MatrixInversionFailed { .. })
-        ));
+        assert_matches!(result, Err(CircumcenterError::MatrixInversionFailed { .. }));
     }
 
     #[test]

--- a/src/geometry/util/conversions.rs
+++ b/src/geometry/util/conversions.rs
@@ -353,6 +353,7 @@ mod tests {
     use crate::geometry::util::{CircumcenterError, RandomPointGenerationError};
     use approx::assert_relative_eq;
     use num_traits::cast;
+    use std::assert_matches;
 
     #[test]
     fn test_safe_usize_to_scalar_basic_success() {
@@ -567,24 +568,24 @@ mod tests {
     fn test_safe_cast_to_f64_non_finite() {
         // Test NaN handling
         let result = safe_cast_to_f64(f64::NAN, 0);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test infinity handling
         let result = safe_cast_to_f64(f64::INFINITY, 1);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test negative infinity
         let result = safe_cast_to_f64(f64::NEG_INFINITY, 2);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test valid finite value
         let result = safe_cast_to_f64(42.5f64, 0);
@@ -596,24 +597,24 @@ mod tests {
     fn test_safe_cast_from_f64_non_finite() {
         // Test NaN handling
         let result: Result<f64, _> = safe_cast_from_f64(f64::NAN, 0);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test infinity handling
         let result: Result<f64, _> = safe_cast_from_f64(f64::INFINITY, 1);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test negative infinity
         let result: Result<f64, _> = safe_cast_from_f64(f64::NEG_INFINITY, 2);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test valid conversion
         let result: Result<f32, _> = safe_cast_from_f64(42.5f64, 0);
@@ -625,18 +626,18 @@ mod tests {
         // Test array with NaN
         let coords_nan = [1.0f32, f32::NAN, 3.0f32];
         let result = safe_coords_to_f64(&coords_nan);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test array with infinity
         let coords_inf = [1.0f32, 2.0f32, f32::INFINITY];
         let result = safe_coords_to_f64(&coords_inf);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test successful conversion
         let coords_valid = [1.0f32, 2.0f32, 3.0f32];
@@ -653,18 +654,18 @@ mod tests {
         // Test array with NaN
         let coords_nan = [1.0f64, f64::NAN, 3.0f64];
         let result: Result<[f32; 3], _> = safe_coords_from_f64(&coords_nan);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test array with infinity
         let coords_inf = [1.0f64, 2.0f64, f64::INFINITY];
         let result: Result<[f32; 3], _> = safe_coords_from_f64(&coords_inf);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test successful conversion
         let coords_valid = [1.0f64, 2.0f64, 3.0f64];
@@ -676,17 +677,17 @@ mod tests {
     fn test_safe_scalar_conversion_edge_cases() {
         // Test scalar to f64 with NaN
         let result = safe_scalar_to_f64(f64::NAN);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test scalar from f64 with NaN
         let result: Result<f32, _> = safe_scalar_from_f64(f64::NAN);
-        assert!(matches!(
+        assert_matches!(
             result,
             Err(CoordinateConversionError::NonFiniteValue { .. })
-        ));
+        );
 
         // Test successful conversions
         let result = safe_scalar_to_f64(42.5f32);
@@ -712,10 +713,10 @@ mod tests {
             // Only test on 64-bit platforms
             let large_value = usize::try_from(MAX_PRECISE + 1).unwrap_or(usize::MAX);
             let result: Result<f64, _> = safe_usize_to_scalar(large_value);
-            assert!(matches!(
+            assert_matches!(
                 result,
                 Err(CoordinateConversionError::ConversionFailed { .. })
-            ));
+            );
         }
 
         // Test normal values

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -312,7 +312,9 @@ where
         for j in 0..D {
             let mut dot_product = 0.0;
             for k in 0..D {
-                dot_product += matrix_get(&edge_matrix, i, k)? * matrix_get(&edge_matrix, j, k)?;
+                let edge_i = matrix_get(&edge_matrix, i, k)?;
+                let edge_j = matrix_get(&edge_matrix, j, k)?;
+                dot_product = edge_i.mul_add(edge_j, dot_product);
             }
             matrix_set(&mut gram_matrix, i, j, dot_product)?;
         }
@@ -653,7 +655,7 @@ where
                 {
                     let di = ai - a0;
                     let dj = aj - a0;
-                    dot_product += di * dj;
+                    dot_product = di.mul_add(dj, dot_product);
                 }
                 matrix_set(&mut gram_matrix, i, j, dot_product)?;
             }
@@ -1013,7 +1015,7 @@ mod tests {
                 for j in 0..k {
                     let mut dot_product = 0.0;
                     for (&a, &b) in edges[i].iter().zip(edges[j].iter()) {
-                        dot_product += a * b;
+                        dot_product = a.mul_add(b, dot_product);
                     }
                     matrix_set(&mut gram_matrix, i, j, dot_product)?;
                 }

--- a/src/geometry/util/point_generation.rs
+++ b/src/geometry/util/point_generation.rs
@@ -722,6 +722,7 @@ pub fn generate_poisson_points<T: CoordinateScalar + SampleUniform, const D: usi
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use std::assert_matches;
 
     // =============================================================================
     // RANDOM POINT GENERATION TESTS
@@ -958,16 +959,16 @@ mod tests {
     #[test]
     fn test_generate_random_points_periodic_invalid_domain() {
         let zero_period = generate_random_points_periodic::<f64, 2>(10, [1.0, 0.0], 7);
-        assert!(matches!(
+        assert_matches!(
             zero_period,
             Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        );
 
         let negative_period = generate_random_points_periodic::<f64, 2>(10, [1.0, -2.0], 7);
-        assert!(matches!(
+        assert_matches!(
             negative_period,
             Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        );
     }
 
     #[test]
@@ -992,7 +993,7 @@ mod tests {
             let mut norm_sq = 0.0_f64;
             for &c in &coords {
                 assert!(c >= -radius && c <= radius);
-                norm_sq += c * c;
+                norm_sq = c.mul_add(c, norm_sq);
             }
             assert!(norm_sq <= radius_sq + 1e-12);
         }
@@ -1015,19 +1016,13 @@ mod tests {
     #[test]
     fn test_generate_random_points_in_ball_rejects_zero_radius() {
         let result = generate_random_points_in_ball::<f64, 4>(10, 0.0);
-        assert!(matches!(
-            result,
-            Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        assert_matches!(result, Err(RandomPointGenerationError::InvalidRange { .. }));
     }
 
     #[test]
     fn test_generate_random_points_in_ball_rejects_negative_radius() {
         let result = generate_random_points_in_ball::<f64, 4>(10, -1.0);
-        assert!(matches!(
-            result,
-            Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        assert_matches!(result, Err(RandomPointGenerationError::InvalidRange { .. }));
     }
 
     #[test]
@@ -1045,19 +1040,13 @@ mod tests {
     #[test]
     fn test_generate_random_points_in_ball_rejects_nan_radius() {
         let result = generate_random_points_in_ball::<f64, 4>(10, f64::NAN);
-        assert!(matches!(
-            result,
-            Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        assert_matches!(result, Err(RandomPointGenerationError::InvalidRange { .. }));
     }
 
     #[test]
     fn test_generate_random_points_in_ball_rejects_infinite_radius() {
         let result = generate_random_points_in_ball::<f64, 4>(10, f64::INFINITY);
-        assert!(matches!(
-            result,
-            Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        assert_matches!(result, Err(RandomPointGenerationError::InvalidRange { .. }));
     }
 
     #[test]
@@ -1072,7 +1061,7 @@ mod tests {
             let mut norm_sq = 0.0_f32;
             for &c in &coords {
                 assert!(c >= -radius && c <= radius);
-                norm_sq += c * c;
+                norm_sq = c.mul_add(c, norm_sq);
             }
             assert!(norm_sq <= radius_sq + 1e-5);
         }
@@ -1542,17 +1531,11 @@ mod tests {
     fn test_generate_random_points_invalid_range() {
         // Test invalid range (min >= max)
         let result = generate_random_points::<f64, 2>(100, (10.0, 5.0));
-        assert!(matches!(
-            result,
-            Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        assert_matches!(result, Err(RandomPointGenerationError::InvalidRange { .. }));
 
         // Test equal min and max
         let result = generate_random_points::<f64, 2>(100, (5.0, 5.0));
-        assert!(matches!(
-            result,
-            Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        assert_matches!(result, Err(RandomPointGenerationError::InvalidRange { .. }));
 
         // Test valid range
         let result = generate_random_points::<f64, 2>(10, (0.0, 1.0));
@@ -1564,10 +1547,7 @@ mod tests {
     fn test_generate_random_points_seeded_invalid_range() {
         // Test invalid range with seed
         let result = generate_random_points_seeded::<f64, 3>(50, (100.0, 10.0), 42);
-        assert!(matches!(
-            result,
-            Err(RandomPointGenerationError::InvalidRange { .. })
-        ));
+        assert_matches!(result, Err(RandomPointGenerationError::InvalidRange { .. }));
 
         // Test valid range produces consistent results
         let points1 = generate_random_points_seeded::<f64, 3>(5, (0.0, 1.0), 42).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,7 +179,7 @@
 //!
 //! // Duplicate coordinates are rejected.
 //! let result = dt.insert(vertex!([0.0, 0.0]));
-//! assert!(matches!(result, Err(InsertionError::DuplicateCoordinates { .. })));
+//! std::assert_matches!(result, Err(InsertionError::DuplicateCoordinates { .. }));
 //!
 //! // On error, the triangulation is unchanged.
 //! assert_eq!(dt.number_of_vertices(), before_vertices);
@@ -666,7 +666,7 @@ pub mod geometry {
         ///     to_type: "u32",
         ///     details: "out of range".to_string(),
         /// };
-        /// assert!(matches!(err, ValueConversionError::ConversionFailed { .. }));
+        /// std::assert_matches!(err, ValueConversionError::ConversionFailed { .. });
         /// ```
         #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
         #[non_exhaustive]
@@ -696,7 +696,7 @@ pub mod geometry {
         ///     min: "1.0".to_string(),
         ///     max: "0.0".to_string(),
         /// };
-        /// assert!(matches!(err, RandomPointGenerationError::InvalidRange { .. }));
+        /// std::assert_matches!(err, RandomPointGenerationError::InvalidRange { .. });
         /// ```
         #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
         #[non_exhaustive]
@@ -737,7 +737,7 @@ pub mod geometry {
         /// use delaunay::prelude::geometry::CircumcenterError;
         ///
         /// let err = CircumcenterError::EmptyPointSet;
-        /// assert!(matches!(err, CircumcenterError::EmptyPointSet));
+        /// std::assert_matches!(err, CircumcenterError::EmptyPointSet);
         /// ```
         #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
         #[non_exhaustive]
@@ -858,7 +858,7 @@ pub mod geometry {
         /// use delaunay::prelude::geometry::{CircumcenterError, SurfaceMeasureError};
         ///
         /// let err = SurfaceMeasureError::GeometryError(CircumcenterError::EmptyPointSet);
-        /// assert!(matches!(err, SurfaceMeasureError::GeometryError(_)));
+        /// std::assert_matches!(err, SurfaceMeasureError::GeometryError(_));
         /// ```
         #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
         #[non_exhaustive]
@@ -1180,10 +1180,10 @@ pub mod tds {
 /// let kernel = AdaptiveKernel::new();
 /// let point = Point::new([0.0, 0.0]);
 ///
-/// assert!(matches!(
+/// std::assert_matches!(
 ///     locate(&tds, &kernel, &point, None),
 ///     Err(LocateError::EmptyTriangulation)
-/// ));
+/// );
 /// ```
 pub mod algorithms {
     #[cfg(any(feature = "diagnostics", all(test, debug_assertions)))]
@@ -1662,10 +1662,10 @@ pub mod prelude {
     /// let kernel = AdaptiveKernel::new();
     /// let point = Point::new([0.0, 0.0]);
     ///
-    /// assert!(matches!(
+    /// std::assert_matches!(
     ///     locate(&tds, &kernel, &point, None),
     ///     Err(LocateError::EmptyTriangulation)
-    /// ));
+    /// );
     /// ```
     pub mod algorithms {
         pub use crate::algorithms::{
@@ -1900,6 +1900,7 @@ mod tests {
         vertex,
     };
     use la_stack::LaError;
+    use std::assert_matches;
 
     #[cfg(feature = "count-allocations")]
     use allocation_counter::measure;
@@ -1989,7 +1990,7 @@ mod tests {
         };
         assert_eq!(outcome.stats.flips_performed, stats.flips_performed);
         let order = RepairQueueOrder::Fifo;
-        assert!(matches!(order, RepairQueueOrder::Fifo));
+        assert_matches!(order, RepairQueueOrder::Fifo);
         assert_eq!(
             DelaunayRepairPolicy::default(),
             DelaunayRepairPolicy::EveryInsertion
@@ -1997,17 +1998,17 @@ mod tests {
         assert_eq!(DelaunayCheckPolicy::default(), DelaunayCheckPolicy::EndOnly);
 
         let err = DelaunayRepairError::from(FlipError::DegenerateSimplex);
-        assert!(matches!(err, DelaunayRepairError::Flip { .. }));
+        assert_matches!(err, DelaunayRepairError::Flip { .. });
         let context_err = FlipContextError::ReplacementPeriodicOffsetCountMismatch {
             simplex_count: 1,
             offset_count: 0,
         };
-        assert!(matches!(
+        assert_matches!(
             context_err,
             FlipContextError::ReplacementPeriodicOffsetCountMismatch { .. }
-        ));
+        );
         let topo = TopologyGuarantee::PLManifold;
-        assert!(matches!(topo, TopologyGuarantee::PLManifold));
+        assert_matches!(topo, TopologyGuarantee::PLManifold);
     }
 
     #[test]

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -255,7 +255,7 @@ fn ordered_lifted_edge(a: &LiftedVertexId, b: &LiftedVertexId) -> (LiftedVertexI
 ///     ridge_key: 1,
 ///     boundary_facet_count: 3,
 /// };
-/// assert!(matches!(err, ManifoldError::BoundaryRidgeMultiplicity { .. }));
+/// std::assert_matches!(err, ManifoldError::BoundaryRidgeMultiplicity { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
@@ -2289,6 +2289,7 @@ fn validate_ridge_link_graph(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::assert_matches;
 
     use crate::core::facet::FacetHandle;
     use crate::core::simplex::Simplex;
@@ -2664,10 +2665,10 @@ mod tests {
         link_simplices.push(simplex(&[b, c]));
         link_simplices.push(simplex(&[c, a]));
 
-        assert!(matches!(
+        assert_matches!(
             validate_vertex_link_d2(vertex_key, false, &link_simplices, 3, 3),
             Err(ManifoldError::VertexLinkNotManifold { .. })
-        ));
+        );
     }
 
     #[test]
@@ -2677,10 +2678,10 @@ mod tests {
         let mut link_simplices: LinkSimplexBuffer = SmallBuffer::new();
         link_simplices.push(simplex(&[vk(1)]));
 
-        assert!(matches!(
+        assert_matches!(
             validate_vertex_link_d2(vertex_key, true, &link_simplices, 1, 1),
             Err(ManifoldError::VertexLinkNotManifold { .. })
-        ));
+        );
     }
 
     #[test]
@@ -2712,10 +2713,10 @@ mod tests {
         tds.insert_simplex_with_mapping(Simplex::new(vec![v0, v1], None).unwrap())
             .unwrap();
 
-        assert!(matches!(
+        assert_matches!(
             validate_single_vertex_link(&tds, v0, true),
             Err(ManifoldError::VertexLinkNotManifold { .. })
-        ));
+        );
     }
 
     #[test]
@@ -2730,10 +2731,10 @@ mod tests {
             .unwrap();
 
         validate_single_vertex_link(&tds, v0, false).unwrap();
-        assert!(matches!(
+        assert_matches!(
             validate_single_vertex_link(&tds, v0, true),
             Err(ManifoldError::VertexLinkNotManifold { .. })
-        ));
+        );
     }
 
     #[test]
@@ -2741,10 +2742,10 @@ mod tests {
         let (tds, [v0, ..]) = build_closed_surface_s2_tds_2d();
 
         validate_single_vertex_link(&tds, v0, true).unwrap();
-        assert!(matches!(
+        assert_matches!(
             validate_single_vertex_link(&tds, v0, false),
             Err(ManifoldError::VertexLinkNotManifold { .. })
-        ));
+        );
     }
 
     #[test]
@@ -2815,14 +2816,14 @@ mod tests {
         validate_vertex_links(&tds, &facet_to_simplices).unwrap();
 
         // And misclassifications should be rejected (guards the interior/boundary distinction).
-        assert!(matches!(
+        assert_matches!(
             validate_single_vertex_link(&tds, va, true),
             Err(ManifoldError::VertexLinkNotManifold { .. })
-        ));
-        assert!(matches!(
+        );
+        assert_matches!(
             validate_single_vertex_link(&tds, center, false),
             Err(ManifoldError::VertexLinkNotManifold { .. })
-        ));
+        );
     }
 
     #[test]

--- a/src/topology/traits/global_topology_model.rs
+++ b/src/topology/traits/global_topology_model.rs
@@ -590,6 +590,7 @@ impl<const D: usize> GlobalTopologyModel<D> for GlobalTopologyModelAdapter<D> {
 mod tests {
     use super::*;
     use approx::assert_relative_eq;
+    use std::assert_matches;
 
     #[test]
     fn model_adapter_dispatch_matches_global_topology_metadata() {
@@ -621,11 +622,11 @@ mod tests {
         let model = ToroidalModel::<2>::new([2.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let mut coords = [f64::INFINITY, 1.0_f64];
         let err = model.canonicalize_point_in_place(&mut coords).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::NonFiniteCoordinate { axis: 0, value }
                 if value.is_infinite() && value.is_sign_positive()
-        ));
+        );
     }
 
     #[test]
@@ -633,11 +634,11 @@ mod tests {
         let model = ToroidalModel::<2>::new([2.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let mut coords = [f64::NAN, 1.0_f64];
         let err = model.canonicalize_point_in_place(&mut coords).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::NonFiniteCoordinate { axis: 0, value }
                 if value.is_nan()
-        ));
+        );
     }
 
     #[test]
@@ -658,11 +659,11 @@ mod tests {
         let err = model
             .lift_for_orientation([f64::NAN, 0.5_f64], Some([1, 0]))
             .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::NonFiniteCoordinate { axis: 0, value }
                 if value.is_nan()
-        ));
+        );
     }
 
     #[test]
@@ -680,12 +681,12 @@ mod tests {
         let err = model
             .lift_for_orientation([0.5_f64, 0.25_f64], Some([1, 0]))
             .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::PeriodicOffsetsUnsupported {
                 kind: TopologyKind::Euclidean,
             }
-        ));
+        );
     }
 
     // =========================================================================
@@ -785,12 +786,12 @@ mod tests {
             Some([1, 0]),
         )
         .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::PeriodicOffsetsUnsupported {
                 kind: TopologyKind::Spherical,
             }
-        ));
+        );
     }
 
     #[test]
@@ -826,12 +827,12 @@ mod tests {
             Some([1, 0]),
         )
         .unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::PeriodicOffsetsUnsupported {
                 kind: TopologyKind::Hyperbolic,
             }
-        ));
+        );
     }
 
     #[test]
@@ -1041,22 +1042,22 @@ mod tests {
     fn toroidal_model_rejects_zero_period() {
         let model = ToroidalModel::<2>::new([0.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let err = model.validate_configuration().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::InvalidToroidalPeriod { axis: 0, period }
                 if period.abs() < f64::EPSILON
-        ));
+        );
     }
 
     #[test]
     fn toroidal_model_rejects_negative_period() {
         let model = ToroidalModel::<2>::new([2.0, -1.0], ToroidalConstructionMode::Canonicalized);
         let err = model.validate_configuration().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::InvalidToroidalPeriod { axis: 1, period }
                 if period < 0.0
-        ));
+        );
     }
 
     #[test]
@@ -1066,11 +1067,11 @@ mod tests {
             ToroidalConstructionMode::Canonicalized,
         );
         let err = model.validate_configuration().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::InvalidToroidalPeriod { axis: 0, period }
                 if period.is_infinite()
-        ));
+        );
     }
 
     #[test]
@@ -1078,11 +1079,11 @@ mod tests {
         let model =
             ToroidalModel::<2>::new([f64::NAN, 3.0], ToroidalConstructionMode::Canonicalized);
         let err = model.validate_configuration().unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::InvalidToroidalPeriod { axis: 0, period }
                 if period.is_nan()
-        ));
+        );
     }
 
     #[test]
@@ -1090,11 +1091,11 @@ mod tests {
         let model = ToroidalModel::<2>::new([2.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let mut coords = [f64::NEG_INFINITY, 1.0_f64];
         let err = model.canonicalize_point_in_place(&mut coords).unwrap_err();
-        assert!(matches!(
+        assert_matches!(
             err,
             GlobalTopologyModelError::NonFiniteCoordinate { axis: 0, value }
                 if value.is_infinite() && value.is_sign_negative()
-        ));
+        );
     }
 
     // =========================================================================

--- a/src/topology/traits/topological_space.rs
+++ b/src/topology/traits/topological_space.rs
@@ -25,7 +25,7 @@ use thiserror::Error;
 ///         message: "facet map invariant failed".to_string(),
 ///     },
 /// };
-/// assert!(matches!(error, TopologyError::FacetMapBuild { .. }));
+/// std::assert_matches!(error, TopologyError::FacetMapBuild { .. });
 /// ```
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]

--- a/tests/coordinate_conversion_errors.rs
+++ b/tests/coordinate_conversion_errors.rs
@@ -3,6 +3,8 @@
 //! This module tests that functions properly handle coordinate conversion errors
 //! when dealing with extreme values, NaN, infinity, etc.
 
+use std::assert_matches;
+
 use delaunay::prelude::geometry::*;
 
 // =============================================================================
@@ -110,12 +112,12 @@ fn test_circumcenter_with_nan_coordinates() {
     // The function should return an error due to NaN coordinate
     let result = circumcenter(&points);
 
-    assert!(matches!(
+    assert_matches!(
         result,
         Err(CircumcenterError::CoordinateConversion {
             source: CoordinateConversionError::NonFiniteValue { .. },
         })
-    ));
+    );
 }
 
 #[test]
@@ -130,12 +132,12 @@ fn test_circumradius_with_infinity_coordinates() {
     // The function should return an error due to infinity coordinate
     let result = circumradius(&points);
 
-    assert!(matches!(
+    assert_matches!(
         result,
         Err(CircumcenterError::CoordinateConversion {
             source: CoordinateConversionError::NonFiniteValue { .. },
         })
-    ));
+    );
 }
 
 #[test]

--- a/tests/insert_with_statistics.rs
+++ b/tests/insert_with_statistics.rs
@@ -15,6 +15,8 @@
 //! - Bootstrap phase (< D+1 vertices)
 //! - Post-bootstrap phase (≥ D+1 vertices)
 
+use std::assert_matches;
+
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee, vertex};
 use delaunay::prelude::insertion::{InsertionError, InsertionOutcome};
 
@@ -32,7 +34,7 @@ fn delaunay_insert_with_statistics_basic_2d() {
         .insert_with_statistics(vertex!([0.0, 0.0]))
         .expect("insertion should succeed");
 
-    assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+    assert_matches!(outcome, InsertionOutcome::Inserted { .. });
     assert_eq!(stats.attempts, 1);
     assert!(!stats.used_perturbation());
     assert!(!stats.skipped());
@@ -46,7 +48,7 @@ fn delaunay_insert_with_statistics_basic_2d() {
         .insert_with_statistics(vertex!([1.0, 0.0]))
         .expect("insertion should succeed");
 
-    assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+    assert_matches!(outcome, InsertionOutcome::Inserted { .. });
     assert_eq!(stats.attempts, 1);
     assert_eq!(dt.number_of_vertices(), 2);
 
@@ -55,7 +57,7 @@ fn delaunay_insert_with_statistics_basic_2d() {
         .insert_with_statistics(vertex!([0.5, 1.0]))
         .expect("insertion should succeed");
 
-    assert!(matches!(outcome, InsertionOutcome::Inserted { hint, .. } if hint.is_some()));
+    assert_matches!(outcome, InsertionOutcome::Inserted { hint, .. } if hint.is_some());
     assert_eq!(stats.attempts, 1);
     assert!(stats.success());
     assert_eq!(dt.number_of_vertices(), 3);
@@ -74,20 +76,14 @@ fn delaunay_insert_with_statistics_hint_caching_3d() {
     let (outcome, _) = dt.insert_with_statistics(vertex!([0.0, 0.0, 1.0])).unwrap();
 
     // After simplex creation, hint should be available
-    assert!(matches!(
-        outcome,
-        InsertionOutcome::Inserted { hint: Some(_), .. }
-    ));
+    assert_matches!(outcome, InsertionOutcome::Inserted { hint: Some(_), .. });
 
     // Insert interior point - should benefit from hint
     let (outcome, stats) = dt
         .insert_with_statistics(vertex!([0.25, 0.25, 0.25]))
         .unwrap();
 
-    assert!(matches!(
-        outcome,
-        InsertionOutcome::Inserted { hint: Some(_), .. }
-    ));
+    assert_matches!(outcome, InsertionOutcome::Inserted { hint: Some(_), .. });
     assert_eq!(stats.attempts, 1);
     assert!(stats.success());
     assert_eq!(dt.number_of_vertices(), 5);
@@ -224,7 +220,7 @@ fn delaunay_insert_with_statistics_bootstrap_happy_path_3d() {
 
     for v in vertices {
         let (outcome, stats) = dt.insert_best_effort_with_statistics(v).unwrap();
-        assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+        assert_matches!(outcome, InsertionOutcome::Inserted { .. });
         assert_eq!(stats.attempts, 1);
     }
 
@@ -246,7 +242,7 @@ fn delaunay_insert_with_statistics_statistics_fields_3d() {
         let (outcome, stats) = dt.insert_with_statistics(vertex!(coords)).unwrap();
 
         // Verify all statistics fields
-        assert!(matches!(outcome, InsertionOutcome::Inserted { .. }));
+        assert_matches!(outcome, InsertionOutcome::Inserted { .. });
         assert!(stats.attempts >= 1);
         assert!(!stats.skipped());
         assert!(stats.success());

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -116,6 +116,8 @@ use delaunay::prelude::repair::{DelaunayCheckPolicy, DelaunayRepairHeuristicConf
 use delaunay::prelude::tds::{InvariantKind, TriangulationValidationReport};
 use delaunay::prelude::validation::ValidationCadence;
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
+#[cfg(feature = "slow-tests")]
+use std::assert_matches;
 use std::env;
 use std::fmt;
 use std::io::{self, Write};
@@ -1756,26 +1758,26 @@ fn regression_issue_230_4d_100_orientation() {
 #[cfg(feature = "slow-tests")]
 fn debug_large_scale_2d() {
     let outcome = debug_large_case::<2>("2D", 40_000);
-    assert!(matches!(outcome, DebugOutcome::Success), "{outcome}");
+    assert_matches!(outcome, DebugOutcome::Success, "{outcome}");
 }
 
 #[test]
 #[cfg(feature = "slow-tests")]
 fn debug_large_scale_3d() {
     let outcome = debug_large_case::<3>("3D", 7_500);
-    assert!(matches!(outcome, DebugOutcome::Success), "{outcome}");
+    assert_matches!(outcome, DebugOutcome::Success, "{outcome}");
 }
 
 #[test]
 #[cfg(feature = "slow-tests")]
 fn debug_large_scale_4d() {
     let outcome = debug_large_case::<4>("4D", 900);
-    assert!(matches!(outcome, DebugOutcome::Success), "{outcome}");
+    assert_matches!(outcome, DebugOutcome::Success, "{outcome}");
 }
 
 #[test]
 #[cfg(feature = "slow-tests")]
 fn debug_large_scale_5d() {
     let outcome = debug_large_case::<5>("5D", 150);
-    assert!(matches!(outcome, DebugOutcome::Success), "{outcome}");
+    assert_matches!(outcome, DebugOutcome::Success, "{outcome}");
 }

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -10,6 +10,8 @@
     reason = "tests preserve typed construction, repair, and delaunayize errors"
 )]
 
+use std::assert_matches;
+
 use delaunay::prelude::DelaunayValidationError;
 use delaunay::prelude::algorithms::LocateResult;
 #[cfg(feature = "diagnostics")]
@@ -80,7 +82,6 @@ use delaunay::prelude::validation::{
 use delaunay::prelude::{
     SecureHashMap, SecureHashSet, ValidationConfigurationError as RootValidationConfigurationError,
 };
-
 #[derive(Debug, thiserror::Error)]
 enum RootApiExportTestError {
     #[error(transparent)]
@@ -153,10 +154,10 @@ fn root_exports_cover_flattened_public_api() -> Result<(), RootApiExportTestErro
 
     assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
     assert_eq!(dt.validation_policy(), ValidationPolicy::ExplicitOnly);
-    assert!(matches!(
+    assert_matches!(
         ValidationCadence::from_optional_every(Some(2)),
         ValidationCadence::EveryN(every) if every.get() == 2
-    ));
+    );
     assert_eq!(
         DelaunayRepairPolicy::default(),
         DelaunayRepairPolicy::EveryInsertion
@@ -186,10 +187,10 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
     ];
     let options =
         ConstructionOptions::default().with_insertion_order(InsertionOrderStrategy::Input);
-    assert!(matches!(
+    assert_matches!(
         options.batch_repair_policy(),
         DelaunayRepairPolicy::EveryInsertion
-    ));
+    );
     let dt = DelaunayTriangulation::new_with_options(&vertices, options)?;
 
     assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
@@ -203,12 +204,12 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
         repair_neighbor_pointers_local(&mut empty_tds, &[], None)?,
         0
     );
-    assert!(matches!(
+    assert_matches!(
         DelaunayConstructionFailure::GeometricDegeneracy {
             message: "synthetic".to_string(),
         },
         DelaunayConstructionFailure::GeometricDegeneracy { .. }
-    ));
+    );
     let unsupported_periodic_dimension =
         DelaunayConstructionFailure::UnsupportedPeriodicDimension {
             dimension: 4,
@@ -237,11 +238,11 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
         CavityRepairStage::PrimaryInsertion.to_string(),
         "primary insertion"
     );
-    assert!(matches!(LocateResult::Outside, LocateResult::Outside));
-    assert!(matches!(
+    assert_matches!(LocateResult::Outside, LocateResult::Outside);
+    assert_matches!(
         ValidationCadence::from_optional_every(Some(128)),
         ValidationCadence::EveryN(every) if every.get() == 128
-    ));
+    );
     assert_send_sync_unpin::<TdsMutationError>();
     assert_send_sync_unpin::<NeighborRebuildError>();
     assert_send_sync_unpin::<ConstructionSkipSample>();
@@ -254,14 +255,14 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
         DegenerateSimplexReason::ZeroOrientation.to_string(),
         "zero orientation"
     );
-    assert!(matches!(
+    assert_matches!(
         MatrixError::OutOfBounds {
             row: 1,
             column: 2,
             dimension: 3
         },
         MatrixError::OutOfBounds { .. }
-    ));
+    );
     let mut root_secure_map: SecureHashMap<[u64; 2], usize> = SecureHashMap::default();
     root_secure_map.insert([1, 2], 3);
     assert_eq!(root_secure_map.get(&[1, 2]), Some(&3));
@@ -350,26 +351,26 @@ fn validation_prelude_covers_configuration_error() {
             validation_policy: FocusedValidationPolicy::Never,
         };
     let root_error: RootValidationConfigurationError = focused_error;
-    assert!(matches!(
+    assert_matches!(
         root_error,
         RootValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
             topology_guarantee: FocusedValidationTopologyGuarantee::PLManifold,
             validation_policy: FocusedValidationPolicy::Never,
         }
-    ));
+    );
 
     let triangulation_error =
         TriangulationValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
             topology_guarantee: TriangulationTopologyGuarantee::PLManifoldStrict,
             validation_policy: TriangulationValidationPolicy::Never,
         };
-    assert!(matches!(
+    assert_matches!(
         triangulation_error,
         TriangulationValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
             topology_guarantee: TriangulationTopologyGuarantee::PLManifoldStrict,
             validation_policy: TriangulationValidationPolicy::Never,
         }
-    ));
+    );
 }
 
 #[test]
@@ -441,10 +442,10 @@ fn diagnostic_preludes_cover_repair_apis() -> Result<(), PreludeExportTestError>
         queue_order: RepairQueueOrder::Fifo,
     };
     assert!(diagnostics.to_string().contains("checked"));
-    assert!(matches!(
+    assert_matches!(
         DelaunayRepairError::from(FlipError::DegenerateSimplex),
         DelaunayRepairError::Flip { .. }
-    ));
+    );
     assert_send_sync_unpin::<FlipEdgeAdjacencyError>();
     assert_send_sync_unpin::<FlipTriangleAdjacencyError>();
     assert_send_sync_unpin::<FlipVertexAdjacencyError>();

--- a/tests/proptest_predicates.rs
+++ b/tests/proptest_predicates.rs
@@ -161,7 +161,7 @@ macro_rules! gen_insphere_inward_scaling_inside {
                         if let Ok(result) = insphere(&simplex, interior_point) {
                             // Check separation to avoid degenerate case
                             let mut dist_sq = 0.0;
-                            for i in 0..$dim { let d = center_coords[i] - centroid[i]; dist_sq += d * d; }
+                            for i in 0..$dim { let d = center_coords[i] - centroid[i]; dist_sq = d.mul_add(d, dist_sq); }
                             if dist_sq > 1e-6 {
                                 prop_assert!(
                                     result == InSphere::INSIDE || result == InSphere::BOUNDARY,
@@ -193,7 +193,7 @@ macro_rules! gen_insphere_distant_point_outside_by_radius {
                         let center_coords = *center.coords();
                         // Build a direction: normalize center if nonzero; else use e0
                         let mut norm_sq = 0.0;
-                        for i in 0..$dim { norm_sq += center_coords[i] * center_coords[i]; }
+                        for i in 0..$dim { norm_sq = center_coords[i].mul_add(center_coords[i], norm_sq); }
                         let mut dir = [0.0_f64; $dim];
                         if norm_sq > 1e-8 {
                             let inv_norm = norm_sq.sqrt().recip();

--- a/tests/proptest_triangulation.rs
+++ b/tests/proptest_triangulation.rs
@@ -257,7 +257,7 @@ macro_rules! test_simplex_quality_properties {
                         let i_f64: f64 = safe_usize_to_scalar(i).unwrap();
                         coords[0] = (10.0 + i_f64) * base_scale;
                         let axis = (i + 1) % $dim;
-                        coords[axis] += 0.05 * base_scale;
+                        coords[axis] = 0.05_f64.mul_add(base_scale, coords[axis]);
                         degenerate_points.push(Point::new(coords));
                     }
 

--- a/tests/semgrep/.github/workflows/action_policy.yml
+++ b/tests/semgrep/.github/workflows/action_policy.yml
@@ -33,6 +33,12 @@ jobs:
         # ruleid: delaunay.github-actions.external-action-version-comment
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
 
+      - name: Allowed setup-python action
+        # ok: delaunay.github-actions.external-action-approved-allowlist
+        # ok: delaunay.github-actions.external-action-sha-pinned
+        # ok: delaunay.github-actions.external-action-version-comment
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+
       - name: Local action
         # ok: delaunay.github-actions.external-action-sha-pinned
         # ok: delaunay.github-actions.external-action-approved-allowlist

--- a/tests/semgrep/.github/workflows/action_policy.yml
+++ b/tests/semgrep/.github/workflows/action_policy.yml
@@ -1,6 +1,8 @@
 name: Action policy fixtures
 on:
   workflow_dispatch:
+  # ruleid: delaunay.github-actions.no-pull-request-target
+  pull_request_target:
 
 jobs:
   fixtures:
@@ -10,6 +12,13 @@ jobs:
         # ok: delaunay.github-actions.external-action-sha-pinned
         # ok: delaunay.github-actions.external-action-approved-allowlist
         # ok: delaunay.github-actions.external-action-version-comment
+        # ok: delaunay.github-actions.checkout-persist-credentials-false
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout without explicit credential persistence
+        # ruleid: delaunay.github-actions.checkout-persist-credentials-false
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Moving tag action
@@ -29,3 +38,27 @@ jobs:
         # ok: delaunay.github-actions.external-action-approved-allowlist
         # ok: delaunay.github-actions.external-action-version-comment
         uses: ./.github/actions/local-action
+
+      - name: Interpolated github-script
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          # ruleid: delaunay.github-actions.github-script-no-expression-interpolation
+          script: |
+            core.info("${{ github.ref_name }}");
+
+      - name: Env-backed github-script
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SAFE_REF_NAME: ${{ github.ref_name }}
+        with:
+          # ok: delaunay.github-actions.github-script-no-expression-interpolation
+          script: |
+            core.info(process.env.SAFE_REF_NAME);
+
+      - name: Unlocked uv sync
+        # ruleid: delaunay.github-actions.uv-sync-locked-in-workflows
+        run: uv sync
+
+      - name: Locked uv sync
+        # ok: delaunay.github-actions.uv-sync-locked-in-workflows
+        run: uv sync --locked

--- a/tests/semgrep/doctests/unwrap_expect.txt
+++ b/tests/semgrep/doctests/unwrap_expect.txt
@@ -1,0 +1,32 @@
+// ruleid: delaunay.rust.no-unwrap-expect-in-doctests
+/// let value = Some(1_u32).unwrap();
+
+// ruleid: delaunay.rust.no-unwrap-expect-in-doctests
+//! let value = Ok::<u32, &'static str>(1).expect("doctest should not panic");
+
+// ok: delaunay.rust.no-unwrap-expect-in-doctests
+/// # fn main() -> delaunay::DelaunayResult<()> { Ok(()) }
+
+// ok: delaunay.rust.no-unwrap-expect-in-doctests
+/// Do not use `.unwrap()` in public examples.
+
+// ok: delaunay.rust.no-unwrap-expect-in-doctests
+/// Prefer `?` to `.expect("message")` in public examples.
+
+// ruleid: delaunay.rust.no-box-dyn-error-in-doctests
+/// # Ok::<(), Box<dyn std::error::Error>>(())
+
+// ruleid: delaunay.rust.no-box-dyn-error-in-doctests
+//! # fn main() -> anyhow::Error { anyhow::anyhow!("erased") }
+
+// ok: delaunay.rust.no-box-dyn-error-in-doctests
+/// # fn main() -> delaunay::DelaunayResult<()> { Ok(()) }
+
+// ruleid: delaunay.rust.prefer-assert-matches-in-doctests
+/// assert!(matches!(value, Some(_)));
+
+// ok: delaunay.rust.prefer-assert-matches-in-doctests
+/// std::assert_matches!(value, Some(_));
+
+// ok: delaunay.rust.prefer-assert-matches-in-doctests
+/// assert!(value.is_some());

--- a/tests/semgrep/scripts/tests/python_exceptions.py
+++ b/tests/semgrep/scripts/tests/python_exceptions.py
@@ -63,6 +63,11 @@ def typed_completed_process() -> subprocess.CompletedProcess[str]:
     return subprocess.CompletedProcess(args=[], returncode=0, stdout="ok", stderr="")
 
 
+def direct_subprocess_run() -> None:
+    # ruleid: delaunay.python.no-direct-subprocess-run-outside-wrapper
+    subprocess.run(["git", "status"], check=False)
+
+
 # ruleid: delaunay.python.no-untyped-defs-in-scripts
 def missing_return_annotation():
     return None

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -57,12 +57,12 @@ pub fn deep_crate_path_fixture() {
 }
 
 pub fn public_unwrap_bypass(value: Option<u8>) -> u8 {
-    // ruleid: delaunay.rust.no-production-unwrap-panic, delaunay.rust.no-public-surface-unwrap-panic
+    // ruleid: delaunay.rust.no-production-unwrap-panic, delaunay.rust.no-public-surface-unwrap-panic, delaunay.rust.no-unwrap-expect-in-benches-examples
     value.unwrap()
 }
 
 pub fn public_expect_bypass(value: Option<u8>) -> u8 {
-    // ruleid: delaunay.rust.no-production-unwrap-panic, delaunay.rust.no-public-surface-unwrap-panic
+    // ruleid: delaunay.rust.no-production-unwrap-panic, delaunay.rust.no-public-surface-unwrap-panic, delaunay.rust.no-unwrap-expect-in-benches-examples
     value.expect("public APIs should return typed errors instead")
 }
 
@@ -73,7 +73,7 @@ pub fn public_panic_bypass() {
 
 fn private_documented_invariant(value: Option<u8>) -> u8 {
     // ok: delaunay.rust.no-production-unwrap-panic
-    // ruleid: delaunay.rust.no-public-surface-unwrap-panic
+    // ruleid: delaunay.rust.no-public-surface-unwrap-panic, delaunay.rust.no-unwrap-expect-in-benches-examples
     value.expect("private helper documents an internal invariant")
 }
 
@@ -105,17 +105,17 @@ fn expect_without_reason_fixture() {}
 #[expect(clippy::too_many_lines, reason = "fixture documents the suppression")]
 fn expect_with_reason_fixture() {}
 
-// ruleid: delaunay.rust.no-box-dyn-error-in-src
+// ruleid: delaunay.rust.no-box-dyn-error-in-src, delaunay.rust.no-box-dyn-error-in-examples-benches
 type ProductionBoxedError = Box<dyn std::error::Error>;
 
 trait ProductionDynamicErrors {
-    // ruleid: delaunay.rust.no-box-dyn-error-in-src
+    // ruleid: delaunay.rust.no-box-dyn-error-in-src, delaunay.rust.no-box-dyn-error-in-examples-benches
     fn boxed_error_result(&self) -> Result<(), Box<dyn std::error::Error>>;
 
-    // ruleid: delaunay.rust.no-box-dyn-error-in-src
+    // ruleid: delaunay.rust.no-box-dyn-error-in-src, delaunay.rust.no-box-dyn-error-in-examples-benches
     fn borrowed_error(&self, error: &dyn std::error::Error);
 
-    // ruleid: delaunay.rust.no-box-dyn-error-in-src
+    // ruleid: delaunay.rust.no-box-dyn-error-in-src, delaunay.rust.no-box-dyn-error-in-examples-benches
     fn anyhow_error(&self, error: anyhow::Error);
 }
 

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -135,6 +135,7 @@ enum PrivateFixtureError {
     Invalid,
 }
 
+/// // ruleid: delaunay.rust.no-box-dyn-error-in-doctests
 /// # Ok::<(), Box<dyn std::error::Error>>(())
 fn doctest_style_error_is_ignored() {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,12 @@ revision = 3
 requires-python = ">=3.11"
 
 [[package]]
+name = "actionlint-py"
+version = "1.7.12.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0b/3f29683dfbe94208fb5c3806806a6ef419972892e25c3c4f95198f68c978/actionlint_py-1.7.12.24.tar.gz", hash = "sha256:7571b0724fde79b2572b98b2b53792c470249d4db29951b57fc49b9cd3eaf11e", size = 12071, upload-time = "2026-03-31T06:21:35.015Z" }
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -321,10 +327,14 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "actionlint-py" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "semgrep" },
+    { name = "shellcheck-py" },
+    { name = "shfmt-py" },
     { name = "ty" },
+    { name = "yamllint" },
 ]
 
 [package.metadata]
@@ -332,10 +342,14 @@ requires-dist = [{ name = "packaging" }]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "actionlint-py", specifier = "==1.7.12.24" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "ruff", specifier = ">=0.12.11" },
     { name = "semgrep", specifier = ">=1.152.0" },
+    { name = "shellcheck-py", specifier = "==0.11.0.1" },
+    { name = "shfmt-py", specifier = "==4.0.0" },
     { name = "ty", specifier = ">=0.0.8" },
+    { name = "yamllint", specifier = "==1.38.0" },
 ]
 
 [[package]]
@@ -679,6 +693,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
 name = "peewee"
 version = "3.19.0"
 source = { registry = "https://pypi.org/simple" }
@@ -925,6 +948,61 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]
@@ -1209,6 +1287,31 @@ wheels = [
 ]
 
 [[package]]
+name = "shellcheck-py"
+version = "0.11.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/55/455b097417b3df3d330eff029c72c32f08b25739e3010acb30ad06d268ef/shellcheck_py-0.11.0.1.tar.gz", hash = "sha256:5c620c88901e8f1d3be5934b31ea99e3310065e1245253741eafd0a275c8c9cc", size = 3139, upload-time = "2025-08-09T17:53:42.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/27/d75b03e5458cefdb6d3b674566cd20476c3e4d3fe6cc9d68b7e3b854b296/shellcheck_py-0.11.0.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b6a3fee28efda2e16e38d6e6d59faf7224300256456639727370d404730849e8", size = 6774472, upload-time = "2025-08-09T17:53:34.573Z" },
+    { url = "https://files.pythonhosted.org/packages/61/ac/2a84c37171c0cf5a10ea4b0a27d43eb0a1d29bd98b49c2c5ffe17ad24bbe/shellcheck_py-0.11.0.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b88d0a244c82ed07e06a53e444da841f69330ca59ae15d4a66c391655dae7a0", size = 11381835, upload-time = "2025-08-09T17:53:36.852Z" },
+    { url = "https://files.pythonhosted.org/packages/96/55/250e0e3367613a5c22bd82e33b16b889287d81ab0f7dda67e6514a4cccf4/shellcheck_py-0.11.0.1-py2.py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b274df81de5b000ff78db433e7328b87e52e3c38481c60f8e488c3095beef05", size = 3800600, upload-time = "2025-08-09T17:53:38.643Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5b/bb14c0a7474463b1aa3c09e866cb172dffc66ed2993b7ea8f1db581e86ee/shellcheck_py-0.11.0.1-py2.py3-none-win_amd64.whl", hash = "sha256:784156289ecb17e91c692cd783ab5152333309588cabb10032a047331c63e759", size = 8027541, upload-time = "2025-08-09T17:53:40.889Z" },
+]
+
+[[package]]
+name = "shfmt-py"
+version = "4.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/d5/c2ad5c6593a34da7344cf39bde65763e8cda752589074ba1619e55b317ad/shfmt_py-4.0.0.tar.gz", hash = "sha256:1e5fdacf40aabaa77a97639d52a6220df0893b46658d82b7f136f4e66e2b2fb0", size = 11947, upload-time = "2026-05-13T09:25:50.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/1d/8f72824e2a0e06dc0bc2687baacaba0573be7d2e93c01d1e895fddd8c13e/shfmt_py-4.0.0-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:75a4919a03fb3bcff9795e3cc7b971e37e74905654d2f11605001cab42e5f92f", size = 1343695, upload-time = "2026-05-13T09:25:42.969Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/82/9564a2c2a76fbec94db1b3a3c37a9a1d00e7eafca2cdd2e0d19082618d7e/shfmt_py-4.0.0-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:bb3d236163ff39c7790953e069938caf247e7646399f7a059f00f65d4e6916d6", size = 1237947, upload-time = "2026-05-13T09:25:44.767Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a9/6fce944efa530db941edd11388d70dc7384aaf12169a3b0847b6a6c987b0/shfmt_py-4.0.0-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:4701336c3cb5f3959a5e85481b14f02054ea094b3c666f3d04649bbe10de3c25", size = 1218771, upload-time = "2026-05-13T09:25:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/64/43/e3965a25bb39555f2791c6860214f62b6f976f9ac7e9786073364bcdd9a6/shfmt_py-4.0.0-py2.py3-none-manylinux2014_x86_64.whl", hash = "sha256:e57877abe0177a9da7bbb5390fe7e96aa19b00958189a025634039aef8834d44", size = 1350939, upload-time = "2026-05-13T09:25:47.584Z" },
+    { url = "https://files.pythonhosted.org/packages/95/20/db2430d9262d2cffadcad2b330441e13031f1ab849ec069659edb7f23257/shfmt_py-4.0.0-py2.py3-none-win_amd64.whl", hash = "sha256:bd4f3d36264d4ba8b014ff73e5e702aaa2345845c021f563480128de3705135b", size = 1427721, upload-time = "2026-05-13T09:25:48.865Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1379,6 +1482,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
     { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
     { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
+]
+
+[[package]]
+name = "yamllint"
+version = "1.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathspec" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a0/8fc2d68e132cf918f18273fdc8a1b8432b60d75ac12fdae4b0ef5c9d2e8d/yamllint-1.38.0.tar.gz", hash = "sha256:09e5f29531daab93366bb061e76019d5e91691ef0a40328f04c927387d1d364d", size = 142446, upload-time = "2026-01-13T07:47:53.276Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/92/aed08e68de6e6a3d7c2328ce7388072cd6affc26e2917197430b646aed02/yamllint-1.38.0-py3-none-any.whl", hash = "sha256:fc394a5b3be980a4062607b8fdddc0843f4fa394152b6da21722f5d59013c220", size = 68940, upload-time = "2026-01-13T07:47:51.343Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Bump the crate MSRV, pinned toolchain, clippy MSRV, and contributor docs to Rust 1.96.0.
- Align pinned developer tools and install Cargo tools through cache-cargo-install-action where appropriate.
- Add the Zizmor workflow and tighten workflow/Semgrep policy for checkout credentials, GitHub script interpolation, doctest error handling, and subprocess wrappers.
- Replace doctest and test assert-matches patterns with std::assert_matches! / assert_matches! diagnostics.

BREAKING CHANGE: The minimum supported Rust version is now 1.96.0.

Closes #430