### PR TITLE
fix(api)!: reject stale adjacency indexes (#451)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # delaunay
 
 [![DOI](https://zenodo.org/badge/729897852.svg)](https://doi.org/10.5281/zenodo.16931097)
-[![Crates.io](https://img.shields.io/crates/v/delaunay.svg)](https://crates.io/crates/delaunay)
-[![Downloads](https://img.shields.io/crates/d/delaunay.svg)](https://crates.io/crates/delaunay)
-[![License](https://img.shields.io/crates/l/delaunay.svg)](https://github.com/acgetchell/delaunay/blob/main/LICENSE)
+[![Crates.io](https://badgen.net/crates/v/delaunay)](https://crates.io/crates/delaunay)
+[![Downloads](https://badgen.net/crates/d/delaunay)](https://crates.io/crates/delaunay)
+[![License](https://badgen.net/github/license/acgetchell/delaunay)](https://github.com/acgetchell/delaunay/blob/main/LICENSE)
 [![Docs.rs](https://docs.rs/delaunay/badge.svg)](https://docs.rs/delaunay)
 [![CI][ci-badge]][ci-workflow]
 [![CodeQL][codeql-badge]][codeql-workflow]

--- a/src/core/adjacency.rs
+++ b/src/core/adjacency.rs
@@ -16,7 +16,9 @@ use crate::core::collections::{
 };
 use crate::core::edge::EdgeKey;
 use crate::core::tds::{SimplexKey, VertexKey};
+use std::sync::Arc;
 use thiserror::Error;
+use uuid::Uuid;
 
 /// Errors that can occur while building an [`AdjacencyIndex`].
 ///
@@ -62,6 +64,9 @@ pub enum AdjacencyIndexBuildError {
 /// ## Notes
 /// - No sorted-order guarantees are provided for the values.
 /// - The collections are optimized for performance (FxHasher-backed).
+/// - An index is tied to the triangulation snapshot that built it. Rebuild it
+///   after mutating the triangulation, and do not share it across
+///   triangulations.
 ///
 /// # Examples
 ///
@@ -95,24 +100,28 @@ pub enum AdjacencyIndexBuildError {
 ///
 /// // Query incident simplices for some vertex key from the triangulation.
 /// let Some((vk, _)) = tri.vertices().next() else { return Ok(()); };
-/// let Some(incident_simplices) = index.vertex_to_simplices.get(&vk) else {
-///     return Ok(());
-/// };
-/// assert!(!incident_simplices.is_empty());
+/// assert!(index.number_of_adjacent_simplices(vk) > 0);
 /// # Ok(())
 /// # }
 /// ```
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct AdjacencyIndex {
+    /// Runtime identity of the TDS snapshot this index was built from.
+    pub(crate) tds_identity: Arc<Uuid>,
+
+    /// Generation of the TDS snapshot this index was built from.
+    pub(crate) tds_generation: u64,
+
     /// Vertex → incident edges.
-    pub vertex_to_edges: FastHashMap<VertexKey, SmallBuffer<EdgeKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
+    pub(crate) vertex_to_edges:
+        FastHashMap<VertexKey, SmallBuffer<EdgeKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
 
     /// Vertex → incident simplices.
-    pub vertex_to_simplices: VertexToSimplicesMap,
+    pub(crate) vertex_to_simplices: VertexToSimplicesMap,
 
     /// Simplex → neighboring simplices (boundary facets omitted).
-    pub simplex_to_neighbors:
+    pub(crate) simplex_to_neighbors:
         FastHashMap<SimplexKey, SmallBuffer<SimplexKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
 }
 

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -49,8 +49,6 @@ use crate::core::validation::{TopologyGuarantee, TriangulationValidationError};
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
-#[cfg(debug_assertions)]
-use crate::geometry::predicates::simplex_orientation;
 use crate::geometry::predicates::{Orientation, simplex_orientation_fast_filter_sign};
 use crate::geometry::robust_predicates::robust_orientation;
 use crate::geometry::traits::coordinate::{
@@ -402,10 +400,20 @@ where
     {
         return Err(FlipContextError::OverlappingFaces.into());
     }
-    debug_assert!(
-        tds.is_coherently_oriented(),
-        "TDS coherent orientation invariant violated before bistellar flip (k={k_move}, direction={direction:?})",
-    );
+    #[cfg(debug_assertions)]
+    {
+        // Coherent orientation is a validation-scale invariant. Keep the typed
+        // diagnostic in debug/test builds, but do not scan the whole TDS inside
+        // every release-mode flip on construction/repair hot paths.
+        if !tds.is_coherently_oriented() {
+            return Err(FlipContextError::CoherentOrientationViolation {
+                stage: FlipOrientationCheckStage::BeforeMutation,
+                k_move,
+                direction,
+            }
+            .into());
+        }
+    }
 
     // Bistellar move legality: the inserted simplex must not already exist in the complex.
     //
@@ -579,10 +587,21 @@ where
         })
     })?;
 
-    debug_assert!(
-        trial.is_coherently_oriented(),
-        "TDS coherent orientation invariant violated after bistellar flip (k={k_move}, direction={direction:?})",
-    );
+    #[cfg(debug_assertions)]
+    {
+        // This is intentionally debug/test-only for the same reason as the
+        // pre-flip scan above: production validation already checks coherent
+        // orientation at explicit validation boundaries.
+        if !trial.is_coherently_oriented() {
+            return Err(FlipError::from(
+                FlipMutationError::CoherentOrientationViolation {
+                    stage: FlipOrientationCheckStage::AfterTrialMutation,
+                    k_move,
+                    direction,
+                },
+            ));
+        }
+    }
 
     *tds = trial;
 
@@ -2274,6 +2293,20 @@ impl FlipDirection {
         }
     }
 }
+
+/// Stage where debug/test flip validation checked coherent orientation.
+///
+/// Coherent orientation is a validation-scale TDS invariant. Release-mode flip
+/// hot paths rely on explicit validation boundaries rather than scanning the
+/// whole TDS before and after every attempted flip.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum FlipOrientationCheckStage {
+    /// Before applying the flip to the trial TDS.
+    BeforeMutation,
+    /// After applying the flip to the trial TDS and before committing it.
+    AfterTrialMutation,
+}
 /// Detect repeated flip signatures and abort on cycles.
 #[derive(Debug, Clone, Copy)]
 struct FlipCycleContext<'a> {
@@ -2626,6 +2659,22 @@ pub enum FlipContextError {
     /// Removed and inserted faces are not disjoint.
     #[error("removed-face and inserted-face must be disjoint")]
     OverlappingFaces,
+    /// The TDS coherent-orientation invariant failed during debug/test flip validation.
+    ///
+    /// This diagnostic is reserved for validation builds because the check scans
+    /// global TDS orientation state. Production callers should use explicit TDS
+    /// or triangulation validation when they need this invariant checked.
+    #[error(
+        "TDS coherent orientation invariant violated during {stage:?} for k={k_move}, direction={direction:?}"
+    )]
+    CoherentOrientationViolation {
+        /// Stage where the invariant was checked.
+        stage: FlipOrientationCheckStage,
+        /// k for the attempted move.
+        k_move: usize,
+        /// Direction of the attempted move.
+        direction: FlipDirection,
+    },
     /// Replacement-simplex offset sidecar length does not match the replacement simplices.
     #[error(
         "replacement periodic offset count {offset_count} does not match replacement simplex count {simplex_count}"
@@ -2920,6 +2969,9 @@ pub enum FlipNeighborCavityFailureKind {
     /// Facet sharing remained invalid after repair.
     #[error("invalid facet sharing after repair")]
     InvalidFacetSharingAfterRepair,
+    /// Cavity filling created the wrong number of replacement simplices.
+    #[error("boundary simplex count mismatch")]
+    BoundarySimplexCountMismatch,
     /// Neighbor rebuild failed.
     #[error("neighbor rebuild")]
     NeighborRebuild,
@@ -2951,6 +3003,9 @@ impl From<&CavityFillingError> for FlipNeighborCavityFailureKind {
             CavityFillingError::EmptyBoundary { .. } => Self::EmptyBoundary,
             CavityFillingError::InvalidFacetSharingAfterRepair { .. } => {
                 Self::InvalidFacetSharingAfterRepair
+            }
+            CavityFillingError::BoundarySimplexCountMismatch { .. } => {
+                Self::BoundarySimplexCountMismatch
             }
             CavityFillingError::NeighborRebuild { .. } => Self::NeighborRebuild,
             CavityFillingError::PerturbationScaleConversion { .. } => {
@@ -3366,6 +3421,22 @@ pub enum FlipMutationError {
         /// Underlying TDS validation error.
         #[source]
         source: TdsValidationFailure,
+    },
+    /// Trial TDS coherent-orientation validation failed before committing a flip.
+    ///
+    /// This diagnostic is debug/test-only in the flip hot path because it scans
+    /// global TDS orientation state. Release-mode callers should use explicit
+    /// validation boundaries when they need this invariant checked.
+    #[error(
+        "trial TDS coherent orientation invariant violated during {stage:?} (k={k_move}, direction={direction:?})"
+    )]
+    CoherentOrientationViolation {
+        /// Stage where the invariant was checked.
+        stage: FlipOrientationCheckStage,
+        /// k for the attempted move.
+        k_move: usize,
+        /// Direction of the attempted move.
+        direction: FlipDirection,
     },
 }
 
@@ -3816,7 +3887,11 @@ impl From<&FlipError> for FlipFailureKind {
                 _ => Self::NeighborWiring,
             },
             FlipError::TdsMutation { reason }
-                if matches!(reason.as_ref(), FlipMutationError::TrialValidation { .. }) =>
+                if matches!(
+                    reason.as_ref(),
+                    FlipMutationError::TrialValidation { .. }
+                        | FlipMutationError::CoherentOrientationViolation { .. }
+                ) =>
             {
                 Self::TrialValidation
             }
@@ -3971,10 +4046,6 @@ impl TriangleHandle {
     /// Creates a canonical triangle handle from vertices already known to be distinct.
     #[must_use]
     pub(crate) fn from_validated_vertices(a: VertexKey, b: VertexKey, c: VertexKey) -> Self {
-        debug_assert!(
-            a != b && a != c && b != c,
-            "triangle vertices must be distinct"
-        );
         let mut verts = [a, b, c];
         verts.sort_unstable_by_key(|v| v.data().as_ffi());
         Self {
@@ -4974,13 +5045,6 @@ fn source_simplex_is_certified_positive<const D: usize>(
 
     let known_positive =
         matches!(simplex_orientation_fast_filter_sign(points), Ok(Some(sign)) if sign > 0);
-    #[cfg(debug_assertions)]
-    if known_positive {
-        debug_assert!(
-            matches!(simplex_orientation(points), Ok(Orientation::POSITIVE)),
-            "stored source simplices must be positive-oriented before using the insphere fast path"
-        );
-    }
     known_positive
 }
 
@@ -14191,6 +14255,56 @@ mod tests {
         }
 
         assert!(tds.is_valid().is_ok());
+    }
+
+    #[test]
+    fn test_coherent_orientation_violation_maps_to_invalid_flip_context() {
+        let err: FlipError = FlipContextError::CoherentOrientationViolation {
+            stage: FlipOrientationCheckStage::BeforeMutation,
+            k_move: 2,
+            direction: FlipDirection::Forward,
+        }
+        .into();
+
+        assert_matches!(
+            err,
+            FlipError::InvalidFlipContext { reason }
+                if matches!(
+                    reason.as_ref(),
+                    FlipContextError::CoherentOrientationViolation {
+                        stage: FlipOrientationCheckStage::BeforeMutation,
+                        k_move: 2,
+                        direction: FlipDirection::Forward
+                    }
+                )
+        );
+    }
+
+    #[test]
+    fn test_coherent_orientation_violation_maps_to_tds_mutation() {
+        let err: FlipError = FlipMutationError::CoherentOrientationViolation {
+            stage: FlipOrientationCheckStage::AfterTrialMutation,
+            k_move: 2,
+            direction: FlipDirection::Forward,
+        }
+        .into();
+
+        assert_eq!(
+            FlipFailureKind::from(&err),
+            FlipFailureKind::TrialValidation
+        );
+        assert_matches!(
+            err,
+            FlipError::TdsMutation { reason }
+                if matches!(
+                    reason.as_ref(),
+                    FlipMutationError::CoherentOrientationViolation {
+                        stage: FlipOrientationCheckStage::AfterTrialMutation,
+                        k_move: 2,
+                        direction: FlipDirection::Forward
+                    }
+                )
+        );
     }
 
     #[test]

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -1262,6 +1262,17 @@ pub enum CavityFillingError {
         stage: CavityRepairStage,
     },
 
+    /// Cavity filling did not create exactly one replacement simplex per boundary facet.
+    #[error(
+        "created {new_simplex_count} replacement simplices for {boundary_facet_count} boundary facets"
+    )]
+    BoundarySimplexCountMismatch {
+        /// Number of boundary facets being filled.
+        boundary_facet_count: usize,
+        /// Number of replacement simplices created.
+        new_simplex_count: usize,
+    },
+
     /// Repairing neighbor pointers after cavity repair failed.
     #[error("failed to repair neighbors after insertion repairs: {reason}")]
     NeighborRebuild {
@@ -1906,6 +1917,7 @@ impl InsertionError {
             | CavityFillingError::RebuiltVertexMissing { .. }
             | CavityFillingError::EmptyConflictRegion { .. }
             | CavityFillingError::EmptyBoundary { .. }
+            | CavityFillingError::BoundarySimplexCountMismatch { .. }
             | CavityFillingError::PerturbationScaleConversion { .. }
             | CavityFillingError::UnsupportedDegenerateLocation { .. }
             | CavityFillingError::EmptyFanTriangulation => false,
@@ -2394,15 +2406,13 @@ where
         new_simplices.push(simplex_key);
     }
 
-    // Defensive check: 1:1 correspondence is guaranteed by construction
-    // (one iteration per boundary facet, one simplex push per iteration)
-    debug_assert_eq!(
-        boundary_facets.len(),
-        new_simplices.len(),
-        "Created {} simplices for {} boundary facets (should be 1:1)",
-        new_simplices.len(),
-        boundary_facets.len()
-    );
+    if boundary_facets.len() != new_simplices.len() {
+        return Err(CavityFillingError::BoundarySimplexCountMismatch {
+            boundary_facet_count: boundary_facets.len(),
+            new_simplex_count: new_simplices.len(),
+        }
+        .into());
+    }
 
     Ok(new_simplices)
 }
@@ -2917,7 +2927,10 @@ where
     if simplex.neighbor_slots().is_none() {
         set_simplex_neighbors_from_keys(simplex, (0..=D).map(|_| None))?;
     }
-    let neighbors = simplex.ensure_neighbors_buffer_mut();
+    let simplex_id = simplex.uuid();
+    let neighbors = simplex
+        .try_ensure_neighbors_buffer_mut()
+        .map_err(|source| TdsError::InvalidSimplex { simplex_id, source })?;
     neighbors[facet_idx] = NeighborSlot::from_neighbor_key(neighbor);
 
     Ok(())
@@ -2939,11 +2952,6 @@ fn set_simplex_neighbors_from_keys<V, const D: usize>(
 /// Uses [`FastHasher`] for deterministic hashing consistent with other
 /// internal collections ([`FastHashMap`], [`FastHashSet`]).
 fn facet_hash_from_sorted_vertices(sorted_vkeys: &[VertexKey]) -> u64 {
-    debug_assert!(
-        sorted_vkeys.windows(2).all(|pair| pair[0] <= pair[1]),
-        "facet_hash_from_sorted_vertices: input must be sorted"
-    );
-
     let mut hasher = FastHasher::default();
     for &vkey in sorted_vkeys {
         vkey.hash(&mut hasher);

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -236,9 +236,8 @@ pub enum ConflictError {
     ///
     /// This is raised when an invariant that must hold by construction does not —
     /// typically a `boundary_facets` or `RidgeInfo` index that is unconditionally
-    /// valid in correct code. Debug builds catch these with `debug_assert!` so the
-    /// error path is only reachable in release mode; returning it rather than
-    /// panicking preserves the caller's transactional rollback guarantees.
+    /// valid in correct code. Returning a structured error rather than panicking
+    /// preserves the caller's transactional rollback guarantees.
     ///
     /// Orthogonality: this variant is distinct from
     /// [`ConflictError::SimplexDataAccessFailed`]. Use `SimplexDataAccessFailed` when
@@ -351,9 +350,8 @@ pub enum ConflictError {
 /// keep them as typed data so callers can `matches!` / `assert_eq!` on them and
 /// so future localized formatting does not need to reparse prose.
 ///
-/// These paths are unreachable in debug builds — the corresponding
-/// `debug_assert!` invariants fire there — and are guarded only to preserve
-/// transactional-rollback semantics in release builds.
+/// These paths are unreachable in correct code and are guarded to preserve
+/// transactional-rollback semantics when an internal invariant is violated.
 ///
 /// # Examples
 ///
@@ -601,15 +599,6 @@ fn collect_ridge_fan_extra_simplices(
     boundary_facets: &CavityBoundaryBuffer,
     info: &RidgeInfo,
 ) -> Result<Vec<SimplexKey>, ConflictError> {
-    debug_assert!(
-        info.extra_facets
-            .iter()
-            .all(|&fi| fi < boundary_facets.len()),
-        "RidgeFan extra_facets index out of bounds: extra_facets={:?}, boundary_facets.len()={}",
-        info.extra_facets,
-        boundary_facets.len(),
-    );
-
     // Deduplicate: multiple extra facets can come from the same simplex. Downstream code
     // expects unique simplex keys when shrinking the conflict region.
     let mut seen = FastHashSet::<SimplexKey>::default();

--- a/src/core/edge.rs
+++ b/src/core/edge.rs
@@ -164,8 +164,6 @@ impl EdgeKey {
     #[inline]
     #[must_use]
     pub(crate) fn from_validated_endpoints(a: VertexKey, b: VertexKey) -> Self {
-        debug_assert_ne!(a, b, "validated edge endpoints must be distinct");
-
         // Use the raw slotmap key representation for ordering to avoid relying on
         // any higher-level semantic ordering.
         let a_raw = a.data().as_ffi();

--- a/src/core/query.rs
+++ b/src/core/query.rs
@@ -16,6 +16,7 @@ use crate::core::tds::{SimplexKey, TdsError, VertexKey};
 use crate::core::triangulation::Triangulation;
 use crate::core::vertex::Vertex;
 use crate::geometry::kernel::Kernel;
+use std::sync::Arc;
 #[cfg(debug_assertions)]
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -24,9 +25,11 @@ static VERTEX_TO_SIMPLICES_SPILL_EVENTS: AtomicU64 = AtomicU64::new(0);
 
 /// Errors returned by read-only triangulation queries.
 ///
-/// These errors indicate that a supposedly read-only query could not derive
-/// its auxiliary topology view because the underlying triangulation state is
-/// inconsistent.
+/// These errors indicate that a read-only query could not safely use the
+/// requested topology view. This can happen because the underlying
+/// triangulation state is inconsistent, or because a precomputed
+/// [`AdjacencyIndex`] no longer matches the triangulation snapshot being
+/// queried.
 ///
 /// # Examples
 ///
@@ -68,6 +71,22 @@ pub enum QueryError {
         /// Typed TDS validation or bookkeeping error that prevented the query.
         #[from]
         source: TdsError,
+    },
+    /// A precomputed adjacency index was built from another triangulation snapshot.
+    ///
+    /// Indexed query helpers reject both cross-triangulation indexes and stale
+    /// same-triangulation indexes after mutation. Rebuild the
+    /// [`AdjacencyIndex`] from the triangulation snapshot being queried.
+    #[error(
+        "AdjacencyIndex snapshot mismatch: identity_matches={identity_matches}, expected generation {expected_generation}, got {actual_generation}"
+    )]
+    AdjacencyIndexSnapshotMismatch {
+        /// Whether the index came from the same TDS runtime identity.
+        identity_matches: bool,
+        /// Current TDS generation.
+        expected_generation: u64,
+        /// Generation captured when the index was built.
+        actual_generation: u64,
     },
 }
 
@@ -357,21 +376,24 @@ where
             .map_err(|source| QueryError::TriangulationCorrupted { source })
     }
 
+    /// Verifies that a caller-supplied [`AdjacencyIndex`] belongs to this exact
+    /// TDS snapshot before an indexed query reads from it.
+    ///
+    /// The identity check catches cross-triangulation reuse, while the generation
+    /// check catches stale same-triangulation indexes after mutation.
     #[inline]
-    fn debug_assert_adjacency_index_matches(&self, index: &AdjacencyIndex) {
-        // AdjacencyIndex is built from a snapshot of a triangulation. We cannot enforce at
-        // compile-time that an index belongs to this triangulation, but we can cheaply catch
-        // obvious mix-ups in debug builds.
-        debug_assert_eq!(
-            index.vertex_to_simplices.len(),
-            self.tds.number_of_vertices(),
-            "AdjacencyIndex vertex_to_simplices size does not match triangulation vertex count"
-        );
-        debug_assert_eq!(
-            index.vertex_to_edges.len(),
-            self.tds.number_of_vertices(),
-            "AdjacencyIndex vertex_to_edges size does not match triangulation vertex count"
-        );
+    fn validate_adjacency_index_matches(&self, index: &AdjacencyIndex) -> Result<(), QueryError> {
+        let identity_matches = Arc::ptr_eq(&index.tds_identity, self.tds.identity());
+        let expected_generation = self.tds.generation();
+        if identity_matches && index.tds_generation == expected_generation {
+            return Ok(());
+        }
+
+        Err(QueryError::AdjacencyIndexSnapshotMismatch {
+            identity_matches,
+            expected_generation,
+            actual_generation: index.tds_generation,
+        })
     }
 
     /// Returns an iterator over all unique edges in the triangulation.
@@ -416,6 +438,11 @@ where
     ///
     /// This avoids per-call deduplication and allocations.
     ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -427,6 +454,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// // A single 3D tetrahedron has 6 unique edges.
@@ -441,7 +470,9 @@ where
     /// let tri = dt.as_triangulation();
     ///
     /// let index = tri.build_adjacency_index()?;
-    /// let edges: std::collections::HashSet<_> = tri.edges_with_index(&index).collect();
+    /// let edges: std::collections::HashSet<_> = tri
+    ///     .edges_with_index(&index)?
+    ///     .collect();
     /// assert_eq!(edges.len(), 6);
     /// # Ok(())
     /// # }
@@ -449,9 +480,9 @@ where
     pub fn edges_with_index<'a>(
         &self,
         index: &'a AdjacencyIndex,
-    ) -> impl Iterator<Item = EdgeKey> + 'a {
-        self.debug_assert_adjacency_index_matches(index);
-        index.edges()
+    ) -> Result<impl Iterator<Item = EdgeKey> + 'a, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.edges())
     }
 
     /// Returns the number of unique edges in the triangulation.
@@ -487,6 +518,11 @@ where
     ///
     /// This is equivalent to `self.edges_with_index(index).count()`.
     ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -497,6 +533,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// # let vertices = vec![
@@ -509,14 +547,16 @@ where
     /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// # let tri = dt.as_triangulation();
     /// # let index = tri.build_adjacency_index()?;
-    /// assert_eq!(tri.number_of_edges_with_index(&index), 6);
+    /// assert_eq!(
+    ///     tri.number_of_edges_with_index(&index)?,
+    ///     6
+    /// );
     /// # Ok(())
     /// # }
     /// ```
-    #[must_use]
-    pub fn number_of_edges_with_index(&self, index: &AdjacencyIndex) -> usize {
-        self.debug_assert_adjacency_index_matches(index);
-        index.number_of_edges()
+    pub fn number_of_edges_with_index(&self, index: &AdjacencyIndex) -> Result<usize, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.number_of_edges())
     }
 
     /// Returns an iterator over all simplices adjacent (incident) to a vertex.
@@ -532,25 +572,104 @@ where
 
     /// Returns an iterator over all simplices adjacent (incident) to a vertex using a precomputed
     /// [`AdjacencyIndex`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// # let vertices = vec![
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
+    /// # ];
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// # let tri = dt.as_triangulation();
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((vertex_key, _)) = tri.vertices().next() else {
+    ///     return Ok(());
+    /// };
+    /// assert_eq!(
+    ///     tri.adjacent_simplices_with_index(&index, vertex_key)?.count(),
+    ///     tri.adjacent_simplices(vertex_key).count()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn adjacent_simplices_with_index<'a>(
         &self,
         index: &'a AdjacencyIndex,
         v: VertexKey,
-    ) -> impl Iterator<Item = SimplexKey> + 'a {
-        self.debug_assert_adjacency_index_matches(index);
-        index.adjacent_simplices(v)
+    ) -> Result<impl Iterator<Item = SimplexKey> + 'a, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.adjacent_simplices(v))
     }
 
     /// Returns the number of simplices adjacent (incident) to a vertex using a precomputed
     /// [`AdjacencyIndex`].
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// # let vertices = vec![
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
+    /// # ];
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// # let tri = dt.as_triangulation();
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((vertex_key, _)) = tri.vertices().next() else {
+    ///     return Ok(());
+    /// };
+    /// assert_eq!(
+    ///     tri.number_of_adjacent_simplices_with_index(&index, vertex_key)?,
+    ///     tri.adjacent_simplices(vertex_key).count()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn number_of_adjacent_simplices_with_index(
         &self,
         index: &AdjacencyIndex,
         v: VertexKey,
-    ) -> usize {
-        self.debug_assert_adjacency_index_matches(index);
-        index.number_of_adjacent_simplices(v)
+    ) -> Result<usize, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.number_of_adjacent_simplices(v))
     }
 
     /// Returns an iterator over all neighbors of a simplex.
@@ -570,24 +689,103 @@ where
     }
 
     /// Returns an iterator over all neighbors of a simplex using a precomputed [`AdjacencyIndex`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// # let vertices = vec![
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
+    /// # ];
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// # let tri = dt.as_triangulation();
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((simplex_key, _)) = tri.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// assert_eq!(
+    ///     tri.simplex_neighbors_with_index(&index, simplex_key)?.count(),
+    ///     tri.simplex_neighbors(simplex_key).count()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn simplex_neighbors_with_index<'a>(
         &self,
         index: &'a AdjacencyIndex,
         c: SimplexKey,
-    ) -> impl Iterator<Item = SimplexKey> + 'a {
-        self.debug_assert_adjacency_index_matches(index);
-        index.simplex_neighbors(c)
+    ) -> Result<impl Iterator<Item = SimplexKey> + 'a, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.simplex_neighbors(c))
     }
 
     /// Returns the number of neighbors of a simplex using a precomputed [`AdjacencyIndex`].
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// # let vertices = vec![
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
+    /// # ];
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// # let tri = dt.as_triangulation();
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((simplex_key, _)) = tri.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// assert_eq!(
+    ///     tri.number_of_simplex_neighbors_with_index(&index, simplex_key)?,
+    ///     tri.simplex_neighbors(simplex_key).count()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn number_of_simplex_neighbors_with_index(
         &self,
         index: &AdjacencyIndex,
         c: SimplexKey,
-    ) -> usize {
-        self.debug_assert_adjacency_index_matches(index);
-        index.number_of_simplex_neighbors(c)
+    ) -> Result<usize, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.number_of_simplex_neighbors(c))
     }
 
     /// Returns an iterator over all unique edges incident to a vertex.
@@ -599,25 +797,104 @@ where
 
     /// Returns an iterator over all unique edges incident to a vertex using a precomputed
     /// [`AdjacencyIndex`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// # let vertices = vec![
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
+    /// # ];
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// # let tri = dt.as_triangulation();
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((vertex_key, _)) = tri.vertices().next() else {
+    ///     return Ok(());
+    /// };
+    /// assert_eq!(
+    ///     tri.incident_edges_with_index(&index, vertex_key)?.count(),
+    ///     tri.incident_edges(vertex_key).count()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn incident_edges_with_index<'a>(
         &self,
         index: &'a AdjacencyIndex,
         v: VertexKey,
-    ) -> impl Iterator<Item = EdgeKey> + 'a {
-        self.debug_assert_adjacency_index_matches(index);
-        index.incident_edges(v)
+    ) -> Result<impl Iterator<Item = EdgeKey> + 'a, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.incident_edges(v))
     }
 
     /// Returns the number of unique edges incident to a vertex using a precomputed
     /// [`AdjacencyIndex`].
-    #[must_use]
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use delaunay::prelude::*;
+    /// # #[derive(Debug, thiserror::Error)]
+    /// # enum ExampleError {
+    /// #     #[error(transparent)]
+    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
+    /// #     #[error(transparent)]
+    /// #     Adjacency(#[from] delaunay::prelude::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::prelude::query::QueryError),
+    /// # }
+    /// # fn main() -> Result<(), ExampleError> {
+    /// # let vertices = vec![
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).expect("finite vertex coordinates"),
+    /// #     delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).expect("finite vertex coordinates"),
+    /// # ];
+    /// # let dt: DelaunayTriangulation<_, (), (), 3> =
+    /// #     DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// # let tri = dt.as_triangulation();
+    /// # let index = tri.build_adjacency_index()?;
+    /// let Some((vertex_key, _)) = tri.vertices().next() else {
+    ///     return Ok(());
+    /// };
+    /// assert_eq!(
+    ///     tri.number_of_incident_edges_with_index(&index, vertex_key)?,
+    ///     tri.incident_edges(vertex_key).count()
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn number_of_incident_edges_with_index(
         &self,
         index: &AdjacencyIndex,
         v: VertexKey,
-    ) -> usize {
-        self.debug_assert_adjacency_index_matches(index);
-        index.number_of_incident_edges(v)
+    ) -> Result<usize, QueryError> {
+        self.validate_adjacency_index_matches(index)?;
+        Ok(index.number_of_incident_edges(v))
     }
 
     /// Returns the number of unique edges incident to a vertex.
@@ -660,6 +937,9 @@ where
     /// - Isolated vertices (present in the vertex store but not referenced by any simplex) are allowed at
     ///   the TDS structural layer, but violate the Level 3 manifold invariants checked by
     ///   [`Triangulation::is_valid`](Self::is_valid). When present, their adjacency lists are empty.
+    /// - The returned index is tied to the current TDS identity and generation.
+    ///   Indexed query helpers return [`QueryError::AdjacencyIndexSnapshotMismatch`]
+    ///   if callers reuse it after mutation or with another triangulation.
     ///
     /// # Errors
     ///
@@ -753,6 +1033,8 @@ where
         }
 
         Ok(AdjacencyIndex {
+            tds_identity: Arc::clone(self.tds.identity()),
+            tds_generation: self.tds.generation(),
             vertex_to_edges,
             vertex_to_simplices,
             simplex_to_neighbors,
@@ -807,6 +1089,7 @@ mod tests {
     use crate::triangulation::DelaunayTriangulation;
 
     use slotmap::KeyData;
+    use std::assert_matches;
     use std::collections::HashSet;
 
     /// Basic accessor tests across dimensions.
@@ -958,9 +1241,16 @@ mod tests {
         assert_eq!(edges.len(), 3);
 
         let index = tri.build_adjacency_index().unwrap();
-        let edges_with_index: HashSet<_> = tri.edges_with_index(&index).collect();
+        let edges_with_index: HashSet<_> = tri
+            .edges_with_index(&index)
+            .expect("fresh adjacency index")
+            .collect();
         assert_eq!(edges_with_index, edges);
-        assert_eq!(tri.number_of_edges_with_index(&index), 3);
+        assert_eq!(
+            tri.number_of_edges_with_index(&index)
+                .expect("fresh adjacency index"),
+            3
+        );
 
         assert!(edges.iter().all(|edge| {
             let (a, b) = edge.endpoints();
@@ -993,24 +1283,32 @@ mod tests {
         assert_eq!(tri.number_of_incident_edges(base_vertex_key), 4);
 
         let index = tri.build_adjacency_index().unwrap();
-        assert_eq!(tri.number_of_edges_with_index(&index), 9);
+        assert_eq!(
+            tri.number_of_edges_with_index(&index)
+                .expect("fresh adjacency index"),
+            9
+        );
         assert_eq!(tri.adjacent_simplices(base_vertex_key).count(), 2);
         assert_eq!(
             tri.adjacent_simplices_with_index(&index, base_vertex_key)
+                .expect("fresh adjacency index")
                 .count(),
             2
         );
         assert_eq!(
-            tri.number_of_adjacent_simplices_with_index(&index, base_vertex_key),
+            tri.number_of_adjacent_simplices_with_index(&index, base_vertex_key)
+                .expect("fresh adjacency index"),
             2
         );
         assert_eq!(
             tri.incident_edges_with_index(&index, base_vertex_key)
+                .expect("fresh adjacency index")
                 .count(),
             4
         );
         assert_eq!(
-            tri.number_of_incident_edges_with_index(&index, base_vertex_key),
+            tri.number_of_incident_edges_with_index(&index, base_vertex_key)
+                .expect("fresh adjacency index"),
             4
         );
 
@@ -1021,22 +1319,26 @@ mod tests {
         assert_eq!(tri.number_of_incident_edges(apex_vertex_key), 3);
         assert_eq!(
             tri.adjacent_simplices_with_index(&index, apex_vertex_key)
+                .expect("fresh adjacency index")
                 .count(),
             1
         );
         assert_eq!(
-            tri.number_of_adjacent_simplices_with_index(&index, apex_vertex_key),
+            tri.number_of_adjacent_simplices_with_index(&index, apex_vertex_key)
+                .expect("fresh adjacency index"),
             1
         );
 
         for (simplex_key, _) in tri.simplices() {
             assert_eq!(
                 tri.simplex_neighbors_with_index(&index, simplex_key)
+                    .expect("fresh adjacency index")
                     .count(),
                 1
             );
             assert_eq!(
-                tri.number_of_simplex_neighbors_with_index(&index, simplex_key),
+                tri.number_of_simplex_neighbors_with_index(&index, simplex_key)
+                    .expect("fresh adjacency index"),
                 1
             );
         }
@@ -1058,22 +1360,26 @@ mod tests {
         assert_eq!(tri.adjacent_simplices(missing_vertex_key).count(), 0);
         assert_eq!(
             tri.adjacent_simplices_with_index(&index, missing_vertex_key)
+                .expect("fresh adjacency index")
                 .count(),
             0
         );
         assert_eq!(
-            tri.number_of_adjacent_simplices_with_index(&index, missing_vertex_key),
+            tri.number_of_adjacent_simplices_with_index(&index, missing_vertex_key)
+                .expect("fresh adjacency index"),
             0
         );
         assert_eq!(tri.incident_edges(missing_vertex_key).count(), 0);
         assert_eq!(
             tri.incident_edges_with_index(&index, missing_vertex_key)
+                .expect("fresh adjacency index")
                 .count(),
             0
         );
         assert_eq!(tri.number_of_incident_edges(missing_vertex_key), 0);
         assert_eq!(
-            tri.number_of_incident_edges_with_index(&index, missing_vertex_key),
+            tri.number_of_incident_edges_with_index(&index, missing_vertex_key)
+                .expect("fresh adjacency index"),
             0
         );
         assert!(tri.vertex_coords(missing_vertex_key).is_none());
@@ -1082,11 +1388,13 @@ mod tests {
         assert_eq!(tri.simplex_neighbors(missing_simplex_key).count(), 0);
         assert_eq!(
             tri.simplex_neighbors_with_index(&index, missing_simplex_key)
+                .expect("fresh adjacency index")
                 .count(),
             0
         );
         assert_eq!(
-            tri.number_of_simplex_neighbors_with_index(&index, missing_simplex_key),
+            tri.number_of_simplex_neighbors_with_index(&index, missing_simplex_key)
+                .expect("fresh adjacency index"),
             0
         );
         assert!(tri.simplex_vertices(missing_simplex_key).is_none());
@@ -1301,11 +1609,11 @@ mod tests {
     #[test]
     fn topology_queries_on_two_tet_triangulation() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices).unwrap();
@@ -1358,33 +1666,39 @@ mod tests {
     #[test]
     fn adjacency_index_with_index_methods() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::new(&vertices).unwrap();
         let tri = dt.as_triangulation();
         let index = tri.build_adjacency_index().unwrap();
 
-        let idx_edges: HashSet<_> = tri.edges_with_index(&index).collect();
+        let idx_edges: HashSet<_> = tri
+            .edges_with_index(&index)
+            .expect("fresh adjacency index")
+            .collect();
         let direct_edges: HashSet<_> = tri.edges().collect();
         assert_eq!(idx_edges, direct_edges);
         assert_eq!(
-            tri.number_of_edges_with_index(&index),
+            tri.number_of_edges_with_index(&index)
+                .expect("fresh adjacency index"),
             tri.number_of_edges()
         );
 
         let vertex_key = tri.vertices().next().unwrap().0;
         let idx_adj: HashSet<_> = tri
             .adjacent_simplices_with_index(&index, vertex_key)
+            .expect("fresh adjacency index")
             .collect();
         let direct_adj: HashSet<_> = tri.adjacent_simplices(vertex_key).collect();
         assert_eq!(idx_adj, direct_adj);
         assert_eq!(
-            tri.number_of_adjacent_simplices_with_index(&index, vertex_key),
+            tri.number_of_adjacent_simplices_with_index(&index, vertex_key)
+                .expect("fresh adjacency index"),
             direct_adj.len()
         );
 
@@ -1392,20 +1706,78 @@ mod tests {
         let direct_neighbors: Vec<_> = tri.simplex_neighbors(simplex_key).collect();
         assert_eq!(
             tri.simplex_neighbors_with_index(&index, simplex_key)
+                .expect("fresh adjacency index")
                 .count(),
             direct_neighbors.len()
         );
         assert_eq!(
-            tri.number_of_simplex_neighbors_with_index(&index, simplex_key),
+            tri.number_of_simplex_neighbors_with_index(&index, simplex_key)
+                .expect("fresh adjacency index"),
             direct_neighbors.len()
         );
 
-        let idx_incident: HashSet<_> = tri.incident_edges_with_index(&index, vertex_key).collect();
+        let idx_incident: HashSet<_> = tri
+            .incident_edges_with_index(&index, vertex_key)
+            .expect("fresh adjacency index")
+            .collect();
         let direct_incident: HashSet<_> = tri.incident_edges(vertex_key).collect();
         assert_eq!(idx_incident, direct_incident);
         assert_eq!(
-            tri.number_of_incident_edges_with_index(&index, vertex_key),
+            tri.number_of_incident_edges_with_index(&index, vertex_key)
+                .expect("fresh adjacency index"),
             direct_incident.len()
+        );
+    }
+
+    #[test]
+    fn adjacency_index_rejects_stale_generation() {
+        let vertices = [
+            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        ];
+        let dt: DelaunayTriangulation<_, (), (), 3> =
+            DelaunayTriangulation::new(&vertices).unwrap();
+        let mut tri = dt.as_triangulation().clone();
+        let index = tri.build_adjacency_index().unwrap();
+
+        tri.tds.clear_all_neighbors();
+
+        assert_matches!(
+            tri.number_of_edges_with_index(&index),
+            Err(QueryError::AdjacencyIndexSnapshotMismatch {
+                identity_matches: true,
+                ..
+            })
+        );
+    }
+
+    #[test]
+    fn adjacency_index_rejects_cross_triangulation_identity() {
+        let vertices = [
+            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        ];
+        let dt_a: DelaunayTriangulation<_, (), (), 3> =
+            DelaunayTriangulation::new(&vertices).unwrap();
+        let dt_b: DelaunayTriangulation<_, (), (), 3> =
+            DelaunayTriangulation::new(&vertices).unwrap();
+        let tri_a = dt_a.as_triangulation();
+        let tri_b = dt_b.as_triangulation();
+        let index_a = tri_a.build_adjacency_index().unwrap();
+
+        let Err(err) = tri_b.edges_with_index(&index_a).map(drop) else {
+            panic!("cross-triangulation adjacency index should be rejected");
+        };
+        assert_matches!(
+            err,
+            QueryError::AdjacencyIndexSnapshotMismatch {
+                identity_matches: false,
+                ..
+            }
         );
     }
 }

--- a/src/core/simplex.rs
+++ b/src/core/simplex.rs
@@ -981,12 +981,9 @@ impl<V, const D: usize> Simplex<V, D> {
             return None;
         }
 
-        // Mirror facet semantics are defined for same-dimensional simplices.
-        debug_assert_eq!(
-            self.vertices().len(),
-            neighbor_simplex.vertices().len(),
-            "mirror_facet_index requires simplices with matching vertex counts",
-        );
+        if self.vertices().len() != neighbor_simplex.vertices().len() {
+            return None;
+        }
 
         // Build the facet vertex set from the source simplex (all except facet_idx)
         let mut facet_vertices: SimplexVertexKeyBuffer = SimplexVertexKeyBuffer::new();
@@ -1089,15 +1086,31 @@ impl<V, const D: usize> Simplex<V, D> {
     /// If the buffer does not exist, it is initialized with D+1 unassigned slots.
     #[inline]
     pub(crate) fn ensure_neighbors_buffer_mut(&mut self) -> &mut NeighborBuffer<NeighborSlot> {
-        debug_assert!(
-            self.neighbors.as_ref().is_none_or(|buf| buf.len() == D + 1),
-            "neighbors buffer must always have length D+1"
-        );
         self.neighbors.get_or_insert_with(|| {
             let mut buffer = NeighborBuffer::new();
             buffer.resize(D + 1, NeighborSlot::Unassigned);
             buffer
         })
+    }
+
+    /// Ensures this simplex has a correctly sized assigned neighbor-slot buffer.
+    ///
+    /// If the buffer does not exist, it is initialized with D+1 unassigned slots.
+    /// If a buffer exists with the wrong length, the invariant violation is
+    /// returned instead of being silently normalized.
+    #[inline]
+    pub(crate) fn try_ensure_neighbors_buffer_mut(
+        &mut self,
+    ) -> Result<&mut NeighborBuffer<NeighborSlot>, SimplexValidationError> {
+        let buffer = self.ensure_neighbors_buffer_mut();
+        if buffer.len() != D + 1 {
+            return Err(SimplexValidationError::InvalidNeighborsLength {
+                actual: buffer.len(),
+                expected: D + 1,
+                dimension: D,
+            });
+        }
+        Ok(buffer)
     }
 }
 
@@ -3981,6 +3994,30 @@ mod tests {
         buf[0] = NeighborSlot::Neighbor(simplex_key);
         let buf2 = simplex.ensure_neighbors_buffer_mut();
         assert_eq!(buf2[0], NeighborSlot::Neighbor(simplex_key));
+    }
+
+    #[test]
+    fn simplex_try_ensure_neighbors_buffer_mut_rejects_malformed_existing_buffer() {
+        let vertices = vec![
+            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
+            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
+            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        ];
+        let dt = DelaunayTriangulation::new(&vertices).unwrap();
+        let (_, simplex_ref) = dt.simplices().next().unwrap();
+
+        let mut simplex = simplex_ref.clone();
+        simplex.ensure_neighbors_buffer_mut().truncate(2);
+
+        assert_matches!(
+            simplex.try_ensure_neighbors_buffer_mut(),
+            Err(SimplexValidationError::InvalidNeighborsLength {
+                actual: 2,
+                expected: 3,
+                dimension: 2
+            })
+        );
+        assert_eq!(simplex.neighbor_slots().unwrap().len(), 2);
     }
 
     #[test]

--- a/src/core/tds.rs
+++ b/src/core/tds.rs
@@ -4766,17 +4766,10 @@ impl<U, V, const D: usize> Tds<U, V, D> {
                 .set_neighbors_from_keys((0..=D).map(|_| None))
                 .map_err(|source| TdsError::InvalidSimplex { simplex_id, source })?;
         }
-        let neighbors = simplex.ensure_neighbors_buffer_mut();
-        if neighbors.len() != D + 1 {
-            return Err(TdsError::InvalidNeighbors {
-                reason: NeighborValidationError::LengthMismatch {
-                    actual: neighbors.len(),
-                    expected: D + 1,
-                    context: "reciprocal neighbor update".to_string(),
-                },
-            });
-        }
-        Ok(neighbors)
+        let simplex_id = simplex.uuid();
+        simplex
+            .try_ensure_neighbors_buffer_mut()
+            .map_err(|source| TdsError::InvalidSimplex { simplex_id, source })
     }
 
     fn set_neighbor_slot(
@@ -5604,11 +5597,13 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     /// # }
     /// ```
     pub fn build_facet_to_simplices_map(&self) -> Result<FacetToSimplicesMap, TdsError> {
-        // Ensure facet indices fit in u8 range
-        debug_assert!(
-            D <= 255,
-            "Dimension D must be <= 255 to fit facet indices in u8 (indices 0..=D)"
-        );
+        if D > usize::from(u8::MAX) {
+            return Err(TdsError::DimensionMismatch {
+                expected: usize::from(u8::MAX),
+                actual: D,
+                context: "facet indices must fit in u8".to_string(),
+            });
+        }
 
         let cap = self.simplices.len().saturating_mul(D.saturating_add(1));
         let mut facet_to_simplices: FacetToSimplicesMap = fast_hash_map_with_capacity(cap);

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -2306,8 +2306,7 @@ where
                                 retry_seed
                                     .wrapping_add(attempt_u64.wrapping_mul(0x9E37_79B9_7F4A_7C15)),
                             );
-                            let (canonical_prefix, image_suffix) = insertion_order.split_at_mut(n);
-                            debug_assert_eq!(canonical_prefix.len(), n);
+                            let (_canonical_prefix, image_suffix) = insertion_order.split_at_mut(n);
                             image_suffix.shuffle(&mut rng);
                         }
 

--- a/src/delaunay/flips.rs
+++ b/src/delaunay/flips.rs
@@ -12,9 +12,10 @@ pub use crate::core::algorithms::flips::{
     BistellarFlipKind, BistellarMove, ConstK, DelaunayRepairDiagnostics, DelaunayRepairError,
     DelaunayRepairStats, DelaunayRepairVerificationContext, FlipContextError, FlipDirection,
     FlipEdgeAdjacencyError, FlipError, FlipInfo, FlipMutationError, FlipNeighborWiringError,
-    FlipPredicateError, FlipPredicateOperation, FlipTriangleAdjacencyError,
-    FlipVertexAdjacencyError, RepairQueueOrder, RidgeHandle, TriangleHandle, TriangleHandleError,
-    verify_delaunay_for_triangulation, verify_delaunay_via_flip_predicates,
+    FlipOrientationCheckStage, FlipPredicateError, FlipPredicateOperation,
+    FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RepairQueueOrder, RidgeHandle,
+    TriangleHandle, TriangleHandleError, verify_delaunay_for_triangulation,
+    verify_delaunay_via_flip_predicates,
 };
 pub use crate::tds::{EdgeKey, FacetHandle, SimplexKey, VertexKey};
 

--- a/src/delaunay/query.rs
+++ b/src/delaunay/query.rs
@@ -874,6 +874,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -932,6 +934,11 @@ where
     /// This is a convenience wrapper around
     /// [`Triangulation::edges_with_index`](crate::Triangulation::edges_with_index).
     ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -944,6 +951,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -956,7 +965,9 @@ where
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// let index = dt.build_adjacency_index()?;
     ///
-    /// let edges: std::collections::HashSet<_> = dt.edges_with_index(&index).collect();
+    /// let edges: std::collections::HashSet<_> = dt
+    ///     .edges_with_index(&index)?
+    ///     .collect();
     /// assert_eq!(edges.len(), 6);
     /// # Ok(())
     /// # }
@@ -964,7 +975,7 @@ where
     pub fn edges_with_index<'a>(
         &self,
         index: &'a AdjacencyIndex,
-    ) -> impl Iterator<Item = EdgeKey> + 'a {
+    ) -> Result<impl Iterator<Item = EdgeKey> + 'a, QueryError> {
         self.as_triangulation().edges_with_index(index)
     }
 
@@ -1011,6 +1022,11 @@ where
     /// This is a convenience wrapper around
     /// [`Triangulation::incident_edges_with_index`](crate::Triangulation::incident_edges_with_index).
     ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1023,6 +1039,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices = vec![
@@ -1038,7 +1056,10 @@ where
     ///     return Ok(());
     /// };
     ///
-    /// assert_eq!(dt.incident_edges_with_index(&index, v0).count(), 3);
+    /// assert_eq!(
+    ///     dt.incident_edges_with_index(&index, v0)?.count(),
+    ///     3
+    /// );
     /// # Ok(())
     /// # }
     /// ```
@@ -1046,7 +1067,7 @@ where
         &self,
         index: &'a AdjacencyIndex,
         v: VertexKey,
-    ) -> impl Iterator<Item = EdgeKey> + 'a {
+    ) -> Result<impl Iterator<Item = EdgeKey> + 'a, QueryError> {
         self.as_triangulation().incident_edges_with_index(index, v)
     }
 
@@ -1092,6 +1113,11 @@ where
     /// This is a convenience wrapper around
     /// [`Triangulation::simplex_neighbors_with_index`](crate::Triangulation::simplex_neighbors_with_index).
     ///
+    /// # Errors
+    ///
+    /// Returns [`QueryError::AdjacencyIndexSnapshotMismatch`] if `index` was built
+    /// from a different triangulation snapshot.
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -1105,6 +1131,8 @@ where
     /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
     /// #     #[error(transparent)]
     /// #     Adjacency(#[from] delaunay::query::AdjacencyIndexBuildError),
+    /// #     #[error(transparent)]
+    /// #     Query(#[from] delaunay::query::QueryError),
     /// # }
     /// # fn main() -> Result<(), ExampleError> {
     /// let vertices: Vec<_> = vec![
@@ -1123,7 +1151,10 @@ where
     /// let Some((simplex_key, _)) = dt.simplices().next() else {
     ///     return Ok(());
     /// };
-    /// assert_eq!(dt.simplex_neighbors_with_index(&index, simplex_key).count(), 1);
+    /// assert_eq!(
+    ///     dt.simplex_neighbors_with_index(&index, simplex_key)?.count(),
+    ///     1
+    /// );
     /// # Ok(())
     /// # }
     /// ```
@@ -1131,7 +1162,7 @@ where
         &self,
         index: &'a AdjacencyIndex,
         c: SimplexKey,
-    ) -> impl Iterator<Item = SimplexKey> + 'a {
+    ) -> Result<impl Iterator<Item = SimplexKey> + 'a, QueryError> {
         self.as_triangulation()
             .simplex_neighbors_with_index(index, c)
     }
@@ -1652,8 +1683,14 @@ mod tests {
         assert_eq!(edges_dt.len(), 6);
 
         let index = dt.build_adjacency_index().unwrap();
-        let edges_dt_index: HashSet<_> = dt.edges_with_index(&index).collect();
-        let edges_tri_index: HashSet<_> = tri.edges_with_index(&index).collect();
+        let edges_dt_index: HashSet<_> = dt
+            .edges_with_index(&index)
+            .expect("fresh adjacency index")
+            .collect();
+        let edges_tri_index: HashSet<_> = tri
+            .edges_with_index(&index)
+            .expect("fresh adjacency index")
+            .collect();
         assert_eq!(edges_dt_index, edges_tri_index);
         assert_eq!(edges_dt_index, edges_dt);
 
@@ -1663,8 +1700,14 @@ mod tests {
         assert_eq!(incident_dt, incident_tri);
         assert_eq!(incident_dt.len(), 3);
 
-        let incident_dt_index: HashSet<_> = dt.incident_edges_with_index(&index, v0).collect();
-        let incident_tri_index: HashSet<_> = tri.incident_edges_with_index(&index, v0).collect();
+        let incident_dt_index: HashSet<_> = dt
+            .incident_edges_with_index(&index, v0)
+            .expect("fresh adjacency index")
+            .collect();
+        let incident_tri_index: HashSet<_> = tri
+            .incident_edges_with_index(&index, v0)
+            .expect("fresh adjacency index")
+            .collect();
         assert_eq!(incident_dt_index, incident_tri_index);
         assert_eq!(incident_dt_index, incident_dt);
 
@@ -1676,9 +1719,11 @@ mod tests {
 
         let neighbors_dt_index: Vec<_> = dt
             .simplex_neighbors_with_index(&index, simplex_key)
+            .expect("fresh adjacency index")
             .collect();
         let neighbors_tri_index: Vec<_> = tri
             .simplex_neighbors_with_index(&index, simplex_key)
+            .expect("fresh adjacency index")
             .collect();
         assert_eq!(neighbors_dt_index, neighbors_tri_index);
         assert_eq!(neighbors_dt_index, neighbors_dt);

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -1259,19 +1259,7 @@ where
         // Two-generation design: creation_generation (immutable) vs cached_generation (mutable)
         // - creation_generation: Set once at from_triangulation(), never changes. Used for stale detection.
         // - cached_generation: Can be reset to 0 by invalidate_cache() to force cache rebuild.
-        let creation_gen = self.creation_generation.get().copied().unwrap_or(0);
-        let tds_gen = tds.generation();
-        let identity_matches = self
-            .creation_identity
-            .get()
-            .is_some_and(|identity| Arc::ptr_eq(identity, tds.identity()));
-
-        debug_assert!(
-            creation_gen == tds_gen && identity_matches,
-            "ConvexHull used with a modified or different TDS; rebuild the hull (creation_gen={creation_gen}, tds_gen={tds_gen}, identity_matches={identity_matches})"
-        );
-
-        // Production build: always check creation_generation for stale detection
+        // Always check creation-generation and TDS identity for stale detection.
         self.ensure_current_for_construction(tri)?;
 
         // Derive facet vertex keys directly from the simplex to avoid UUID↔key roundtrips.

--- a/src/geometry/predicates.rs
+++ b/src/geometry/predicates.rs
@@ -121,8 +121,18 @@ fn fill_relative_insphere_matrix<const D: usize, const K: usize>(
     simplex_points: &[Point<D>],
     test_point: &Point<D>,
 ) -> Result<(), CoordinateConversionError> {
-    debug_assert_eq!(K, D + 1);
-    debug_assert_eq!(simplex_points.len(), D + 1);
+    if K != D + 1 {
+        return Err(
+            StackMatrixDispatchError::ActiveBlockDimensionMismatch { k: D + 1, dim: K }.into(),
+        );
+    }
+    if simplex_points.len() != D + 1 {
+        return Err(CoordinateConversionError::InvalidSimplexPointCount {
+            actual: simplex_points.len(),
+            expected: D + 1,
+            dimension: D,
+        });
+    }
 
     let reference_coords = simplex_points[0].coords();
 
@@ -2278,6 +2288,50 @@ mod tests {
         assert_matches!(
             err,
             StackMatrixDispatchError::ActiveBlockDimensionMismatch { k: 4, dim: 3 }
+        );
+    }
+
+    #[test]
+    fn test_fill_relative_insphere_matrix_rejects_dimension_mismatch() {
+        let simplex_points = [
+            Point::from_validated_coords([0.0, 0.0]),
+            Point::from_validated_coords([1.0, 0.0]),
+            Point::from_validated_coords([0.0, 1.0]),
+        ];
+        let test_point = Point::from_validated_coords([0.25, 0.25]);
+        let mut matrix = Matrix::<4>::zero();
+
+        let err = fill_relative_insphere_matrix::<2, 4>(&mut matrix, &simplex_points, &test_point)
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            CoordinateConversionError::MatrixDimensionMismatch {
+                active: 3,
+                matrix_dimension: 4
+            }
+        );
+    }
+
+    #[test]
+    fn test_fill_relative_insphere_matrix_rejects_simplex_point_count_mismatch() {
+        let simplex_points = [
+            Point::from_validated_coords([0.0, 0.0]),
+            Point::from_validated_coords([1.0, 0.0]),
+        ];
+        let test_point = Point::from_validated_coords([0.25, 0.25]);
+        let mut matrix = Matrix::<3>::zero();
+
+        let err = fill_relative_insphere_matrix::<2, 3>(&mut matrix, &simplex_points, &test_point)
+            .unwrap_err();
+
+        assert_matches!(
+            err,
+            CoordinateConversionError::InvalidSimplexPointCount {
+                actual: 2,
+                expected: 3,
+                dimension: 2
+            }
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1108,9 +1108,9 @@ pub mod prelude {
     pub use crate::flips::{
         DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats,
         DelaunayRepairVerificationContext, FlipContextError, FlipEdgeAdjacencyError, FlipError,
-        FlipMutationError, FlipNeighborWiringError, FlipPredicateError, FlipPredicateOperation,
-        FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RepairQueueOrder,
-        TriangleHandleError,
+        FlipMutationError, FlipNeighborWiringError, FlipOrientationCheckStage, FlipPredicateError,
+        FlipPredicateOperation, FlipTriangleAdjacencyError, FlipVertexAdjacencyError,
+        RepairQueueOrder, TriangleHandleError,
     };
 
     // Re-export commonly used collection types from the public collections facade.
@@ -1256,9 +1256,9 @@ pub mod prelude {
         pub use crate::flips::{
             BistellarFlipKind, BistellarFlips, FlipContextError, FlipDirection,
             FlipEdgeAdjacencyError, FlipError, FlipInfo, FlipMutationError,
-            FlipNeighborWiringError, FlipPredicateError, FlipPredicateOperation,
-            FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RidgeHandle, TriangleHandle,
-            TriangleHandleError,
+            FlipNeighborWiringError, FlipOrientationCheckStage, FlipPredicateError,
+            FlipPredicateOperation, FlipTriangleAdjacencyError, FlipVertexAdjacencyError,
+            RidgeHandle, TriangleHandle, TriangleHandleError,
         };
         pub use crate::flips::{BistellarMove, ConstK};
         pub use crate::tds::{EdgeKey, EdgeKeyError, FacetHandle, SimplexKey, VertexKey};
@@ -1308,10 +1308,10 @@ pub mod prelude {
         pub use crate::flips::{
             DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairStats,
             DelaunayRepairVerificationContext, FlipContextError, FlipEdgeAdjacencyError, FlipError,
-            FlipMutationError, FlipNeighborWiringError, FlipPredicateError, FlipPredicateOperation,
-            FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RepairQueueOrder,
-            TriangleHandleError, verify_delaunay_for_triangulation,
-            verify_delaunay_via_flip_predicates,
+            FlipMutationError, FlipNeighborWiringError, FlipOrientationCheckStage,
+            FlipPredicateError, FlipPredicateOperation, FlipTriangleAdjacencyError,
+            FlipVertexAdjacencyError, RepairQueueOrder, TriangleHandleError,
+            verify_delaunay_for_triangulation, verify_delaunay_via_flip_predicates,
         };
         pub use crate::repair::{
             DelaunayCheckPolicy, DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds,

--- a/src/topology/characteristics/euler.rs
+++ b/src/topology/characteristics/euler.rs
@@ -398,8 +398,6 @@ fn insert_simplices_of_size(
         return;
     }
 
-    debug_assert!(vertex_keys.windows(2).all(|w| w[0] <= w[1]));
-
     let mut indices: SmallBuffer<usize, MAX_PRACTICAL_DIMENSION_SIZE> = (0..simplex_size).collect();
 
     'outer: loop {

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -51,7 +51,9 @@ use delaunay::prelude::diagnostics::{
     debug_print_first_delaunay_violation, delaunay_violation_report,
     verify_conflict_region_completeness,
 };
-use delaunay::prelude::flips::BistellarFlips;
+use delaunay::prelude::flips::{
+    BistellarFlips, FlipOrientationCheckStage as FocusedFlipOrientationCheckStage,
+};
 use delaunay::prelude::generators::{
     CoordinateRange, CoordinateRangeError, InvalidPositiveScalar, RandomTriangulationBuilder,
     generate_grid_points, generate_random_points_in_range_seeded,
@@ -85,8 +87,8 @@ use delaunay::prelude::repair::{
     DelaunayCheckPolicy, DelaunayRepairDiagnostics, DelaunayRepairError, DelaunayRepairOperation,
     DelaunayRepairOutcome, DelaunayRepairStats, DelaunayRepairVerificationContext,
     DelaunayTriangulationValidationError, FlipEdgeAdjacencyError, FlipError,
-    FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RepairQueueOrder,
-    verify_delaunay_for_triangulation,
+    FlipOrientationCheckStage as RepairFlipOrientationCheckStage, FlipTriangleAdjacencyError,
+    FlipVertexAdjacencyError, RepairQueueOrder, verify_delaunay_for_triangulation,
 };
 #[cfg(feature = "diagnostics")]
 use delaunay::prelude::tds::Tds;
@@ -121,7 +123,8 @@ use delaunay::prelude::validation::{
     ValidationPolicy as FocusedValidationPolicy,
 };
 use delaunay::prelude::{
-    CoordinateRange as RootCoordinateRange, SecureHashMap, SecureHashSet,
+    CoordinateRange as RootCoordinateRange,
+    FlipOrientationCheckStage as RootFlipOrientationCheckStage, SecureHashMap, SecureHashSet,
     ValidationConfigurationError as RootValidationConfigurationError,
 };
 use delaunay::query::{
@@ -333,6 +336,26 @@ fn root_exports_cover_flattened_public_api() -> Result<(), RootApiExportTestErro
     assert!(!outcome.used_fallback_rebuild);
     assert!(outcome.topology_repair.succeeded);
     Ok(())
+}
+
+#[test]
+fn flip_preludes_cover_orientation_check_stage() {
+    assert_matches!(
+        FocusedFlipOrientationCheckStage::BeforeMutation,
+        FocusedFlipOrientationCheckStage::BeforeMutation
+    );
+    assert_matches!(
+        RepairFlipOrientationCheckStage::AfterTrialMutation,
+        RepairFlipOrientationCheckStage::AfterTrialMutation
+    );
+    assert_matches!(
+        RootFlipOrientationCheckStage::AfterTrialMutation,
+        RootFlipOrientationCheckStage::AfterTrialMutation
+    );
+    assert_matches!(
+        delaunay::flips::FlipOrientationCheckStage::BeforeMutation,
+        delaunay::flips::FlipOrientationCheckStage::BeforeMutation
+    );
 }
 
 #[test]

--- a/tests/public_topology_api.rs
+++ b/tests/public_topology_api.rs
@@ -20,6 +20,8 @@ enum PublicTopologyApiTestError {
     CoordinateConversion(#[from] CoordinateConversionError),
     #[error(transparent)]
     AdjacencyIndex(#[from] AdjacencyIndexBuildError),
+    #[error(transparent)]
+    Query(#[from] QueryError),
     #[error("single tetrahedron triangulation has no vertices")]
     EmptySingleTetrahedronVertices,
     #[error("single tetrahedron triangulation has no simplices")]
@@ -57,7 +59,7 @@ fn edges_and_incident_edges_on_single_tetrahedron() -> Result<(), PublicTopology
     assert_eq!(edges.len(), 6);
 
     let index = tri.build_adjacency_index()?;
-    let edges_with_index: HashSet<_> = dt.edges_with_index(&index).collect();
+    let edges_with_index: HashSet<_> = dt.edges_with_index(&index)?.collect();
     assert_eq!(edges_with_index, edges);
 
     // Pick an arbitrary vertex; in a tetrahedron its degree is 3.
@@ -67,7 +69,7 @@ fn edges_and_incident_edges_on_single_tetrahedron() -> Result<(), PublicTopology
         .map(|(vertex_key, _)| vertex_key)
         .ok_or(PublicTopologyApiTestError::EmptySingleTetrahedronVertices)?;
     assert_eq!(dt.incident_edges(v0).count(), 3);
-    assert_eq!(dt.incident_edges_with_index(&index, v0).count(), 3);
+    assert_eq!(dt.incident_edges_with_index(&index, v0)?.count(), 3);
 
     let incident: HashSet<_> = dt.incident_edges(v0).collect();
     assert_eq!(incident.len(), 3);
@@ -80,7 +82,8 @@ fn edges_and_incident_edges_on_single_tetrahedron() -> Result<(), PublicTopology
         .ok_or(PublicTopologyApiTestError::EmptySingleTetrahedronSimplices)?;
     assert_eq!(dt.simplex_neighbors(simplex_key).count(), 0);
     assert_eq!(
-        dt.simplex_neighbors_with_index(&index, simplex_key).count(),
+        dt.simplex_neighbors_with_index(&index, simplex_key)?
+            .count(),
         0
     );
 
@@ -153,17 +156,17 @@ fn adjacency_index_on_double_tetrahedron() -> Result<(), PublicTopologyApiTestEr
 
     // Triangulation-level with_index helpers should match the index and the baseline APIs.
     assert_eq!(
-        tri.adjacent_simplices_with_index(&index, shared_vertex_key)
+        tri.adjacent_simplices_with_index(&index, shared_vertex_key)?
             .count(),
         2
     );
     assert_eq!(
-        tri.number_of_adjacent_simplices_with_index(&index, shared_vertex_key),
+        tri.number_of_adjacent_simplices_with_index(&index, shared_vertex_key)?,
         2
     );
 
     for &ck in &simplex_keys {
-        assert_eq!(dt.simplex_neighbors_with_index(&index, ck).count(), 1);
+        assert_eq!(dt.simplex_neighbors_with_index(&index, ck)?.count(), 1);
     }
 
     // Shared vertex should have 2 incident simplices.
@@ -178,7 +181,7 @@ fn adjacency_index_on_double_tetrahedron() -> Result<(), PublicTopologyApiTestEr
 
     // Triangulation-level with_index helper should match index-based incident edges.
     let incident_edges_with_index: HashSet<_> = dt
-        .incident_edges_with_index(&index, shared_vertex_key)
+        .incident_edges_with_index(&index, shared_vertex_key)?
         .collect();
     assert_eq!(incident_edges_with_index.len(), incident_edges.len());
 
@@ -193,7 +196,7 @@ fn adjacency_index_on_double_tetrahedron() -> Result<(), PublicTopologyApiTestEr
     assert_eq!(edges.len(), tri.number_of_edges());
 
     // Triangulation-level edges_with_index should match the index edges().
-    let edges_via_tri: HashSet<_> = tri.edges_with_index(&index).collect();
+    let edges_via_tri: HashSet<_> = tri.edges_with_index(&index)?.collect();
     assert_eq!(edges_via_tri, edges);
 
     // Missing keys should yield empty iterators.
@@ -202,17 +205,17 @@ fn adjacency_index_on_double_tetrahedron() -> Result<(), PublicTopologyApiTestEr
     assert_eq!(index.simplex_neighbors(SimplexKey::default()).count(), 0);
 
     assert_eq!(
-        tri.adjacent_simplices_with_index(&index, VertexKey::default())
+        tri.adjacent_simplices_with_index(&index, VertexKey::default())?
             .count(),
         0
     );
     assert_eq!(
-        dt.incident_edges_with_index(&index, VertexKey::default())
+        dt.incident_edges_with_index(&index, VertexKey::default())?
             .count(),
         0
     );
     assert_eq!(
-        dt.simplex_neighbors_with_index(&index, SimplexKey::default())
+        dt.simplex_neighbors_with_index(&index, SimplexKey::default())?
             .count(),
         0
     );

--- a/tests/trait_bound_ergonomics.rs
+++ b/tests/trait_bound_ergonomics.rs
@@ -6,7 +6,7 @@ use delaunay::DelaunayTriangulation;
 use delaunay::prelude::Triangulation;
 use delaunay::prelude::geometry::{Coordinate, CoordinateValidationError, FastKernel};
 use delaunay::prelude::query::BoundaryAnalysis;
-use delaunay::prelude::tds::{Simplex, SimplexKey, Tds, verify_facet_index_consistency};
+use delaunay::prelude::tds::{Simplex, SimplexKey, Tds, VertexKey, verify_facet_index_consistency};
 use delaunay::prelude::topology::validation::validate_triangulation_euler;
 
 struct Payload;
@@ -83,9 +83,10 @@ fn read_only_topology_apis_accept_non_datatype_payloads() {
     );
 
     let index = tri.build_adjacency_index().unwrap();
-    assert!(index.vertex_to_simplices.is_empty());
-    assert!(index.simplex_to_neighbors.is_empty());
-    assert!(index.vertex_to_edges.is_empty());
+    assert_eq!(index.number_of_edges(), 0);
+    assert_eq!(index.number_of_adjacent_simplices(VertexKey::default()), 0);
+    assert_eq!(index.number_of_incident_edges(VertexKey::default()), 0);
+    assert_eq!(index.number_of_simplex_neighbors(SimplexKey::default()), 0);
 
     let tds: Tds<Payload, Payload, 2> = Tds::empty();
     assert!(tds.build_facet_to_simplices_map().unwrap().is_empty());


### PR DESCRIPTION
- Validate caller-supplied AdjacencyIndex values against the originating TDS identity and generation before indexed topology queries.
- Keep AdjacencyIndex internals immutable to downstream callers and route public use through accessor methods.
- Convert several debug-only invariant checks into typed errors for malformed topology, predicate matrix arity, and cavity replacement mismatches.
- Avoid release-mode coherent-orientation scans in flip hot paths while preserving structured debug/test diagnostics.
- Refresh README badges to use Badgen endpoints.

BREAKING CHANGE: Indexed topology helpers that accept AdjacencyIndex now return Result<_, QueryError>, and AdjacencyIndex no longer exposes its backing maps publicly. Use the accessor methods and rebuild indexes after mutating a triangulation.