### PR TITLE
refactor(api)!: return fallible facet iterators

### DIFF
--- a/benches/README.md
+++ b/benches/README.md
@@ -66,9 +66,12 @@ benchmark-harness compile errors rather than publishing benchmark data.
 the release-mode large-scale harness. It runs the same 2D-5D cases as
 `just debug-large-scale-{2,3,4,5}d` with their local defaults, caps each test
 runtime at 60 seconds by default, and reports all failing dimensions before
-exiting. This is useful while iterating, but it is not a Criterion comparison
-and should not be treated as published benchmark data. Run it before pushing
-Rust or benchmark changes to catch obvious local performance drift early.
+exiting. At the end it also prints a compact 2D-5D summary table with the
+reported insertion wall time, total wall time, and pass/fail status so you do
+not have to scroll through the full nextest output. This is useful while
+iterating, but it is not a Criterion comparison and should not be treated as
+published benchmark data. Run it before pushing Rust or benchmark changes to
+catch obvious local performance drift early.
 
 For ordinary Rust or benchmark pushes, use the quick smoke guard with the usual
 correctness checks:

--- a/benches/boundary_uuid_iter.rs
+++ b/benches/boundary_uuid_iter.rs
@@ -50,8 +50,11 @@ fn bench_boundary_facets_micro(c: &mut Criterion) {
 
     for &requested_vertices in BOUNDARY_COUNTS_3D {
         let dt = boundary_triangulation_3d(requested_vertices);
-        let boundary_count =
-            bench_result(dt.boundary_facets(), "boundary facets should be available").count();
+        let boundary_count = bench_result(
+            bench_result(dt.boundary_facets(), "boundary facets should be available")
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1)),
+            "boundary facets should be valid",
+        );
         group.throughput(Throughput::Elements(bench_result(
             u64::try_from(boundary_count),
             "boundary facet count fits in u64",
@@ -62,17 +65,20 @@ fn bench_boundary_facets_micro(c: &mut Criterion) {
             &dt,
             |b, dt| {
                 b.iter(|| {
-                    black_box(
+                    black_box(bench_result(
                         bench_result(dt.boundary_facets(), "boundary facets should be available")
-                            .count(),
-                    );
+                            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1)),
+                        "boundary facets should be valid",
+                    ));
                 });
             },
         );
 
-        let boundary_facets =
+        let boundary_facets = bench_result(
             bench_result(dt.boundary_facets(), "boundary facets should be available")
-                .collect::<Vec<_>>();
+                .collect::<Result<Vec<_>, _>>(),
+            "boundary facets should be valid",
+        );
         group.bench_with_input(
             BenchmarkId::new("is_boundary_facet_3d", requested_vertices),
             &(&dt, boundary_facets),

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -335,6 +335,12 @@ The following previously deferred checks are now repository-owned Semgrep rules:
   no longer matched, while focused root modules such as `delaunay::flips::*`
   still trigger guidance toward the orthogonal prelude modules in public
   samples.
+- `delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers` keeps local
+  repair/topology simplex-key frontiers on `SimplexKeyBuffer` instead of raw
+  `Vec<SimplexKey>`. The rule is intentionally name-based and heuristic:
+  unbounded full-TDS snapshots, public/error payloads, serialization
+  boundaries, and other deliberately heap-backed collections should remain
+  `Vec`.
 
 ## Public Sample Error Handling
 

--- a/examples/topology_editing.rs
+++ b/examples/topology_editing.rs
@@ -32,7 +32,7 @@ use delaunay::prelude::geometry::{
 };
 use delaunay::prelude::insertion::InsertionError;
 use delaunay::prelude::validation::DelaunayTriangulationValidationError;
-use delaunay::prelude::{EdgeKeyError, TdsError, VertexKey};
+use delaunay::prelude::{EdgeKeyError, FacetError, TdsError, VertexKey};
 
 type ExampleResult<T = ()> = Result<T, TopologyEditingExampleError>;
 
@@ -48,6 +48,8 @@ enum TopologyEditingExampleError {
     Flip(#[from] FlipError),
     #[error(transparent)]
     Edge(#[from] EdgeKeyError),
+    #[error(transparent)]
+    Facet(#[from] FacetError),
     #[error(transparent)]
     Tds(#[from] TdsError),
     #[error(transparent)]
@@ -262,7 +264,7 @@ fn edit_api_2d_k2() -> ExampleResult {
 
     // Find an interior edge to flip
     let facet =
-        find_interior_facet_2d(&dt).ok_or(TopologyEditingExampleError::NoInteriorFacet {
+        find_interior_facet_2d(&dt)?.ok_or(TopologyEditingExampleError::NoInteriorFacet {
             demo: "2D k=2 demo",
         })?;
 
@@ -462,7 +464,7 @@ fn edit_api_3d_k2() -> ExampleResult {
     print_stats_3d(&dt);
 
     // Find an interior facet to flip
-    if let Some(facet) = find_interior_facet_3d(&dt) {
+    if let Some(facet) = find_interior_facet_3d(&dt)? {
         match dt.flip_k2(facet) {
             Ok(flip_info) => {
                 println!("\nApplied k=2 flip:");
@@ -534,7 +536,7 @@ fn edit_api_3d_k3() -> ExampleResult {
     print_stats_3d(&dt);
 
     // Try to find and flip a ridge
-    if let Some(ridge) = find_flippable_ridge_3d(&dt) {
+    if let Some(ridge) = find_flippable_ridge_3d(&dt)? {
         match dt.flip_k3(ridge) {
             Ok(flip_info) => {
                 println!("\n✓ k=3 flip succeeded:");
@@ -577,7 +579,7 @@ fn print_stats_3d<K: Kernel<3, Scalar = f64>>(dt: &DelaunayTriangulation<K, (), 
 
 fn find_interior_facet_2d<K: Kernel<2, Scalar = f64>>(
     dt: &DelaunayTriangulation<K, (), (), 2>,
-) -> Option<FacetHandle> {
+) -> ExampleResult<Option<FacetHandle>> {
     for (simplex_key, simplex) in dt.simplices() {
         if let Some(neighbors) = simplex.neighbors() {
             for (facet_idx, neighbor) in neighbors.enumerate() {
@@ -585,17 +587,21 @@ fn find_interior_facet_2d<K: Kernel<2, Scalar = f64>>(
                     let Ok(facet_idx) = u8::try_from(facet_idx) else {
                         continue;
                     };
-                    return FacetHandle::try_new(dt.tds(), simplex_key, facet_idx).ok();
+                    return Ok(Some(FacetHandle::try_new(
+                        dt.tds(),
+                        simplex_key,
+                        facet_idx,
+                    )?));
                 }
             }
         }
     }
-    None
+    Ok(None)
 }
 
 fn find_interior_facet_3d<K: Kernel<3, Scalar = f64>>(
     dt: &DelaunayTriangulation<K, (), (), 3>,
-) -> Option<FacetHandle> {
+) -> ExampleResult<Option<FacetHandle>> {
     for (simplex_key, simplex) in dt.simplices() {
         if let Some(neighbors) = simplex.neighbors() {
             for (facet_idx, neighbor) in neighbors.enumerate() {
@@ -603,17 +609,21 @@ fn find_interior_facet_3d<K: Kernel<3, Scalar = f64>>(
                     let Ok(facet_idx) = u8::try_from(facet_idx) else {
                         continue;
                     };
-                    return FacetHandle::try_new(dt.tds(), simplex_key, facet_idx).ok();
+                    return Ok(Some(FacetHandle::try_new(
+                        dt.tds(),
+                        simplex_key,
+                        facet_idx,
+                    )?));
                 }
             }
         }
     }
-    None
+    Ok(None)
 }
 
 fn find_flippable_ridge_3d<K: Kernel<3, Scalar = f64>>(
     dt: &DelaunayTriangulation<K, (), (), 3>,
-) -> Option<RidgeHandle> {
+) -> ExampleResult<Option<RidgeHandle>> {
     // Try to find any ridge (edge in 3D shared by multiple tetrahedra)
     for (simplex_key, simplex) in dt.simplices() {
         let vertex_count = simplex.number_of_vertices();
@@ -628,14 +638,12 @@ fn find_flippable_ridge_3d<K: Kernel<3, Scalar = f64>>(
             let Ok(omit_b) = u8::try_from(i + 1) else {
                 continue;
             };
-            let Ok(ridge) = RidgeHandle::try_new(dt.tds(), simplex_key, omit_a, omit_b) else {
-                continue;
-            };
+            let ridge = RidgeHandle::try_new(dt.tds(), simplex_key, omit_a, omit_b)?;
 
             // Just return the first one we find
             // (In practice, you'd want to check if it's actually flippable)
-            return Some(ridge);
+            return Ok(Some(ridge));
         }
     }
-    None
+    Ok(None)
 }

--- a/examples/triangulation_and_hull.rs
+++ b/examples/triangulation_and_hull.rs
@@ -95,7 +95,14 @@ fn run_case<const D: usize>(
     let index = dt.build_adjacency_index()?;
     println!("  edges:     {}", index.number_of_edges());
 
-    println!("  boundary facets: {}", dt.boundary_facets()?.count());
+    let boundary_facet_count = dt.boundary_facets()?.try_fold(0_usize, |count, facet| {
+        facet
+            .map(|_| count + 1)
+            .map_err(|source| QueryError::TriangulationCorrupted {
+                source: source.into(),
+            })
+    })?;
+    println!("  boundary facets: {boundary_facet_count}");
 
     let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;
     println!("  hull facets: {}", hull.number_of_facets());

--- a/justfile
+++ b/justfile
@@ -535,6 +535,7 @@ perf-large-scale-smoke max_secs="60": _ensure-nextest
 
     status=0
     failures=()
+    summaries=()
 
     run_case() {
         local dimension="$1"
@@ -542,6 +543,8 @@ perf-large-scale-smoke max_secs="60": _ensure-nextest
         local n_env="$3"
         local n_points="$4"
         local progress_every="$5"
+        local log_file
+        log_file="$(mktemp "${TMPDIR:-/tmp}/delaunay-large-scale-${dimension}.XXXXXX")"
 
         echo ""
         echo "▶ ${dimension}: ${test_name} (${n_points} vertices, ${max_secs}s cap)"
@@ -550,20 +553,39 @@ perf-large-scale-smoke max_secs="60": _ensure-nextest
             DELAUNAY_LARGE_DEBUG_MAX_RUNTIME_SECS="$max_secs" \
             "$n_env=$n_points" \
             DELAUNAY_LARGE_DEBUG_REPAIR_EVERY=1 \
-            cargo nextest run --release --profile slow --features slow-tests --test large_scale_debug "$test_name" -- --exact --nocapture; then
+            cargo nextest run --release --profile slow --features slow-tests --test large_scale_debug "$test_name" -- --exact --nocapture 2>&1 | tee "$log_file"; then
             echo "✅ ${dimension} completed within the ${max_secs}s test-runtime cap"
+            case_status="PASS"
         else
             local code=$?
             echo "❌ ${dimension} failed or exceeded the ${max_secs}s test-runtime cap (exit ${code})"
             failures+=("$dimension")
             status=1
+            case_status="FAIL"
         fi
+
+        local insertion_time total_time
+        insertion_time="$(awk -F': ' '/Insertion wall time:/ { value=$2 } END { print value }' "$log_file")"
+        total_time="$(awk -F': ' '/Total wall time:/ { value=$2 } END { print value }' "$log_file")"
+        [[ -n "$insertion_time" ]] || insertion_time="n/a"
+        [[ -n "$total_time" ]] || total_time="n/a"
+        summaries+=("$dimension|$n_points|$insertion_time|$total_time|$case_status")
+        rm -f "$log_file"
     }
 
     run_case "2D" "debug_large_scale_2d" "DELAUNAY_LARGE_DEBUG_N_2D" "36000" "2000"
     run_case "3D" "debug_large_scale_3d" "DELAUNAY_LARGE_DEBUG_N_3D" "7500" "500"
     run_case "4D" "debug_large_scale_4d" "DELAUNAY_LARGE_DEBUG_N_4D" "800" "100"
     run_case "5D" "debug_large_scale_5d" "DELAUNAY_LARGE_DEBUG_N_5D" "140" "20"
+
+    echo ""
+    echo "Large-scale smoke summary:"
+    printf '%-4s %10s %18s %18s %8s\n' "Dim" "Vertices" "Insertion wall" "Total wall" "Status"
+    printf '%-4s %10s %18s %18s %8s\n' "----" "--------" "--------------" "----------" "------"
+    for row in "${summaries[@]}"; do
+        IFS='|' read -r dimension n_points insertion_time total_time case_status <<< "$row"
+        printf '%-4s %10s %18s %18s %8s\n' "$dimension" "$n_points" "$insertion_time" "$total_time" "$case_status"
+    done
 
     if (( ${#failures[@]} > 0 )); then
         echo ""

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -152,6 +152,28 @@ rules:
               ...
           }
 
+  - id: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    languages:
+      - generic
+    severity: WARNING
+    message: >-
+      Raw Vec<SimplexKey> used for a local repair/topology frontier. Prefer
+      SimplexKeyBuffer unless this is an unbounded full-TDS snapshot, public
+      error payload, serialization boundary, or other intentionally heap-backed
+      collection.
+    metadata:
+      category: performance
+      rationale: >-
+        Local repair, mutation, and diagnostic frontiers are usually small and
+        should use the repository's semantic stack-backed buffer alias. Full
+        triangulation snapshots and public error payloads should remain Vec.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/project_rules/**/*.rs"
+    pattern-regex: >-
+      \b(?:(?:(?:pending|repair|seed|soft_fail|touched|affected|frontier|sample)_[A-Za-z0-9_]*|conflict_preview|(?:new|removed)_simplices)\s*:\s*(?:&\s*mut\s*)?Vec\s*<\s*SimplexKey\s*>|let\s+(?:mut\s+)?(?:(?:pending|repair|seed|soft_fail|touched|affected|frontier|sample)_[A-Za-z0-9_]*|conflict_preview|(?:new|removed)_simplices)\s*=\s*Vec\s*::\s*<\s*SimplexKey\s*>\s*::\s*(?:new|with_capacity)\s*\()
+
   - id: delaunay.rust.no-silent-conversion-fallbacks
     languages:
       - rust

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -172,7 +172,7 @@ rules:
         - "/src/**/*.rs"
         - "/tests/semgrep/src/project_rules/**/*.rs"
     pattern-regex: >-
-      \b(?:(?:(?:pending|repair|seed|soft_fail|touched|affected|frontier|sample)_[A-Za-z0-9_]*|conflict_preview|(?:new|removed)_simplices)\s*:\s*(?:&\s*mut\s*)?Vec\s*<\s*SimplexKey\s*>|let\s+(?:mut\s+)?(?:(?:pending|repair|seed|soft_fail|touched|affected|frontier|sample)_[A-Za-z0-9_]*|conflict_preview|(?:new|removed)_simplices)\s*=\s*Vec\s*::\s*<\s*SimplexKey\s*>\s*::\s*(?:new|with_capacity)\s*\()
+      \b(?:(?:(?:pending|repair|seed|soft_fail|touched|affected|frontier|sample)_[A-Za-z0-9_]*|conflict_preview|(?:new|removed)_simplices)\s*:\s*(?:&\s*mut\s*)?Vec\s*<\s*SimplexKey\s*>|let\s+(?:mut\s+)?(?:(?:pending|repair|seed|soft_fail|touched|affected|frontier|sample)_[A-Za-z0-9_]*|conflict_preview|(?:new|removed)_simplices)\s*=\s*Vec\s*::\s*(?:(?:<\s*SimplexKey\s*>\s*::\s*)?)(?:new|with_capacity)\s*\()
 
   - id: delaunay.rust.no-silent-conversion-fallbacks
     languages:

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -5801,6 +5801,7 @@ where
         }
     } else {
         for facet in AllFacetsIter::try_new(tds)? {
+            let facet = facet?;
             let handle = FacetHandle::from_validated(facet.simplex_key(), facet.facet_index());
             enqueue_facet(
                 tds,
@@ -7722,7 +7723,7 @@ where
             stats.max_queue_len = stats.max_queue_len.max(queues.total_len());
         }
         if repair_trace_enabled() {
-            let seed_sample: Vec<SimplexKey> = seeds.iter().copied().take(8).collect();
+            let seed_sample: SimplexKeyBuffer = seeds.iter().copied().take(8).collect();
             tracing::debug!(
                 "[repair] seed_repair_queues: seeds={} present={} missing={}",
                 seeds.len(),
@@ -7745,6 +7746,7 @@ where
         }
     } else {
         for facet in AllFacetsIter::try_new(tds)? {
+            let facet = facet?;
             let handle = FacetHandle::from_validated(facet.simplex_key(), facet.facet_index());
             enqueue_facet(
                 tds,
@@ -14093,7 +14095,7 @@ mod tests {
         let info = apply_bistellar_flip_k2(&mut tds, &context).unwrap();
 
         let kernel = AdaptiveKernel::<f64>::new();
-        let seed_simplices: Vec<SimplexKey> = info.new_simplices.iter().copied().collect();
+        let seed_simplices: SimplexKeyBuffer = info.new_simplices.iter().copied().collect();
         let stats = repair_delaunay_with_flips_k2_k3(
             &mut tds,
             &kernel,
@@ -14169,7 +14171,7 @@ mod tests {
         let info = apply_bistellar_flip_k3(&mut tds, &context).unwrap();
 
         let kernel = AdaptiveKernel::<f64>::new();
-        let seed_simplices: Vec<SimplexKey> = info.new_simplices.iter().copied().collect();
+        let seed_simplices: SimplexKeyBuffer = info.new_simplices.iter().copied().collect();
         let result = repair_delaunay_with_flips_k2_k3(
             &mut tds,
             &kernel,

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -3104,7 +3104,7 @@ where
 
     // Expand once through existing pointers.  This keeps the repair local while
     // including the surviving simplices whose facets may now match a repaired seed.
-    let seed_snapshot: Vec<SimplexKey> = affected_simplices.iter().copied().collect();
+    let seed_snapshot: SimplexKeyBuffer = affected_simplices.iter().copied().collect();
     for simplex_key in seed_snapshot {
         let Some(simplex) = tds.simplex(simplex_key) else {
             continue;
@@ -3306,7 +3306,7 @@ where
 {
     type FacetIncidents = SmallBuffer<(SimplexKey, u8), 2>;
 
-    let simplex_keys: Vec<SimplexKey> = tds.simplices().map(|(key, _)| key).collect();
+    let simplex_keys: SimplexKeyBuffer = tds.simplices().map(|(key, _)| key).collect();
 
     #[cfg(debug_assertions)]
     tracing::trace!(
@@ -3464,7 +3464,7 @@ where
     V: DataType,
 {
     // Sample a few simplices and try walking through their neighbor graph.
-    let sample_simplices: Vec<SimplexKey> = tds.simplices().map(|(key, _)| key).take(10).collect();
+    let sample_simplices: SimplexKeyBuffer = tds.simplices().map(|(key, _)| key).take(10).collect();
     let max_simplices = tds.number_of_simplices();
 
     for &start_simplex in &sample_simplices {
@@ -3531,7 +3531,7 @@ where
     U: DataType,
     V: DataType,
 {
-    let sample_simplices: Vec<SimplexKey> = sample_simplices.iter().copied().take(10).collect();
+    let sample_simplices: SimplexKeyBuffer = sample_simplices.iter().copied().take(10).collect();
     let max_simplices = tds.number_of_simplices();
 
     for &start_simplex in &sample_simplices {
@@ -3721,8 +3721,8 @@ where
 
         if boundary_facets.len() != 2 {
             return Err(InsertionError::HullExtension {
-                reason: HullExtensionReason::Other {
-                    message: format!(
+                reason: HullExtensionReason::InvalidPatch {
+                    details: format!(
                         "2D boundary edge split expected 2 facets, got {}",
                         boundary_facets.len()
                     ),
@@ -3759,7 +3759,11 @@ where
 
     #[cfg(debug_assertions)]
     if std::env::var_os("DELAUNAY_DEBUG_HULL").is_some() {
-        let total_boundary = tds.boundary_facets().map_or(0, Iterator::count);
+        let total_boundary = tds.boundary_facets().map_or(0, |mut facets| {
+            facets
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap_or(0)
+        });
         tracing::debug!(
             point = ?point,
             visible_facets = visible_facets.len(),
@@ -3786,6 +3790,41 @@ where
     Ok(new_simplices)
 }
 
+fn hull_extension_tds_error(source: impl Into<TdsError>) -> InsertionError {
+    InsertionError::HullExtension {
+        reason: HullExtensionReason::Tds(source.into()),
+    }
+}
+
+fn boundary_facet_iteration_error(source: FacetError) -> InsertionError {
+    hull_extension_tds_error(source)
+}
+
+fn missing_boundary_simplex(simplex_key: SimplexKey, context: &'static str) -> InsertionError {
+    hull_extension_tds_error(TdsError::SimplexNotFound {
+        simplex_key,
+        context: context.to_string(),
+    })
+}
+
+fn missing_boundary_vertex(
+    vertex_key: VertexKey,
+    simplex_key: SimplexKey,
+    context: &'static str,
+) -> InsertionError {
+    hull_extension_tds_error(TdsError::VertexNotFound {
+        vertex_key,
+        context: format!("{context} {simplex_key:?}"),
+    })
+}
+
+fn invalid_boundary_facet_index(facet_index: u8, facet_count: usize) -> InsertionError {
+    hull_extension_tds_error(FacetError::InvalidFacetIndex {
+        index: facet_index,
+        facet_count,
+    })
+}
+
 fn find_boundary_edge_split_facet<U, V, const D: usize>(
     tds: &Tds<U, V, D>,
     point: &Point<D>,
@@ -3808,27 +3847,20 @@ where
         })?;
 
     for facet_view in boundary_facets {
+        let facet_view = facet_view.map_err(boundary_facet_iteration_error)?;
         let simplex_key = facet_view.simplex_key();
         let facet_index = facet_view.facet_index();
-        let simplex = tds
-            .simplex(simplex_key)
-            .ok_or_else(|| InsertionError::HullExtension {
-                reason: HullExtensionReason::Other {
-                    message: format!("Boundary facet simplex {simplex_key:?} not found"),
-                },
-            })?;
+        let simplex = tds.simplex(simplex_key).ok_or_else(|| {
+            missing_boundary_simplex(simplex_key, "2D boundary edge split facet lookup")
+        })?;
 
         let mut edge_points = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
         let mut opposite_point: Option<Point<D>> = None;
 
         for (i, &vkey) in simplex.vertices().iter().enumerate() {
-            let vertex = tds
-                .vertex(vkey)
-                .ok_or_else(|| InsertionError::HullExtension {
-                    reason: HullExtensionReason::Other {
-                        message: format!("Vertex {vkey:?} not found in TDS"),
-                    },
-                })?;
+            let vertex = tds.vertex(vkey).ok_or_else(|| {
+                missing_boundary_vertex(vkey, simplex_key, "2D boundary edge split facet")
+            })?;
             if i == usize::from(facet_index) {
                 opposite_point = Some(*vertex.point());
             } else {
@@ -3840,13 +3872,8 @@ where
             continue;
         }
 
-        let opposite_point = opposite_point.ok_or_else(|| InsertionError::HullExtension {
-            reason: HullExtensionReason::Other {
-                message: format!(
-                    "Opposite vertex missing for facet {facet_index} in simplex {simplex_key:?}"
-                ),
-            },
-        })?;
+        let opposite_point = opposite_point
+            .ok_or_else(|| invalid_boundary_facet_index(facet_index, simplex.vertices().len()))?;
 
         let mut simplex_points = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
         simplex_points.extend(edge_points.iter().copied());
@@ -3903,15 +3930,14 @@ where
             && p[1] <= max_y + tol;
 
         if on_segment {
-            let handle = FacetHandle::from_validated(simplex_key, facet_index);
             if match_facet.is_some() {
                 return Err(InsertionError::HullExtension {
-                    reason: HullExtensionReason::Other {
-                        message: "2D boundary edge split matched multiple facets".to_string(),
+                    reason: HullExtensionReason::InvalidPatch {
+                        details: "2D boundary edge split matched multiple facets".to_string(),
                     },
                 });
             }
-            match_facet = Some(handle);
+            match_facet = Some(FacetHandle::from_validated(simplex_key, facet_index));
         }
     }
 
@@ -3996,6 +4022,7 @@ where
 
     // Test each boundary facet for visibility
     for facet_view in boundary_facets {
+        let facet_view = facet_view.map_err(boundary_facet_iteration_error)?;
         #[cfg(debug_assertions)]
         if track_orientations {
             boundary_facets_count += 1;
@@ -4004,26 +4031,18 @@ where
         let facet_index = facet_view.facet_index();
 
         // Get the simplex and its vertices
-        let simplex = tds
-            .simplex(simplex_key)
-            .ok_or_else(|| InsertionError::HullExtension {
-                reason: HullExtensionReason::Other {
-                    message: format!("Boundary facet simplex {simplex_key:?} not found"),
-                },
-            })?;
+        let simplex = tds.simplex(simplex_key).ok_or_else(|| {
+            missing_boundary_simplex(simplex_key, "visible boundary facet lookup")
+        })?;
 
         // Collect points for the simplex in canonical order: facet vertices + opposite vertex.
         let mut simplex_points = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
         let mut opposite_point: Option<Point<D>> = None;
 
         for (i, &vkey) in simplex.vertices().iter().enumerate() {
-            let vertex = tds
-                .vertex(vkey)
-                .ok_or_else(|| InsertionError::HullExtension {
-                    reason: HullExtensionReason::Other {
-                        message: format!("Vertex {vkey:?} not found in TDS"),
-                    },
-                })?;
+            let vertex = tds.vertex(vkey).ok_or_else(|| {
+                missing_boundary_vertex(vkey, simplex_key, "visible boundary facet")
+            })?;
             if i == usize::from(facet_index) {
                 opposite_point = Some(*vertex.point());
             } else {
@@ -4031,13 +4050,8 @@ where
             }
         }
 
-        let opposite_point = opposite_point.ok_or_else(|| InsertionError::HullExtension {
-            reason: HullExtensionReason::Other {
-                message: format!(
-                    "Opposite vertex missing for facet {facet_index} in simplex {simplex_key:?}"
-                ),
-            },
-        })?;
+        let opposite_point = opposite_point
+            .ok_or_else(|| invalid_boundary_facet_index(facet_index, simplex.vertices().len()))?;
 
         // Append opposite vertex in canonical order.
         simplex_points.push(opposite_point);

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -3719,16 +3719,7 @@ where
                 || facet.facet_index() != edge_facet.facet_index()
         });
 
-        if boundary_facets.len() != 2 {
-            return Err(InsertionError::HullExtension {
-                reason: HullExtensionReason::InvalidPatch {
-                    details: format!(
-                        "2D boundary edge split expected 2 facets, got {}",
-                        boundary_facets.len()
-                    ),
-                },
-            });
-        }
+        validate_boundary_edge_split_facet_count(boundary_facets.len())?;
 
         let external_facets =
             external_facets_for_boundary(tds, &conflict_simplices, &boundary_facets)?;
@@ -3759,11 +3750,16 @@ where
 
     #[cfg(debug_assertions)]
     if std::env::var_os("DELAUNAY_DEBUG_HULL").is_some() {
-        let total_boundary = tds.boundary_facets().map_or(0, |mut facets| {
-            facets
-                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
-                .unwrap_or(0)
-        });
+        let total_boundary = tds
+            .boundary_facets()
+            .map_err(|e| InsertionError::HullExtension {
+                reason: HullExtensionReason::Tds(e),
+            })
+            .and_then(|mut facets| {
+                facets
+                    .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                    .map_err(boundary_facet_iteration_error)
+            })?;
         tracing::debug!(
             point = ?point,
             visible_facets = visible_facets.len(),
@@ -3822,6 +3818,18 @@ fn invalid_boundary_facet_index(facet_index: u8, facet_count: usize) -> Insertio
     hull_extension_tds_error(FacetError::InvalidFacetIndex {
         index: facet_index,
         facet_count,
+    })
+}
+
+fn validate_boundary_edge_split_facet_count(facet_count: usize) -> Result<(), InsertionError> {
+    if facet_count == 2 {
+        return Ok(());
+    }
+
+    Err(InsertionError::HullExtension {
+        reason: HullExtensionReason::InvalidPatch {
+            details: format!("2D boundary edge split expected 2 facets, got {facet_count}"),
+        },
     })
 }
 
@@ -6065,6 +6073,55 @@ mod tests {
         );
     }
 
+    #[test]
+    fn hull_extension_error_helpers_preserve_typed_sources() {
+        let simplex_key = SimplexKey::from(KeyData::from_ffi(1));
+        let vertex_key = VertexKey::from(KeyData::from_ffi(2));
+
+        assert_matches!(
+            missing_boundary_simplex(simplex_key, "facet lookup"),
+            InsertionError::HullExtension {
+                reason: HullExtensionReason::Tds(TdsError::SimplexNotFound {
+                    simplex_key: found_simplex_key,
+                    context,
+                }),
+            } if found_simplex_key == simplex_key && context == "facet lookup"
+        );
+
+        assert_matches!(
+            missing_boundary_vertex(vertex_key, simplex_key, "visible boundary facet"),
+            InsertionError::HullExtension {
+                reason: HullExtensionReason::Tds(TdsError::VertexNotFound {
+                    vertex_key: found_vertex_key,
+                    context,
+                }),
+            } if found_vertex_key == vertex_key
+                && context.starts_with("visible boundary facet")
+                && context.contains(&format!("{simplex_key:?}"))
+        );
+
+        assert_matches!(
+            invalid_boundary_facet_index(3, 2),
+            InsertionError::HullExtension {
+                reason: HullExtensionReason::Tds(TdsError::FacetError(
+                    FacetError::InvalidFacetIndex {
+                        index: 3,
+                        facet_count: 2,
+                    }
+                )),
+            }
+        );
+
+        assert_matches!(
+            boundary_facet_iteration_error(FacetError::InsideVertexNotFound),
+            InsertionError::HullExtension {
+                reason: HullExtensionReason::Tds(TdsError::FacetError(
+                    FacetError::InsideVertexNotFound
+                )),
+            }
+        );
+    }
+
     // repair_neighbor_pointers tests
 
     /// Macro to generate `repair_neighbor_pointers` tests for different dimensions
@@ -6519,6 +6576,19 @@ mod tests {
     }
 
     #[test]
+    fn test_boundary_edge_split_invalid_boundary_count_is_retryable_invalid_patch() {
+        let err = validate_boundary_edge_split_facet_count(1).unwrap_err();
+
+        assert!(err.is_retryable());
+        assert_matches!(
+            err,
+            InsertionError::HullExtension {
+                reason: HullExtensionReason::InvalidPatch { details },
+            } if details == "2D boundary edge split expected 2 facets, got 1"
+        );
+    }
+
+    #[test]
     fn test_find_boundary_edge_split_facet_on_segment_2d() {
         let vertices = vec![
             crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
@@ -6530,6 +6600,27 @@ mod tests {
 
         let facet = find_boundary_edge_split_facet(dt.tds(), &point).unwrap();
         assert!(facet.is_some());
+    }
+
+    #[test]
+    fn test_find_boundary_edge_split_facet_hull_vertex_is_retryable_invalid_patch() {
+        let vertices = vec![
+            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
+            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
+            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        ];
+        let dt = DelaunayTriangulation::<_, (), (), 2>::new(&vertices).unwrap();
+        let point = Point::from_validated_coords([0.0, 0.0]);
+
+        let err = find_boundary_edge_split_facet(dt.tds(), &point).unwrap_err();
+
+        assert!(err.is_retryable());
+        assert_matches!(
+            err,
+            InsertionError::HullExtension {
+                reason: HullExtensionReason::InvalidPatch { details },
+            } if details == "2D boundary edge split matched multiple facets"
+        );
     }
 
     #[test]

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -547,7 +547,7 @@ fn log_first_ridge_fan_dump<U, V, const D: usize>(
     }
     participating_indices.extend(info.extra_facets.iter().copied());
 
-    let conflict_preview: Vec<SimplexKey> = conflict_simplices.iter().copied().take(16).collect();
+    let conflict_preview: SimplexKeyBuffer = conflict_simplices.iter().copied().take(16).collect();
     let ridge_vertices = format_vertex_refs(tds, info.ridge_vertices.as_slice());
 
     let participating_facets: Vec<String> = participating_indices

--- a/src/core/boundary.rs
+++ b/src/core/boundary.rs
@@ -57,15 +57,19 @@ impl<U, V, const D: usize> BoundaryAnalysis<U, V, D> for Tds<U, V, D> {
     /// # Returns
     ///
     /// A `Result<BoundaryFacetsIter<'_, U, V, D>, TdsError>` containing an iterator over boundary facets.
-    /// The iterator yields facets lazily without pre-allocating vectors, providing better performance.
+    /// The iterator yields `Result<FacetView, FacetError>` items lazily without pre-allocating vectors,
+    /// providing better performance while still surfacing corrupted facet views during iteration.
     ///
     /// # Errors
     ///
     /// Returns a [`TdsError`] (typically
     /// [`crate::prelude::tds::FacetError`]) if:
-    /// - Any boundary facet cannot be created from the simplices
+    /// - The boundary-facet iterator cannot be constructed
     /// - A facet index is out of bounds (indicates data corruption)
     /// - A referenced simplex is not found in the triangulation (indicates data corruption)
+    ///
+    /// Individual iterator items return [`FacetError`] if a boundary facet cannot
+    /// be created or keyed from the simplices.
     ///
     /// # Examples
     ///
@@ -80,6 +84,8 @@ impl<U, V, const D: usize> BoundaryAnalysis<U, V, D> for Tds<U, V, D> {
     /// #     Query(#[from] delaunay::query::QueryError),
     /// #     #[error(transparent)]
     /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// // Create a simple 3D triangulation (single tetrahedron)
@@ -92,10 +98,16 @@ impl<U, V, const D: usize> BoundaryAnalysis<U, V, D> for Tds<U, V, D> {
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // High-level API returns `QueryError` if the underlying TDS is corrupted.
-    /// assert_eq!(dt.boundary_facets()?.count(), 4);
+    /// let high_level_count = dt
+    ///     .boundary_facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
+    /// assert_eq!(high_level_count, 4);
     ///
     /// // TDS-level API (fallible): returns `TdsError` on corruption.
-    /// let count = dt.tds().boundary_facets()?.count();
+    /// let count = dt
+    ///     .tds()
+    ///     .boundary_facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
     /// assert_eq!(count, 4);
     /// # Ok(())
     /// # }
@@ -146,6 +158,8 @@ impl<U, V, const D: usize> BoundaryAnalysis<U, V, D> for Tds<U, V, D> {
     /// #     Query(#[from] delaunay::query::QueryError),
     /// #     #[error(transparent)]
     /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -157,7 +171,7 @@ impl<U, V, const D: usize> BoundaryAnalysis<U, V, D> for Tds<U, V, D> {
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Get boundary facets using the new iterator API
-    /// let Some(first_facet) = dt.boundary_facets()?.next() else {
+    /// let Some(first_facet) = dt.boundary_facets()?.next().transpose()? else {
     ///     return Ok(());
     /// };
     /// // In a single tetrahedron, all facets are boundary facets
@@ -204,6 +218,8 @@ impl<U, V, const D: usize> BoundaryAnalysis<U, V, D> for Tds<U, V, D> {
     /// #     Query(#[from] delaunay::query::QueryError),
     /// #     #[error(transparent)]
     /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -219,6 +235,7 @@ impl<U, V, const D: usize> BoundaryAnalysis<U, V, D> for Tds<U, V, D> {
     ///
     /// // Check boundary facets efficiently using the iterator API
     /// for facet in dt.boundary_facets()? {
+    ///     let facet = facet?;
     ///     let is_boundary = dt.tds().is_boundary_facet_with_map(&facet, &facet_to_simplices)?;
     ///     println!("Facet is boundary: {is_boundary}");
     /// }
@@ -337,7 +354,11 @@ mod tests {
             );
             assert_eq!(dt.dim(), 2, "Should be 2-dimensional");
 
-            let boundary_count = dt.boundary_facets().unwrap().count();
+            let boundary_count = dt
+                .boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap();
             assert_eq!(
                 boundary_count, 3,
                 "2D triangle should have 3 boundary facets"
@@ -349,6 +370,7 @@ mod tests {
                 .build_facet_to_simplices_map()
                 .expect("Should build facet map");
             assert!(dt.boundary_facets().unwrap().all(|f| {
+                let f = f.expect("valid boundary facet");
                 dt.tds()
                     .is_boundary_facet_with_map(&f, &facet_to_simplices)
                     .expect("Should not fail for valid facets")
@@ -373,7 +395,11 @@ mod tests {
             );
             assert_eq!(dt.dim(), 3, "Should be 3-dimensional");
 
-            let boundary_count = dt.boundary_facets().unwrap().count();
+            let boundary_count = dt
+                .boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap();
             assert_eq!(
                 boundary_count, 4,
                 "3D tetrahedron should have 4 boundary facets"
@@ -385,6 +411,7 @@ mod tests {
                 .build_facet_to_simplices_map()
                 .expect("Should build facet map");
             assert!(dt.boundary_facets().unwrap().all(|f| {
+                let f = f.expect("valid boundary facet");
                 dt.tds()
                     .is_boundary_facet_with_map(&f, &facet_to_simplices)
                     .expect("Should not fail for valid facets")
@@ -410,7 +437,11 @@ mod tests {
             );
             assert_eq!(dt.dim(), 4, "Should be 4-dimensional");
 
-            let boundary_count = dt.boundary_facets().unwrap().count();
+            let boundary_count = dt
+                .boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap();
             assert_eq!(
                 boundary_count, 5,
                 "4D simplex should have 5 boundary facets"
@@ -425,6 +456,7 @@ mod tests {
                 .boundary_facets()
                 .unwrap()
                 .filter(|f| {
+                    let f = f.as_ref().expect("valid boundary facet");
                     dt.tds()
                         .is_boundary_facet_with_map(f, &facet_to_simplices)
                         .expect("Should not fail for valid facets")
@@ -445,7 +477,11 @@ mod tests {
                 "Empty triangulation should have no simplices"
             );
 
-            let boundary_count = dt.boundary_facets().unwrap().count();
+            let boundary_count = dt
+                .boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap();
             assert_eq!(
                 boundary_count, 0,
                 "Empty triangulation should have no boundary facets"
@@ -473,7 +509,11 @@ mod tests {
             let dt = DelaunayTriangulation::new(&vertices).unwrap();
 
             // Test boundary_facets() normal path
-            let boundary_count = dt.boundary_facets().unwrap().count();
+            let boundary_count = dt
+                .boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap();
             assert_eq!(
                 boundary_count, 4,
                 "Single tetrahedron has 4 boundary facets"
@@ -481,6 +521,7 @@ mod tests {
 
             // Test is_boundary_facet() delegation (builds facet map internally)
             if let Some(facet) = dt.boundary_facets().unwrap().next() {
+                let facet = facet.unwrap();
                 let result = dt.tds().is_boundary_facet(&facet);
                 assert!(result.is_ok(), "Should not error on valid facet");
                 assert!(
@@ -509,7 +550,11 @@ mod tests {
             );
 
             // Exercise capacity allocation, cache initialization, and vector push operations
-            let boundary_count = dt.boundary_facets().unwrap().count();
+            let boundary_count = dt
+                .boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap();
             assert!(boundary_count > 0, "Should have boundary facets");
             assert!(
                 boundary_count >= 4,
@@ -599,6 +644,7 @@ mod tests {
         let mut boundary_count = 0;
 
         for boundary_facet in dt.boundary_facets().unwrap() {
+            let boundary_facet = boundary_facet.unwrap();
             let is_boundary = dt
                 .tds()
                 .is_boundary_facet_with_map(&boundary_facet, &facet_to_simplices)
@@ -618,7 +664,11 @@ mod tests {
         );
 
         // Verify consistency
-        let reported_count = dt.boundary_facets().unwrap().count();
+        let reported_count = dt
+            .boundary_facets()
+            .unwrap()
+            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+            .unwrap();
         assert_eq!(
             boundary_count, reported_count,
             "Boundary facet count should be consistent"
@@ -638,7 +688,7 @@ mod tests {
         ];
         let vertices = Vertex::from_points(&points);
         let dt = DelaunayTriangulation::new(&vertices).unwrap();
-        let facet = dt.boundary_facets().unwrap().next().unwrap();
+        let facet = dt.boundary_facets().unwrap().next().unwrap().unwrap();
         let facet_key = facet.key().unwrap();
 
         let mut facet_to_simplices = dt.tds().build_facet_to_simplices_map().unwrap();
@@ -743,7 +793,11 @@ mod tests {
         let dt = DelaunayTriangulation::new(&vertices).unwrap();
 
         // Test both methods return consistent results
-        let boundary_facets_count = dt.boundary_facets().unwrap().count();
+        let boundary_facets_count = dt
+            .boundary_facets()
+            .unwrap()
+            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+            .unwrap();
         let boundary_count = dt
             .tds()
             .number_of_boundary_facets()

--- a/src/core/boundary.rs
+++ b/src/core/boundary.rs
@@ -488,8 +488,58 @@ mod tests {
             );
         }
 
+        // Test Case 5: 5D simplex - all 6 facets should be boundary facets
+        {
+            let points = vec![
+                Point::from_validated_coords([0.0, 0.0, 0.0, 0.0, 0.0]),
+                Point::from_validated_coords([1.0, 0.0, 0.0, 0.0, 0.0]),
+                Point::from_validated_coords([0.0, 1.0, 0.0, 0.0, 0.0]),
+                Point::from_validated_coords([0.0, 0.0, 1.0, 0.0, 0.0]),
+                Point::from_validated_coords([0.0, 0.0, 0.0, 1.0, 0.0]),
+                Point::from_validated_coords([0.0, 0.0, 0.0, 0.0, 1.0]),
+            ];
+            let vertices = Vertex::from_points(&points);
+            let dt = DelaunayTriangulation::new(&vertices).unwrap();
+
+            assert_eq!(
+                dt.number_of_simplices(),
+                1,
+                "5D simplex should have 1 simplex"
+            );
+            assert_eq!(dt.dim(), 5, "Should be 5-dimensional");
+
+            let boundary_count = dt
+                .boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap();
+            assert_eq!(
+                boundary_count, 6,
+                "5D simplex should have 6 boundary facets"
+            );
+
+            let facet_to_simplices = dt
+                .tds()
+                .build_facet_to_simplices_map()
+                .expect("Should build facet map");
+            let confirmed_boundary = dt
+                .boundary_facets()
+                .unwrap()
+                .filter(|f| {
+                    let f = f.as_ref().expect("valid boundary facet");
+                    dt.tds()
+                        .is_boundary_facet_with_map(f, &facet_to_simplices)
+                        .expect("Should not fail for valid facets")
+                })
+                .count();
+            assert_eq!(
+                confirmed_boundary, 6,
+                "All 5D simplex facets should be boundary facets"
+            );
+        }
+
         println!(
-            "✓ Single simplex boundary analysis works correctly in 2D, 3D, 4D, and empty cases"
+            "✓ Single simplex boundary analysis works correctly in 2D, 3D, 4D, 5D, and empty cases"
         );
     }
 

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -1145,7 +1145,7 @@ impl<'tds, U, V, const D: usize> Iterator for AllFacetsIter<'tds, U, V, D> {
                                 facet_count: simplex.number_of_vertices(),
                             };
                         } else {
-                            self.state = AllFacetsIterState::PendingSimplex;
+                            return Some(Err(FacetError::SimplexNotFoundInTriangulation));
                         }
                     } else {
                         self.state = AllFacetsIterState::Exhausted;
@@ -1869,6 +1869,16 @@ mod tests {
                 facet_count: 257,
             }))
         );
+    }
+
+    #[test]
+    fn all_facets_iter_stays_exhausted_after_completion() {
+        let tds = tetrahedron_tds();
+        let mut iter = tds.facets().unwrap();
+
+        while iter.next().transpose().unwrap().is_some() {}
+
+        assert!(iter.next().is_none());
     }
 
     #[test]

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -368,6 +368,8 @@ impl FacetHandle {
     /// #     Construction(#[from] DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = [
@@ -959,11 +961,12 @@ pub fn all_facets_for_simplex<U, V, const D: usize>(
 /// This iterator provides efficient access to all facets without allocating
 /// a vector. It's particularly useful for performance-critical operations
 /// like boundary detection and cavity analysis in triangulation insertion.
+/// Each item is a `Result` so structurally invalid facet views are reported
+/// to callers instead of being skipped.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::tds::AllFacetsIter;
 /// use delaunay::prelude::*;
 ///
 /// # #[derive(Debug, thiserror::Error)]
@@ -972,6 +975,8 @@ pub fn all_facets_for_simplex<U, V, const D: usize>(
 /// #     Construction(#[from] DelaunayTriangulationConstructionError),
 /// #     #[error(transparent)]
 /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// #     #[error(transparent)]
+/// #     Tds(#[from] delaunay::prelude::tds::TdsError),
 /// # }
 /// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
@@ -982,7 +987,8 @@ pub fn all_facets_for_simplex<U, V, const D: usize>(
 /// ];
 /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let count = AllFacetsIter::try_new(dt.tds())?.count();
+/// let count = dt.tds().facets()?
+///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
 /// assert_eq!(count, 4);
 /// # Ok(())
 /// # }
@@ -990,10 +996,20 @@ pub fn all_facets_for_simplex<U, V, const D: usize>(
 #[derive(Clone)]
 pub struct AllFacetsIter<'tds, U, V, const D: usize> {
     tds: &'tds Tds<U, V, D>,
-    simplex_keys: std::vec::IntoIter<SimplexKey>,
-    current_simplex_key: Option<SimplexKey>,
-    current_facet_index: usize,
-    current_simplex_facet_count: usize,
+    simplex_keys: slotmap::dense::Keys<'tds, SimplexKey, Simplex<V, D>>,
+    state: AllFacetsIterState,
+}
+
+/// Encodes whether facet iteration is between simplices, inside one, or done.
+#[derive(Clone)]
+enum AllFacetsIterState {
+    PendingSimplex,
+    InSimplex {
+        simplex_key: SimplexKey,
+        next_facet_index: usize,
+        facet_count: usize,
+    },
+    Exhausted,
 }
 
 impl<'tds, U, V, const D: usize> AllFacetsIter<'tds, U, V, D> {
@@ -1007,7 +1023,6 @@ impl<'tds, U, V, const D: usize> AllFacetsIter<'tds, U, V, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::tds::AllFacetsIter;
     /// use delaunay::prelude::*;
     ///
     /// # #[derive(Debug, thiserror::Error)]
@@ -1016,6 +1031,8 @@ impl<'tds, U, V, const D: usize> AllFacetsIter<'tds, U, V, D> {
     /// #     Construction(#[from] DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -1026,12 +1043,12 @@ impl<'tds, U, V, const D: usize> AllFacetsIter<'tds, U, V, D> {
     /// ];
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let mut iter = AllFacetsIter::try_new(dt.tds())?;
-    /// assert!(iter.next().is_some());
+    /// let mut iter = dt.tds().facets()?;
+    /// assert!(iter.next().transpose()?.is_some());
     /// # Ok(())
     /// # }
     /// ```
-    pub fn try_new(tds: &'tds Tds<U, V, D>) -> Result<Self, FacetError> {
+    pub(crate) fn try_new(tds: &'tds Tds<U, V, D>) -> Result<Self, FacetError> {
         // Dimension check: facets per simplex = D+1, so D must be <= 255
         if D > usize::from(u8::MAX) {
             return Err(FacetError::FacetIndexCapacityExceeded {
@@ -1040,60 +1057,101 @@ impl<'tds, U, V, const D: usize> AllFacetsIter<'tds, U, V, D> {
             });
         }
 
-        // We collect here because we need an owned iterator to store in the struct
-        // SimplexKey is just u64, so this is efficient
-        #[expect(
-            clippy::needless_collect,
-            reason = "iterator owns a stable snapshot of simplex keys before yielding facets"
-        )]
-        let simplex_keys: Vec<SimplexKey> = tds.simplex_keys().collect();
         Ok(Self {
             tds,
-            simplex_keys: simplex_keys.into_iter(),
-            current_simplex_key: None,
-            current_facet_index: 0,
-            current_simplex_facet_count: 0,
+            simplex_keys: tds.simplex_key_iter(),
+            state: AllFacetsIterState::PendingSimplex,
         })
     }
 }
 
+impl<U, V, const D: usize> Tds<U, V, D> {
+    /// Returns an iterator over all facets in the TDS.
+    ///
+    /// This is the TDS-level counterpart to
+    /// [`BoundaryAnalysis::boundary_facets`](crate::query::BoundaryAnalysis::boundary_facets):
+    /// it constructs the concrete [`AllFacetsIter`] while preserving construction
+    /// failures as [`TdsError`]. Individual iterator items return [`FacetError`]
+    /// if a facet view cannot be constructed from the current TDS state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TdsError`] if the facet iterator cannot represent facet indices
+    /// for this dimension.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::*;
+    ///
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+    /// #     #[error(transparent)]
+    /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// let vertices = vec![
+    ///     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    ///     delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    ///     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).expect("finite vertex coordinates"),
+    ///     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
+    /// ];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let facet_count = dt
+    ///     .tds()
+    ///     .facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
+    ///
+    /// assert_eq!(facet_count, 4);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn facets(&self) -> Result<AllFacetsIter<'_, U, V, D>, TdsError> {
+        AllFacetsIter::try_new(self).map_err(TdsError::from)
+    }
+}
+
 impl<'tds, U, V, const D: usize> Iterator for AllFacetsIter<'tds, U, V, D> {
-    type Item = FacetView<'tds, U, V, D>;
+    type Item = Result<FacetView<'tds, U, V, D>, FacetError>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            // If we have a current simplex and more facets in it
-            if let Some(simplex_key) = self.current_simplex_key
-                && self.current_facet_index < self.current_simplex_facet_count
-            {
-                let facet_index = self.current_facet_index;
-                self.current_facet_index += 1;
+            match &mut self.state {
+                AllFacetsIterState::InSimplex {
+                    simplex_key,
+                    next_facet_index,
+                    facet_count,
+                } if *next_facet_index < *facet_count => {
+                    let facet_index = *next_facet_index;
+                    *next_facet_index += 1;
 
-                // Create FacetView - we know this is valid since we're iterating within bounds
-                let Ok(facet_u8) = usize_to_u8(facet_index, self.current_simplex_facet_count)
-                else {
-                    // Fail fast instead of silently skipping in release.
-                    // If D can exceed 255, widen the index type.
-                    return None;
-                };
-                if let Ok(facet_view) = FacetView::try_new(self.tds, simplex_key, facet_u8) {
-                    return Some(facet_view);
+                    let facet_u8 = match usize_to_u8(facet_index, *facet_count) {
+                        Ok(facet_u8) => facet_u8,
+                        Err(err) => return Some(Err(err)),
+                    };
+                    return Some(FacetView::try_new(self.tds, *simplex_key, facet_u8));
                 }
-            }
-
-            // Move to next simplex
-            if let Some(next_simplex_key) = self.simplex_keys.next() {
-                if let Some(simplex) = self.tds.simplex(next_simplex_key) {
-                    self.current_simplex_key = Some(next_simplex_key);
-                    self.current_facet_index = 0;
-                    self.current_simplex_facet_count = simplex.number_of_vertices();
-                    // Continue loop to process first facet of new simplex
-                } else {
-                    // Simplex not found, skip to next (continue is implicit at end of loop)
+                AllFacetsIterState::Exhausted => return None,
+                AllFacetsIterState::PendingSimplex | AllFacetsIterState::InSimplex { .. } => {
+                    if let Some(next_simplex_key) = self.simplex_keys.next() {
+                        if let Some(simplex) = self.tds.simplex(next_simplex_key) {
+                            self.state = AllFacetsIterState::InSimplex {
+                                simplex_key: next_simplex_key,
+                                next_facet_index: 0,
+                                facet_count: simplex.number_of_vertices(),
+                            };
+                        } else {
+                            self.state = AllFacetsIterState::PendingSimplex;
+                        }
+                    } else {
+                        self.state = AllFacetsIterState::Exhausted;
+                        return None;
+                    }
                 }
-            } else {
-                // No more simplices
-                return None;
             }
         }
     }
@@ -1103,6 +1161,8 @@ impl<'tds, U, V, const D: usize> Iterator for AllFacetsIter<'tds, U, V, D> {
 ///
 /// This iterator efficiently identifies and yields only the boundary facets
 /// (facets that belong to only one simplex) without pre-computing all facets.
+/// Each item is a `Result` so facet-view construction or key-derivation
+/// failures propagate to the caller during iteration.
 ///
 /// # Examples
 ///
@@ -1126,7 +1186,8 @@ impl<'tds, U, V, const D: usize> Iterator for AllFacetsIter<'tds, U, V, D> {
 ///     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
 /// ];
 /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
-/// let count = dt.tds().boundary_facets()?.count();
+/// let count = dt.tds().boundary_facets()?
+///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
 /// assert_eq!(count, 4);
 /// # Ok(())
 /// # }
@@ -1168,7 +1229,7 @@ impl<'tds, U, V, const D: usize> BoundaryFacetsIter<'tds, U, V, D> {
     /// ];
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let mut iter = dt.tds().boundary_facets()?;
-    /// assert!(iter.next().is_some());
+    /// assert!(iter.next().transpose()?.is_some());
     /// # Ok(())
     /// # }
     /// ```
@@ -1184,20 +1245,41 @@ impl<'tds, U, V, const D: usize> BoundaryFacetsIter<'tds, U, V, D> {
 }
 
 impl<'tds, U, V, const D: usize> Iterator for BoundaryFacetsIter<'tds, U, V, D> {
-    type Item = FacetView<'tds, U, V, D>;
+    type Item = Result<FacetView<'tds, U, V, D>, FacetError>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // Find the next boundary facet
-        self.all_facets.find(|facet_view| {
-            // Check if this facet is a boundary facet using the precomputed map
-            if let Ok(facet_key) = facet_view.key()
-                && let Some(simplex_list) = self.facet_to_simplices_map.get(&facet_key)
-            {
-                // Boundary facets appear in exactly one simplex
-                return simplex_list.len() == 1;
+        for facet_result in self.all_facets.by_ref() {
+            let facet_view = match facet_result {
+                Ok(facet_view) => facet_view,
+                Err(err) => return Some(Err(err)),
+            };
+            let facet_key = match facet_view.key() {
+                Ok(facet_key) => facet_key,
+                Err(err) => return Some(Err(err)),
+            };
+            let Some(simplex_list) = self.facet_to_simplices_map.get(&facet_key) else {
+                let vertex_uuids = match facet_view.vertices() {
+                    Ok(vertices) => vertices.map(Vertex::uuid).collect(),
+                    Err(err) => return Some(Err(err)),
+                };
+                return Some(Err(FacetError::FacetKeyNotFoundInCache {
+                    facet_key,
+                    cache_size: self.facet_to_simplices_map.len(),
+                    vertex_uuids,
+                }));
+            };
+            match simplex_list.len() {
+                1 => return Some(Ok(facet_view)),
+                2 => {}
+                found => {
+                    return Some(Err(FacetError::InvalidFacetMultiplicity {
+                        facet_key,
+                        found,
+                    }));
+                }
             }
-            false
-        })
+        }
+        None
     }
 }
 
@@ -1293,6 +1375,7 @@ mod tests {
         ConstructionOptions, InitialSimplexStrategy, InsertionOrderStrategy,
     };
     use crate::core::tds::{Tds, VertexKey};
+    use crate::core::triangulation::Triangulation;
     use crate::core::validation::TopologyGuarantee;
     use crate::core::vertex::Vertex;
     use crate::geometry::kernel::AdaptiveKernel;
@@ -1726,6 +1809,137 @@ mod tests {
                 dimension: 256,
                 max_dimension: 255,
             }
+        );
+    }
+
+    /// Builds a deliberately corrupted 2D TDS whose lone simplex has more
+    /// vertices than can be represented by the `u8` facet-index storage.
+    fn overwide_simplex_tds() -> Tds<(), (), 2> {
+        let vertices = vec![
+            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        ];
+        let mut tds =
+            Triangulation::<AdaptiveKernel<f64>, (), (), 2>::build_initial_simplex(&vertices)
+                .unwrap();
+        let simplex_key = tds.simplex_keys().next().unwrap();
+        let first_vertex = tds.simplex(simplex_key).unwrap().vertices()[0];
+
+        {
+            let simplex = tds.simplex_mut(simplex_key).unwrap();
+            while simplex.number_of_vertices() <= usize::from(u8::MAX) + 1 {
+                simplex.push_vertex_key(first_vertex);
+            }
+        }
+
+        tds
+    }
+
+    fn tetrahedron_tds() -> Tds<(), (), 3> {
+        let vertices = vec![
+            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        ];
+        Triangulation::<AdaptiveKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap()
+    }
+
+    fn first_facet_view(tds: &Tds<(), (), 3>) -> FacetView<'_, (), (), 3> {
+        tds.facets().unwrap().next().unwrap().unwrap()
+    }
+
+    #[test]
+    fn all_facets_iter_yields_overflow_error() {
+        let tds = overwide_simplex_tds();
+        let mut iter = tds.facets().unwrap();
+
+        for facet in iter.by_ref().take(usize::from(u8::MAX) + 1) {
+            assert!(
+                facet.is_ok(),
+                "facet indices up to u8::MAX remain representable"
+            );
+        }
+
+        assert_matches!(
+            iter.next(),
+            Some(Err(FacetError::InvalidFacetIndexOverflow {
+                original_index: 256,
+                facet_count: 257,
+            }))
+        );
+    }
+
+    #[test]
+    fn boundary_facets_iter_propagates_inner_errors() {
+        let tds = overwide_simplex_tds();
+        let mut facet_to_simplices = FacetToSimplicesMap::default();
+        for facet in tds.facets().unwrap().take(usize::from(u8::MAX) + 1) {
+            let facet = facet.unwrap();
+            let mut incidents = SmallBuffer::new();
+            let handle = FacetHandle::from_validated(facet.simplex_key(), facet.facet_index());
+            incidents.push(handle);
+            incidents.push(handle);
+            facet_to_simplices.insert(facet.key().unwrap(), incidents);
+        }
+        let mut iter = BoundaryFacetsIter::try_new(&tds, facet_to_simplices).unwrap();
+
+        assert_matches!(
+            iter.next(),
+            Some(Err(FacetError::InvalidFacetIndexOverflow {
+                original_index: 256,
+                facet_count: 257,
+            }))
+        );
+    }
+
+    #[test]
+    fn boundary_facets_iter_errors_when_facet_map_is_missing_key() {
+        let tds = tetrahedron_tds();
+        let mut iter = BoundaryFacetsIter::try_new(&tds, FacetToSimplicesMap::default()).unwrap();
+
+        assert_matches!(
+            iter.next(),
+            Some(Err(FacetError::FacetKeyNotFoundInCache {
+                cache_size: 0,
+                vertex_uuids,
+                ..
+            })) if vertex_uuids.len() == 3
+        );
+    }
+
+    #[test]
+    fn boundary_facets_iter_errors_on_empty_multiplicity() {
+        let tds = tetrahedron_tds();
+        let first_facet = first_facet_view(&tds);
+        let mut facet_to_simplices = FacetToSimplicesMap::default();
+        facet_to_simplices.insert(first_facet.key().unwrap(), SmallBuffer::new());
+        let mut iter = BoundaryFacetsIter::try_new(&tds, facet_to_simplices).unwrap();
+
+        assert_matches!(
+            iter.next(),
+            Some(Err(FacetError::InvalidFacetMultiplicity { found: 0, .. }))
+        );
+    }
+
+    #[test]
+    fn boundary_facets_iter_errors_on_overshared_multiplicity() {
+        let tds = tetrahedron_tds();
+        let first_facet = first_facet_view(&tds);
+        let handle =
+            FacetHandle::from_validated(first_facet.simplex_key(), first_facet.facet_index());
+        let mut incidents = SmallBuffer::new();
+        incidents.push(handle);
+        incidents.push(handle);
+        incidents.push(handle);
+        let mut facet_to_simplices = FacetToSimplicesMap::default();
+        facet_to_simplices.insert(first_facet.key().unwrap(), incidents);
+        let mut iter = BoundaryFacetsIter::try_new(&tds, facet_to_simplices).unwrap();
+
+        assert_matches!(
+            iter.next(),
+            Some(Err(FacetError::InvalidFacetMultiplicity { found: 3, .. }))
         );
     }
 

--- a/src/core/insertion.rs
+++ b/src/core/insertion.rs
@@ -220,7 +220,7 @@ fn log_cavity_reduction_event<F>(
         return;
     }
 
-    let conflict_preview: Vec<SimplexKey> = conflict_simplices.iter().copied().take(12).collect();
+    let conflict_preview: SimplexKeyBuffer = conflict_simplices.iter().copied().take(12).collect();
     let event = event();
     tracing::debug!(
         target: "delaunay::cavity_reduction",
@@ -1362,9 +1362,9 @@ where
                             iterations,
                             conflict_simplices,
                             || {
-                                let added: Vec<SimplexKey> =
-                                    simplices_to_add.iter().copied().collect();
-                                format!("disconnected_boundary_expand add_simplices={added:?}")
+                                format!(
+                                    "disconnected_boundary_expand add_simplices={simplices_to_add:?}"
+                                )
                             },
                         );
                         conflict_simplices.extend(simplices_to_add);

--- a/src/core/orientation.rs
+++ b/src/core/orientation.rs
@@ -298,7 +298,7 @@ where
             return Ok(());
         }
 
-        let simplex_keys: SimplexKeyBuffer = self.tds.simplex_keys().collect();
+        let simplex_keys: Vec<SimplexKey> = self.tds.simplex_keys().collect();
         let mut flipped_any = false;
         for simplex_key in simplex_keys {
             let Some(simplex) = self.tds.simplex_mut(simplex_key) else {

--- a/src/core/query.rs
+++ b/src/core/query.rs
@@ -39,6 +39,8 @@ static VERTEX_TO_SIMPLICES_SPILL_EVENTS: AtomicU64 = AtomicU64::new(0);
 /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
 /// #     #[error(transparent)]
 /// #     Query(#[from] delaunay::query::QueryError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
 /// # }
 /// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
@@ -49,7 +51,10 @@ static VERTEX_TO_SIMPLICES_SPILL_EVENTS: AtomicU64 = AtomicU64::new(0);
 /// ];
 /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 ///
-/// let boundary_count = dt.as_triangulation().boundary_facets()?.count();
+/// let boundary_count = dt
+///     .as_triangulation()
+///     .boundary_facets()?
+///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
 /// assert_eq!(boundary_count, 4);
 /// # Ok(())
 /// # }
@@ -240,17 +245,20 @@ where
     /// Returns an iterator over all facets in the triangulation.
     ///
     /// This provides efficient access to all facets without pre-allocating a vector.
-    /// Each facet is represented as a lightweight `FacetView` that references the
+    /// Each successful facet is a lightweight `FacetView` that references the
     /// underlying triangulation data.
     ///
     /// # Returns
     ///
-    /// An iterator yielding `FacetView` objects for all facets in the triangulation.
+    /// An iterator yielding `Result<FacetView, FacetError>` items for all facets
+    /// in the triangulation.
     ///
     /// # Errors
     ///
     /// Returns [`QueryError::TriangulationCorrupted`] if the facet iterator cannot
-    /// represent facet indices for this dimension.
+    /// represent facet indices for this dimension. Individual iterator items
+    /// return [`FacetError`](crate::prelude::tds::FacetError) if a facet view
+    /// cannot be constructed from the current TDS state.
     ///
     /// # Examples
     ///
@@ -263,6 +271,8 @@ where
     /// #     Construction(#[from] DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -274,14 +284,17 @@ where
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
     /// // Iterate over all facets
-    /// let facet_count = dt.as_triangulation().facets()?.count();
+    /// let facet_count = dt
+    ///     .as_triangulation()
+    ///     .facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
     /// assert_eq!(facet_count, 4); // Tetrahedron has 4 facets
     /// # Ok(())
     /// # }
     /// ```
     pub fn facets(&self) -> Result<AllFacetsIter<'_, U, V, D>, QueryError> {
-        AllFacetsIter::try_new(&self.tds)
-            .map_err(TdsError::from)
+        self.tds
+            .facets()
             .map_err(|source| QueryError::TriangulationCorrupted { source })
     }
 
@@ -292,7 +305,8 @@ where
     ///
     /// # Returns
     ///
-    /// An iterator yielding `FacetView` objects for boundary facets only.
+    /// An iterator yielding `Result<FacetView, FacetError>` items for boundary
+    /// facets only.
     ///
     /// # Examples
     ///
@@ -305,6 +319,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -315,7 +331,10 @@ where
     /// ];
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let boundary_count = dt.as_triangulation().boundary_facets()?.count();
+    /// let boundary_count = dt
+    ///     .as_triangulation()
+    ///     .boundary_facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
     /// assert_eq!(boundary_count, 4); // All facets are on boundary
     /// # Ok(())
     /// # }
@@ -326,6 +345,8 @@ where
     /// Returns [`QueryError::TriangulationCorrupted`] if facet-map construction
     /// detects invalid simplex or facet bookkeeping. The variant preserves the
     /// underlying [`TdsError`] so callers can inspect the structural failure.
+    /// Individual iterator items return [`FacetError`](crate::prelude::tds::FacetError)
+    /// if a boundary facet cannot be created or keyed from the simplices.
     pub fn boundary_facets(&self) -> Result<BoundaryFacetsIter<'_, U, V, D>, QueryError> {
         let facet_map = self
             .tds
@@ -801,8 +822,22 @@ mod tests {
                     assert_eq!(empty.dim(), -1);
                     assert_eq!(empty.simplices().count(), 0);
                     assert_eq!(empty.vertices().count(), 0);
-                    assert_eq!(empty.facets().unwrap().count(), 0);
-                    assert_eq!(empty.boundary_facets().unwrap().count(), 0);
+                    assert_eq!(
+                        empty
+                            .facets()
+                            .unwrap()
+                            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                            .unwrap(),
+                        0
+                    );
+                    assert_eq!(
+                        empty
+                            .boundary_facets()
+                            .unwrap()
+                            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                            .unwrap(),
+                        0
+                    );
 
                     let vertices = vec![
                         $(crate::core::vertex::Vertex::<(), _>::try_new($simplex_coords).unwrap()),+
@@ -822,8 +857,20 @@ mod tests {
                     assert_eq!(tri.dim(), $dim as i32);
                     assert_eq!(tri.simplices().count(), 1);
                     assert_eq!(tri.vertices().count(), expected_vertex_count);
-                    assert_eq!(tri.facets().unwrap().count(), expected_vertex_count);
-                    assert_eq!(tri.boundary_facets().unwrap().count(), expected_vertex_count);
+                    assert_eq!(
+                        tri.facets()
+                            .unwrap()
+                            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                            .unwrap(),
+                        expected_vertex_count
+                    );
+                    assert_eq!(
+                        tri.boundary_facets()
+                            .unwrap()
+                            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                            .unwrap(),
+                        expected_vertex_count
+                    );
                 }
             }
         };
@@ -1269,8 +1316,15 @@ mod tests {
         assert_eq!(edges_collected.len(), edge_count);
         assert!(edge_count >= 6);
 
-        assert!(tri.facets().unwrap().next().is_some());
-        assert!(tri.boundary_facets().unwrap().next().is_some());
+        assert!(tri.facets().unwrap().next().transpose().unwrap().is_some());
+        assert!(
+            tri.boundary_facets()
+                .unwrap()
+                .next()
+                .transpose()
+                .unwrap()
+                .is_some()
+        );
 
         let (simplex_key, _) = tri.simplices().next().unwrap();
         let simplex_vertices = tri.simplex_vertices(simplex_key).unwrap();

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -1873,7 +1873,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         &self,
         simplex_key: SimplexKey,
         vertices: &[VertexKey],
-    ) -> Result<Vec<(Uuid, [i8; D])>, TdsError> {
+    ) -> Result<SimplexUuidSortKey<D>, TdsError> {
         let simplex = self
             .simplices
             .get(simplex_key)
@@ -1893,7 +1893,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
             });
         }
 
-        let mut vertex_uuid_offsets: Vec<(Uuid, [i8; D])> = Vec::with_capacity(vertices.len());
+        let mut vertex_uuid_offsets = SimplexUuidSortKey::<D>::new();
         for (vertex_idx, &vertex_key) in vertices.iter().enumerate() {
             let vertex = self
                 .vertices
@@ -2380,6 +2380,12 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     /// # }
     /// ```
     pub fn simplex_keys(&self) -> impl Iterator<Item = SimplexKey> + '_ {
+        self.simplices.keys()
+    }
+
+    /// Returns the concrete simplex-key iterator for internal iterator structs
+    /// that need to store traversal state without allocating a key snapshot.
+    pub(crate) fn simplex_key_iter(&self) -> slotmap::dense::Keys<'_, SimplexKey, Simplex<V, D>> {
         self.simplices.keys()
     }
 
@@ -3064,7 +3070,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     fn candidate_periodic_vertex_uuid_offsets(
         &self,
         simplex: &Simplex<V, D>,
-    ) -> Result<Vec<(Uuid, [i8; D])>, TdsError> {
+    ) -> Result<SimplexUuidSortKey<D>, TdsError> {
         let vertices = simplex.vertices();
         let periodic_offsets = simplex.periodic_vertex_offsets();
         if let Some(offsets) = periodic_offsets
@@ -3080,7 +3086,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
             });
         }
 
-        let mut vertex_uuid_offsets = Vec::with_capacity(vertices.len());
+        let mut vertex_uuid_offsets = SimplexUuidSortKey::<D>::new();
         for (vertex_idx, &vertex_key) in vertices.iter().enumerate() {
             let vertex = self
                 .vertices
@@ -5957,7 +5963,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     fn validate_no_duplicate_simplices(&self) -> Result<(), TdsError> {
         // Include periodic per-vertex offsets in the duplicate key so periodic quotient simplices
         // with identical vertex sets but distinct lattice offsets are not collapsed.
-        let mut unique_simplices: FastHashMap<Vec<(Uuid, [i8; D])>, SimplexKey> =
+        let mut unique_simplices: FastHashMap<SimplexUuidSortKey<D>, SimplexKey> =
             fast_hash_map_with_capacity(self.simplices.len());
         let mut duplicates = Vec::new();
 
@@ -5967,7 +5973,6 @@ impl<U, V, const D: usize> Tds<U, V, D> {
                 self.build_periodic_vertex_uuid_offsets(simplex_key, &vertices)?;
 
             if let Some(existing_simplex_key) = unique_simplices.get(&vertex_uuid_offsets) {
-                // Convert to Vec only for error message payload
                 duplicates.push((
                     simplex_key,
                     *existing_simplex_key,
@@ -7271,7 +7276,8 @@ impl<U, V, const D: usize> Tds<U, V, D> {
 // TRAIT IMPLEMENTATIONS
 // =============================================================================
 
-type SimplexUuidSortKey<const D: usize> = Vec<(Uuid, [i8; D])>;
+type SimplexUuidSortKey<const D: usize> =
+    SmallBuffer<(Uuid, [i8; D]), MAX_PRACTICAL_DIMENSION_SIZE>;
 type SimplexUuidSortEntry<'a, V, const D: usize> = (SimplexUuidSortKey<D>, &'a Simplex<V, D>);
 
 /// Builds stable simplex sort keys once so equality does not hide dangling
@@ -7293,7 +7299,7 @@ where
                 return None;
             }
 
-            let mut ids = Vec::with_capacity(simplex.number_of_vertices());
+            let mut ids = SimplexUuidSortKey::<D>::new();
             for (idx, &vkey) in simplex.vertices().iter().enumerate() {
                 let uuid = tds.vertex(vkey).map(Vertex::uuid)?;
                 let offset = offsets.map_or([0_i8; D], |offsets| offsets[idx]);

--- a/src/core/traits/boundary_analysis.rs
+++ b/src/core/traits/boundary_analysis.rs
@@ -25,6 +25,8 @@ use crate::core::{
 /// #     Query(#[from] delaunay::query::QueryError),
 /// #     #[error(transparent)]
 /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+/// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
 /// # }
 /// # fn main() -> Result<(), ExampleError> {
 /// // Create a simple 3D triangulation (single tetrahedron)
@@ -39,8 +41,10 @@ use crate::core::{
 /// let tds = dt.tds();
 ///
 /// // Use the trait methods
-/// let boundary_facets = tds.boundary_facets()?;
-/// assert_eq!(boundary_facets.count(), 4); // Tetrahedron has 4 boundary faces
+/// let boundary_count = tds
+///     .boundary_facets()?
+///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
+/// assert_eq!(boundary_count, 4); // Tetrahedron has 4 boundary faces
 ///
 /// let count = tds.number_of_boundary_facets()?;
 /// assert_eq!(count, 4);
@@ -57,11 +61,14 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// # Returns
     ///
     /// A `Result<BoundaryFacetsIter<'_, U, V, D>, TdsError>` containing an iterator over boundary facets.
-    /// The iterator yields facets lazily without pre-allocating a vector, providing better performance.
+    /// The iterator yields `Result<FacetView, FacetError>` items lazily without pre-allocating a vector,
+    /// providing better performance while still surfacing corrupted facet views during iteration.
     ///
     /// # Errors
     ///
-    /// Returns a [`TdsError`] if any boundary facet cannot be created from the simplices.
+    /// Returns a [`TdsError`] if the boundary-facet iterator cannot be constructed.
+    /// Individual iterator items return [`FacetError`](crate::prelude::tds::FacetError)
+    /// if a boundary facet cannot be created or keyed from the simplices.
     ///
     /// # Examples
     ///
@@ -76,6 +83,8 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// #     Query(#[from] delaunay::query::QueryError),
     /// #     #[error(transparent)]
     /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -89,8 +98,10 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// let tds = dt.tds();
     ///
     /// // A single tetrahedron has 4 boundary facets (all facets are on the boundary)
-    /// let boundary_facets_iter = tds.boundary_facets()?;
-    /// assert_eq!(boundary_facets_iter.count(), 4);
+    /// let boundary_count = tds
+    ///     .boundary_facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
+    /// assert_eq!(boundary_count, 4);
     /// # Ok(())
     /// # }
     /// ```
@@ -129,6 +140,8 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// #     Query(#[from] delaunay::query::QueryError),
     /// #     #[error(transparent)]
     /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -143,7 +156,7 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     ///
     /// // Get a boundary facet using the new iterator API
     /// let mut boundary_facets = tds.boundary_facets()?;
-    /// let Some(first_facet) = boundary_facets.next() else {
+    /// let Some(first_facet) = boundary_facets.next().transpose()? else {
     ///     return Ok(());
     /// };
     /// // In a single tetrahedron, all facets are boundary facets
@@ -190,6 +203,8 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// #     Query(#[from] delaunay::query::QueryError),
     /// #     #[error(transparent)]
     /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -208,6 +223,7 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// // Check boundary facets efficiently using the iterator API and cached map
     /// let boundary_facets = tds.boundary_facets()?;
     /// for facet in boundary_facets {
+    ///     let facet = facet?;
     ///     let is_boundary = tds.is_boundary_facet_with_map(&facet, &facet_to_simplices)?;
     ///     println!("Facet is boundary: {is_boundary}");
     ///     // In a single tetrahedron, all facets are boundary facets
@@ -251,6 +267,8 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// #     Query(#[from] delaunay::query::QueryError),
     /// #     #[error(transparent)]
     /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -267,7 +285,9 @@ pub trait BoundaryAnalysis<U, V, const D: usize> {
     /// assert_eq!(tds.number_of_boundary_facets()?, 4);
     ///
     /// // Alternative: using iterator (useful for additional processing)
-    /// let count_via_iter = dt.boundary_facets()?.count();
+    /// let count_via_iter = dt
+    ///     .boundary_facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
     /// assert_eq!(count_via_iter, 4);
     /// # Ok(())
     /// # }

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -384,6 +384,7 @@ where
             })?;
 
     for facet_view in boundary_facets {
+        let facet_view = facet_view?;
         // Use the existing FacetView::key() method
         let facet_id = facet_view.key()?;
         facet_ids.insert(facet_id);

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -1431,7 +1431,7 @@ where
         validate_local_pseudomanifold_for_simplices(&self.tds, simplices)?;
 
         if self.topology_guarantee.requires_ridge_links() {
-            validate_ridge_links_for_simplices(&self.tds, simplices)?;
+            validate_ridge_links_for_simplices(&self.tds, simplices.iter().copied())?;
         }
 
         self.validate_geometric_simplex_orientation_for_simplices(simplices)?;

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -56,7 +56,8 @@ use crate::core::algorithms::incremental_insertion::{
 use crate::core::algorithms::locate::{ConflictError, LocateError};
 use crate::core::collections::spatial_hash_grid::HashGridIndex;
 use crate::core::collections::{
-    FastHashSet, FastHasher, MAX_PRACTICAL_DIMENSION_SIZE, SecureHashMap, SmallBuffer,
+    FastHashSet, FastHasher, MAX_PRACTICAL_DIMENSION_SIZE, SecureHashMap, SimplexKeyBuffer,
+    SmallBuffer,
 };
 use crate::core::construction::TriangulationConstructionError;
 use crate::core::insertion::record_duplicate_detection_metrics;
@@ -2989,8 +2990,8 @@ where
             stats.record_insertion(&simplex_stats);
         }
 
-        let mut soft_fail_seeds: Vec<SimplexKey> = Vec::new();
-        let mut pending_repair_seeds: Vec<SimplexKey> = Vec::new();
+        let mut soft_fail_seeds = SimplexKeyBuffer::new();
+        let mut pending_repair_seeds = SimplexKeyBuffer::new();
         let insert_loop_started = Instant::now();
         let insert_result = dt.insert_remaining_vertices_seeded(
             vertices,
@@ -3105,8 +3106,8 @@ where
         let original_repair_policy = dt.insertion_state.delaunay_repair_policy;
         dt.insertion_state.delaunay_repair_policy = DelaunayRepairPolicy::Never;
         dt.insertion_state.use_global_repair_fallback = use_global_repair_fallback;
-        let mut soft_fail_seeds: Vec<SimplexKey> = Vec::new();
-        let mut pending_repair_seeds: Vec<SimplexKey> = Vec::new();
+        let mut soft_fail_seeds = SimplexKeyBuffer::new();
+        let mut pending_repair_seeds = SimplexKeyBuffer::new();
         dt.insert_remaining_vertices_seeded(
             vertices,
             perturbation_seed,
@@ -3181,9 +3182,9 @@ where
         &mut self,
         index: usize,
         trigger: BatchLocalRepairTrigger,
-        pending_seed_simplices: &mut Vec<SimplexKey>,
+        pending_seed_simplices: &mut SimplexKeyBuffer,
         pending_seen: &mut FastHashSet<SimplexKey>,
-        soft_fail_seeds: &mut Vec<SimplexKey>,
+        soft_fail_seeds: &mut SimplexKeyBuffer,
         mut construction_telemetry: Option<&mut ConstructionTelemetry>,
     ) -> Result<(), DelaunayTriangulationConstructionError> {
         retain_live_simplex_seeds(&self.tri.tds, pending_seed_simplices, pending_seen);
@@ -3312,8 +3313,8 @@ where
         grid_cell_size: Option<f64>,
         batch_repair_policy: DelaunayRepairPolicy,
         construction_stats: Option<&mut ConstructionStatistics>,
-        pending_repair_seeds: &mut Vec<SimplexKey>,
-        soft_fail_seeds: &mut Vec<SimplexKey>,
+        pending_repair_seeds: &mut SimplexKeyBuffer,
+        soft_fail_seeds: &mut SimplexKeyBuffer,
     ) -> Result<(), DelaunayTriangulationConstructionError> {
         let mut grid_index: Option<HashGridIndex<D>> = match grid_cell_size {
             Some(cell_size) => Some(hash_grid_from_validated_cell_size(cell_size)?),
@@ -3801,7 +3802,7 @@ where
         self.insertion_state.delaunay_repair_policy = original_repair_policy;
 
         let has_simplices = self.tri.tds.number_of_simplices() > 0;
-        let mut completion_seed_simplices = Vec::new();
+        let mut completion_seed_simplices = SimplexKeyBuffer::new();
         let mut completion_seen = FastHashSet::default();
         for &simplex_key in pending_repair_seeds.iter().chain(soft_fail_seeds.iter()) {
             if self.tri.tds.contains_simplex(simplex_key) && completion_seen.insert(simplex_key) {

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -569,14 +569,6 @@ where
             return Ok(());
         }
 
-        let validate_simplices = |simplices: &[SimplexKey]| {
-            if simplices.is_empty() {
-                return Ok(());
-            }
-            validate_ridge_links_for_simplices(&self.tri.tds, simplices)
-                .map_err(ridge_link_repair_validation_error)
-        };
-
         if !run.touched_simplices.is_empty() {
             if run.used_full_reseed && env::var_os("DELAUNAY_REPAIR_TRACE").is_some() {
                 tracing::debug!(
@@ -584,11 +576,15 @@ where
                     run.touched_simplices.len()
                 );
             }
-            return validate_simplices(&run.touched_simplices);
+            return validate_ridge_links_for_simplices(
+                &self.tri.tds,
+                run.touched_simplices.iter().copied(),
+            )
+            .map_err(ridge_link_repair_validation_error);
         }
 
-        let validation_simplices: Vec<SimplexKey> = self.tri.tds.simplex_keys().collect();
-        validate_simplices(&validation_simplices)
+        validate_ridge_links_for_simplices(&self.tri.tds, self.tri.tds.simplex_keys())
+            .map_err(ridge_link_repair_validation_error)
     }
 
     /// Merge the inserted vertex star with any simplices that cavity reduction touched and
@@ -597,9 +593,9 @@ where
         &self,
         vertex_key: VertexKey,
         extra_seed_simplices: &[SimplexKey],
-    ) -> Vec<SimplexKey> {
+    ) -> SimplexKeyBuffer {
         let mut seen: FastHashSet<SimplexKey> = FastHashSet::default();
-        let mut seed_simplices = Vec::new();
+        let mut seed_simplices = SimplexKeyBuffer::new();
 
         // Keep the inserted vertex star first because it is the hottest local region and
         // the best chance of fixing ordinary post-insertion violations cheaply.

--- a/src/delaunay/locality.rs
+++ b/src/delaunay/locality.rs
@@ -29,7 +29,7 @@ pub struct LocalConflictSeedSimplices {
 pub fn accumulate_live_simplex_seeds<U, V, const D: usize>(
     tds: &Tds<U, V, D>,
     candidate_seed_simplices: &[SimplexKey],
-    pending_seed_simplices: &mut Vec<SimplexKey>,
+    pending_seed_simplices: &mut SimplexKeyBuffer,
     pending_seen: &mut FastHashSet<SimplexKey>,
 ) -> usize
 where
@@ -78,7 +78,7 @@ where
 /// Retains only live, deduplicated simplices in a pending local repair frontier.
 pub fn retain_live_simplex_seeds<U, V, const D: usize>(
     tds: &Tds<U, V, D>,
-    seed_simplices: &mut Vec<SimplexKey>,
+    seed_simplices: &mut SimplexKeyBuffer,
     seen: &mut FastHashSet<SimplexKey>,
 ) where
     U: DataType,
@@ -91,7 +91,7 @@ pub fn retain_live_simplex_seeds<U, V, const D: usize>(
 
 /// Clears a local repair frontier and its deduplication set together.
 pub fn clear_simplex_seed_set(
-    seed_simplices: &mut Vec<SimplexKey>,
+    seed_simplices: &mut SimplexKeyBuffer,
     seen: &mut FastHashSet<SimplexKey>,
 ) {
     seed_simplices.clear();
@@ -207,7 +207,8 @@ mod tests {
         );
 
         let stale_simplex = SimplexKey::from(KeyData::from_ffi(999_999));
-        let mut pending_seed_simplices = vec![all_simplices[0]];
+        let mut pending_seed_simplices = SimplexKeyBuffer::new();
+        pending_seed_simplices.push(all_simplices[0]);
         let mut pending_seen: FastHashSet<SimplexKey> =
             pending_seed_simplices.iter().copied().collect();
         let added = accumulate_live_simplex_seeds(
@@ -224,7 +225,7 @@ mod tests {
 
         assert_eq!(added, 1);
         assert_eq!(
-            pending_seed_simplices,
+            pending_seed_simplices.iter().copied().collect::<Vec<_>>(),
             vec![all_simplices[0], all_simplices[1]]
         );
         assert!(!pending_seed_simplices.contains(&stale_simplex));
@@ -237,7 +238,7 @@ mod tests {
         );
         assert_eq!(added_again, 0);
         assert_eq!(
-            pending_seed_simplices,
+            pending_seed_simplices.iter().copied().collect::<Vec<_>>(),
             vec![all_simplices[0], all_simplices[1]]
         );
     }
@@ -300,23 +301,28 @@ mod tests {
         );
 
         let stale_simplex = SimplexKey::from(KeyData::from_ffi(999_999));
-        let mut seed_simplices = vec![
+        let mut seed_simplices = SimplexKeyBuffer::new();
+        seed_simplices.extend([
             all_simplices[0],
             stale_simplex,
             all_simplices[1],
             all_simplices[0],
-        ];
+        ]);
         let mut seen = FastHashSet::default();
         retain_live_simplex_seeds(dt.tds(), &mut seed_simplices, &mut seen);
 
-        assert_eq!(seed_simplices, vec![all_simplices[0], all_simplices[1]]);
+        assert_eq!(
+            seed_simplices.iter().copied().collect::<Vec<_>>(),
+            vec![all_simplices[0], all_simplices[1]]
+        );
         assert_eq!(seen.len(), 2);
     }
 
     #[test]
     fn clear_simplex_seed_set_clears_both_collections() {
         let stale_simplex = SimplexKey::from(KeyData::from_ffi(999_999));
-        let mut seed_simplices = vec![stale_simplex];
+        let mut seed_simplices = SimplexKeyBuffer::new();
+        seed_simplices.push(stale_simplex);
         let mut seen = FastHashSet::default();
         seen.insert(stale_simplex);
 

--- a/src/delaunay/query.rs
+++ b/src/delaunay/query.rs
@@ -397,7 +397,8 @@ where
     ///
     /// # Returns
     ///
-    /// An iterator yielding `FacetView` objects for boundary facets only.
+    /// An iterator yielding `Result<FacetView, FacetError>` items for boundary
+    /// facets only.
     ///
     /// # Examples
     ///
@@ -410,6 +411,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -420,7 +423,9 @@ where
     /// ];
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let boundary_count = dt.boundary_facets()?.count();
+    /// let boundary_count = dt
+    ///     .boundary_facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
     /// assert_eq!(boundary_count, 4); // All facets are on boundary
     /// # Ok(())
     /// # }
@@ -431,6 +436,8 @@ where
     /// Returns [`QueryError::TriangulationCorrupted`] if facet-map construction
     /// detects invalid simplex or facet bookkeeping. The variant preserves the
     /// lower-level [`TdsError`](crate::tds::TdsError) for diagnostics.
+    /// Individual iterator items return [`FacetError`](crate::prelude::tds::FacetError)
+    /// if a boundary facet cannot be created or keyed from the simplices.
     pub fn boundary_facets(&self) -> Result<BoundaryFacetsIter<'_, U, V, D>, QueryError> {
         self.tri.boundary_facets()
     }
@@ -799,12 +806,14 @@ where
     ///
     /// # Returns
     ///
-    /// An iterator yielding `FacetView` objects for all facets.
+    /// An iterator yielding `Result<FacetView, FacetError>` items for all facets.
     ///
     /// # Errors
     ///
     /// Returns [`QueryError::TriangulationCorrupted`] if the facet iterator cannot
-    /// represent facet indices for this dimension.
+    /// represent facet indices for this dimension. Individual iterator items
+    /// return [`FacetError`](crate::prelude::tds::FacetError) if a facet view
+    /// cannot be constructed from the current TDS state.
     ///
     /// # Examples
     ///
@@ -819,6 +828,8 @@ where
     /// #     Construction(#[from] DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Query(#[from] delaunay::query::QueryError),
+    /// #     #[error(transparent)]
+    /// #     Facet(#[from] delaunay::prelude::tds::FacetError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -829,7 +840,9 @@ where
     /// ];
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     ///
-    /// let facet_count = dt.facets()?.count();
+    /// let facet_count = dt
+    ///     .facets()?
+    ///     .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
     /// assert_eq!(facet_count, 4); // Tetrahedron has 4 facets
     /// # Ok(())
     /// # }
@@ -1313,7 +1326,13 @@ mod tests {
                 spatial_index: None,
             };
 
-        assert_eq!(dt.boundary_facets().unwrap().count(), 0);
+        assert_eq!(
+            dt.boundary_facets()
+                .unwrap()
+                .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+                .unwrap(),
+            0
+        );
     }
 
     #[test]

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -1056,9 +1056,17 @@ where
         // These can be used to reconstruct FacetViews when needed
         let hull_facets: Vec<_> = hull_facets_iter
             .map(|facet_view| {
-                FacetHandle::from_validated(facet_view.simplex_key(), facet_view.facet_index())
+                let facet_view = facet_view.map_err(|source| {
+                    ConvexHullConstructionError::BoundaryFacetExtractionFailed {
+                        source: source.into(),
+                    }
+                })?;
+                Ok::<_, ConvexHullConstructionError>(FacetHandle::from_validated(
+                    facet_view.simplex_key(),
+                    facet_view.facet_index(),
+                ))
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
 
         // Additional validation: ensure we have at least one boundary facet
         if hull_facets.is_empty() {

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -789,6 +789,8 @@ fn facet_measure_gram_matrix<const D: usize>(
 /// #     #[error(transparent)]
 /// #     Tds(#[from] delaunay::prelude::tds::TdsError),
 /// #     #[error(transparent)]
+/// #     Facet(#[from] delaunay::prelude::tds::FacetError),
+/// #     #[error(transparent)]
 /// #     SurfaceMeasure(#[from] delaunay::prelude::geometry::SurfaceMeasureError),
 /// # }
 /// # fn main() -> Result<(), ExampleError> {
@@ -803,7 +805,7 @@ fn facet_measure_gram_matrix<const D: usize>(
 /// let tds = dt.tds();
 ///
 /// // Get boundary facets as FacetViews
-/// let boundary_facets = tds.boundary_facets()?.collect::<Vec<_>>();
+/// let boundary_facets = tds.boundary_facets()?.collect::<Result<Vec<_>, _>>()?;
 ///
 /// // Calculate surface area
 /// let surface_area = surface_measure(&boundary_facets)?;
@@ -1608,7 +1610,12 @@ mod tests {
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices).unwrap();
-        let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
+        let boundary_facets: Vec<_> = dt
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         // Find the facet opposite to v4 (contains vertices v1, v2, v3)
         let tarfacet = boundary_facets
@@ -1652,7 +1659,12 @@ mod tests {
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices).unwrap();
-        let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
+        let boundary_facets: Vec<_> = dt
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         // Take first two boundary facets for testing
         let facet1 = boundary_facets[0];
@@ -1962,7 +1974,12 @@ mod tests {
         ];
         let dt1: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices1).unwrap();
-        let boundary_facets1: Vec<_> = dt1.tds().boundary_facets().unwrap().collect();
+        let boundary_facets1: Vec<_> = dt1
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         // Find the facet opposite to v4 (triangle with v1, v2, v3) - area = 0.5
         let small_facet = boundary_facets1
@@ -1994,7 +2011,12 @@ mod tests {
         ];
         let dt2: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices2).unwrap();
-        let boundary_facets2: Vec<_> = dt2.tds().boundary_facets().unwrap().collect();
+        let boundary_facets2: Vec<_> = dt2
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         // Find the facet opposite to v8 (triangle with v5, v6, v7) - area = 24.0
         let large_facet = boundary_facets2
@@ -2040,7 +2062,12 @@ mod tests {
 
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::new(&vertices).unwrap();
-        let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
+        let boundary_facets: Vec<_> = dt
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         // In 2D, boundary facets are edges
         let total_perimeter = surface_measure(&boundary_facets).unwrap();
@@ -2064,7 +2091,12 @@ mod tests {
 
         let dt: DelaunayTriangulation<_, (), (), 4> =
             DelaunayTriangulation::new(&vertices).unwrap();
-        let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
+        let boundary_facets: Vec<_> = dt
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         let total_surface = surface_measure(&boundary_facets).unwrap();
 
@@ -2095,7 +2127,12 @@ mod tests {
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices).unwrap();
-        let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
+        let boundary_facets: Vec<_> = dt
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         // Test with valid facets - should work
         let result = surface_measure(&boundary_facets[0..1]);
@@ -2156,7 +2193,12 @@ mod tests {
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices).unwrap();
-        let boundary_facets: Vec<_> = dt.tds().boundary_facets().unwrap().collect();
+        let boundary_facets: Vec<_> = dt
+            .tds()
+            .boundary_facets()
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
 
         // Tetrahedron has exactly 4 boundary facets
         assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1031,8 +1031,8 @@ pub mod query {
     pub use crate::geometry::traits::coordinate::Coordinate;
     pub use crate::geometry::{insphere, insphere_distance, insphere_lifted};
     pub use crate::tds::{
-        AdjacencyIndex, AdjacencyIndexBuildError, EdgeKey, EdgeKeyError, FacetView, Simplex,
-        SimplexKey, Vertex, VertexKey,
+        AdjacencyIndex, AdjacencyIndexBuildError, AllFacetsIter, BoundaryFacetsIter, EdgeKey,
+        EdgeKeyError, FacetView, Simplex, SimplexKey, Vertex, VertexKey,
     };
     pub use crate::{DelaunayTriangulation, Triangulation};
 }
@@ -1224,9 +1224,9 @@ pub mod prelude {
         };
         pub use crate::geometry::point::Point;
         pub use crate::query::{
-            AdjacencyIndex, AdjacencyIndexBuildError, BoundaryAnalysis, DataCopy, DataDebug,
-            DataDeserialize, DataIdentity, DataSerde, DataSerialize, DataType, EdgeKey,
-            EdgeKeyError, FacetView, QueryError,
+            AdjacencyIndex, AdjacencyIndexBuildError, AllFacetsIter, BoundaryAnalysis,
+            BoundaryFacetsIter, DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde,
+            DataSerialize, DataType, EdgeKey, EdgeKeyError, FacetView, QueryError,
         };
         pub use crate::tds::{
             FacetHandle, InvariantError, InvariantErrorSummary, InvariantErrorSummaryDetail,
@@ -1558,8 +1558,9 @@ pub mod prelude {
         };
         pub use crate::geometry::traits::coordinate::Coordinate;
         pub use crate::query::{
-            BoundaryAnalysis, DataCopy, DataDebug, DataDeserialize, DataIdentity, DataSerde,
-            DataSerialize, DataType, FacetView, QueryError, Simplex, Vertex,
+            AllFacetsIter, BoundaryAnalysis, BoundaryFacetsIter, DataCopy, DataDebug,
+            DataDeserialize, DataIdentity, DataSerde, DataSerialize, DataType, FacetView,
+            QueryError, Simplex, Vertex,
         };
 
         // Read-only predicates (useful in benchmarks / lightweight geometry checks)

--- a/src/topology/characteristics/euler.rs
+++ b/src/topology/characteristics/euler.rs
@@ -491,7 +491,8 @@ pub fn count_boundary_simplices<U, V, const D: usize>(
     let boundary_facets: Vec<_> = tds
         .boundary_facets()
         .map_err(|source| TopologyError::BoundaryFacetEnumeration { source })?
-        .collect();
+        .map(|facet| facet.map_err(|source| TopologyError::BoundaryFacetSimplexAccess { source }))
+        .collect::<Result<Vec<_>, _>>()?;
 
     if boundary_facets.is_empty() {
         // No boundary - return zero counts for (D-1)-dimensional complex

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -1330,19 +1330,21 @@ fn build_ridge_star_map<U, V, const D: usize>(
 
 fn build_ridge_star_map_for_simplices<U, V, const D: usize>(
     tds: &Tds<U, V, D>,
-    simplices: &[SimplexKey],
+    simplices: impl IntoIterator<Item = SimplexKey>,
 ) -> Result<FastHashMap<u64, RidgeStar>, ManifoldError> {
     if D < 2 {
         return Ok(FastHashMap::default());
     }
 
-    if simplices.is_empty() {
-        return Ok(FastHashMap::default());
-    }
+    let simplices = simplices.into_iter();
+    let (lower_bound, upper_bound) = simplices.size_hint();
+    let estimated_simplex_count = upper_bound.unwrap_or(lower_bound);
 
     // Each D-simplex has C(D+1, 2) ridges (omit two vertices).
     let ridges_per_simplex = (D + 1).saturating_mul(D) / 2;
-    let estimated_unique_ridges = simplices.len().saturating_mul(ridges_per_simplex).max(1);
+    let estimated_unique_ridges = estimated_simplex_count
+        .saturating_mul(ridges_per_simplex)
+        .max(1);
 
     // Build a set of ridges touched by the specified simplices.
     // For periodic simplices we store both lifted vertices (for ridge identity and
@@ -1356,7 +1358,7 @@ fn build_ridge_star_map_for_simplices<U, V, const D: usize>(
     let mut ridge_vertices_lifted: LiftedVertexBuffer =
         LiftedVertexBuffer::with_capacity(D.saturating_sub(1));
 
-    for &simplex_key in simplices {
+    for simplex_key in simplices {
         if !tds.contains_simplex(simplex_key) {
             continue;
         }
@@ -1672,20 +1674,16 @@ pub fn validate_ridge_links<U, V, const D: usize>(tds: &Tds<U, V, D>) -> Result<
 /// let tds = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices)?;
 /// let simplices: SimplexKeyBuffer = tds.simplices().map(|(k, _)| k).collect();
 ///
-/// validate_ridge_links_for_simplices(&tds, &simplices)?;
+/// validate_ridge_links_for_simplices(&tds, simplices.iter().copied())?;
 /// # Ok(())
 /// # }
 /// ```
 pub fn validate_ridge_links_for_simplices<U, V, const D: usize>(
     tds: &Tds<U, V, D>,
-    simplices: &[SimplexKey],
+    simplices: impl IntoIterator<Item = SimplexKey>,
 ) -> Result<(), ManifoldError> {
     // Ridge links are only meaningful for D>=2.
     if D < 2 {
-        return Ok(());
-    }
-
-    if simplices.is_empty() {
         return Ok(());
     }
 
@@ -3872,7 +3870,7 @@ mod tests {
         let tds: Tds<(), (), 1> = Tds::empty();
         let simplex_key = SimplexKey::from(KeyData::from_ffi(0));
 
-        let map = build_ridge_star_map_for_simplices(&tds, &[simplex_key]).unwrap();
+        let map = build_ridge_star_map_for_simplices(&tds, [simplex_key]).unwrap();
         assert!(map.is_empty());
     }
 
@@ -3906,7 +3904,8 @@ mod tests {
             )
             .unwrap();
 
-        let map = build_ridge_star_map_for_simplices(&tds, &[]).unwrap();
+        let map =
+            build_ridge_star_map_for_simplices(&tds, std::iter::empty::<SimplexKey>()).unwrap();
         assert!(map.is_empty());
     }
 
@@ -3918,7 +3917,7 @@ mod tests {
         // Include a missing simplex key to ensure it is skipped, not treated as an error.
         let missing = SimplexKey::from(KeyData::from_ffi(u64::MAX));
 
-        let map = build_ridge_star_map_for_simplices(&tds, &[c1, missing]).unwrap();
+        let map = build_ridge_star_map_for_simplices(&tds, [c1, missing]).unwrap();
 
         // In 3D, ridges are edges: a tetrahedron has C(4,2) = 6 edges.
         assert_eq!(map.len(), 6);
@@ -3959,7 +3958,7 @@ mod tests {
     fn test_build_ridge_star_map_for_simplices_3d_two_simplices_includes_union_of_ridges() {
         let (tds, [v0, v1, v2, v3, v4], [c1, c2]) = build_two_tetrahedra_sharing_facet_tds_3d();
 
-        let map = build_ridge_star_map_for_simplices(&tds, &[c1, c2]).unwrap();
+        let map = build_ridge_star_map_for_simplices(&tds, [c1, c2]).unwrap();
 
         // Each tetrahedron has 6 edges and they share 3 edges on the shared facet => 6+6-3=9.
         assert_eq!(map.len(), 9);
@@ -3992,7 +3991,7 @@ mod tests {
         let (tds, v0, incident, _nonincident) = build_wedge_two_spheres_share_vertex_tds_2d();
 
         // In 2D, ridges are vertices. A single triangle touches 3 ridges.
-        let map = build_ridge_star_map_for_simplices(&tds, &[incident]).unwrap();
+        let map = build_ridge_star_map_for_simplices(&tds, [incident]).unwrap();
         assert_eq!(map.len(), 3);
 
         // The shared vertex v0 should have a star consisting of 6 incident triangles (3 from each sphere).
@@ -4040,7 +4039,7 @@ mod tests {
             simplex.push_vertex_key(v1);
         }
 
-        match build_ridge_star_map_for_simplices(&tds, &[simplex_key]) {
+        match build_ridge_star_map_for_simplices(&tds, [simplex_key]) {
             Err(ManifoldError::Tds(TdsError::DimensionMismatch {
                 expected: 3,
                 actual: 2,
@@ -4065,10 +4064,10 @@ mod tests {
             Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
 
         let simplices: Vec<SimplexKey> = tds.simplices().map(|(k, _)| k).collect();
-        validate_ridge_links_for_simplices(&tds, &simplices).unwrap();
+        validate_ridge_links_for_simplices(&tds, simplices.iter().copied()).unwrap();
 
         // And it should be a no-op on empty simplex lists.
-        validate_ridge_links_for_simplices(&tds, &[]).unwrap();
+        validate_ridge_links_for_simplices(&tds, std::iter::empty::<SimplexKey>()).unwrap();
     }
 
     #[test]
@@ -4077,7 +4076,7 @@ mod tests {
         let tds: Tds<(), (), 3> = Tds::empty();
         let missing = SimplexKey::from(KeyData::from_ffi(u64::MAX));
 
-        assert!(validate_ridge_links_for_simplices(&tds, &[missing]).is_ok());
+        assert!(validate_ridge_links_for_simplices(&tds, [missing]).is_ok());
     }
 
     #[test]
@@ -4099,7 +4098,7 @@ mod tests {
             .insert_simplex_with_mapping(Simplex::try_new_with_data(vec![v0, v1], None).unwrap())
             .unwrap();
 
-        assert!(validate_ridge_links_for_simplices(&tds, &[c01]).is_ok());
+        assert!(validate_ridge_links_for_simplices(&tds, [c01]).is_ok());
     }
 
     #[test]
@@ -4108,7 +4107,7 @@ mod tests {
 
         let expected_ridge_key = facet_key_from_vertices(&[v0]);
 
-        match validate_ridge_links_for_simplices(&tds, &[incident]) {
+        match validate_ridge_links_for_simplices(&tds, [incident]) {
             Err(ManifoldError::RidgeLinkNotManifold {
                 ridge_key,
                 link_vertex_count,
@@ -4135,7 +4134,7 @@ mod tests {
         let (tds, _v0, _incident, nonincident) = build_wedge_two_spheres_share_vertex_tds_2d();
 
         // Validate a triangle that does NOT touch the shared vertex; this should not detect the wedge.
-        assert!(validate_ridge_links_for_simplices(&tds, &[nonincident]).is_ok());
+        assert!(validate_ridge_links_for_simplices(&tds, [nonincident]).is_ok());
     }
 
     fn build_cone_on_torus_tds() -> (Tds<(), (), 3>, VertexKey) {
@@ -4463,7 +4462,7 @@ mod tests {
             .unwrap();
         let c2 = tds.insert_simplex_with_mapping(simplex2).unwrap();
 
-        let map = build_ridge_star_map_for_simplices(&tds, &[c1, c2]).unwrap();
+        let map = build_ridge_star_map_for_simplices(&tds, [c1, c2]).unwrap();
 
         // In 2D, ridges have D-1 = 1 vertex. Single-vertex ridges are identified
         // modulo global periodic translation, so v0@base and v0@[1,0] represent
@@ -4605,7 +4604,7 @@ mod tests {
             .unwrap();
         let c2 = tds.insert_simplex_with_mapping(simplex2).unwrap();
 
-        match validate_ridge_links_for_simplices(&tds, &[c1, c2]) {
+        match validate_ridge_links_for_simplices(&tds, [c1, c2]) {
             Err(ManifoldError::RidgeLinkNotManifold { .. }) => {}
             other => panic!("Expected RidgeLinkNotManifold, got {other:?}"),
         }

--- a/tests/example_workflows.rs
+++ b/tests/example_workflows.rs
@@ -24,7 +24,14 @@ fn triangulation_and_hull_workflow_remains_valid() -> Result<(), WorkflowTestErr
     let index = dt.build_adjacency_index()?;
     assert!(index.number_of_edges() > 0);
 
-    let boundary_facets: Vec<_> = dt.boundary_facets()?.collect();
+    let boundary_facets: Vec<_> = dt
+        .boundary_facets()?
+        .map(|facet| {
+            facet.map_err(|source| QueryError::TriangulationCorrupted {
+                source: source.into(),
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
     assert!(!boundary_facets.is_empty());
 
     let hull = ConvexHull::from_triangulation(dt.as_triangulation())?;

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -77,7 +77,10 @@ use delaunay::prelude::ordering::{
     hilbert_sorted_indices_in_range, try_hilbert_index, try_hilbert_quantize,
     try_hilbert_sort_by_stable, try_hilbert_sort_by_unstable, try_hilbert_sorted_indices,
 };
-use delaunay::prelude::query::{ConvexHull, QueryError};
+use delaunay::prelude::query::{
+    AllFacetsIter as QueryAllFacetsIter, BoundaryFacetsIter as QueryBoundaryFacetsIter, ConvexHull,
+    QueryError,
+};
 use delaunay::prelude::repair::{
     DelaunayCheckPolicy, DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairOperation,
     DelaunayRepairOutcome, DelaunayRepairStats, DelaunayRepairVerificationContext,
@@ -88,7 +91,8 @@ use delaunay::prelude::repair::{
 #[cfg(feature = "diagnostics")]
 use delaunay::prelude::tds::Tds;
 use delaunay::prelude::tds::{
-    FacetError, InvariantErrorSummaryDetail, NeighborSlot, TdsError, TdsErrorKind, VertexKey,
+    AllFacetsIter as TdsAllFacetsIter, BoundaryFacetsIter as TdsBoundaryFacetsIter, FacetError,
+    InvariantErrorSummaryDetail, NeighborSlot, TdsError, TdsErrorKind, VertexKey,
 };
 use delaunay::prelude::topology::spaces::{
     GlobalTopology, GlobalTopologyModelError, TopologyKind, ToroidalConstructionMode,
@@ -99,6 +103,8 @@ use delaunay::prelude::topology::validation::{
     RidgeVerticesError, ridge_star_simplices,
 };
 use delaunay::prelude::triangulation::{
+    AllFacetsIter as TriangulationAllFacetsIter,
+    BoundaryFacetsIter as TriangulationBoundaryFacetsIter,
     FacetIssuesMap as TriangulationFacetIssuesMap, FastKernel as TriangulationFastKernel,
     InsertionError as TriangulationInsertionError, QueryError as TriangulationQueryError,
     SpatialIndexConstructionFailure as GenericSpatialIndexConstructionFailure,
@@ -116,6 +122,9 @@ use delaunay::prelude::validation::{
 use delaunay::prelude::{
     CoordinateRange as RootCoordinateRange, SecureHashMap, SecureHashSet,
     ValidationConfigurationError as RootValidationConfigurationError,
+};
+use delaunay::query::{
+    AllFacetsIter as QueryFacadeAllFacetsIter, BoundaryFacetsIter as QueryFacadeBoundaryFacetsIter,
 };
 #[derive(Debug, thiserror::Error)]
 enum RootApiExportTestError {
@@ -342,12 +351,27 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
     let dt = DelaunayTriangulation::new_with_options(&vertices, options)?;
 
     assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
-    assert!(dt.boundary_facets()?.count() > 0);
+    let _query_facade_all_facets: QueryFacadeAllFacetsIter<'_, (), (), 3> = dt.facets()?;
+    let _query_facade_boundary_facets: QueryFacadeBoundaryFacetsIter<'_, (), (), 3> =
+        dt.boundary_facets()?;
+    let _query_prelude_all_facets: QueryAllFacetsIter<'_, (), (), 3> = dt.facets()?;
+    let _query_prelude_boundary_facets: QueryBoundaryFacetsIter<'_, (), (), 3> =
+        dt.boundary_facets()?;
+    let boundary_facet_count = dt.boundary_facets()?.try_fold(0_usize, |count, facet| {
+        facet
+            .map(|_| count + 1)
+            .map_err(|source| QueryError::TriangulationCorrupted {
+                source: source.into(),
+            })
+    })?;
+    assert!(boundary_facet_count > 0);
     let _hull = ConvexHull::from_triangulation(dt.as_triangulation()).unwrap();
     dt.validate().unwrap();
     assert_bistellar_flips(&dt);
 
     let mut empty_tds: InsertionTds<(), (), 2> = InsertionTds::empty();
+    let _tds_all_facets: TdsAllFacetsIter<'_, (), (), 2> = empty_tds.facets().unwrap();
+    let _tds_boundary_facets: Option<TdsBoundaryFacetsIter<'static, (), (), 2>> = None;
     assert_eq!(
         repair_neighbor_pointers_local(&mut empty_tds, &[], None)?,
         0
@@ -799,13 +823,23 @@ fn triangulation_prelude_covers_generic_layer() -> Result<(), GenericTriangulati
     tri.set_topology_guarantee(TriangulationTopologyGuarantee::Pseudomanifold);
     tri.set_validation_policy(TriangulationValidationPolicy::Never);
     tri.validate().unwrap();
+    let _triangulation_all_facets: TriangulationAllFacetsIter<'_, (), (), 2> =
+        tri.facets().unwrap();
+    let _triangulation_boundary_facets: TriangulationBoundaryFacetsIter<'_, (), (), 2> =
+        tri.boundary_facets().unwrap();
 
     let empty_issues = TriangulationFacetIssuesMap::default();
     let removed = tri
         .repair_local_facet_issues(&empty_issues, 0)
         .expect("empty issue set should not fail generic local repair");
     assert_eq!(removed, 0);
-    assert_eq!(tri.boundary_facets().unwrap().count(), 0);
+    assert_eq!(
+        tri.boundary_facets()
+            .unwrap()
+            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+            .unwrap(),
+        0
+    );
 
     assert_send_sync_unpin::<TriangulationInsertionError>();
     assert_send_sync_unpin::<TriangulationQueryError>();

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -664,9 +664,15 @@ fn regression_insertion_order_3d_case_001() {
 // =============================================================================
 
 macro_rules! gen_incremental_insertion_validity {
-    ($dim:literal, $min:literal, $max:literal $(, #[$attr:meta])*) => {
+    ($dim:literal, $min:literal, $max:literal $(, cases = $cases:literal)? $(, #[$attr:meta])*) => {
         pastey::paste! {
             proptest! {
+                $(
+                    #![proptest_config(Config {
+                        cases: $cases,
+                        ..Config::default()
+                    })]
+                )?
                 $(#[$attr])*
                 #[test]
                 fn [<prop_incremental_insertion_maintains_validity_ $dim d>](
@@ -804,7 +810,7 @@ proptest! {
     }
 }
 gen_incremental_insertion_validity!(4, 5, 7);
-gen_incremental_insertion_validity!(5, 6, 8);
+gen_incremental_insertion_validity!(5, 6, 8, cases = 12);
 
 proptest! {
     #![proptest_config(Config {

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -56,6 +56,43 @@ pub fn deep_crate_path_fixture() {
     let _buffer = crate::core::collections::SimplexKeyBuffer::new();
 }
 
+pub struct RawSimplexSeedFrontier {
+    // ruleid: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    seed_simplices: Vec<SimplexKey>,
+}
+
+pub struct BufferedSimplexSeedFrontier {
+    // ok: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    seed_simplices: SimplexKeyBuffer,
+}
+
+pub struct ConflictErrorPayloadFixture {
+    // ok: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    extra_simplices: Vec<SimplexKey>,
+}
+
+pub fn raw_simplex_frontier_vec_fixture(
+    // ruleid: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    pending_seed_simplices: &mut Vec<SimplexKey>,
+) {
+    // ruleid: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    let mut touched_simplices: Vec<SimplexKey> = Vec::new();
+    // ruleid: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    let conflict_preview: Vec<SimplexKey> = pending_seed_simplices.iter().copied().collect();
+
+    touched_simplices.extend(conflict_preview);
+}
+
+pub fn simplex_frontier_buffer_fixture(pending_seed_simplices: &mut SimplexKeyBuffer) {
+    // ok: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    let mut touched_simplices = SimplexKeyBuffer::new();
+    // ok: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    let all_simplices: Vec<SimplexKey> = Vec::new();
+
+    touched_simplices.extend(pending_seed_simplices.iter().copied());
+    let _ = all_simplices;
+}
+
 pub fn public_unwrap_bypass(value: Option<u8>) -> u8 {
     // ruleid: delaunay.rust.no-production-unwrap-panic, delaunay.rust.no-public-surface-unwrap-panic, delaunay.rust.no-unwrap-expect-in-benches-examples
     value.unwrap()

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -79,8 +79,13 @@ pub fn raw_simplex_frontier_vec_fixture(
     let mut touched_simplices: Vec<SimplexKey> = Vec::new();
     // ruleid: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
     let conflict_preview: Vec<SimplexKey> = pending_seed_simplices.iter().copied().collect();
+    // ruleid: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    let mut pending_repair_simplices = Vec::new();
+    // ruleid: delaunay.rust.prefer-simplex-key-buffer-for-local-frontiers
+    let removed_simplices = Vec::with_capacity(4);
 
     touched_simplices.extend(conflict_preview);
+    pending_repair_simplices.extend(removed_simplices);
 }
 
 pub fn simplex_frontier_buffer_fixture(pending_seed_simplices: &mut SimplexKeyBuffer) {

--- a/tests/trait_bound_ergonomics.rs
+++ b/tests/trait_bound_ergonomics.rs
@@ -74,7 +74,13 @@ fn read_only_topology_apis_accept_non_datatype_payloads() {
 
     assert_eq!(tri.number_of_vertices(), 0);
     assert_eq!(tri.number_of_simplices(), 0);
-    assert_eq!(tri.boundary_facets().unwrap().count(), 0);
+    assert_eq!(
+        tri.boundary_facets()
+            .unwrap()
+            .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))
+            .unwrap(),
+        0
+    );
 
     let index = tri.build_adjacency_index().unwrap();
     assert!(index.vertex_to_simplices.is_empty());


### PR DESCRIPTION
- Make all-facet and boundary-facet traversal yield `Result<FacetView, FacetError>` so corrupted facet views and invalid boundary incidence are surfaced instead of skipped.
- Route boundary-facet consumers, hull extraction, Euler counting, examples, benches, and prelude coverage through explicit item-error handling.
- Use `SimplexKeyBuffer` for local repair and topology frontiers, and add a Semgrep guard for future raw `Vec<SimplexKey>` regressions.
- Add a compact 2D-5D timing summary to `just perf-large-scale-smoke`.

BREAKING CHANGE: facet iteration APIs now yield `Result<FacetView, FacetError>` items, `AllFacetsIter::try_new` is crate-private in favor of `Tds::facets()`, and `validate_ridge_links_for_simplices` now accepts `IntoIterator<Item = SimplexKey>`; slice callers should pass `.iter().copied()`.