### PR TITLE
feat(api): add common Delaunay result alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,27 +100,13 @@ cargo add delaunay@0.7.8
 
 Use `cargo add delaunay` instead if you want Cargo to select the newest published release.
 
-`thiserror` is used in the example only to keep the local typed error wrapper compact; `delaunay` APIs
-return concrete typed errors. Requirements:
-
 - Rust 1.96.0 or newer, pinned by `Cargo.toml` and `rust-toolchain.toml`.
 - `f64` coordinates for caller-facing construction, predicate, validation, and generator APIs.
 
 ```rust
-use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
-};
-use delaunay::prelude::geometry::CoordinateConversionError;
+use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder, vertex};
 
-#[derive(Debug, thiserror::Error)]
-enum ExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -66,25 +66,10 @@ For most use cases, the builder with default options is sufficient:
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
-use delaunay::prelude::insertion::InsertionError;
-use delaunay::prelude::tds::InvariantError;
 
-#[derive(Debug, thiserror::Error)]
-enum ExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Insertion(#[from] InsertionError),
-    #[error(transparent)]
-    Topology(#[from] InvariantError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ExampleError> {
+fn main() -> DelaunayResult<()> {
     // Simple construction from vertices (Euclidean space, default options)
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
@@ -113,24 +98,11 @@ use `DelaunayTriangulationBuilder`:
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
-    vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
-use delaunay::prelude::insertion::InsertionError;
 use delaunay::prelude::validation::ValidationPolicy;
 
-#[derive(Debug, thiserror::Error)]
-enum ExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Insertion(#[from] InsertionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ExampleError> {
+fn main() -> DelaunayResult<()> {
     // Canonicalized toroidal triangulation in 2D
     let vertices = vec![
         vertex![0.1, 0.1]?,

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -398,8 +398,11 @@ just verify-expect-counts
 The `verify-expect-counts` recipe tracks only that remaining doctest baseline.
 When extending the zero-tolerance Semgrep rule to doctests, prefer:
 
-- `fn main() -> Result<(), ExampleError>` in examples, with local
-  `#[derive(thiserror::Error)]` enums that wrap the crate's typed errors.
+- `fn main() -> DelaunayResult<()>` in examples whose fallible surface is
+  covered by `DelaunayError`.
+- Local `#[derive(thiserror::Error)]` enums only when examples also need
+  workflow-specific typed errors such as convex-hull, flip, repair, or
+  delaunayize failures.
 - Setup helpers returning typed `Result` values in benchmarks; Criterion entry
   points may still abort setup explicitly, but benchmark bodies should not hide
   fallible API calls behind panic-only setup.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -69,20 +69,9 @@ delaunay = { version = "...", features = ["diagnostics"] }
 For most validation work, start with the always-available APIs:
 
 ```rust
-use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
-};
-use delaunay::prelude::geometry::CoordinateConversionError;
+use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder, vertex};
 
-#[derive(Debug, thiserror::Error)]
-enum DiagnosticsExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), DiagnosticsExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -94,23 +94,11 @@ deviates from the happy-path and trips internal **suspicion flags**, e.g.:
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
-    vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
-use delaunay::prelude::validation::{ValidationConfigurationError, ValidationPolicy};
+use delaunay::prelude::validation::ValidationPolicy;
 
-#[derive(Debug, thiserror::Error)]
-enum ValidationExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-    #[error(transparent)]
-    Configuration(#[from] ValidationConfigurationError),
-}
-
-fn main() -> Result<(), ValidationExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,
@@ -162,21 +150,11 @@ PL-manifoldness. You can trigger that final certification via
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
-    vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
 use delaunay::prelude::validation::ValidationPolicy;
 
-#[derive(Debug, thiserror::Error)]
-enum ValidationExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ValidationExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,
@@ -323,21 +301,11 @@ Validates the combinatorial structure of the Triangulation Data Structure.
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
-    vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
 use delaunay::prelude::validation::ValidationPolicy;
 
-#[derive(Debug, thiserror::Error)]
-enum ValidationExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ValidationExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,
@@ -417,21 +385,11 @@ Validates that the triangulation forms a valid topological manifold.
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
-    vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
 use delaunay::prelude::validation::ValidationPolicy;
 
-#[derive(Debug, thiserror::Error)]
-enum ValidationExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ValidationExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,
@@ -498,21 +456,11 @@ Validates the geometric optimality of the triangulation.
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
-    vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
 use delaunay::prelude::validation::ValidationPolicy;
 
-#[derive(Debug, thiserror::Error)]
-enum ValidationExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ValidationExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -18,20 +18,9 @@ snippets into an application.
 For most use cases, construction is a single call:
 
 ```rust
-use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
-};
-use delaunay::prelude::geometry::CoordinateConversionError;
+use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder, vertex};
 
-#[derive(Debug, thiserror::Error)]
-enum ExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,
@@ -183,20 +172,11 @@ detections, etc.).
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
 use delaunay::prelude::repair::DelaunayRepairError;
 
-#[derive(Debug, thiserror::Error)]
-enum RepairExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), RepairExampleError> {
+fn main() -> DelaunayResult<()> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0]?,
         vertex![1.0, 0.0, 0.0]?,
@@ -282,22 +262,10 @@ uses the image-point method to build a true periodic quotient in the validated
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
-use delaunay::prelude::insertion::InsertionError;
 
-#[derive(Debug, thiserror::Error)]
-enum ToroidalExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Insertion(#[from] InsertionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), ToroidalExampleError> {
+fn main() -> DelaunayResult<()> {
     // 2D canonicalized toroidal triangulation with unit square domain
     let vertices = vec![
         vertex![0.1, 0.1]?,
@@ -338,19 +306,10 @@ accessor, and modified post-construction via `set_vertex_data` / `set_simplex_da
 
 ```rust
 use delaunay::prelude::construction::{
-    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, Vertex, vertex,
+    DelaunayResult, DelaunayTriangulationBuilder, Vertex, vertex,
 };
-use delaunay::prelude::geometry::CoordinateConversionError;
 
-#[derive(Debug, thiserror::Error)]
-enum DataExampleError {
-    #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), DataExampleError> {
+fn main() -> DelaunayResult<()> {
     // Attach integer labels at construction time
     let vertices: [Vertex<i32, 2>; 3] = [
         vertex![0.0, 0.0; data = 10i32]?,
@@ -409,19 +368,10 @@ want to keep going after skipped vertices, use the explicitly best-effort
 `insert_best_effort_with_statistics()`.
 
 ```rust
-use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
-use delaunay::prelude::geometry::CoordinateConversionError;
-use delaunay::prelude::insertion::{InsertionError, InsertionOutcome};
+use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulation, vertex};
+use delaunay::prelude::insertion::InsertionOutcome;
 
-#[derive(Debug, thiserror::Error)]
-enum InsertionStatsExampleError {
-    #[error(transparent)]
-    Insertion(#[from] InsertionError),
-    #[error(transparent)]
-    Coordinate(#[from] CoordinateConversionError),
-}
-
-fn main() -> Result<(), InsertionStatsExampleError> {
+fn main() -> DelaunayResult<()> {
     let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
 
     let (outcome, stats) = dt.insert_best_effort_with_statistics(vertex![0.5, 0.5, 0.5]?)?;

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -37,18 +37,9 @@
 //! ## Standard Euclidean construction
 //!
 //! ```rust
-//! use delaunay::prelude::construction::{DelaunayTriangulationBuilder};
+//! use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-//! #     #[error(transparent)]
-//! #     Topology(#[from] delaunay::prelude::construction::ToroidalDomainError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     delaunay::vertex![0.0, 0.0]?,
 //!     delaunay::vertex![1.0, 0.0]?,
@@ -66,18 +57,9 @@
 //! ## Toroidal construction (canonicalization only)
 //!
 //! ```rust
-//! use delaunay::prelude::construction::{DelaunayTriangulationBuilder};
+//! use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-//! #     #[error(transparent)]
-//! #     Topology(#[from] delaunay::prelude::construction::ToroidalDomainError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! // Vertices that fall outside [0, 1)² are wrapped before triangulation.
 //! let vertices = vec![
 //!     delaunay::vertex![0.2, 0.3]?,
@@ -103,18 +85,9 @@
 //!
 //! ```rust,no_run
 //! use delaunay::prelude::geometry::RobustKernel;
-//! use delaunay::prelude::construction::{DelaunayTriangulationBuilder};
+//! use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-//! #     #[error(transparent)]
-//! #     Topology(#[from] delaunay::prelude::construction::ToroidalDomainError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     delaunay::vertex![0.1, 0.2]?,
 //!     delaunay::vertex![0.4, 0.7]?,
@@ -1051,17 +1024,10 @@ fn validate_explicit_simplex_specs<const D: usize>(
 ///
 /// ```rust
 /// use delaunay::prelude::construction::{
-///     ConstructionOptions, DelaunayTriangulationBuilder, TopologyGuarantee,
+///     ConstructionOptions, DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
 /// };
 ///
-/// # #[derive(Debug, thiserror::Error)]
-/// # enum ExampleError {
-/// #     #[error(transparent)]
-/// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-/// #     #[error(transparent)]
-/// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-/// # }
-/// # fn main() -> Result<(), ExampleError> {
+/// # fn main() -> DelaunayResult<()> {
 /// let vertices = vec![
 ///     delaunay::vertex![0.0, 0.0, 0.0]?,
 ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -1130,17 +1096,10 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, Vertex,
+    ///     DelaunayResult, DelaunayTriangulationBuilder, Vertex,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// // No vertex data (U = () inferred)
     /// let vertices = vec![delaunay::vertex![0.0, 0.0]?, delaunay::vertex![1.0, 0.0]?, delaunay::vertex![0.0, 1.0]?];
     /// let _dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
@@ -1317,21 +1276,10 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     /// ```rust,no_run
     /// use delaunay::prelude::geometry::RobustKernel;
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder,
+    ///     DelaunayResult, DelaunayTriangulationBuilder,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// #     #[error(transparent)]
-    /// #     Explicit(#[from] delaunay::prelude::construction::ExplicitConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Topology(#[from] delaunay::prelude::construction::ToroidalDomainError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.1, 0.2]?,
     ///     delaunay::vertex![0.4, 0.7]?,
@@ -1372,20 +1320,11 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::geometry::RobustKernel;
     /// use delaunay::prelude::topology::spaces::ToroidalDomain;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// #     #[error(transparent)]
-    /// #     Topology(#[from] delaunay::prelude::construction::ToroidalDomainError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.1, 0.2]?,
     ///     delaunay::vertex![0.4, 0.7]?,
@@ -1428,19 +1367,10 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder,
+    ///     DelaunayResult, DelaunayTriangulationBuilder,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// #     #[error(transparent)]
-    /// #     Topology(#[from] delaunay::prelude::construction::ToroidalDomainError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.2, 0.3]?,
     ///     delaunay::vertex![0.8, 0.1]?,
@@ -1479,17 +1409,10 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::topology::spaces::ToroidalDomain;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.2, 0.3]?,
     ///     delaunay::vertex![0.8, 0.1]?,
@@ -1523,17 +1446,10 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder, TopologyGuarantee,
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0]?,
@@ -1623,17 +1539,11 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     ConstructionOptions, DelaunayTriangulationBuilder, InsertionOrderStrategy,
+    ///     ConstructionOptions, DelaunayResult, DelaunayTriangulationBuilder,
+    ///     InsertionOrderStrategy,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0]?,
@@ -1822,17 +1732,10 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder,
+    ///     DelaunayResult, DelaunayTriangulationBuilder,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -1883,17 +1786,10 @@ where
     /// ```rust
     /// use delaunay::prelude::geometry::RobustKernel;
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder,
+    ///     DelaunayResult, DelaunayTriangulationBuilder,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::prelude::construction::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -16,19 +16,11 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     ConstructionOptions, DelaunayTriangulationBuilder,
-//!     DelaunayTriangulationConstructionError, InitialSimplexStrategy,
-//!     InsertionOrderStrategy, Vertex,
+//!     ConstructionOptions, DelaunayResult, DelaunayTriangulationBuilder,
+//!     InitialSimplexStrategy, InsertionOrderStrategy,
 //! };
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     delaunay::vertex![0.0, 0.0]?,
 //!     delaunay::vertex![1.0, 0.0]?,
@@ -83,19 +75,23 @@ use crate::core::util::{
     DeduplicationError, HilbertBitDepth, coords_equal_exact, coords_within_epsilon,
     hilbert_quantize_batch_in_range, stable_hash_u64_slice,
 };
-use crate::core::validation::{TopologyGuarantee, TriangulationValidationError, ValidationPolicy};
+use crate::core::validation::{
+    TopologyGuarantee, TriangulationValidationError, ValidationConfigurationError, ValidationPolicy,
+};
 use crate::core::vertex::Vertex;
 use crate::diagnostics::{BatchLocalRepairTrigger, ConstructionTelemetry, LocalRepairSample};
 use crate::geometry::coordinate_range::CoordinateRange;
 use crate::geometry::kernel::{AdaptiveKernel, Kernel};
 use crate::geometry::point::Point;
-use crate::geometry::traits::coordinate::{CoordinateValidationError, CoordinateValues};
+use crate::geometry::traits::coordinate::{
+    CoordinateConversionError, CoordinateValidationError, CoordinateValues,
+};
 use crate::geometry::util::{RandomPointGenerationError, safe_usize_to_scalar, simplex_volume};
 use crate::locality::{
     accumulate_live_simplex_seeds, clear_simplex_seed_set, retain_live_simplex_seeds,
 };
 use crate::repair::DelaunayRepairPolicy;
-use crate::topology::traits::{GlobalTopology, GlobalTopologyModelError};
+use crate::topology::traits::{GlobalTopology, GlobalTopologyModelError, ToroidalDomainError};
 use crate::triangulation::DelaunayTriangulation;
 use crate::validation::DelaunayTriangulationValidationError;
 use core::{cmp::Ordering, fmt};
@@ -200,6 +196,100 @@ pub(crate) mod test_hooks {
         }
     }
 }
+
+/// Common errors for user-facing Delaunay triangulation workflows.
+///
+/// This convenience error covers the fallible path most examples use:
+/// converting caller coordinates into vertices, constructing a
+/// [`DelaunayTriangulation`], editing it through
+/// the Delaunay insertion API, and validating its Delaunay invariants. More
+/// specialized workflows such as convex hull extraction, bistellar flips,
+/// repair, and delaunayize continue to expose their narrower error types
+/// directly.
+///
+/// # Examples
+///
+/// Use [`DelaunayResult`] for examples, binaries, and quick workflows whose
+/// fallible operations stay inside coordinate conversion, construction,
+/// insertion, and validation:
+///
+/// ```rust
+/// use delaunay::prelude::construction::{
+///     DelaunayResult, DelaunayTriangulationBuilder, vertex,
+/// };
+///
+/// fn main() -> DelaunayResult<()> {
+///     let vertices = vec![
+///         vertex![0.0, 0.0]?,
+///         vertex![1.0, 0.0]?,
+///         vertex![0.0, 1.0]?,
+///     ];
+///
+///     let mut dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+///     dt.insert(vertex![0.25, 0.25]?)?;
+///     dt.validate()?;
+///
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone, Debug, Error, PartialEq)]
+#[non_exhaustive]
+pub enum DelaunayError {
+    /// Delaunay triangulation construction failed.
+    #[error(transparent)]
+    Construction {
+        /// Underlying construction failure.
+        #[from]
+        source: DelaunayTriangulationConstructionError,
+    },
+
+    /// Coordinate conversion or validation failed before construction.
+    #[error(transparent)]
+    CoordinateConversion {
+        /// Underlying coordinate conversion failure.
+        #[from]
+        source: CoordinateConversionError,
+    },
+
+    /// Incremental Delaunay insertion failed.
+    #[error(transparent)]
+    Insertion {
+        /// Underlying insertion failure.
+        #[from]
+        source: InsertionError,
+    },
+
+    /// Validation policy configuration failed.
+    #[error(transparent)]
+    ValidationConfiguration {
+        /// Underlying validation configuration failure.
+        #[from]
+        source: ValidationConfigurationError,
+    },
+
+    /// Delaunay triangulation validation failed.
+    #[error(transparent)]
+    Validation {
+        /// Underlying validation failure.
+        #[from]
+        source: DelaunayTriangulationValidationError,
+    },
+
+    /// Toroidal-domain setup failed.
+    #[error(transparent)]
+    ToroidalDomain {
+        /// Underlying toroidal-domain validation failure.
+        #[from]
+        source: ToroidalDomainError,
+    },
+}
+
+/// Result alias for common user-facing Delaunay triangulation workflows.
+///
+/// This is equivalent to `Result<T, DelaunayError>` with [`DelaunayError`] as
+/// the error type, and is intended for caller-facing examples and applications
+/// that use the standard construction, insertion, and validation APIs.
+pub type DelaunayResult<T> = Result<T, DelaunayError>;
 
 /// Errors that can occur during Delaunay triangulation construction.
 #[derive(Clone, Debug, Error, PartialEq)]
@@ -2101,16 +2191,9 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulation;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulation};
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -2274,17 +2357,11 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     ConstructionOptions, DedupPolicy, DelaunayTriangulation, InsertionOrderStrategy,
+    ///     ConstructionOptions, DedupPolicy, DelaunayResult, DelaunayTriangulation,
+    ///     InsertionOrderStrategy,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -2330,17 +2407,10 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, TopologyGuarantee,
+    ///     DelaunayResult, DelaunayTriangulation, TopologyGuarantee,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![delaunay::vertex![0.0, 0.0]?, delaunay::vertex![1.0, 0.0]?, delaunay::vertex![0.0, 1.0]?];
     /// let dt: DelaunayTriangulation<_, (), (), 2> =
     ///     DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -2404,16 +2474,9 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![delaunay::vertex![0.0, 0.0]?, delaunay::vertex![1.0, 0.0]?, delaunay::vertex![0.0, 1.0]?];
     /// let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
     /// assert_eq!(dt.number_of_vertices(), 3);
@@ -4091,17 +4154,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulation;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulation};
     /// use delaunay::prelude::geometry::RobustKernel;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -4138,18 +4194,11 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, TopologyGuarantee,
+    ///     DelaunayResult, DelaunayTriangulation, TopologyGuarantee,
     /// };
     /// use delaunay::prelude::geometry::RobustKernel;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -4195,18 +4244,11 @@ where
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     ConstructionOptions, DelaunayTriangulation, TopologyGuarantee,
+    ///     ConstructionOptions, DelaunayResult, DelaunayTriangulation, TopologyGuarantee,
     /// };
     /// use delaunay::prelude::geometry::RobustKernel;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -123,17 +123,9 @@ where
     /// Incremental insertion from empty triangulation:
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation};
-    /// use delaunay::prelude::insertion::InsertionError;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulation};
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] InsertionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// // Start with empty triangulation
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     /// assert_eq!(dt.number_of_vertices(), 0);
@@ -162,18 +154,9 @@ where
     /// Using batch construction (traditional approach):
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulationBuilder};
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Insertion(#[from] delaunay::InsertionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// // Create initial triangulation with 5 vertices (4-simplex)
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0, 0.0]?,
@@ -289,17 +272,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation};
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulation};
     /// use delaunay::prelude::insertion::{InsertionError, InsertionOutcome};
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Coordinates(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// #     #[error(transparent)]
-    /// #     Insertion(#[from] InsertionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     ///
     /// let vertex = delaunay::vertex![0.0, 0.0, 0.0]?;
@@ -345,17 +321,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::{DelaunayTriangulation};
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulation};
     /// use delaunay::prelude::insertion::InsertionOutcome;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::InsertionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let mut dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::empty();
     ///
     /// let (outcome, stats) = dt

--- a/src/delaunay/triangulation.rs
+++ b/src/delaunay/triangulation.rs
@@ -51,18 +51,9 @@ use crate::core::triangulation::Triangulation;
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::construction::{
-///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
-/// };
+/// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
 ///
-/// # #[derive(Debug, thiserror::Error)]
-/// # enum ExampleError {
-/// #     #[error(transparent)]
-/// #     Source(#[from] DelaunayTriangulationConstructionError),
-/// #     #[error(transparent)]
-/// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-/// # }
-/// # fn main() -> Result<(), ExampleError> {
+/// # fn main() -> DelaunayResult<()> {
 /// let vertices = vec![
 ///     delaunay::vertex![0.0, 0.0, 0.0]?,
 ///     delaunay::vertex![1.0, 0.0, 0.0]?,

--- a/src/delaunay/validation.rs
+++ b/src/delaunay/validation.rs
@@ -298,17 +298,10 @@ impl From<&DelaunayVerificationError> for DelaunayVerificationErrorKind {
 /// # Examples
 ///
 /// ```rust
-/// use delaunay::prelude::construction::{DelaunayTriangulationBuilder};
+/// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
 /// use delaunay::prelude::validation::DelaunayTriangulationValidationError;
 ///
-/// # #[derive(Debug, thiserror::Error)]
-/// # enum ExampleError {
-/// #     #[error(transparent)]
-/// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-/// #     #[error(transparent)]
-/// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-/// # }
-/// # fn main() -> Result<(), ExampleError> {
+/// # fn main() -> DelaunayResult<()> {
 /// let vertices = vec![
 ///     delaunay::vertex![0.0, 0.0, 0.0]?,
 ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -506,17 +499,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::*;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices_4d = [
     ///     delaunay::vertex![0.0, 0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0, 0.0]?,
@@ -555,17 +541,10 @@ where
     /// # Examples
     ///
     /// ```
-    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::*;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -598,17 +577,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::*;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices_4d = [
     ///     delaunay::vertex![0.0, 0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0, 0.0]?,
@@ -649,17 +621,10 @@ where
     /// # Examples
     ///
     /// ```rust
-    /// use delaunay::prelude::construction::DelaunayTriangulationBuilder;
+    /// use delaunay::prelude::construction::{DelaunayResult, DelaunayTriangulationBuilder};
     /// use delaunay::prelude::query::*;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = [
     ///     delaunay::vertex![0.0, 0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0, 0.0]?,
@@ -818,19 +783,10 @@ where
     /// ```rust
     /// use delaunay::prelude::geometry::FastKernel;
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, DelaunayTriangulationBuilder, TopologyGuarantee,
+    ///     DelaunayResult, DelaunayTriangulation, DelaunayTriangulationBuilder, TopologyGuarantee,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0]?,
@@ -880,19 +836,11 @@ where
     /// ```rust
     /// use delaunay::prelude::geometry::FastKernel;
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulation, DelaunayTriangulationBuilder, GlobalTopology, TopologyGuarantee,
+    ///     DelaunayResult, DelaunayTriangulation, DelaunayTriangulationBuilder, GlobalTopology,
+    ///     TopologyGuarantee,
     /// };
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Construction(#[from] delaunay::DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Validation(#[from] delaunay::DelaunayTriangulationValidationError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] delaunay::prelude::geometry::CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     delaunay::vertex![0.0, 0.0]?,
     ///     delaunay::vertex![1.0, 0.0]?,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,19 +100,10 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+//!     DelaunayResult, DelaunayTriangulationBuilder, vertex,
 //! };
-//! use delaunay::prelude::geometry::CoordinateConversionError;
-//! use delaunay::prelude::insertion::InsertionError;
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] CoordinateConversionError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     vertex![0.0, 0.0, 0.0]?,
 //!     vertex![1.0, 0.0, 0.0]?,
@@ -140,20 +131,11 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, TopologyGuarantee,
-//!     vertex,
+//!     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee, vertex,
 //! };
-//! use delaunay::prelude::geometry::CoordinateConversionError;
 //! use delaunay::prelude::validation::ValidationPolicy;
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] CoordinateConversionError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     vertex![0.0, 0.0, 0.0]?,
 //!     vertex![1.0, 0.0, 0.0]?,
@@ -178,19 +160,11 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+//!     DelaunayResult, DelaunayTriangulationBuilder, vertex,
 //! };
-//! use delaunay::prelude::geometry::CoordinateConversionError;
 //! use delaunay::prelude::insertion::InsertionError;
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] CoordinateConversionError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     vertex![0.0, 0.0]?,
 //!     vertex![1.0, 0.0]?,
@@ -296,24 +270,11 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+//!     DelaunayResult, DelaunayTriangulationBuilder, vertex,
 //! };
-//! use delaunay::prelude::geometry::CoordinateConversionError;
-//! use delaunay::prelude::insertion::InsertionError;
-//! use delaunay::prelude::validation::{ValidationConfigurationError, ValidationPolicy};
+//! use delaunay::prelude::validation::ValidationPolicy;
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Construction(#[from] DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Insertion(#[from] InsertionError),
-//! #     #[error(transparent)]
-//! #     ValidationConfiguration(#[from] ValidationConfigurationError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] CoordinateConversionError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     vertex![0.0, 0.0, 0.0]?,
 //!     vertex![1.0, 0.0, 0.0]?,
@@ -360,18 +321,10 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+//!     DelaunayResult, DelaunayTriangulationBuilder, vertex,
 //! };
-//! use delaunay::prelude::geometry::CoordinateConversionError;
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] CoordinateConversionError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     vertex![0.0, 0.0, 0.0]?,
 //!     vertex![1.0, 0.0, 0.0]?,
@@ -389,18 +342,10 @@
 //!
 //! ```rust
 //! use delaunay::prelude::construction::{
-//!     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+//!     DelaunayResult, DelaunayTriangulationBuilder, vertex,
 //! };
-//! use delaunay::prelude::geometry::CoordinateConversionError;
 //!
-//! # #[derive(Debug, thiserror::Error)]
-//! # enum ExampleError {
-//! #     #[error(transparent)]
-//! #     Source(#[from] DelaunayTriangulationConstructionError),
-//! #     #[error(transparent)]
-//! #     Coordinate(#[from] CoordinateConversionError),
-//! # }
-//! # fn main() -> Result<(), ExampleError> {
+//! # fn main() -> DelaunayResult<()> {
 //! let vertices = vec![
 //!     vertex![0.0, 0.0, 0.0]?,
 //!     vertex![1.0, 0.0, 0.0]?,
@@ -778,9 +723,9 @@ pub use crate::builder::DelaunayTriangulationBuilder;
 pub use crate::construction::{
     ConstructionOptions, ConstructionSkipSample, ConstructionSlowInsertionSample,
     ConstructionStatistics, DedupPolicy, DedupTolerance, DelaunayConstructionFailure,
-    DelaunayConstructionRepairPhase, DelaunayTriangulationConstructionError,
-    DelaunayTriangulationConstructionErrorWithStatistics, InitialSimplexStrategy,
-    InsertionOrderStrategy, RetryPolicy,
+    DelaunayConstructionRepairPhase, DelaunayError, DelaunayResult,
+    DelaunayTriangulationConstructionError, DelaunayTriangulationConstructionErrorWithStatistics,
+    InitialSimplexStrategy, InsertionOrderStrategy, RetryPolicy,
 };
 pub use crate::core::algorithms::incremental_insertion::{
     CavityFillingError, CavityRepairStage, DelaunayRepairErrorKind, DelaunayRepairErrorSummary,
@@ -898,9 +843,9 @@ pub fn try_vertices_from_points<const D: usize>(
 /// #     #[error(transparent)]
 /// #     Construction(#[from] DelaunayTriangulationConstructionError),
 /// #     #[error(transparent)]
-/// #     Topology(#[from] delaunay::topology::TopologyError),
-/// #     #[error(transparent)]
 /// #     Coordinate(#[from] CoordinateConversionError),
+/// #     #[error(transparent)]
+/// #     Topology(#[from] delaunay::topology::TopologyError),
 /// # }
 /// # fn main() -> Result<(), ExampleError> {
 /// let vertices = vec![
@@ -1146,9 +1091,9 @@ pub mod prelude {
     pub use crate::{
         ConstructionOptions, ConstructionSkipSample, ConstructionSlowInsertionSample,
         ConstructionStatistics, DedupPolicy, DedupTolerance, DelaunayCheckPolicy,
-        DelaunayConstructionFailure, DelaunayConstructionRepairPhase,
+        DelaunayConstructionFailure, DelaunayConstructionRepairPhase, DelaunayError,
         DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds, DelaunayRepairOperation,
-        DelaunayRepairOutcome, DelaunayRepairPolicy, DelaunayTriangulation,
+        DelaunayRepairOutcome, DelaunayRepairPolicy, DelaunayResult, DelaunayTriangulation,
         DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
         DelaunayTriangulationConstructionErrorWithStatistics, DelaunayTriangulationValidationError,
         DelaunayVerificationError, DelaunayVerificationErrorKind, DuplicateDetectionMetrics,
@@ -1242,18 +1187,10 @@ pub mod prelude {
     ///
     /// ```rust
     /// use delaunay::prelude::construction::{
-    ///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+    ///     DelaunayResult, DelaunayTriangulationBuilder, vertex,
     /// };
-    /// use delaunay::prelude::geometry::CoordinateConversionError;
     ///
-    /// # #[derive(Debug, thiserror::Error)]
-    /// # enum ExampleError {
-    /// #     #[error(transparent)]
-    /// #     Source(#[from] DelaunayTriangulationConstructionError),
-    /// #     #[error(transparent)]
-    /// #     Coordinate(#[from] CoordinateConversionError),
-    /// # }
-    /// # fn main() -> Result<(), ExampleError> {
+    /// # fn main() -> DelaunayResult<()> {
     /// let vertices = vec![
     ///     vertex![0.0, 0.0]?,
     ///     vertex![1.0, 0.0]?,
@@ -1277,7 +1214,8 @@ pub mod prelude {
         pub use crate::construction::{
             ConstructionOptions, ConstructionSkipSample, ConstructionSlowInsertionSample,
             ConstructionStatistics, DedupPolicy, DedupTolerance, DelaunayConstructionFailure,
-            DelaunayConstructionRepairPhase, DelaunayTriangulationConstructionError,
+            DelaunayConstructionRepairPhase, DelaunayError, DelaunayResult,
+            DelaunayTriangulationConstructionError,
             DelaunayTriangulationConstructionErrorWithStatistics, InitialSimplexStrategy,
             InsertionOrderStrategy, RetryPolicy,
         };
@@ -1901,6 +1839,7 @@ mod tests {
         assert!(is_normal::<PlManifoldRepairError>());
         assert!(is_normal::<PlManifoldRepairStats<(), (), 3>>());
         assert!(is_normal::<SimplexValidationError>());
+        assert!(is_normal::<DelaunayError>());
         assert!(is_normal::<DelaunayTriangulationConstructionError>());
     }
 

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -13,6 +13,8 @@
 use std::{assert_matches, num::NonZeroUsize};
 
 use approx::assert_relative_eq;
+use slotmap::KeyData;
+
 use delaunay::geometry::CoordinateRange as GeometryCoordinateRange;
 use delaunay::prelude::DelaunayValidationError;
 use delaunay::prelude::algorithms::LocateResult;
@@ -26,8 +28,9 @@ use delaunay::prelude::construction::{
     ConstructionSlowInsertionSample, CoordinateRangeError as ConstructionCoordinateRangeError,
     CoordinateRangeOrdering as ConstructionCoordinateRangeOrdering,
     CoordinateValidationError as ConstructionCoordinateValidationError, DedupPolicy,
-    DedupTolerance, DeduplicationError, DelaunayConstructionFailure, DelaunayRepairPolicy,
-    DelaunayTriangulation, DelaunayTriangulationConstructionError,
+    DedupTolerance, DeduplicationError, DelaunayConstructionFailure, DelaunayError,
+    DelaunayRepairPolicy, DelaunayResult, DelaunayTriangulation, DelaunayTriangulationBuilder,
+    DelaunayTriangulationConstructionError,
     DelaunayTriangulationValidationError as ConstructionDelaunayTriangulationValidationError,
     DelaunayVerificationError as ConstructionDelaunayVerificationError,
     DelaunayVerificationErrorKind as ConstructionDelaunayVerificationErrorKind,
@@ -105,8 +108,8 @@ use delaunay::prelude::repair::{
 use delaunay::prelude::tds::Tds;
 use delaunay::prelude::tds::{
     AllFacetsIter as TdsAllFacetsIter, BoundaryFacetsIter as TdsBoundaryFacetsIter, FacetError,
-    FacetHandle, FacetView, InvariantErrorSummaryDetail, NeighborSlot, TdsError, TdsErrorKind,
-    VertexKey,
+    FacetHandle, FacetView, InvariantErrorSummaryDetail, NeighborSlot, SimplexKey, TdsError,
+    TdsErrorKind, VertexKey,
 };
 use delaunay::prelude::topology::spaces::{
     GlobalTopology, GlobalTopologyModelError, TopologyKind, ToroidalConstructionMode,
@@ -135,7 +138,8 @@ use delaunay::prelude::validation::{
     ValidationPolicy as FocusedValidationPolicy,
 };
 use delaunay::prelude::{
-    CoordinateRange as RootCoordinateRange,
+    CoordinateRange as RootCoordinateRange, DelaunayError as RootDelaunayError,
+    DelaunayResult as RootDelaunayResult,
     FlipOrientationCheckStage as RootFlipOrientationCheckStage, SecureHashMap, SecureHashSet,
     ValidationConfigurationError as RootValidationConfigurationError, vertex as root_vertex,
 };
@@ -200,6 +204,90 @@ const fn assert_root_bistellar_flips(_: &impl delaunay::flips::BistellarFlips<3,
 }
 
 const fn assert_send_sync_unpin<T: Send + Sync + Unpin>() {}
+
+#[test]
+fn construction_prelude_exports_common_delaunay_error_aliases() {
+    let source = CoordinateConversionError::InvalidSimplexPointCount {
+        actual: 2,
+        expected: 3,
+        dimension: 2,
+    };
+
+    let focused_error = DelaunayError::from(source.clone());
+    assert_matches!(
+        focused_error,
+        DelaunayError::CoordinateConversion { source: err } if err == source
+    );
+
+    let root_error = RootDelaunayError::from(source.clone());
+    assert_matches!(
+        root_error,
+        RootDelaunayError::CoordinateConversion { source: err } if err == source
+    );
+
+    let no_vertices: [Vertex<(), 2>; 0] = [];
+    let construction = DelaunayTriangulationBuilder::new(&no_vertices)
+        .build::<()>()
+        .expect_err("empty Delaunay construction should fail");
+    assert_matches!(
+        DelaunayError::from(construction),
+        DelaunayError::Construction {
+            source: DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayConstructionFailure::InsufficientVertices { dimension: 2, .. }
+            )
+        }
+    );
+
+    let insertion = InsertionError::DuplicateCoordinates {
+        coordinates: CoordinateValues::from([0.0, 0.0]),
+    };
+    assert_matches!(
+        DelaunayError::from(insertion.clone()),
+        DelaunayError::Insertion { source: err } if err == insertion
+    );
+
+    let configuration =
+        FocusedValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+            topology_guarantee: TopologyGuarantee::PLManifold,
+            validation_policy: FocusedValidationPolicy::Never,
+        };
+    let expected_configuration =
+        FocusedValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
+            topology_guarantee: TopologyGuarantee::PLManifold,
+            validation_policy: FocusedValidationPolicy::Never,
+        };
+    assert_matches!(
+        DelaunayError::from(configuration),
+        DelaunayError::ValidationConfiguration { source: err }
+            if err == expected_configuration
+    );
+
+    let toroidal_domain = ToroidalDomainError::InvalidPeriod {
+        axis: 0,
+        period: 0.0,
+    };
+    assert_matches!(
+        DelaunayError::from(toroidal_domain),
+        DelaunayError::ToroidalDomain {
+            source: ToroidalDomainError::InvalidPeriod { axis, period }
+        } if axis == 0 && period.to_bits() == 0.0_f64.to_bits()
+    );
+
+    let simplex_key = SimplexKey::from(KeyData::from_ffi(1));
+    let validation = ConstructionDelaunayTriangulationValidationError::VerificationFailed {
+        source: Box::new(ConstructionDelaunayVerificationError::from(
+            DelaunayValidationError::DelaunayViolation { simplex_key },
+        )),
+    };
+    assert_matches!(
+        DelaunayError::from(validation.clone()),
+        DelaunayError::Validation { source: err } if err == validation
+    );
+
+    let focused_result: DelaunayResult<()> = Ok(());
+    let root_result: RootDelaunayResult<()> = focused_result;
+    assert!(root_result.is_ok());
+}
 
 #[test]
 fn construction_prelude_covers_dedup_policy() {
@@ -484,6 +572,7 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
     assert_send_sync_unpin::<NeighborRebuildError>();
     assert_send_sync_unpin::<ConstructionSkipSample>();
     assert_send_sync_unpin::<ConstructionSlowInsertionSample>();
+    assert_send_sync_unpin::<DelaunayError>();
     assert_send_sync_unpin::<CoordinateConversionError>();
     assert_send_sync_unpin::<DegenerateSimplexReason>();
     assert_send_sync_unpin::<LaError>();


### PR DESCRIPTION
- Add DelaunayError and DelaunayResult for common construction, insertion, validation, coordinate conversion, and toroidal-domain setup workflows.
- Re-export the aliases from the crate root and construction preludes for downstream examples and applications.
- Update public docs and examples to use DelaunayResult when workflow-specific errors are not required.