### PR TITLE
refactor(api)!: require refined generator and ordering parameters

### DIFF
--- a/src/core/util/hilbert.rs
+++ b/src/core/util/hilbert.rs
@@ -10,7 +10,12 @@
 #![forbid(unsafe_code)]
 
 use crate::geometry::traits::coordinate::CoordinateScalar;
+use core::fmt;
 use num_traits::cast;
+use std::num::NonZeroU32;
+
+/// Maximum supported Hilbert bit depth per coordinate accepted by [`HilbertBitDepth`].
+pub const MAX_HILBERT_BITS: u32 = 31;
 
 /// Errors that can occur during Hilbert curve operations.
 #[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
@@ -99,42 +104,125 @@ pub enum HilbertError {
     },
 }
 
+/// Validated Hilbert bit depth per coordinate.
+///
+/// Values are constrained to the inclusive range from `1` through
+/// [`MAX_HILBERT_BITS`], matching the `u32` quantization grid used by the
+/// Hilbert ordering implementation. Public Hilbert APIs accept this type so raw
+/// bit-depth validation happens once at the boundary instead of being repeated
+/// during sorting or index computation.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError, MAX_HILBERT_BITS};
+///
+/// let bits = HilbertBitDepth::try_new(8)?;
+/// assert_eq!(bits.get(), 8);
+/// assert!(HilbertBitDepth::try_new(MAX_HILBERT_BITS).is_ok());
+///
+/// std::assert_matches!(
+///     HilbertBitDepth::try_new(0),
+///     Err(HilbertError::InvalidBitsParameter { bits: 0 })
+/// );
+/// # Ok::<(), HilbertError>(())
+/// ```
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[must_use]
+pub struct HilbertBitDepth(NonZeroU32);
+
+impl HilbertBitDepth {
+    /// Parses a raw bit depth into a validated Hilbert bit depth.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HilbertError::InvalidBitsParameter`] if `bits` is outside
+    /// the supported `1..=31` range.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError};
+    ///
+    /// let bits = HilbertBitDepth::try_new(12)?;
+    /// assert_eq!(bits.get(), 12);
+    ///
+    /// std::assert_matches!(
+    ///     HilbertBitDepth::try_new(32),
+    ///     Err(HilbertError::InvalidBitsParameter { bits: 32 })
+    /// );
+    /// # Ok::<(), HilbertError>(())
+    /// ```
+    pub const fn try_new(bits: u32) -> Result<Self, HilbertError> {
+        let Some(bits) = NonZeroU32::new(bits) else {
+            return Err(HilbertError::InvalidBitsParameter { bits: 0 });
+        };
+        if bits.get() > MAX_HILBERT_BITS {
+            return Err(HilbertError::InvalidBitsParameter { bits: bits.get() });
+        }
+        Ok(Self(bits))
+    }
+
+    /// Returns the validated bit depth as a raw integer.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError};
+    ///
+    /// let bits = HilbertBitDepth::try_new(16)?;
+    /// assert_eq!(bits.get(), 16);
+    /// # Ok::<(), HilbertError>(())
+    /// ```
+    #[must_use]
+    pub const fn get(self) -> u32 {
+        self.0.get()
+    }
+}
+
+impl TryFrom<u32> for HilbertBitDepth {
+    type Error = HilbertError;
+
+    fn try_from(bits: u32) -> Result<Self, Self::Error> {
+        Self::try_new(bits)
+    }
+}
+
+impl fmt::Display for HilbertBitDepth {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(f)
+    }
+}
+
 /// Converts a validated bit depth into a scalar grid maximum so Hilbert
 /// ordering cannot silently collapse when a coordinate type cannot represent it.
-fn quantization_scale<T: CoordinateScalar>(bits: u32) -> Result<(u32, T), HilbertError> {
-    let max_grid_value = (1_u32 << bits) - 1;
+fn quantization_scale<T: CoordinateScalar>(
+    bits: HilbertBitDepth,
+) -> Result<(u32, T), HilbertError> {
+    let bits_value = bits.get();
+    let max_grid_value = (1_u32 << bits_value) - 1;
     let Some(max_grid_value_scalar): Option<T> = cast(max_grid_value) else {
         return Err(HilbertError::QuantizationScaleConversionFailed {
-            bits,
+            bits: bits_value,
             max_grid_value,
         });
     };
     Ok((max_grid_value, max_grid_value_scalar))
 }
 
-/// Keeps every Hilbert entry point on the same accepted bit-depth range.
-const fn validate_bits(bits: u32) -> Result<(), HilbertError> {
-    if bits == 0 || bits > 31 {
-        return Err(HilbertError::InvalidBitsParameter { bits });
-    }
-    Ok(())
-}
-
 /// Computes encoded index width once so overflow errors report consistent context.
-fn total_bits<const D: usize>(bits: u32) -> Result<u128, HilbertError> {
+fn total_bits<const D: usize>(bits: HilbertBitDepth) -> Result<u128, HilbertError> {
     let d_u32 = u32::try_from(D).map_err(|_| HilbertError::DimensionTooLarge { dimension: D })?;
-    Ok(u128::from(d_u32) * u128::from(bits))
+    Ok(u128::from(d_u32) * u128::from(bits.get()))
 }
 
 /// Centralizes index-width validation shared by indexing and ordering APIs.
-fn validate_index_params<const D: usize>(bits: u32) -> Result<(), HilbertError> {
-    validate_bits(bits)?;
-
+fn validate_index_params<const D: usize>(bits: HilbertBitDepth) -> Result<(), HilbertError> {
     let total_bits = total_bits::<D>(bits)?;
     if total_bits > 128 {
         return Err(HilbertError::IndexOverflow {
             dimension: D,
-            bits,
+            bits: bits.get(),
             total_bits,
         });
     }
@@ -147,8 +235,6 @@ fn validate_index_params<const D: usize>(bits: u32) -> Result<(), HilbertError> 
 /// dimension and then clamped to `[0, 1]` before quantization.
 ///
 /// # Errors
-///
-/// Returns [`HilbertError::InvalidBitsParameter`] if `bits` is 0 or greater than 31.
 ///
 /// Returns [`HilbertError::QuantizationScaleConversionFailed`] if the quantization
 /// grid maximum cannot be represented by the coordinate scalar type.
@@ -165,20 +251,18 @@ fn validate_index_params<const D: usize>(bits: u32) -> Result<(), HilbertError> 
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::ordering::{hilbert_quantize, HilbertError};
+/// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError, hilbert_quantize};
 ///
 /// let coords = [0.5_f64, 0.25];
-/// let q = hilbert_quantize(&coords, (0.0, 1.0), 2)?;
+/// let q = hilbert_quantize(&coords, (0.0, 1.0), HilbertBitDepth::try_new(2)?)?;
 /// assert!(q[0] <= 3 && q[1] <= 3);
 /// # Ok::<(), HilbertError>(())
 /// ```
 pub fn hilbert_quantize<T: CoordinateScalar, const D: usize>(
     coords: &[T; D],
     bounds: (T, T),
-    bits: u32,
+    bits: HilbertBitDepth,
 ) -> Result<[u32; D], HilbertError> {
-    validate_bits(bits)?;
-
     if D == 0 {
         return Ok([0_u32; D]);
     }
@@ -194,7 +278,7 @@ pub fn hilbert_quantize<T: CoordinateScalar, const D: usize>(
 fn quantize_with_scale<T: CoordinateScalar, const D: usize>(
     coords: &[T; D],
     bounds: (T, T),
-    bits: u32,
+    bits: HilbertBitDepth,
     max_val_u32: u32,
     max_val_t: T,
 ) -> Result<[u32; D], HilbertError> {
@@ -236,7 +320,7 @@ fn quantize_with_scale<T: CoordinateScalar, const D: usize>(
         // Round to nearest grid cell (instead of truncating) for fairer distribution.
         let Some(value) = scaled.round().to_u32() else {
             return Err(HilbertError::QuantizedCoordinateConversionFailed {
-                bits,
+                bits: bits.get(),
                 max_grid_value: max_val_u32,
                 coordinate_index: i,
             });
@@ -274,8 +358,6 @@ fn apply_order<Item>(items: &mut [Item], order: Vec<usize>) {
 ///
 /// # Errors
 ///
-/// Returns [`HilbertError::InvalidBitsParameter`] if `bits` is 0 or greater than 31.
-///
 /// Returns [`HilbertError::IndexOverflow`] if `D * bits > 128` (index would not fit in `u128`).
 ///
 /// Returns [`HilbertError::DimensionTooLarge`] if the dimension `D` exceeds `u32::MAX`
@@ -296,16 +378,16 @@ fn apply_order<Item>(items: &mut [Item], order: Vec<usize>) {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::ordering::{hilbert_index, HilbertError};
+/// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError, hilbert_index};
 ///
-/// let idx = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), 4)?;
+/// let idx = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), HilbertBitDepth::try_new(4)?)?;
 /// assert_eq!(idx, 0);
 /// # Ok::<(), HilbertError>(())
 /// ```
 pub fn hilbert_index<T: CoordinateScalar, const D: usize>(
     coords: &[T; D],
     bounds: (T, T),
-    bits: u32,
+    bits: HilbertBitDepth,
 ) -> Result<u128, HilbertError> {
     validate_index_params::<D>(bits)?;
 
@@ -325,7 +407,8 @@ pub fn hilbert_index<T: CoordinateScalar, const D: usize>(
 /// The resulting ordering is continuous on the integer grid (successive indices move to
 /// adjacent cells).
 #[must_use]
-fn index_from_quantized<const D: usize>(coords: &[u32; D], bits: u32) -> u128 {
+fn index_from_quantized<const D: usize>(coords: &[u32; D], bits: HilbertBitDepth) -> u128 {
+    let bits = bits.get();
     debug_assert!(D > 0, "caller should handle D==0");
     debug_assert!(
         bits > 0 && bits <= 31,
@@ -408,8 +491,6 @@ fn index_from_quantized<const D: usize>(coords: &[u32; D], bits: u32) -> u128 {
 ///
 /// # Errors
 ///
-/// Returns [`HilbertError::InvalidBitsParameter`] if `bits` is 0 or greater than 31.
-///
 /// Returns [`HilbertError::IndexOverflow`] if `D * bits > 128` (index would not fit in `u128`).
 ///
 /// Returns [`HilbertError::DimensionTooLarge`] if the dimension `D` exceeds `u32::MAX`
@@ -430,18 +511,18 @@ fn index_from_quantized<const D: usize>(coords: &[u32; D], bits: u32) -> u128 {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::ordering::{hilbert_sort_by_stable, HilbertError};
+/// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError, hilbert_sort_by_stable};
 ///
 /// let mut points = vec![[0.9_f64, 0.9], [0.1, 0.1], [0.5, 0.5]];
-/// hilbert_sort_by_stable(&mut points, (0.0, 1.0), 8, |p| *p)?;
+/// hilbert_sort_by_stable(&mut points, (0.0, 1.0), HilbertBitDepth::try_new(8)?, |p| *p)?;
 /// assert_eq!(points[0], [0.1, 0.1]);
 /// # Ok::<(), HilbertError>(())
 /// ```
 pub fn hilbert_sort_by_stable<Item, T: CoordinateScalar, const D: usize>(
     items: &mut [Item],
     bounds: (T, T),
-    bits: u32,
-    coords_of: impl Fn(&Item) -> [T; D],
+    bits: HilbertBitDepth,
+    mut coords_of: impl FnMut(&Item) -> [T; D],
 ) -> Result<(), HilbertError> {
     validate_index_params::<D>(bits)?;
 
@@ -479,8 +560,6 @@ pub fn hilbert_sort_by_stable<Item, T: CoordinateScalar, const D: usize>(
 ///
 /// # Errors
 ///
-/// Returns [`HilbertError::InvalidBitsParameter`] if `bits` is 0 or greater than 31.
-///
 /// Returns [`HilbertError::IndexOverflow`] if `D * bits > 128` (index would not fit in `u128`).
 ///
 /// Returns [`HilbertError::DimensionTooLarge`] if the dimension `D` exceeds `u32::MAX`
@@ -501,18 +580,18 @@ pub fn hilbert_sort_by_stable<Item, T: CoordinateScalar, const D: usize>(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::ordering::{hilbert_sort_by_unstable, HilbertError};
+/// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError, hilbert_sort_by_unstable};
 ///
 /// let mut points = vec![[0.9_f64, 0.9], [0.1, 0.1], [0.5, 0.5]];
-/// hilbert_sort_by_unstable(&mut points, (0.0, 1.0), 8, |p| *p)?;
+/// hilbert_sort_by_unstable(&mut points, (0.0, 1.0), HilbertBitDepth::try_new(8)?, |p| *p)?;
 /// assert_eq!(points[0], [0.1, 0.1]);
 /// # Ok::<(), HilbertError>(())
 /// ```
 pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
     items: &mut [Item],
     bounds: (T, T),
-    bits: u32,
-    coords_of: impl Fn(&Item) -> [T; D],
+    bits: HilbertBitDepth,
+    mut coords_of: impl FnMut(&Item) -> [T; D],
 ) -> Result<(), HilbertError> {
     validate_index_params::<D>(bits)?;
 
@@ -553,8 +632,6 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
 ///
 /// # Errors
 ///
-/// Returns [`HilbertError::InvalidBitsParameter`] if `bits` is 0 or greater than 31.
-///
 /// Returns [`HilbertError::IndexOverflow`] if `D * bits > 128` (index would not fit in `u128`).
 ///
 /// Returns [`HilbertError::DimensionTooLarge`] if the dimension `D` exceeds `u32::MAX`
@@ -563,11 +640,13 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::ordering::{hilbert_indices_prequantized, hilbert_quantize, HilbertError};
+/// use delaunay::prelude::ordering::{
+///     HilbertBitDepth, HilbertError, hilbert_indices_prequantized, hilbert_quantize,
+/// };
 ///
 /// let coords = vec![[0.1_f64, 0.2], [0.5, 0.5], [0.9, 0.8]];
 /// let bounds = (0.0, 1.0);
-/// let bits = 8;
+/// let bits = HilbertBitDepth::try_new(8)?;
 ///
 /// // Quantize once
 /// let quantized: Vec<[u32; 2]> = coords
@@ -584,22 +663,29 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
 /// Error handling:
 ///
 /// ```rust
-/// use delaunay::prelude::ordering::{hilbert_indices_prequantized, HilbertError};
+/// use delaunay::prelude::ordering::{
+///     HilbertBitDepth, HilbertError, hilbert_indices_prequantized,
+/// };
 ///
+/// # fn main() -> Result<(), HilbertError> {
 /// let quantized = vec![[1_u32, 2]];
 ///
-/// // Invalid bits parameter
-/// let result = hilbert_indices_prequantized(&quantized, 0);
-/// std::assert_matches!(result, Err(HilbertError::InvalidBitsParameter { bits: 0 }));
+/// // Zero cannot cross the typed API boundary.
+/// std::assert_matches!(
+///     HilbertBitDepth::try_new(0),
+///     Err(HilbertError::InvalidBitsParameter { bits: 0 })
+/// );
 ///
 /// // Overflow (D=5, bits=26 => 130 > 128)
 /// let quantized_5d = vec![[1_u32, 2, 3, 4, 5]];
-/// let result = hilbert_indices_prequantized(&quantized_5d, 26);
+/// let result = hilbert_indices_prequantized(&quantized_5d, HilbertBitDepth::try_new(26)?);
 /// std::assert_matches!(result, Err(HilbertError::IndexOverflow { .. }));
+/// # Ok(())
+/// # }
 /// ```
 pub fn hilbert_indices_prequantized<const D: usize>(
     quantized: &[[u32; D]],
-    bits: u32,
+    bits: HilbertBitDepth,
 ) -> Result<Vec<u128>, HilbertError> {
     validate_index_params::<D>(bits)?;
 
@@ -621,8 +707,6 @@ pub fn hilbert_indices_prequantized<const D: usize>(
 ///
 /// # Errors
 ///
-/// Returns [`HilbertError::InvalidBitsParameter`] if `bits` is 0 or greater than 31.
-///
 /// Returns [`HilbertError::IndexOverflow`] if `D * bits > 128` (index would not fit in `u128`).
 ///
 /// Returns [`HilbertError::DimensionTooLarge`] if the dimension `D` exceeds `u32::MAX`
@@ -643,17 +727,17 @@ pub fn hilbert_indices_prequantized<const D: usize>(
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::ordering::{hilbert_sorted_indices, HilbertError};
+/// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError, hilbert_sorted_indices};
 ///
 /// let coords = vec![[0.9_f64, 0.9], [0.1, 0.1], [0.5, 0.5]];
-/// let order = hilbert_sorted_indices(&coords, (0.0, 1.0), 8)?;
+/// let order = hilbert_sorted_indices(&coords, (0.0, 1.0), HilbertBitDepth::try_new(8)?)?;
 /// assert_eq!(order.len(), coords.len());
 /// # Ok::<(), HilbertError>(())
 /// ```
 pub fn hilbert_sorted_indices<T: CoordinateScalar, const D: usize>(
     coords: &[[T; D]],
     bounds: (T, T),
-    bits: u32,
+    bits: HilbertBitDepth,
 ) -> Result<Vec<usize>, HilbertError> {
     validate_index_params::<D>(bits)?;
 
@@ -685,11 +769,44 @@ mod tests {
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::Coordinate;
 
+    fn bit_depth(value: u32) -> HilbertBitDepth {
+        HilbertBitDepth::try_new(value).expect("test bit depth must be valid")
+    }
+
+    #[test]
+    fn test_hilbert_bit_depth_boundaries_and_traits() {
+        let min_bits = HilbertBitDepth::try_new(1).expect("minimum bit depth should be valid");
+        let max_bits =
+            HilbertBitDepth::try_new(MAX_HILBERT_BITS).expect("maximum bit depth should be valid");
+
+        assert_eq!(min_bits.get(), 1);
+        assert_eq!(max_bits.get(), MAX_HILBERT_BITS);
+        assert_eq!(max_bits.to_string(), MAX_HILBERT_BITS.to_string());
+        assert_eq!(HilbertBitDepth::try_from(8), HilbertBitDepth::try_new(8));
+        assert_matches!(
+            HilbertBitDepth::try_new(0),
+            Err(HilbertError::InvalidBitsParameter { bits: 0 })
+        );
+        assert_matches!(
+            HilbertBitDepth::try_new(32),
+            Err(HilbertError::InvalidBitsParameter { bits: 32 })
+        );
+        assert_matches!(
+            HilbertBitDepth::try_from(0),
+            Err(HilbertError::InvalidBitsParameter { bits: 0 })
+        );
+        assert_matches!(
+            HilbertBitDepth::try_from(MAX_HILBERT_BITS + 1),
+            Err(HilbertError::InvalidBitsParameter { bits }) if bits == MAX_HILBERT_BITS + 1
+        );
+    }
+
     #[test]
     fn test_hilbert_index_2d() {
-        let origin = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), 4).unwrap();
-        let corner = hilbert_index(&[1.0_f64, 1.0], (0.0, 1.0), 4).unwrap();
-        let center = hilbert_index(&[0.5_f64, 0.5], (0.0, 1.0), 4).unwrap();
+        let bits = bit_depth(4);
+        let origin = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), bits).unwrap();
+        let corner = hilbert_index(&[1.0_f64, 1.0], (0.0, 1.0), bits).unwrap();
+        let center = hilbert_index(&[0.5_f64, 0.5], (0.0, 1.0), bits).unwrap();
 
         assert_eq!(origin, 0);
         assert_ne!(origin, center);
@@ -698,8 +815,9 @@ mod tests {
 
     #[test]
     fn test_hilbert_index_3d() {
-        let origin = hilbert_index(&[0.0_f64, 0.0, 0.0], (-1.0, 1.0), 8).unwrap();
-        let corner = hilbert_index(&[1.0_f64, 1.0, 1.0], (-1.0, 1.0), 8).unwrap();
+        let bits = bit_depth(8);
+        let origin = hilbert_index(&[0.0_f64, 0.0, 0.0], (-1.0, 1.0), bits).unwrap();
+        let corner = hilbert_index(&[1.0_f64, 1.0, 1.0], (-1.0, 1.0), bits).unwrap();
         assert_ne!(origin, corner);
     }
 
@@ -707,28 +825,57 @@ mod tests {
     fn test_hilbert_sorted_indices_and_sort_helpers() {
         let coords: Vec<[f64; 2]> =
             vec![[0.9, 0.9], [0.1, 0.1], [0.5, 0.5], [0.1, 0.9], [0.9, 0.1]];
-        let order = hilbert_sorted_indices(&coords, (0.0, 1.0), 16).unwrap();
+        let bits = bit_depth(16);
+        let order = hilbert_sorted_indices(&coords, (0.0, 1.0), bits).unwrap();
         assert_eq!(order.len(), coords.len());
 
         // Apply the ordering to a parallel payload.
         let mut payload: Vec<usize> = (0..coords.len()).collect();
-        hilbert_sort_by_stable(&mut payload, (0.0_f64, 1.0), 16, |&i| coords[i]).unwrap();
+        hilbert_sort_by_stable(&mut payload, (0.0_f64, 1.0), bits, |&i| coords[i]).unwrap();
 
         // Sorting by stable helper should be deterministic.
         let mut payload2: Vec<usize> = (0..coords.len()).collect();
-        hilbert_sort_by_stable(&mut payload2, (0.0_f64, 1.0), 16, |&i| coords[i]).unwrap();
+        hilbert_sort_by_stable(&mut payload2, (0.0_f64, 1.0), bits, |&i| coords[i]).unwrap();
         assert_eq!(payload, order);
         assert_eq!(payload, payload2);
+    }
+
+    #[test]
+    fn test_sort_helpers_accept_stateful_coordinate_closures() {
+        let coords: Vec<[f64; 2]> = vec![[0.9, 0.9], [0.1, 0.1], [0.5, 0.5]];
+        let bits = bit_depth(8);
+        let expected_order = hilbert_sorted_indices(&coords, (0.0, 1.0), bits).unwrap();
+
+        let mut stable_calls = 0_usize;
+        let mut stable_payload: Vec<usize> = (0..coords.len()).collect();
+        hilbert_sort_by_stable(&mut stable_payload, (0.0_f64, 1.0), bits, |&i| {
+            stable_calls += 1;
+            coords[i]
+        })
+        .unwrap();
+        assert_eq!(stable_payload, expected_order);
+        assert_eq!(stable_calls, coords.len());
+
+        let mut unstable_calls = 0_usize;
+        let mut unstable_payload: Vec<usize> = (0..coords.len()).collect();
+        hilbert_sort_by_unstable(&mut unstable_payload, (0.0_f64, 1.0), bits, |&i| {
+            unstable_calls += 1;
+            coords[i]
+        })
+        .unwrap();
+        assert_eq!(unstable_payload, expected_order);
+        assert_eq!(unstable_calls, coords.len());
     }
 
     #[test]
     fn test_unstable_sort_orders_by_key() {
         let coords: Vec<[f64; 2]> =
             vec![[0.9, 0.9], [0.1, 0.1], [0.5, 0.5], [0.1, 0.9], [0.9, 0.1]];
-        let expected_order = hilbert_sorted_indices(&coords, (0.0, 1.0), 16).unwrap();
+        let bits = bit_depth(16);
+        let expected_order = hilbert_sorted_indices(&coords, (0.0, 1.0), bits).unwrap();
 
         let mut payload: Vec<usize> = (0..coords.len()).collect();
-        hilbert_sort_by_unstable(&mut payload, (0.0_f64, 1.0), 16, |&i| coords[i]).unwrap();
+        hilbert_sort_by_unstable(&mut payload, (0.0_f64, 1.0), bits, |&i| coords[i]).unwrap();
 
         assert_eq!(payload, expected_order);
     }
@@ -736,21 +883,28 @@ mod tests {
     #[test]
     fn test_zero_dim_sort_helpers_noop() {
         let coords: Vec<[f64; 0]> = vec![[], [], []];
-        let order = hilbert_sorted_indices(&coords, (0.0, 1.0), 8).unwrap();
+        let bits = bit_depth(8);
+        let order = hilbert_sorted_indices(&coords, (0.0, 1.0), bits).unwrap();
         assert_eq!(order, vec![0, 1, 2]);
 
         let mut stable_payload = vec![3, 2, 1];
-        hilbert_sort_by_stable(&mut stable_payload, (0.0_f64, 1.0), 8, |_| []).unwrap();
+        hilbert_sort_by_stable(&mut stable_payload, (0.0_f64, 1.0), bits, |_| []).unwrap();
         assert_eq!(stable_payload, vec![3, 2, 1]);
 
         let mut unstable_payload = vec![3, 2, 1];
-        hilbert_sort_by_unstable(&mut unstable_payload, (0.0_f64, 1.0), 8, |_| []).unwrap();
+        hilbert_sort_by_unstable(&mut unstable_payload, (0.0_f64, 1.0), bits, |_| []).unwrap();
         assert_eq!(unstable_payload, vec![3, 2, 1]);
     }
 
     #[test]
     fn test_scaled_quantize_reports_conversion_error() {
-        let result = quantize_with_scale(&[1.0_f64], (0.0, 1.0), 31, u32::MAX, f64::INFINITY);
+        let result = quantize_with_scale(
+            &[1.0_f64],
+            (0.0, 1.0),
+            bit_depth(31),
+            u32::MAX,
+            f64::INFINITY,
+        );
 
         assert_matches!(
             result,
@@ -764,7 +918,7 @@ mod tests {
 
     #[test]
     fn test_quantize_rejects_nonfinite_bounds() {
-        let result = hilbert_quantize(&[0.5_f64], (f64::NAN, 1.0), 8);
+        let result = hilbert_quantize(&[0.5_f64], (f64::NAN, 1.0), bit_depth(8));
 
         assert_eq!(
             result,
@@ -777,14 +931,14 @@ mod tests {
 
     #[test]
     fn test_quantize_rejects_nonfinite_extent() {
-        let result = hilbert_quantize(&[0.0_f64], (-f64::MAX, f64::MAX), 8);
+        let result = hilbert_quantize(&[0.0_f64], (-f64::MAX, f64::MAX), bit_depth(8));
 
         assert_eq!(result, Err(HilbertError::NonFiniteBoundsExtent {}));
     }
 
     #[test]
     fn test_quantize_rejects_nonfinite_coordinate() {
-        let result = hilbert_quantize(&[0.25_f64, f64::INFINITY], (0.0, 1.0), 8);
+        let result = hilbert_quantize(&[0.25_f64, f64::INFINITY], (0.0, 1.0), bit_depth(8));
 
         assert_eq!(
             result,
@@ -796,7 +950,7 @@ mod tests {
 
     #[test]
     fn test_quantize_rejects_nonfinite_normalized() {
-        let result = hilbert_quantize(&[f64::MAX], (-f64::MAX / 2.0, f64::MAX / 2.0), 8);
+        let result = hilbert_quantize(&[f64::MAX], (-f64::MAX / 2.0, f64::MAX / 2.0), bit_depth(8));
 
         assert_eq!(
             result,
@@ -811,7 +965,7 @@ mod tests {
         let coords = [[0.5_f64], [f64::NAN], [0.25]];
         let mut payload = vec![0_usize, 1, 2];
 
-        let result = hilbert_sort_by_stable(&mut payload, (0.0, 1.0), 8, |&i| coords[i]);
+        let result = hilbert_sort_by_stable(&mut payload, (0.0, 1.0), bit_depth(8), |&i| coords[i]);
 
         assert_eq!(
             result,
@@ -824,7 +978,7 @@ mod tests {
 
     #[test]
     fn test_quantize_clamps_f32_endpoint() {
-        let q = hilbert_quantize(&[1.0_f32], (0.0, 1.0), 31).unwrap();
+        let q = hilbert_quantize(&[1.0_f32], (0.0, 1.0), bit_depth(31)).unwrap();
 
         assert_eq!(q, [(1_u32 << 31) - 1]);
     }
@@ -840,7 +994,7 @@ mod tests {
         for x in 0..n {
             for y in 0..n {
                 let q = [x, y];
-                let idx = index_from_quantized(&q, bits);
+                let idx = index_from_quantized(&q, bit_depth(bits));
                 points.push((q, idx));
             }
         }
@@ -876,7 +1030,7 @@ mod tests {
                 for z in 0..n {
                     for w in 0..n {
                         let q = [x, y, z, w];
-                        let idx = index_from_quantized(&q, bits);
+                        let idx = index_from_quantized(&q, bit_depth(bits));
                         points.push((q, idx));
                     }
                 }
@@ -906,20 +1060,22 @@ mod tests {
     #[test]
     fn test_point_coords_work_with_hilbert() {
         let p: Point<f64, 2> = Point::new([0.25, 0.75]);
-        let idx = hilbert_index(p.coords(), (0.0, 1.0), 16).unwrap();
+        let idx = hilbert_index(p.coords(), (0.0, 1.0), bit_depth(16)).unwrap();
         assert!(idx > 0);
     }
 
     #[test]
     fn test_hilbert_bits_boundaries() {
-        let origin = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), 1).unwrap();
-        let corner = hilbert_index(&[1.0_f64, 1.0], (0.0, 1.0), 1).unwrap();
+        let coarsest_bits = bit_depth(1);
+        let origin = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), coarsest_bits).unwrap();
+        let corner = hilbert_index(&[1.0_f64, 1.0], (0.0, 1.0), coarsest_bits).unwrap();
         tracing::debug!(origin, corner, "bits=1 boundaries");
         assert_eq!(origin, 0, "bits=1 origin should map to 0");
         assert_ne!(origin, corner, "bits=1 should distinguish corners");
 
-        let origin_31 = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), 31).unwrap();
-        let corner_31 = hilbert_index(&[1.0_f64, 1.0], (0.0, 1.0), 31).unwrap();
+        let finest_bits = bit_depth(31);
+        let origin_31 = hilbert_index(&[0.0_f64, 0.0], (0.0, 1.0), finest_bits).unwrap();
+        let corner_31 = hilbert_index(&[1.0_f64, 1.0], (0.0, 1.0), finest_bits).unwrap();
         tracing::debug!(origin_31, corner_31, "bits=31 boundaries");
         assert_eq!(origin_31, 0, "bits=31 origin should map to 0");
         assert_ne!(origin_31, corner_31, "bits=31 should distinguish corners");
@@ -928,7 +1084,7 @@ mod tests {
     #[test]
     fn test_hilbert_index_1d_monotonic() {
         let bounds = (0.0_f64, 1.0_f64);
-        let bits = 8;
+        let bits = bit_depth(8);
         let a = hilbert_index(&[0.0_f64], bounds, bits).unwrap();
         let b = hilbert_index(&[0.25_f64], bounds, bits).unwrap();
         let c = hilbert_index(&[0.5_f64], bounds, bits).unwrap();
@@ -944,8 +1100,9 @@ mod tests {
     fn test_hilbert_degenerate_bounds_quantize_to_zero() {
         let bounds = (1.0_f64, 1.0_f64);
         let coords = [2.0_f64, -2.0_f64];
-        let q = hilbert_quantize(&coords, bounds, 8).unwrap();
-        let idx = hilbert_index(&coords, bounds, 8).unwrap();
+        let bits = bit_depth(8);
+        let q = hilbert_quantize(&coords, bounds, bits).unwrap();
+        let idx = hilbert_index(&coords, bounds, bits).unwrap();
         tracing::debug!(?q, idx, "degenerate bounds");
         assert_eq!(q, [0, 0], "degenerate bounds should quantize to zeros");
         assert_eq!(idx, 0, "degenerate bounds should map to index 0");
@@ -954,10 +1111,10 @@ mod tests {
     #[test]
     fn test_hilbert_quantize_clamps_out_of_range() {
         let bounds = (0.0_f64, 1.0_f64);
-        let bits = 4;
+        let bits = bit_depth(4);
         let coords = [-1.0_f64, 2.0_f64];
         let q = hilbert_quantize(&coords, bounds, bits).unwrap();
-        let max_val = (1_u32 << bits) - 1;
+        let max_val = (1_u32 << bits.get()) - 1;
         tracing::debug!(?q, max_val, "clamp quantize");
         assert_eq!(
             q,
@@ -984,7 +1141,7 @@ mod tests {
             [1.0, 1.0, 1.0],
         ];
         let bounds = (0.0_f64, 1.0_f64);
-        let bits = 8;
+        let bits = bit_depth(8);
 
         // Quantize all coordinates
         let quantized: Vec<[u32; 3]> = coords
@@ -1009,7 +1166,7 @@ mod tests {
     #[test]
     fn test_hilbert_indices_prequantized_empty_input() {
         let empty: Vec<[u32; 2]> = vec![];
-        let bits = 4;
+        let bits = bit_depth(4);
 
         let indices =
             hilbert_indices_prequantized(&empty, bits).expect("valid parameters should succeed");
@@ -1017,24 +1174,10 @@ mod tests {
     }
 
     #[test]
-    fn test_hilbert_indices_prequantized_validates_bits_zero() {
-        let quantized = vec![[1_u32, 2]];
-        let result = hilbert_indices_prequantized(&quantized, 0);
-        assert_matches!(result, Err(HilbertError::InvalidBitsParameter { bits: 0 }));
-    }
-
-    #[test]
-    fn test_hilbert_indices_prequantized_validates_bits_too_large() {
-        let quantized = vec![[1_u32, 2]];
-        let result = hilbert_indices_prequantized(&quantized, 32);
-        assert_matches!(result, Err(HilbertError::InvalidBitsParameter { bits: 32 }));
-    }
-
-    #[test]
     fn test_hilbert_indices_prequantized_validates_overflow() {
         // With D=5 and bits=26, total_bits = 130 > 128
         let quantized = vec![[1_u32, 2, 3, 4, 5]];
-        let result = hilbert_indices_prequantized(&quantized, 26);
+        let result = hilbert_indices_prequantized(&quantized, bit_depth(26));
         assert_matches!(
             result,
             Err(HilbertError::IndexOverflow {
@@ -1049,7 +1192,7 @@ mod tests {
     fn test_hilbert_indices_prequantized_handles_zero_dimension() {
         // Zero-dimensional space has only one point, all map to index 0
         let quantized: Vec<[u32; 0]> = vec![[], [], []];
-        let bits = 8;
+        let bits = bit_depth(8);
 
         let indices = hilbert_indices_prequantized(&quantized, bits).expect("D=0 should succeed");
 
@@ -1060,7 +1203,7 @@ mod tests {
     #[test]
     fn test_hilbert_quantize_uses_rounding_not_truncation() {
         let bounds = (0.0_f64, 1.0_f64);
-        let bits = 2; // Grid has 4 cells: 0, 1, 2, 3
+        let bits = bit_depth(2); // Grid has 4 cells: 0, 1, 2, 3
 
         // With bits=2, max_val = 3, so we scale by 3.0.
         // coord * 3.0 is then rounded to nearest integer.

--- a/src/core/util/hilbert.rs
+++ b/src/core/util/hilbert.rs
@@ -102,6 +102,23 @@ pub enum HilbertError {
         /// The coordinate index whose rounded scaled value could not be converted.
         coordinate_index: usize,
     },
+
+    /// A pre-quantized coordinate exceeded the grid range implied by the bit depth.
+    #[error(
+        "pre-quantized Hilbert coordinate at point {point_index}, coordinate {coordinate_index} has value {coordinate}, which exceeds the maximum {max_grid_value} for {bits} bits"
+    )]
+    PrequantizedCoordinateOutOfRange {
+        /// The requested number of Hilbert bits per coordinate.
+        bits: u32,
+        /// The computed grid maximum, `2^bits - 1`.
+        max_grid_value: u32,
+        /// The point index whose pre-quantized coordinate was out of range.
+        point_index: usize,
+        /// The coordinate index whose value was out of range.
+        coordinate_index: usize,
+        /// The out-of-range pre-quantized coordinate value.
+        coordinate: u32,
+    },
 }
 
 /// Validated Hilbert bit depth per coordinate.
@@ -200,7 +217,7 @@ fn quantization_scale<T: CoordinateScalar>(
     bits: HilbertBitDepth,
 ) -> Result<(u32, T), HilbertError> {
     let bits_value = bits.get();
-    let max_grid_value = (1_u32 << bits_value) - 1;
+    let max_grid_value = max_quantized_coordinate(bits);
     let Some(max_grid_value_scalar): Option<T> = cast(max_grid_value) else {
         return Err(HilbertError::QuantizationScaleConversionFailed {
             bits: bits_value,
@@ -208,6 +225,14 @@ fn quantization_scale<T: CoordinateScalar>(
         });
     };
     Ok((max_grid_value, max_grid_value_scalar))
+}
+
+/// Returns the largest coordinate accepted by Hilbert APIs for the selected grid.
+///
+/// Keeping this calculation shared prevents the quantization and pre-quantized
+/// validation paths from drifting on the inclusive `0..=2^bits - 1` contract.
+const fn max_quantized_coordinate(bits: HilbertBitDepth) -> u32 {
+    (1_u32 << bits.get()) - 1
 }
 
 /// Computes encoded index width once so overflow errors report consistent context.
@@ -618,17 +643,47 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
     Ok(())
 }
 
+/// Validates that caller-supplied pre-quantized coordinates fit the selected grid.
+///
+/// This protects [`hilbert_indices_prequantized`] from passing high-bit values
+/// into [`index_from_quantized`], where bits above the selected depth are
+/// intentionally ignored by the Hilbert interleaving loop.
+fn validate_prequantized_coordinates<const D: usize>(
+    quantized: &[[u32; D]],
+    bits: HilbertBitDepth,
+) -> Result<(), HilbertError> {
+    let max_grid_value = max_quantized_coordinate(bits);
+    for (point_index, point) in quantized.iter().enumerate() {
+        for (coordinate_index, &coordinate) in point.iter().enumerate() {
+            if coordinate > max_grid_value {
+                return Err(HilbertError::PrequantizedCoordinateOutOfRange {
+                    bits: bits.get(),
+                    max_grid_value,
+                    point_index,
+                    coordinate_index,
+                    coordinate,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
 /// Compute Hilbert indices for a batch of pre-quantized coordinates.
 ///
 /// This is a bulk API that avoids recomputing quantization parameters for large
 /// insertion batches. When inserting many points, quantize them once using
 /// [`hilbert_quantize`] and then call this function to compute all indices in bulk.
+/// Pre-quantized coordinates must be in the inclusive range `0..=2^bits - 1`;
+/// values outside that grid are rejected instead of being truncated.
 ///
 /// # Performance
 ///
-/// This function validates parameters once and then maps each quantized coordinate
-/// through the internal Hilbert index computation. For large batches, this is significantly
-/// faster than calling [`hilbert_index`] individually for each point.
+/// This function validates index width and pre-quantized coordinate ranges, then
+/// maps each quantized coordinate through the internal Hilbert index computation.
+/// For large batches, this is significantly faster than calling [`hilbert_index`]
+/// individually for each point.
 ///
 /// # Errors
 ///
@@ -636,6 +691,9 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
 ///
 /// Returns [`HilbertError::DimensionTooLarge`] if the dimension `D` exceeds `u32::MAX`
 /// (extremely unlikely in practice).
+///
+/// Returns [`HilbertError::PrequantizedCoordinateOutOfRange`] if any pre-quantized
+/// coordinate exceeds `2^bits - 1`.
 ///
 /// # Examples
 ///
@@ -680,6 +738,14 @@ pub fn hilbert_sort_by_unstable<Item, T: CoordinateScalar, const D: usize>(
 /// let quantized_5d = vec![[1_u32, 2, 3, 4, 5]];
 /// let result = hilbert_indices_prequantized(&quantized_5d, HilbertBitDepth::try_new(26)?);
 /// std::assert_matches!(result, Err(HilbertError::IndexOverflow { .. }));
+///
+/// // Pre-quantized coordinates must fit the selected grid.
+/// let out_of_range = vec![[4_u32, 1]];
+/// let result = hilbert_indices_prequantized(&out_of_range, HilbertBitDepth::try_new(2)?);
+/// std::assert_matches!(
+///     result,
+///     Err(HilbertError::PrequantizedCoordinateOutOfRange { .. })
+/// );
 /// # Ok(())
 /// # }
 /// ```
@@ -693,6 +759,8 @@ pub fn hilbert_indices_prequantized<const D: usize>(
     if D == 0 {
         return Ok(vec![0_u128; quantized.len()]);
     }
+
+    validate_prequantized_coordinates(quantized, bits)?;
 
     Ok(quantized
         .iter()
@@ -773,6 +841,26 @@ mod tests {
         HilbertBitDepth::try_new(value).expect("test bit depth must be valid")
     }
 
+    /// Asserts that the bulk pre-quantized API matches per-point Hilbert indexing.
+    fn assert_prequantized_matches_hilbert_index<const D: usize>(
+        coords: &[[f64; D]],
+        bounds: (f64, f64),
+        bits: HilbertBitDepth,
+    ) {
+        let quantized: Vec<[u32; D]> = coords
+            .iter()
+            .map(|c| hilbert_quantize(c, bounds, bits).unwrap())
+            .collect();
+        let indices_bulk =
+            hilbert_indices_prequantized(&quantized, bits).expect("valid quantized points");
+        let indices_individual: Vec<u128> = coords
+            .iter()
+            .map(|c| hilbert_index(c, bounds, bits).unwrap())
+            .collect();
+
+        assert_eq!(indices_bulk, indices_individual);
+    }
+
     #[test]
     fn test_hilbert_bit_depth_boundaries_and_traits() {
         let min_bits = HilbertBitDepth::try_new(1).expect("minimum bit depth should be valid");
@@ -820,6 +908,34 @@ mod tests {
         let corner = hilbert_index(&[1.0_f64, 1.0, 1.0], (-1.0, 1.0), bits).unwrap();
         assert_ne!(origin, corner);
     }
+
+    macro_rules! gen_prequantized_matches_hilbert_index_tests {
+        ($dim:literal, $coords:expr, $bounds:expr, $bits:expr) => {
+            pastey::paste! {
+                #[test]
+                fn [<test_hilbert_indices_prequantized_matches_hilbert_index_ $dim d>]() {
+                    let coords: [[f64; $dim]; 4] = $coords;
+                    assert_prequantized_matches_hilbert_index(
+                        &coords,
+                        $bounds,
+                        bit_depth($bits),
+                    );
+                }
+            }
+        };
+    }
+
+    gen_prequantized_matches_hilbert_index_tests!(
+        5,
+        [
+            [-2.0, -1.0, 0.0, 1.0, 2.0],
+            [-1.5, 0.25, 1.75, 2.5, -0.5],
+            [0.1, -0.7, 2.2, -1.8, 1.4],
+            [3.0, 3.0, -2.0, -2.0, 0.5],
+        ],
+        (-2.0_f64, 3.0_f64),
+        8
+    );
 
     #[test]
     fn test_hilbert_sorted_indices_and_sort_helpers() {
@@ -1184,6 +1300,24 @@ mod tests {
                 dimension: 5,
                 bits: 26,
                 total_bits: 130
+            })
+        );
+    }
+
+    #[test]
+    fn test_hilbert_indices_prequantized_validates_coordinate_range() {
+        let bits = bit_depth(2);
+        let quantized = vec![[0_u32, 3], [4, 1]];
+        let result = hilbert_indices_prequantized(&quantized, bits);
+
+        assert_matches!(
+            result,
+            Err(HilbertError::PrequantizedCoordinateOutOfRange {
+                bits: 2,
+                max_grid_value: 3,
+                point_index: 1,
+                coordinate_index: 0,
+                coordinate: 4
             })
         );
     }

--- a/src/core/util/hilbert.rs
+++ b/src/core/util/hilbert.rs
@@ -926,6 +926,34 @@ mod tests {
     }
 
     gen_prequantized_matches_hilbert_index_tests!(
+        2,
+        [[-2.0, -1.0], [-1.5, 0.25], [0.1, -0.7], [3.0, 3.0]],
+        (-2.0_f64, 3.0_f64),
+        8
+    );
+    gen_prequantized_matches_hilbert_index_tests!(
+        3,
+        [
+            [-2.0, -1.0, 0.0],
+            [-1.5, 0.25, 1.75],
+            [0.1, -0.7, 2.2],
+            [3.0, 3.0, -2.0],
+        ],
+        (-2.0_f64, 3.0_f64),
+        8
+    );
+    gen_prequantized_matches_hilbert_index_tests!(
+        4,
+        [
+            [-2.0, -1.0, 0.0, 1.0],
+            [-1.5, 0.25, 1.75, 2.5],
+            [0.1, -0.7, 2.2, -1.8],
+            [3.0, 3.0, -2.0, -2.0],
+        ],
+        (-2.0_f64, 3.0_f64),
+        8
+    );
+    gen_prequantized_matches_hilbert_index_tests!(
         5,
         [
             [-2.0, -1.0, 0.0, 1.0, 2.0],

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -69,8 +69,8 @@ use crate::core::tds::{TdsConstructionError, TdsError};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
 use crate::core::util::{
-    coords_equal_exact, coords_within_epsilon, hilbert_indices_prequantized, hilbert_quantize,
-    stable_hash_u64_slice,
+    HilbertBitDepth, coords_equal_exact, coords_within_epsilon, hilbert_indices_prequantized,
+    hilbert_quantize, stable_hash_u64_slice,
 };
 use crate::core::validation::{TopologyGuarantee, ValidationPolicy};
 use crate::core::vertex::Vertex;
@@ -1779,7 +1779,7 @@ where
 
 /// Computes the largest per-axis Hilbert precision that still fits in the
 /// u128-backed index.
-fn hilbert_bits_per_coord<const D: usize>() -> Option<u32> {
+fn hilbert_bits_per_coord<const D: usize>() -> Option<HilbertBitDepth> {
     if D == 0 {
         return None;
     }
@@ -1791,11 +1791,7 @@ fn hilbert_bits_per_coord<const D: usize>() -> Option<u32> {
     // `hilbert_index` encodes D coordinates with `bits` bits each into a `u128`.
     // Use as many bits as possible (up to the `hilbert` module's `bits <= 31` bound).
     let bits_per_coord = (128_u32 / d_u32).min(31);
-    if bits_per_coord == 0 {
-        return None;
-    }
-
-    Some(bits_per_coord)
+    HilbertBitDepth::try_new(bits_per_coord).ok()
 }
 
 /// Converts vertex coordinates for diagnostics without synthesizing sentinel values.

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -4821,6 +4821,41 @@ mod tests {
 
     type TestDelaunay<const D: usize> = DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D>;
 
+    #[test]
+    fn test_random_point_generation_error_variant_preserved() {
+        let source = crate::geometry::util::RandomPointGenerationError::InvalidRange {
+            min: "5.0".to_string(),
+            max: "1.0".to_string(),
+        };
+        let err = DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayConstructionFailure::RandomPointGeneration {
+                source: source.clone(),
+            },
+        );
+
+        assert!(!matches!(
+            &err,
+            DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayConstructionFailure::GeometricDegeneracy { .. }
+            )
+        ));
+
+        let mut current_source = std::error::Error::source(&err);
+        let mut preserved_source = None;
+        while let Some(source_error) = current_source {
+            if let Some(random_source) =
+                source_error.downcast_ref::<crate::geometry::util::RandomPointGenerationError>()
+            {
+                preserved_source = Some(random_source);
+                break;
+            }
+            current_source = source_error.source();
+        }
+        let preserved_source =
+            preserved_source.expect("RandomPointGeneration should preserve its typed source");
+        assert_eq!(preserved_source, &source);
+    }
+
     fn init_tracing() {
         static INIT: Once = Once::new();
         INIT.call_once(|| {

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -266,6 +266,14 @@ pub enum DelaunayConstructionFailure {
         source: SimplexValidationError,
     },
 
+    /// Random point generation failed before construction could begin.
+    #[error("random point generation failed: {source}")]
+    RandomPointGeneration {
+        /// Structured random point generation failure.
+        #[source]
+        source: crate::geometry::util::RandomPointGenerationError,
+    },
+
     /// Geometric degeneracy prevented construction.
     #[error("geometric degeneracy encountered during construction: {message}")]
     GeometricDegeneracy {

--- a/src/geometry/util/point_generation.rs
+++ b/src/geometry/util/point_generation.rs
@@ -483,7 +483,8 @@ pub fn generate_random_points_in_ball_seeded<
 /// # Errors
 ///
 /// Returns [`RandomPointGenerationError::RandomGenerationFailed`] if the requested
-/// grid size overflows `usize` or exceeds the grid allocation safety cap.
+/// grid size overflows `usize`, exceeds the grid allocation safety cap, or a
+/// grid index cannot be represented exactly by the coordinate scalar type.
 ///
 /// # References
 ///
@@ -565,13 +566,7 @@ pub fn generate_grid_points<T: CoordinateScalar, const D: usize>(
     for _ in 0..total_points {
         let mut coords = [T::zero(); D];
         for d in 0..D {
-            let index_as_scalar = safe_usize_to_scalar::<T>(idx[d]).map_err(|_| {
-                RandomPointGenerationError::RandomGenerationFailed {
-                    min: "0".to_string(),
-                    max: format!("{}", points_per_dim - 1),
-                    details: format!("Failed to convert grid index {idx:?} to coordinate type"),
-                }
-            })?;
+            let index_as_scalar = grid_index_as_scalar::<T, D>(&idx, d, points_per_dim)?;
             coords[d] = offset[d] + index_as_scalar * spacing;
         }
         points.push(Point::new(coords));
@@ -587,6 +582,24 @@ pub fn generate_grid_points<T: CoordinateScalar, const D: usize>(
     }
 
     Ok(points)
+}
+
+/// Converts one mixed-radix grid index component into the coordinate scalar type.
+///
+/// This keeps [`generate_grid_points`] from silently rounding large grid indices
+/// when a scalar type such as `f32` cannot represent every `usize` exactly.
+fn grid_index_as_scalar<T: CoordinateScalar, const D: usize>(
+    idx: &[usize; D],
+    coordinate_index: usize,
+    points_per_dim: usize,
+) -> Result<T, RandomPointGenerationError> {
+    safe_usize_to_scalar::<T>(idx[coordinate_index]).map_err(|_| {
+        RandomPointGenerationError::RandomGenerationFailed {
+            min: "0".to_string(),
+            max: format!("{}", points_per_dim - 1),
+            details: format!("Failed to convert grid index {idx:?} to coordinate type"),
+        }
+    })
 }
 
 /// Generate points using Poisson disk sampling for uniform distribution.
@@ -1333,6 +1346,25 @@ mod tests {
         } else {
             panic!("Expected RandomGenerationFailed error due to overflow");
         }
+    }
+
+    #[test]
+    fn test_generate_grid_points_index_conversion_failure() {
+        let first_inexact_f32_index = 1_usize << f32::MANTISSA_DIGITS;
+        let idx = [first_inexact_f32_index];
+        let result =
+            grid_index_as_scalar::<f32, 1>(&idx, 0, first_inexact_f32_index.saturating_add(1));
+
+        assert_matches!(
+            result,
+            Err(RandomPointGenerationError::RandomGenerationFailed {
+                min,
+                max,
+                details
+            }) if min == "0"
+                && max == first_inexact_f32_index.to_string()
+                && details.contains("Failed to convert grid index [16777216] to coordinate type")
+        );
     }
 
     // =============================================================================

--- a/src/geometry/util/point_generation.rs
+++ b/src/geometry/util/point_generation.rs
@@ -12,6 +12,7 @@ use crate::geometry::traits::coordinate::{Coordinate, CoordinateScalar};
 use rand::distr::uniform::SampleUniform;
 use rand::rngs::StdRng;
 use rand::{RngExt, SeedableRng};
+use std::num::NonZeroUsize;
 
 // Re-export error type
 pub use super::RandomPointGenerationError;
@@ -471,7 +472,7 @@ pub fn generate_random_points_in_ball_seeded<
 ///
 /// # Arguments
 ///
-/// * `points_per_dim` - Number of points along each dimension
+/// * `points_per_dim` - Non-zero number of points along each dimension
 /// * `spacing` - Distance between adjacent grid points
 /// * `offset` - Translation offset for the entire grid
 ///
@@ -481,7 +482,8 @@ pub fn generate_random_points_in_ball_seeded<
 ///
 /// # Errors
 ///
-/// * `RandomPointGenerationError::InvalidPointCount` if `points_per_dim` is zero
+/// Returns [`RandomPointGenerationError::RandomGenerationFailed`] if the requested
+/// grid size overflows `usize` or exceeds the grid allocation safety cap.
 ///
 /// # References
 ///
@@ -494,30 +496,39 @@ pub fn generate_random_points_in_ball_seeded<
 /// use delaunay::prelude::generators::{
 ///     RandomPointGenerationError, generate_grid_points,
 /// };
+/// use std::num::NonZeroUsize;
 ///
 /// # fn main() -> Result<(), RandomPointGenerationError> {
+/// let Some(four) = NonZeroUsize::new(4) else {
+///     return Ok(());
+/// };
+/// let Some(three) = NonZeroUsize::new(3) else {
+///     return Ok(());
+/// };
+/// let Some(two) = NonZeroUsize::new(2) else {
+///     return Ok(());
+/// };
+///
 /// // Generate 2D grid: 4x4 = 16 points with unit spacing
-/// let grid_2d = generate_grid_points::<f64, 2>(4, 1.0, [0.0, 0.0])?;
+/// let grid_2d = generate_grid_points::<f64, 2>(four, 1.0, [0.0, 0.0])?;
 /// assert_eq!(grid_2d.len(), 16);
 ///
 /// // Generate 3D grid: 3x3x3 = 27 points with spacing 2.0
-/// let grid_3d = generate_grid_points::<f64, 3>(3, 2.0, [0.0, 0.0, 0.0])?;
+/// let grid_3d = generate_grid_points::<f64, 3>(three, 2.0, [0.0, 0.0, 0.0])?;
 /// assert_eq!(grid_3d.len(), 27);
 ///
 /// // Generate 4D grid centered at origin
-/// let grid_4d = generate_grid_points::<f64, 4>(2, 1.0, [-0.5, -0.5, -0.5, -0.5])?;
+/// let grid_4d = generate_grid_points::<f64, 4>(two, 1.0, [-0.5, -0.5, -0.5, -0.5])?;
 /// assert_eq!(grid_4d.len(), 16); // 2^4 = 16 points
 /// # Ok(())
 /// # }
 /// ```
 pub fn generate_grid_points<T: CoordinateScalar, const D: usize>(
-    points_per_dim: usize,
+    points_per_dim: NonZeroUsize,
     spacing: T,
     offset: [T; D],
 ) -> Result<Vec<Point<T, D>>, RandomPointGenerationError> {
-    if points_per_dim == 0 {
-        return Err(RandomPointGenerationError::InvalidPointCount { n_points: 0 });
-    }
+    let points_per_dim = points_per_dim.get();
 
     // Compute total_points with overflow checking (avoids debug panic or release wrap)
     let mut total_points: usize = 1;
@@ -723,6 +734,11 @@ mod tests {
     use super::*;
     use approx::assert_relative_eq;
     use std::assert_matches;
+
+    /// Builds non-zero test literals so grid-generation tests exercise the typed boundary.
+    const fn nonzero(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("test point count must be non-zero")
+    }
 
     // =============================================================================
     // RANDOM POINT GENERATION TESTS
@@ -1172,7 +1188,7 @@ mod tests {
     #[test]
     fn test_generate_grid_points_2d() {
         // Test 2D grid generation
-        let grid = generate_grid_points::<f64, 2>(3, 1.0, [0.0, 0.0]).unwrap();
+        let grid = generate_grid_points::<f64, 2>(nonzero(3), 1.0, [0.0, 0.0]).unwrap();
 
         assert_eq!(grid.len(), 9); // 3^2 = 9 points
 
@@ -1205,7 +1221,7 @@ mod tests {
     #[test]
     fn test_generate_grid_points_3d() {
         // Test 3D grid generation
-        let grid = generate_grid_points::<f64, 3>(2, 2.0, [1.0, 1.0, 1.0]).unwrap();
+        let grid = generate_grid_points::<f64, 3>(nonzero(2), 2.0, [1.0, 1.0, 1.0]).unwrap();
 
         assert_eq!(grid.len(), 8); // 2^3 = 8 points
 
@@ -1221,7 +1237,8 @@ mod tests {
     #[test]
     fn test_generate_grid_points_4d() {
         // Test 4D grid generation
-        let grid = generate_grid_points::<f32, 4>(2, 0.5, [-0.5, -0.5, -0.5, -0.5]).unwrap();
+        let grid =
+            generate_grid_points::<f32, 4>(nonzero(2), 0.5, [-0.5, -0.5, -0.5, -0.5]).unwrap();
 
         assert_eq!(grid.len(), 16); // 2^4 = 16 points
 
@@ -1237,7 +1254,8 @@ mod tests {
     #[test]
     fn test_generate_grid_points_5d() {
         // Test 5D grid generation
-        let grid = generate_grid_points::<f64, 5>(2, 1.0, [0.0, 0.0, 0.0, 0.0, 0.0]).unwrap();
+        let grid =
+            generate_grid_points::<f64, 5>(nonzero(2), 1.0, [0.0, 0.0, 0.0, 0.0, 0.0]).unwrap();
 
         assert_eq!(grid.len(), 32); // 2^5 = 32 points
 
@@ -1253,7 +1271,7 @@ mod tests {
     #[test]
     fn test_generate_grid_points_edge_cases() {
         // Test single point grid
-        let grid = generate_grid_points::<f64, 3>(1, 1.0, [0.0, 0.0, 0.0]).unwrap();
+        let grid = generate_grid_points::<f64, 3>(nonzero(1), 1.0, [0.0, 0.0, 0.0]).unwrap();
         assert_eq!(grid.len(), 1);
         let coords = *grid[0].coords();
         // Use approx for floating point comparison
@@ -1262,7 +1280,7 @@ mod tests {
         }
 
         // Test zero spacing
-        let grid = generate_grid_points::<f64, 2>(2, 0.0, [5.0, 5.0]).unwrap();
+        let grid = generate_grid_points::<f64, 2>(nonzero(2), 0.0, [5.0, 5.0]).unwrap();
         assert_eq!(grid.len(), 4);
         for point in &grid {
             let coords = *point.coords();
@@ -1275,18 +1293,11 @@ mod tests {
 
     #[test]
     fn test_generate_grid_points_error_handling() {
-        // Test zero points per dimension
-        let result = generate_grid_points::<f64, 2>(0, 1.0, [0.0, 0.0]);
-        assert!(result.is_err());
-        match result {
-            Err(RandomPointGenerationError::InvalidPointCount { n_points }) => {
-                assert_eq!(n_points, 0);
-            }
-            _ => panic!("Expected InvalidPointCount error"),
-        }
+        // Zero points per dimension cannot cross the typed API boundary.
+        assert_eq!(NonZeroUsize::new(0), None);
 
         // Test safety cap for excessive points (prevents OOM)
-        let result = generate_grid_points::<f64, 3>(1000, 1.0, [0.0, 0.0, 0.0]);
+        let result = generate_grid_points::<f64, 3>(nonzero(1000), 1.0, [0.0, 0.0, 0.0]);
         assert!(result.is_err());
         let error_msg = format!("{}", result.unwrap_err());
         assert!(error_msg.contains("cap"));
@@ -1306,7 +1317,7 @@ mod tests {
         let spacing = 0.1; // This would require 10^64 points which overflows usize
         let points_per_dim = 10;
 
-        let result = generate_grid_points::<f64, LARGE_D>(points_per_dim, spacing, offset);
+        let result = generate_grid_points::<f64, LARGE_D>(nonzero(points_per_dim), spacing, offset);
         assert!(result.is_err(), "Expected error due to usize overflow");
 
         if let Err(RandomPointGenerationError::RandomGenerationFailed {
@@ -1563,11 +1574,11 @@ mod tests {
     fn test_generate_grid_points_overflow_detection_edge_cases() {
         // Test cases that would cause potential memory issues in grid point calculation
         // Generate small grid to test the function works
-        let result = generate_grid_points::<f64, 2>(10, 0.1, [0.0, 0.0]);
+        let result = generate_grid_points::<f64, 2>(nonzero(10), 0.1, [0.0, 0.0]);
         assert!(result.is_ok());
 
         // Test very fine spacing which would generate lots of points
-        let result = generate_grid_points::<f64, 2>(1000, 0.0001, [0.0, 0.0]);
+        let result = generate_grid_points::<f64, 2>(nonzero(1000), 0.0001, [0.0, 0.0]);
         // Should either succeed or fail gracefully
         if let Ok(points) = result {
             assert!(!points.is_empty());

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -5,10 +5,12 @@
 
 #![forbid(unsafe_code)]
 
-use super::point_generation::{generate_random_points, generate_random_points_seeded};
+use super::point_generation::{
+    RandomPointGenerationError, generate_random_points, generate_random_points_seeded,
+};
 use crate::construction::{
-    ConstructionOptions, DelaunayTriangulationConstructionError, InsertionOrderStrategy,
-    RetryPolicy,
+    ConstructionOptions, DelaunayConstructionFailure, DelaunayTriangulationConstructionError,
+    InsertionOrderStrategy, RetryPolicy,
 };
 use crate::core::construction::TriangulationConstructionError;
 use crate::core::simplex::SimplexValidationError;
@@ -28,6 +30,42 @@ use std::num::NonZeroUsize;
 const RANDOM_TRIANGULATION_MAX_SHUFFLE_ATTEMPTS: usize = 6;
 const RANDOM_TRIANGULATION_MAX_POINTSET_ATTEMPTS: usize = 6;
 const RANDOM_TRIANGULATION_POINTSET_SEED_MIX: u64 = 0x9E37_79B9_7F4A_7C15;
+
+/// Wraps random point generation failures in the construction error hierarchy.
+///
+/// Keeping this mapping centralized preserves the public contract that invalid
+/// random-generation parameters remain distinguishable from geometric
+/// degeneracy during triangulation construction.
+const fn random_point_generation_error(
+    source: RandomPointGenerationError,
+) -> DelaunayTriangulationConstructionError {
+    DelaunayTriangulationConstructionError::Triangulation(
+        DelaunayConstructionFailure::RandomPointGeneration { source },
+    )
+}
+
+/// Generates random points through the seeded or unseeded public generator path.
+///
+/// This helper keeps all random triangulation entry points on the same typed
+/// error boundary: generation failures become
+/// [`DelaunayConstructionFailure::RandomPointGeneration`] before construction
+/// or validation can reinterpret them as geometric failures.
+fn random_points_with_seed<T, const D: usize>(
+    n_points: usize,
+    bounds: (T, T),
+    seed: Option<u64>,
+) -> Result<Vec<Point<T, D>>, DelaunayTriangulationConstructionError>
+where
+    T: CoordinateScalar + SampleUniform,
+{
+    seed.map_or_else(
+        || generate_random_points(n_points, bounds).map_err(random_point_generation_error),
+        |seed_value| {
+            generate_random_points_seeded(n_points, bounds, seed_value)
+                .map_err(random_point_generation_error)
+        },
+    )
+}
 
 fn validate_random_triangulation<K, U, V, const D: usize>(
     dt: DelaunayTriangulation<K, U, V, D>,
@@ -190,12 +228,9 @@ where
 ///
 /// Returns `DelaunayTriangulationConstructionError` with different variants depending on the failure:
 ///
-/// **Invalid parameters** (mapped to `GeometricDegeneracy`):
+/// **Random point generation** (`RandomPointGeneration`):
 /// - Point generation fails due to invalid bounds (e.g., `min > max`)
 /// - Random number generator initialization fails
-/// - **Note**: These are not strictly geometric degeneracy but are mapped to this
-///   error variant for API simplicity. Consider validating bounds before calling
-///   if you need to distinguish parameter errors from geometric issues.
 ///
 /// **Insufficient vertices** (`InsufficientVertices`):
 /// - When `n_points < D + 1` (need at least D+1 points for a D-dimensional simplex)
@@ -327,17 +362,11 @@ where
 /// # Errors
 ///
 /// Returns `Err(DelaunayTriangulationConstructionError)` if:
-/// - Random point generation fails (invalid bounds or RNG issues), mapped to
-///   `TriangulationConstructionError::GeometricDegeneracy`.
+/// - Random point generation fails (invalid bounds or RNG issues).
 /// - Triangulation construction fails due to geometric degeneracy, insertion errors, or the
 ///   requested topology guarantee not being satisfiable.
 /// - Validation fails after the robust fallback attempts.
-///
-/// # Errors
-///
-/// Returns `DelaunayTriangulationConstructionError` if internal point-set bookkeeping
-/// is inconsistent (initial point set unexpectedly consumed), point generation fails,
-/// or all construction attempts fail validation.
+/// - Internal point-set bookkeeping is inconsistent (initial point set unexpectedly consumed).
 ///
 /// # Examples
 ///
@@ -388,22 +417,7 @@ where
         .into());
     }
 
-    // Generate random points (seeded or unseeded)
-    // Note: GeometricDegeneracy error wraps both point generation failures (invalid bounds, RNG issues)
-    // and actual geometric degeneracy. This is a semantic approximation - point generation failures
-    // are not strictly geometric degeneracy, but map to this error for API simplicity.
-    let points: Vec<Point<T, D>> =
-        match seed {
-            Some(seed_value) => generate_random_points_seeded(n_points, bounds, seed_value)
-                .map_err(|e| TriangulationConstructionError::GeometricDegeneracy {
-                    message: format!("Random point generation failed: {e}"),
-                })?,
-            None => generate_random_points(n_points, bounds).map_err(|e| {
-                TriangulationConstructionError::GeometricDegeneracy {
-                    message: format!("Random point generation failed: {e}"),
-                }
-            })?,
-        };
+    let points: Vec<Point<T, D>> = random_points_with_seed(n_points, bounds, seed)?;
 
     let min_vertices = (n_points / 6).max(D + 1);
 
@@ -435,17 +449,7 @@ where
                 )
             })?
         } else {
-            match point_seed {
-                Some(seed_value) => generate_random_points_seeded(n_points, bounds, seed_value)
-                    .map_err(|e| TriangulationConstructionError::GeometricDegeneracy {
-                        message: format!("Random point generation failed: {e}"),
-                    })?,
-                None => generate_random_points(n_points, bounds).map_err(|e| {
-                    TriangulationConstructionError::GeometricDegeneracy {
-                        message: format!("Random point generation failed: {e}"),
-                    }
-                })?,
-            }
+            random_points_with_seed(n_points, bounds, point_seed)?
         };
 
         let vertices = random_triangulation_build_vertices(points, vertex_data);
@@ -710,18 +714,7 @@ where
             .into());
         }
 
-        // Generate random points
-        let points: Vec<Point<T, D>> = match self.seed {
-            Some(seed_value) => generate_random_points_seeded(n_points, self.bounds, seed_value)
-                .map_err(|e| TriangulationConstructionError::GeometricDegeneracy {
-                    message: format!("Random point generation failed: {e}"),
-                })?,
-            None => generate_random_points(n_points, self.bounds).map_err(|e| {
-                TriangulationConstructionError::GeometricDegeneracy {
-                    message: format!("Random point generation failed: {e}"),
-                }
-            })?,
-        };
+        let points: Vec<Point<T, D>> = random_points_with_seed(n_points, self.bounds, self.seed)?;
 
         // Convert to vertices
         let vertices = random_triangulation_build_vertices(points, vertex_data);
@@ -853,17 +846,90 @@ mod tests {
 
     #[test]
     fn test_generate_random_triangulation_error_cases() {
-        // Test invalid bounds
         let result = generate_random_triangulation::<f64, (), (), 2>(
             nonzero(10),
             (5.0, 1.0), // min > max
             None,
             Some(42),
         );
-        assert!(result.is_err());
+        let Err(DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayConstructionFailure::RandomPointGeneration { source },
+        )) = result
+        else {
+            panic!("expected RandomPointGeneration error");
+        };
+        assert_eq!(
+            source,
+            RandomPointGenerationError::InvalidRange {
+                min: "5.0".to_string(),
+                max: "1.0".to_string(),
+            }
+        );
 
         // Zero points cannot cross the typed API boundary.
         assert_eq!(NonZeroUsize::new(0), None);
+    }
+
+    #[test]
+    fn test_random_triangulation_builder_success_and_error_paths() {
+        let triangulation = RandomTriangulationBuilder::new(nonzero(10), (-5.0, 5.0))
+            .seed(42)
+            .build::<(), (), 2>()
+            .unwrap();
+        assert_eq!(triangulation.dim(), 2);
+        assert!(triangulation.number_of_vertices() >= 3);
+        assert!(triangulation.is_valid().is_ok());
+
+        let too_few_vertices =
+            RandomTriangulationBuilder::new(nonzero(2), (-1.0, 1.0)).build::<(), (), 2>();
+        let Err(DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayConstructionFailure::InsufficientVertices { dimension, source },
+        )) = too_few_vertices
+        else {
+            panic!("expected InsufficientVertices error");
+        };
+        assert_eq!(dimension, 2);
+        assert_eq!(
+            source,
+            SimplexValidationError::InsufficientVertices {
+                actual: 2,
+                expected: 3,
+                dimension: 2,
+            }
+        );
+
+        let invalid_bounds =
+            RandomTriangulationBuilder::new(nonzero(10), (5.0, 1.0)).build::<(), (), 2>();
+        let Err(DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayConstructionFailure::RandomPointGeneration { source },
+        )) = invalid_bounds
+        else {
+            panic!("expected RandomPointGeneration error");
+        };
+        assert_eq!(
+            source,
+            RandomPointGenerationError::InvalidRange {
+                min: "5.0".to_string(),
+                max: "1.0".to_string(),
+            }
+        );
+
+        let seeded_invalid_bounds = RandomTriangulationBuilder::new(nonzero(10), (5.0, 1.0))
+            .seed(42)
+            .build::<(), (), 2>();
+        let Err(DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayConstructionFailure::RandomPointGeneration { source },
+        )) = seeded_invalid_bounds
+        else {
+            panic!("expected seeded RandomPointGeneration error");
+        };
+        assert_eq!(
+            source,
+            RandomPointGenerationError::InvalidRange {
+                min: "5.0".to_string(),
+                max: "1.0".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -23,6 +23,7 @@ use rand::SeedableRng;
 use rand::distr::uniform::SampleUniform;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
+use std::num::NonZeroUsize;
 
 const RANDOM_TRIANGULATION_MAX_SHUFFLE_ATTEMPTS: usize = 6;
 const RANDOM_TRIANGULATION_MAX_POINTSET_ATTEMPTS: usize = 6;
@@ -174,7 +175,7 @@ where
 ///
 /// # Arguments
 ///
-/// * `n_points` - Number of random points to generate
+/// * `n_points` - Non-zero number of random points to generate
 /// * `bounds` - Coordinate bounds as `(min, max)` tuple
 /// * `vertex_data` - Optional data to attach to each generated vertex
 /// * `seed` - Optional seed for reproducible results. If `None`, uses thread-local RNG
@@ -196,12 +197,8 @@ where
 ///   error variant for API simplicity. Consider validating bounds before calling
 ///   if you need to distinguish parameter errors from geometric issues.
 ///
-/// **Empty triangulation** (special case):
-/// - When `n_points = 0`, returns an empty triangulation with 0 vertices and `dim()` = -1
-/// - This is not an error; use incremental insertion to add vertices later
-///
 /// **Insufficient vertices** (`InsufficientVertices`):
-/// - When `0 < n_points < D + 1` (need at least D+1 points for a D-dimensional simplex)
+/// - When `n_points < D + 1` (need at least D+1 points for a D-dimensional simplex)
 /// - Example: 1-2 points in 2D, 1-3 points in 3D
 ///
 /// **Geometric degeneracy** (`GeometricDegeneracy`):
@@ -221,11 +218,21 @@ where
 /// ```no_run
 /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::generators::generate_random_triangulation;
+/// use std::num::NonZeroUsize;
 ///
 /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+/// # let Some(fifty) = NonZeroUsize::new(50) else {
+/// #     return Ok(());
+/// # };
+/// # let Some(thirty) = NonZeroUsize::new(30) else {
+/// #     return Ok(());
+/// # };
+/// # let Some(twenty) = NonZeroUsize::new(20) else {
+/// #     return Ok(());
+/// # };
 /// // Generate a 2D triangulation with 50 points, no seed (random each time)
 /// let triangulation_2d = generate_random_triangulation::<f64, (), (), 2>(
-///     50,
+///     fifty,
 ///     (-10.0, 10.0),
 ///     None,
 ///     None
@@ -233,7 +240,7 @@ where
 ///
 /// // Generate a 3D triangulation with 30 points, seeded for reproducibility  
 /// let triangulation_3d = generate_random_triangulation::<f64, (), (), 3>(
-///     30,
+///     thirty,
 ///     (-5.0, 5.0),
 ///     None,
 ///     Some(42)
@@ -241,7 +248,7 @@ where
 ///
 /// // Generate a 4D triangulation with custom vertex data
 /// let triangulation_4d = generate_random_triangulation::<f64, i32, (), 4>(
-///     20,
+///     twenty,
 ///     (0.0, 1.0),
 ///     Some(123),
 ///     Some(456)
@@ -249,7 +256,7 @@ where
 ///
 /// // For string-like data, use fixed-size character arrays (Copy types)
 /// let triangulation_with_strings = generate_random_triangulation::<f64, [char; 8], (), 2>(
-///     20,
+///     twenty,
 ///     (0.0, 1.0),
 ///     Some(['v', 'e', 'r', 't', 'e', 'x', '_', 'A']),
 ///     Some(789)
@@ -285,7 +292,7 @@ where
 /// - [`DelaunayTriangulationBuilder`](crate::DelaunayTriangulationBuilder) - For creating triangulations from existing vertices
 /// - [`RandomTriangulationBuilder`] - For more control over construction options
 pub fn generate_random_triangulation<T, U, V, const D: usize>(
-    n_points: usize,
+    n_points: NonZeroUsize,
     bounds: (T, T),
     vertex_data: Option<U>,
     seed: Option<u64>,
@@ -298,7 +305,7 @@ where
     #[cfg(debug_assertions)]
     if std::env::var_os("DELAUNAY_DEBUG_UNUSED_IMPORTS").is_some() {
         tracing::debug!(
-            n_points,
+            n_points = n_points.get(),
             dimension = D,
             seed = ?seed,
             "triangulation_generation::generate_random_triangulation called"
@@ -338,10 +345,14 @@ where
 /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
 /// use delaunay::prelude::generators::generate_random_triangulation_with_topology_guarantee;
 /// use delaunay::prelude::TopologyGuarantee;
+/// use std::num::NonZeroUsize;
 ///
 /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+/// # let Some(twenty) = NonZeroUsize::new(20) else {
+/// #     return Ok(());
+/// # };
 /// let dt = generate_random_triangulation_with_topology_guarantee::<f64, (), (), 3>(
-///     20,
+///     twenty,
 ///     (-1.0, 1.0),
 ///     None,
 ///     Some(123),
@@ -352,7 +363,7 @@ where
 /// # }
 /// ```
 pub fn generate_random_triangulation_with_topology_guarantee<T, U, V, const D: usize>(
-    n_points: usize,
+    n_points: NonZeroUsize,
     bounds: (T, T),
     vertex_data: Option<U>,
     seed: Option<u64>,
@@ -363,15 +374,7 @@ where
     U: DataType,
     V: DataType,
 {
-    // Handle empty triangulation case (0 points)
-    if n_points == 0 {
-        return Ok(
-            DelaunayTriangulation::with_empty_kernel_and_topology_guarantee(
-                make_adaptive_kernel::<T>(),
-                topology_guarantee,
-            ),
-        );
-    }
+    let n_points = n_points.get();
 
     if n_points < D + 1 {
         return Err(TriangulationConstructionError::InsufficientVertices {
@@ -477,16 +480,23 @@ where
 /// use delaunay::prelude::generators::RandomTriangulationBuilder;
 /// use delaunay::prelude::generators::InsertionOrderStrategy;
 /// use delaunay::prelude::TopologyGuarantee;
+/// use std::num::NonZeroUsize;
 ///
 /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+/// # let Some(twenty) = NonZeroUsize::new(20) else {
+/// #     return Ok(());
+/// # };
+/// # let Some(one_hundred) = NonZeroUsize::new(100) else {
+/// #     return Ok(());
+/// # };
 /// // Override the default `Hilbert` ordering with `Input` ordering.
-/// let dt = RandomTriangulationBuilder::new(20, (-3.0, 3.0))
+/// let dt = RandomTriangulationBuilder::new(twenty, (-3.0, 3.0))
 ///     .seed(666)
 ///     .insertion_order(InsertionOrderStrategy::Input)
 ///     .build::<(), (), 3>()?;
 ///
 /// // Build with PLManifold guarantee
-/// let dt_manifold = RandomTriangulationBuilder::new(100, (-10.0, 10.0))
+/// let dt_manifold = RandomTriangulationBuilder::new(one_hundred, (-10.0, 10.0))
 ///     .seed(777)
 ///     .topology_guarantee(TopologyGuarantee::PLManifold)
 ///     .build::<(), (), 4>()?;
@@ -494,7 +504,7 @@ where
 /// # }
 /// ```
 pub struct RandomTriangulationBuilder<T> {
-    n_points: usize,
+    n_points: NonZeroUsize,
     bounds: (T, T),
     seed: Option<u64>,
     topology_guarantee: TopologyGuarantee,
@@ -506,7 +516,7 @@ impl<T> RandomTriangulationBuilder<T> {
     ///
     /// # Arguments
     ///
-    /// * `n_points` - Number of random points to generate
+    /// * `n_points` - Non-zero number of random points to generate
     /// * `bounds` - Coordinate bounds as `(min, max)` tuple
     ///
     /// # Defaults
@@ -523,12 +533,16 @@ impl<T> RandomTriangulationBuilder<T> {
     ///
     /// ```no_run
     /// use delaunay::prelude::generators::RandomTriangulationBuilder;
+    /// use std::num::NonZeroUsize;
     ///
-    /// let builder = RandomTriangulationBuilder::new(10, (-1.0, 1.0)).seed(42);
+    /// # let Some(ten) = NonZeroUsize::new(10) else {
+    /// #     return;
+    /// # };
+    /// let builder = RandomTriangulationBuilder::new(ten, (-1.0, 1.0)).seed(42);
     /// let _ = builder;
     /// ```
     #[must_use]
-    pub fn new(n_points: usize, bounds: (T, T)) -> Self {
+    pub fn new(n_points: NonZeroUsize, bounds: (T, T)) -> Self {
         Self {
             n_points,
             bounds,
@@ -562,10 +576,14 @@ impl<T> RandomTriangulationBuilder<T> {
     /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
     /// use delaunay::prelude::generators::RandomTriangulationBuilder;
     /// use delaunay::prelude::generators::InsertionOrderStrategy;
+    /// use std::num::NonZeroUsize;
     ///
     /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
+    /// # let Some(twenty) = NonZeroUsize::new(20) else {
+    /// #     return Ok(());
+    /// # };
     /// // Override the default `Hilbert` ordering with `Input` ordering.
-    /// let dt = RandomTriangulationBuilder::new(20, (-3.0, 3.0))
+    /// let dt = RandomTriangulationBuilder::new(twenty, (-3.0, 3.0))
     ///     .seed(666)
     ///     .insertion_order(InsertionOrderStrategy::Input)
     ///     .build::<(), (), 3>()?;
@@ -613,9 +631,13 @@ where
     /// ```no_run
     /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
     /// use delaunay::prelude::generators::RandomTriangulationBuilder;
+    /// use std::num::NonZeroUsize;
     ///
     /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
-    /// let dt = RandomTriangulationBuilder::new(12, (-2.0, 2.0))
+    /// # let Some(twelve) = NonZeroUsize::new(12) else {
+    /// #     return Ok(());
+    /// # };
+    /// let dt = RandomTriangulationBuilder::new(twelve, (-2.0, 2.0))
     ///     .seed(7)
     ///     .build::<(), (), 3>()?;
     /// assert_eq!(dt.dim(), 3);
@@ -650,9 +672,13 @@ where
     /// ```no_run
     /// use delaunay::prelude::construction::DelaunayTriangulationConstructionError;
     /// use delaunay::prelude::generators::RandomTriangulationBuilder;
+    /// use std::num::NonZeroUsize;
     ///
     /// # fn main() -> Result<(), DelaunayTriangulationConstructionError> {
-    /// let dt = RandomTriangulationBuilder::new(12, (-2.0, 2.0))
+    /// # let Some(twelve) = NonZeroUsize::new(12) else {
+    /// #     return Ok(());
+    /// # };
+    /// let dt = RandomTriangulationBuilder::new(twelve, (-2.0, 2.0))
     ///     .seed(7)
     ///     .build_with_vertex_data::<(), (), 3>(None)?;
     /// assert_eq!(dt.dim(), 3);
@@ -670,21 +696,13 @@ where
         U: DataType,
         V: DataType,
     {
-        // Handle empty triangulation case (0 points)
-        if self.n_points == 0 {
-            return Ok(
-                DelaunayTriangulation::with_empty_kernel_and_topology_guarantee(
-                    make_adaptive_kernel::<T>(),
-                    self.topology_guarantee,
-                ),
-            );
-        }
+        let n_points = self.n_points.get();
 
-        if self.n_points < D + 1 {
+        if n_points < D + 1 {
             return Err(TriangulationConstructionError::InsufficientVertices {
                 dimension: D,
                 source: SimplexValidationError::InsufficientVertices {
-                    actual: self.n_points,
+                    actual: n_points,
                     expected: D + 1,
                     dimension: D,
                 },
@@ -694,14 +712,11 @@ where
 
         // Generate random points
         let points: Vec<Point<T, D>> = match self.seed {
-            Some(seed_value) => {
-                generate_random_points_seeded(self.n_points, self.bounds, seed_value).map_err(
-                    |e| TriangulationConstructionError::GeometricDegeneracy {
-                        message: format!("Random point generation failed: {e}"),
-                    },
-                )?
-            }
-            None => generate_random_points(self.n_points, self.bounds).map_err(|e| {
+            Some(seed_value) => generate_random_points_seeded(n_points, self.bounds, seed_value)
+                .map_err(|e| TriangulationConstructionError::GeometricDegeneracy {
+                    message: format!("Random point generation failed: {e}"),
+                })?,
+            None => generate_random_points(n_points, self.bounds).map_err(|e| {
                 TriangulationConstructionError::GeometricDegeneracy {
                     message: format!("Random point generation failed: {e}"),
                 }
@@ -715,7 +730,7 @@ where
         #[cfg(debug_assertions)]
         if std::env::var_os("DELAUNAY_DEBUG_RANDOM_BUILDER").is_some() {
             tracing::debug!(
-                n_points = self.n_points,
+                n_points,
                 topology_guarantee = ?self.topology_guarantee,
                 insertion_order = ?self.construction_options.insertion_order(),
                 dedup_policy = ?self.construction_options.dedup_policy(),
@@ -737,6 +752,12 @@ where
 mod tests {
     use super::*;
     use crate::vertex;
+
+    /// Builds non-zero point-count literals for random triangulation tests.
+    const fn nonzero(value: usize) -> NonZeroUsize {
+        NonZeroUsize::new(value).expect("test point count must be non-zero")
+    }
+
     // =============================================================================
     // RANDOM TRIANGULATION GENERATION TESTS
     // =============================================================================
@@ -744,9 +765,13 @@ mod tests {
     #[test]
     fn test_generate_random_triangulation_basic() {
         // Test 2D triangulation creation
-        let triangulation_2d =
-            generate_random_triangulation::<f64, (), (), 2>(10, (-5.0, 5.0), None, Some(42))
-                .unwrap();
+        let triangulation_2d = generate_random_triangulation::<f64, (), (), 2>(
+            nonzero(10),
+            (-5.0, 5.0),
+            None,
+            Some(42),
+        )
+        .unwrap();
 
         assert!(
             triangulation_2d.number_of_vertices() >= 3,
@@ -761,9 +786,13 @@ mod tests {
         assert!(valid_2d.is_ok());
 
         // Test 3D triangulation creation with data
-        let triangulation_3d =
-            generate_random_triangulation::<f64, i32, (), 3>(8, (0.0, 1.0), Some(123), Some(456))
-                .unwrap();
+        let triangulation_3d = generate_random_triangulation::<f64, i32, (), 3>(
+            nonzero(8),
+            (0.0, 1.0),
+            Some(123),
+            Some(456),
+        )
+        .unwrap();
 
         assert!(
             triangulation_3d.number_of_vertices() >= 4,
@@ -778,13 +807,21 @@ mod tests {
         assert!(valid_3d.is_ok());
 
         // Exercise repeatable construction with two deterministic seeds.
-        let triangulation_seeded =
-            generate_random_triangulation::<f64, (), (), 2>(5, (-1.0, 1.0), None, Some(789))
-                .unwrap();
+        let triangulation_seeded = generate_random_triangulation::<f64, (), (), 2>(
+            nonzero(5),
+            (-1.0, 1.0),
+            None,
+            Some(789),
+        )
+        .unwrap();
 
-        let triangulation_different_seed =
-            generate_random_triangulation::<f64, (), (), 2>(5, (-1.0, 1.0), None, Some(790))
-                .unwrap();
+        let triangulation_different_seed = generate_random_triangulation::<f64, (), (), 2>(
+            nonzero(5),
+            (-1.0, 1.0),
+            None,
+            Some(790),
+        )
+        .unwrap();
 
         // Both should be valid
         let valid_seeded = triangulation_seeded.is_valid();
@@ -818,32 +855,35 @@ mod tests {
     fn test_generate_random_triangulation_error_cases() {
         // Test invalid bounds
         let result = generate_random_triangulation::<f64, (), (), 2>(
-            10,
+            nonzero(10),
             (5.0, 1.0), // min > max
             None,
             Some(42),
         );
         assert!(result.is_err());
 
-        // Test zero points - should succeed with empty triangulation
-        let result =
-            generate_random_triangulation::<f64, (), (), 2>(0, (-1.0, 1.0), None, Some(42));
-        assert!(result.is_ok());
-        let triangulation = result.unwrap();
-        assert_eq!(triangulation.number_of_vertices(), 0);
-        assert_eq!(triangulation.dim(), -1);
+        // Zero points cannot cross the typed API boundary.
+        assert_eq!(NonZeroUsize::new(0), None);
     }
 
     #[test]
     fn test_generate_random_triangulation_reproducibility() {
         // Same seed should produce identical triangulations
-        let triangulation1 =
-            generate_random_triangulation::<f64, (), (), 3>(6, (-2.0, 2.0), None, Some(12345))
-                .unwrap();
+        let triangulation1 = generate_random_triangulation::<f64, (), (), 3>(
+            nonzero(6),
+            (-2.0, 2.0),
+            None,
+            Some(12345),
+        )
+        .unwrap();
 
-        let triangulation2 =
-            generate_random_triangulation::<f64, (), (), 3>(6, (-2.0, 2.0), None, Some(12345))
-                .unwrap();
+        let triangulation2 = generate_random_triangulation::<f64, (), (), 3>(
+            nonzero(6),
+            (-2.0, 2.0),
+            None,
+            Some(12345),
+        )
+        .unwrap();
 
         // Should have same structural properties
         assert_eq!(
@@ -885,30 +925,46 @@ mod tests {
         // point sets in each dimension.
 
         // 2D with sufficient points for full triangulation
-        let tri_2d =
-            generate_random_triangulation::<f64, (), (), 2>(15, (0.0, 10.0), None, Some(555))
-                .unwrap();
+        let tri_2d = generate_random_triangulation::<f64, (), (), 2>(
+            nonzero(15),
+            (0.0, 10.0),
+            None,
+            Some(555),
+        )
+        .unwrap();
         assert_eq!(tri_2d.dim(), 2);
         assert!(tri_2d.number_of_simplices() > 0);
 
         // 3D with sufficient points for full triangulation
-        let tri_3d =
-            generate_random_triangulation::<f64, (), (), 3>(20, (-3.0, 3.0), None, Some(666))
-                .unwrap();
+        let tri_3d = generate_random_triangulation::<f64, (), (), 3>(
+            nonzero(20),
+            (-3.0, 3.0),
+            None,
+            Some(666),
+        )
+        .unwrap();
         assert_eq!(tri_3d.dim(), 3);
         assert!(tri_3d.number_of_simplices() > 0);
 
         // 4D with sufficient points for full triangulation
-        let tri_4d =
-            generate_random_triangulation::<f64, (), (), 4>(12, (-1.0, 1.0), None, Some(777))
-                .unwrap();
+        let tri_4d = generate_random_triangulation::<f64, (), (), 4>(
+            nonzero(12),
+            (-1.0, 1.0),
+            None,
+            Some(777),
+        )
+        .unwrap();
         assert_eq!(tri_4d.dim(), 4);
         assert!(tri_4d.number_of_simplices() > 0);
 
         // 5D with sufficient points for full triangulation
-        let tri_5d =
-            generate_random_triangulation::<f64, (), (), 5>(10, (0.0, 5.0), None, Some(888))
-                .unwrap();
+        let tri_5d = generate_random_triangulation::<f64, (), (), 5>(
+            nonzero(10),
+            (0.0, 5.0),
+            None,
+            Some(888),
+        )
+        .unwrap();
         assert_eq!(tri_5d.dim(), 5);
         assert!(tri_5d.number_of_simplices() > 0);
     }
@@ -921,7 +977,7 @@ mod tests {
         // NOTE: This is a workaround for the DataType trait requiring Copy, which
         // prevents using String or &str directly due to lifetime/ownership constraints
         let tri_with_char_array = generate_random_triangulation::<f64, [char; 8], (), 2>(
-            6,
+            nonzero(6),
             (-2.0, 2.0),
             Some(['v', 'e', 'r', 't', 'e', 'x', '_', 'd']),
             Some(888),
@@ -953,7 +1009,7 @@ mod tests {
         let mut last_err: Option<String> = None;
         for seed in seeds {
             match generate_random_triangulation::<f64, u32, (), 3>(
-                8,
+                nonzero(8),
                 (0.0, 5.0),
                 Some(42u32),
                 Some(seed),
@@ -985,9 +1041,13 @@ mod tests {
         assert!(valid_int.is_ok());
 
         // Test without data (None)
-        let tri_no_data =
-            generate_random_triangulation::<f64, (), (), 2>(5, (-1.0, 1.0), None, Some(111))
-                .unwrap();
+        let tri_no_data = generate_random_triangulation::<f64, (), (), 2>(
+            nonzero(5),
+            (-1.0, 1.0),
+            None,
+            Some(111),
+        )
+        .unwrap();
 
         assert!(
             tri_no_data.number_of_vertices() >= 3,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1279,8 +1279,9 @@ pub mod prelude {
     // In particular, exporting a local `uuid` module conflicts with the external `uuid`
     // crate name, making `use uuid::Uuid;` ambiguous for downstream users.
     pub use self::ordering::{
-        HilbertError, hilbert_index, hilbert_indices_prequantized, hilbert_quantize,
-        hilbert_sort_by_stable, hilbert_sort_by_unstable, hilbert_sorted_indices,
+        HilbertBitDepth, HilbertError, MAX_HILBERT_BITS, hilbert_index,
+        hilbert_indices_prequantized, hilbert_quantize, hilbert_sort_by_stable,
+        hilbert_sort_by_unstable, hilbert_sorted_indices,
     };
     pub use crate::core::util::{
         DeduplicationError, DelaunayValidationError, dedup_vertices_epsilon, dedup_vertices_exact,
@@ -1823,18 +1824,20 @@ pub mod prelude {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::ordering::{hilbert_sorted_indices, HilbertError};
+    /// use delaunay::prelude::ordering::{HilbertBitDepth, HilbertError, hilbert_sorted_indices};
     ///
     /// let coords = [[0.9_f64, 0.9], [0.1, 0.1], [0.5, 0.5]];
-    /// let order = hilbert_sorted_indices(&coords, (0.0, 1.0), 8)?;
+    /// let bits = HilbertBitDepth::try_new(8)?;
+    /// let order = hilbert_sorted_indices(&coords, (0.0, 1.0), bits)?;
     ///
     /// assert_eq!(order.len(), coords.len());
     /// # Ok::<(), HilbertError>(())
     /// ```
     pub mod ordering {
         pub use crate::core::util::{
-            HilbertError, hilbert_index, hilbert_indices_prequantized, hilbert_quantize,
-            hilbert_sort_by_stable, hilbert_sort_by_unstable, hilbert_sorted_indices,
+            HilbertBitDepth, HilbertError, MAX_HILBERT_BITS, hilbert_index,
+            hilbert_indices_prequantized, hilbert_quantize, hilbert_sort_by_stable,
+            hilbert_sort_by_unstable, hilbert_sorted_indices,
         };
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1376,6 +1376,7 @@ pub mod prelude {
             DelaunayTriangulationConstructionErrorWithStatistics, InitialSimplexStrategy,
             InsertionOrderStrategy, RetryPolicy,
         };
+        pub use crate::geometry::util::RandomPointGenerationError;
         pub use crate::repair::DelaunayRepairPolicy;
         pub use crate::tds::{
             SimplexValidationError, Vertex, VertexBuilder, VertexBuilderError,

--- a/tests/delaunay_edge_cases.rs
+++ b/tests/delaunay_edge_cases.rs
@@ -18,6 +18,12 @@ use delaunay::prelude::generators::generate_random_points_in_ball_seeded;
 use delaunay::prelude::geometry::RobustKernel;
 use rand::SeedableRng;
 use rand::seq::SliceRandom;
+use std::num::NonZeroUsize;
+
+const fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test point count must be non-zero")
+}
+
 fn init_tracing() {
     static INIT: std::sync::Once = std::sync::Once::new();
     INIT.call_once(|| {
@@ -465,7 +471,8 @@ test_regression_config!(
 #[test]
 fn test_regression_non_manifold_3d_seed123_50pts() {
     // Exact configuration from CI failure (matches ci_performance_suite.rs)
-    let n_points = 50;
+    let n_points = nonzero(50);
+    let raw_n_points = n_points.get();
     let result = delaunay::geometry::util::generate_random_triangulation_with_topology_guarantee::<
         f64,
         (),
@@ -491,10 +498,10 @@ fn test_regression_non_manifold_3d_seed123_50pts() {
     // Verify basic properties
     // Note: Some vertices may be skipped due to geometric degeneracy
     let num_vertices = dt.number_of_vertices();
-    let min_vertices = (n_points / 6).max(4);
+    let min_vertices = (raw_n_points / 6).max(4);
     assert!(
-        num_vertices <= n_points,
-        "Should have ≤{n_points} vertices, got {num_vertices}"
+        num_vertices <= raw_n_points,
+        "Should have ≤{raw_n_points} vertices, got {num_vertices}"
     );
     assert!(
         num_vertices >= min_vertices,
@@ -518,8 +525,9 @@ fn test_regression_non_manifold_3d_seed123_50pts() {
 #[test]
 fn test_regression_non_manifold_nearby_seeds() {
     let test_seeds = [120, 121, 122, 123, 124, 125, 126];
-    let n_points = 50;
-    let min_vertices = (n_points / 6).max(4);
+    let n_points = nonzero(50);
+    let raw_n_points = n_points.get();
+    let min_vertices = (raw_n_points / 6).max(4);
 
     for seed in test_seeds {
         let result =
@@ -547,7 +555,7 @@ fn test_regression_non_manifold_nearby_seeds() {
 
         let num_vertices = dt.number_of_vertices();
         assert!(
-            num_vertices <= n_points,
+            num_vertices <= raw_n_points,
             "Seed {seed}: too many vertices ({num_vertices})"
         );
         assert!(

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -51,8 +51,8 @@ use delaunay::prelude::insertion::{
     repair_neighbor_pointers_local,
 };
 use delaunay::prelude::ordering::{
-    HilbertError, hilbert_index, hilbert_indices_prequantized, hilbert_quantize,
-    hilbert_sort_by_stable, hilbert_sort_by_unstable, hilbert_sorted_indices,
+    HilbertBitDepth, HilbertError, MAX_HILBERT_BITS, hilbert_index, hilbert_indices_prequantized,
+    hilbert_quantize, hilbert_sort_by_stable, hilbert_sort_by_unstable, hilbert_sorted_indices,
 };
 use delaunay::prelude::query::{ConvexHull, QueryError};
 use delaunay::prelude::repair::{
@@ -612,25 +612,27 @@ fn diagnostics_prelude_covers_opt_in_helpers() -> Result<(), PreludeExportTestEr
 #[test]
 fn ordering_prelude_covers_hilbert_apis() -> Result<(), HilbertError> {
     let coords = [[0.9_f64, 0.9], [0.1, 0.1], [0.5, 0.5]];
-    let order = hilbert_sorted_indices(&coords, (0.0, 1.0), 8)?;
+    assert_eq!(MAX_HILBERT_BITS, 31);
+    let bits = HilbertBitDepth::try_new(8)?;
+    let order = hilbert_sorted_indices(&coords, (0.0, 1.0), bits)?;
     assert_eq!(order.len(), coords.len());
 
     let quantized: Vec<[u32; 2]> = coords
         .iter()
-        .map(|coord| hilbert_quantize(coord, (0.0, 1.0), 8))
+        .map(|coord| hilbert_quantize(coord, (0.0, 1.0), bits))
         .collect::<Result<_, _>>()?;
-    let indices = hilbert_indices_prequantized(&quantized, 8)?;
+    let indices = hilbert_indices_prequantized(&quantized, bits)?;
     assert_eq!(indices.len(), coords.len());
 
-    let index = hilbert_index(&coords[0], (0.0, 1.0), 8)?;
+    let index = hilbert_index(&coords[0], (0.0, 1.0), bits)?;
     assert_eq!(index, indices[0]);
 
     let mut stable_payload = vec![0_usize, 1, 2];
-    hilbert_sort_by_stable(&mut stable_payload, (0.0, 1.0), 8, |&i| coords[i])?;
+    hilbert_sort_by_stable(&mut stable_payload, (0.0, 1.0), bits, |&i| coords[i])?;
     assert_eq!(stable_payload, order);
 
     let mut unstable_payload = vec![0_usize, 1, 2];
-    hilbert_sort_by_unstable(&mut unstable_payload, (0.0, 1.0), 8, |&i| coords[i])?;
+    hilbert_sort_by_unstable(&mut unstable_payload, (0.0, 1.0), bits, |&i| coords[i])?;
     assert_eq!(unstable_payload, order);
 
     Ok(())

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -26,7 +26,8 @@ use delaunay::prelude::construction::{
     ExplicitDelaunayValidationError, ExplicitDelaunayValidationErrorKind,
     ExplicitDelaunayValidationSourceKind, ExplicitInsertionError, ExplicitInsertionErrorKind,
     ExplicitInvariantError, ExplicitInvariantErrorKind, ExplicitTdsError, ExplicitTdsErrorKind,
-    InsertionOrderStrategy, SimplexValidationError, TopologyGuarantee, Vertex, vertex,
+    InsertionOrderStrategy, RandomPointGenerationError, SimplexValidationError, TopologyGuarantee,
+    Vertex, vertex,
 };
 use delaunay::prelude::delaunayize::{
     DelaunayTriangulationBuilder as DelaunayizeDelaunayTriangulationBuilder, DelaunayizeConfig,
@@ -40,7 +41,7 @@ use delaunay::prelude::diagnostics::{
     verify_conflict_region_completeness,
 };
 use delaunay::prelude::flips::BistellarFlips;
-use delaunay::prelude::generators::{RandomPointGenerationError, generate_random_points_seeded};
+use delaunay::prelude::generators::generate_random_points_seeded;
 #[cfg(feature = "diagnostics")]
 use delaunay::prelude::geometry::{AdaptiveKernel, Coordinate};
 use delaunay::prelude::geometry::{
@@ -527,6 +528,19 @@ fn triangulation_prelude_covers_generic_layer() -> Result<(), GenericTriangulati
     assert_send_sync_unpin::<TriangulationQueryError>();
     assert_send_sync_unpin::<TriangulationTdsError>();
     Ok(())
+}
+
+#[test]
+fn construction_prelude_covers_random_point_generation_failure_variant() {
+    assert_matches!(
+        DelaunayConstructionFailure::RandomPointGeneration {
+            source: RandomPointGenerationError::InvalidRange {
+                min: "1.0".to_string(),
+                max: "0.0".to_string(),
+            },
+        },
+        DelaunayConstructionFailure::RandomPointGeneration { .. }
+    );
 }
 
 #[test]

--- a/tests/proptest_euler_characteristic.rs
+++ b/tests/proptest_euler_characteristic.rs
@@ -20,6 +20,7 @@ use delaunay::geometry::util::generate_random_triangulation_with_topology_guaran
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee, vertex};
 use delaunay::topology::characteristics::{euler, validation};
 use proptest::prelude::*;
+use std::num::NonZeroUsize;
 
 // =============================================================================
 // TEST CONFIGURATION
@@ -28,6 +29,11 @@ use proptest::prelude::*;
 /// Strategy for generating finite f64 coordinates
 fn finite_coordinate() -> impl Strategy<Value = f64> {
     (-100.0..100.0).prop_filter("must be finite", |x: &f64| x.is_finite())
+}
+
+/// Builds non-zero point-count literals for deterministic generator checks.
+const fn nonzero(value: usize) -> NonZeroUsize {
+    NonZeroUsize::new(value).expect("test point count must be non-zero")
 }
 
 // =============================================================================
@@ -166,7 +172,7 @@ macro_rules! test_euler_properties {
 #[test]
 fn test_seeded_random_generator_euler_consistent() {
     let dt_2d = generate_random_triangulation_with_topology_guarantee::<f64, (), (), 2>(
-        15,
+        nonzero(15),
         (0.0, 10.0),
         None,
         Some(555),
@@ -185,7 +191,7 @@ fn test_seeded_random_generator_euler_consistent() {
     );
 
     let dt_3d = generate_random_triangulation_with_topology_guarantee::<f64, (), (), 3>(
-        20,
+        nonzero(20),
         (-3.0, 3.0),
         None,
         Some(666),

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -15,7 +15,9 @@ use delaunay::prelude::geometry::{Point, RobustKernel};
 use delaunay::prelude::insertion::{
     HullExtensionReason, InsertionError, InsertionErrorKind, InsertionErrorSummary,
 };
-use delaunay::prelude::ordering::{hilbert_indices_prequantized, hilbert_quantize};
+use delaunay::prelude::ordering::{
+    HilbertBitDepth, hilbert_indices_prequantized, hilbert_quantize,
+};
 
 /// Replays a full Hilbert ordering while keeping only the prefix that first
 /// exposed issue #307, so the regression stays fast and deterministic.
@@ -24,7 +26,7 @@ fn hilbert_ordered_prefix<const D: usize>(
     prefix_len: usize,
 ) -> Vec<Vertex<f64, (), D>> {
     let (min, max) = coordinate_bounds(&points);
-    let bits_per_coord = 31;
+    let bits_per_coord = HilbertBitDepth::try_new(31).expect("test bit depth must be valid");
     let quantized: Vec<[u32; D]> = points
         .iter()
         .map(|point| {


### PR DESCRIPTION
- Add `HilbertBitDepth` for validated Hilbert ordering precision and route public ordering helpers through it.
- Require `NonZeroUsize` for grid and random triangulation generation counts.
- Remove the random generator's zero-count empty-triangulation path so empty triangulations stay on explicit constructors.

BREAKING CHANGE: Hilbert ordering APIs now take `HilbertBitDepth` instead of raw `u32` bit depths. `generate_grid_points`, `generate_random_triangulation`, `generate_random_triangulation_with_topology_guarantee`, and `RandomTriangulationBuilder::new` now take `NonZeroUsize`; random triangulation generation no longer accepts `0` to create an empty triangulation.

Closes #425