### PR TITLE
feat(io): add validated mesh export schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,11 +51,12 @@ workflow. Agents must load every file in `docs/dev/` before making changes.
 - **Do not revert user changes.** The worktree may be dirty; preserve unrelated
   changes and work with any overlapping edits.
 - **Unsafe Rust is forbidden.** The crate enforces `#![forbid(unsafe_code)]`.
-- **Validate with the right command.** Non-test Rust changes require final
-  `just ci`. Rust unit-test-only, integration-test-only, and benchmark-only
-  changes use the matching focused validators from `docs/dev/commands.md`.
-  Docs/config changes use `just check`; Python-only changes use
-  `just python-check`.
+- **Validate with the right command.** Core Rust changes require final
+  `just ci`. Documentation, configuration, Python, notebook, Rust
+  unit-test-only, doctest-only, integration-test-only, benchmark-only, and
+  example-only changes use the matching focused validators from
+  `docs/dev/commands.md`; compose those validators once each when multiple
+  focused surfaces changed.
 - **Do not edit generated changelogs manually.** Changelog and documentation
   maintenance rules live in `docs/dev/docs.md`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Merged Pull Requests
 
+- Add 2D edge-to-facet incidence queries [#478](https://github.com/acgetchell/delaunay/pull/478)
 - Split Pachner moves from vertex lifecycle edits [#477](https://github.com/acgetchell/delaunay/pull/477)
 - Make topology views and boundaries owner-aware [#476](https://github.com/acgetchell/delaunay/pull/476)
 - Borrow topology views from canonical storage [#472](https://github.com/acgetchell/delaunay/pull/472) [#474](https://github.com/acgetchell/delaunay/pull/474)
@@ -84,6 +85,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add DelaunayError and DelaunayResult for common construction, insertion, validation, coordinate conversion, and toroidal-domain setup workflows.
   - Re-export the aliases from the crate root and construction preludes for downstream examples and applications.
   - Update public docs and examples to use DelaunayResult when workflow-specific errors are not required.
+- Add 2D edge-to-facet incidence queries [#478](https://github.com/acgetchell/delaunay/pull/478)
+  [`af2620b`](https://github.com/acgetchell/delaunay/commit/af2620b51a29c2fed7d33eabb5cfc0e867f0a419)
+
+  - Add 2D `try_incident_facets_to_edge_2d` and
+    `try_interior_facet_for_edge_2d` APIs on triangulation query surfaces.
+
+  - Re-export `FacetHandle` from query-focused surfaces for callers that consume
+    simplex-local facet handles outside Pachner-only imports.
+
+  - Optimize `EdgeKey::try_new` to prove live edges from endpoint incidence while
+    preserving typed incidence metadata errors.
+
+  - Add edge-key construction benchmarks and document the simplex-local incidence
+    query vocabulary.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ meshing, or production-scale dynamic remeshing.
   normalized volume, plus Jaccard set-similarity diagnostics.
 - [x] Incremental insertion, insertion statistics, and transactional `delete_vertex` rollback on failed
   repair/canonicalization.
+- [x] JSON-exportable simplicial-complex primitives with stable vertex/simplex UUIDs for notebooks and
+  downstream analysis tools.
 - [x] Optional Cargo feature gates for allocation counting, diagnostics, benchmark logging, and slow
   correctness tests.
 - [x] PL-manifold validation by default, with pseudomanifold checks available as an explicit opt-out.
@@ -163,6 +165,7 @@ explicit full-validation checkpoints.
 - [Examples](examples/README.md) - Runnable examples for construction, hulls, topology editing, diagnostics, and repair.
 - [Invariants](docs/invariants.md) - Topological and geometric invariants enforced by the crate.
 - [Limitations](docs/limitations.md) - Supported dimensions, predicate limits, toroidal modes, and feature gaps.
+- [Mesh Export](docs/mesh_export.md) - Stable UUID-based simplicial-complex export for notebooks and downstream tools.
 - [Numerical Robustness Guide](docs/numerical_robustness_guide.md) - Predicate kernels, SoS, retry, and repair behavior.
 - [Orientation Spec](docs/ORIENTATION_SPEC.md) - Coherent combinatorial and geometric orientation rules.
 - [Property Testing Summary](docs/property_testing_summary.md) - Property-test layout and coverage summary.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Historical design notes, investigations, and completed optimization roadmaps liv
 - [`topology.md`](topology.md): Level 3 topology invariants (manifold checks, Euler characteristic).
 - [`validation.md`](validation.md): the four-level validation model (Levels 1–4) and how to configure it.
 - [`diagnostics.md`](diagnostics.md): opt-in diagnostic helpers, structured reports, and debug switches.
+- [`mesh_export.md`](mesh_export.md): stable simplicial-complex export schema for notebooks and downstream tools.
 - [`workflows.md`](workflows.md): practical recipes for construction, deletion, and local Pachner moves.
 - [`limitations.md`](limitations.md): supported dimensions, predicate limits, large-scale cautions, and feature gaps.
 

--- a/docs/architecture/module_map.md
+++ b/docs/architecture/module_map.md
@@ -118,6 +118,18 @@ crate-level documentation map. Delaunay-facing modules are exposed directly as
 `delaunay::repair`, `delaunay::validation`, and focused preludes rather than
 through a nested `delaunay::delaunay` facade.
 
+## I/O And Export Layer
+
+`src/io/` owns public downstream-facing export data models:
+
+- `visualization.rs` - generic simplicial-complex primitives for notebooks,
+  visualization tools, analysis pipelines, and downstream crates.
+
+This layer is distinct from the TDS snapshot/hydration boundary. TDS serde
+remains the canonical validated persistence path; `io::visualization` exposes
+stable UUID-based records for consumers that should not depend on runtime
+slotmap handles.
+
 ## Topology Layer
 
 `src/topology/` owns topology analysis and validation:

--- a/docs/architecture/prelude_reference.md
+++ b/docs/architecture/prelude_reference.md
@@ -10,6 +10,7 @@ they exercise.
 | Collection aliases and small buffers | `use delaunay::prelude::collections::*` |
 | Construct/configure a Delaunay triangulation | `use delaunay::prelude::construction::*` |
 | Construction telemetry diagnostics | `use delaunay::prelude::diagnostics::*` |
+| Export stable simplicial-complex primitives | `use delaunay::prelude::export::*` |
 | Construction validation cadence/policy | `use delaunay::prelude::validation::*` |
 | Delaunay repair diagnostics and policies | `use delaunay::prelude::repair::*` |
 | Delaunayize workflow | `use delaunay::prelude::delaunayize::*` |

--- a/docs/architecture/project_structure.md
+++ b/docs/architecture/project_structure.md
@@ -68,6 +68,7 @@ delaunay/
 │   ├── core/
 │   ├── delaunay/
 │   ├── geometry/
+│   ├── io/
 │   ├── topology/
 │   └── lib.rs
 ├── tests/

--- a/docs/architecture/project_structure.md
+++ b/docs/architecture/project_structure.md
@@ -48,6 +48,7 @@ delaunay/
 │   ├── diagnostics.md
 │   ├── invariants.md
 │   ├── limitations.md
+│   ├── mesh_export.md
 │   ├── numerical_robustness_guide.md
 │   ├── property_testing_summary.md
 │   ├── topology.md
@@ -61,6 +62,7 @@ delaunay/
 │   ├── benchmark_models.py
 │   ├── benchmark_utils.py
 │   ├── hardware_utils.py
+│   ├── notebook_check.py
 │   ├── postprocess_changelog.py
 │   ├── subprocess_utils.py
 │   └── tag_release.py
@@ -74,6 +76,7 @@ delaunay/
 ├── tests/
 │   ├── semgrep/
 │   ├── proptest_*.rs
+│   ├── mesh_export.rs
 │   ├── pachner_roundtrip.rs
 │   ├── prelude_exports.rs
 │   └── regressions.rs

--- a/docs/code_organization.md
+++ b/docs/code_organization.md
@@ -32,6 +32,8 @@ into architecture docs; link to the command guide instead.
 - `src/geometry/` owns points, coordinate ranges, kernels, predicates,
   geometric quality measures, convex hull support, and coordinate conversion
   utilities.
+- `src/io/` owns downstream-facing export data models for notebooks,
+  visualization, analysis, and interchange. It does not own TDS hydration.
 - `src/topology/` owns topology-space models, Euler characteristic helpers,
   manifold validation, ridge queries, and PL-manifold reasoning.
 - `src/lib.rs` wires public modules, root re-exports, focused preludes, and the

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -50,32 +50,58 @@ These commands ensure:
 - static analysis
 - tests
 
+Treat this as a menu, not a required sequence. The validation matrix below is
+the handoff source of truth.
+
 ## Validation Command Selection
 
 Use the smallest non-mutating validator that covers the files you changed while
-iterating. For final handoff validation, match the command to the changed Rust
-surface instead of defaulting all Rust edits to full CI. Non-test Rust code
-still requires `just ci`; Rust test-only and benchmark-only changes use the
-focused validators below.
+iterating. For final handoff validation, match commands to the changed file
+surfaces instead of defaulting all edits to full CI.
+
+Core Rust code means production Rust or manifest changes that can affect library
+behavior, public API, features, examples, benchmarks, or downstream users. It
+does not include Rust doctest-only, unit-test-only, integration-test-only,
+benchmark-only, or example-only edits when the focused validator covers the
+changed surface.
 
 | Touched surface | Iteration validation | Final validation |
 |-----|-----|-----|
-| Documentation or configuration only | `just check` | `just check` |
-| Python-only changes under `scripts/` | `just python-check` | `just python-check` |
+| Markdown documentation (`*.md`) | `just markdown-check` | `just markdown-check` |
+| Python under `scripts/` | Targeted pytest or `just test-python`; add `just python-check` for logic/style | `just python-check` and `just test-python` |
+| Jupyter notebooks (`notebooks/**/*.ipynb`) | `just notebook-lint` | `just notebook-check` |
+| Configuration only (JSON, TOML, YAML, CFF, workflows) | Matching config validator | `just lint-config` |
 | Rust unit tests only (`#[cfg(test)]` in `src/**`) | Targeted `cargo test --lib <filter>` or `just test-unit` | `just test-unit` |
+| Rust doctests only (`///` examples or crate docs) | Targeted `cargo test --doc <filter>` or `just test-doc` | `just test-doc` |
 | Rust integration tests only (`tests/**`) | Targeted `cargo nextest run --test <name>` or `just test-integration-fast` | `just test-integration` |
 | Rust benchmark files only (`benches/**`) | Targeted benchmark command or `just bench-smoke` | Matching benchmark validator |
 | Rust examples only (`examples/**`) | Targeted `cargo run --example <name>` or `just examples` | `just examples` |
-| Cargo manifest, features, public API, or non-test Rust code | Focused checks, `just check`, or targeted tests | `just ci` |
-| Mixed Rust test categories | Run each matching focused validator | Run each matching focused validator |
-| Mixed non-test Rust plus tests/benches/examples | Focused checks while iterating | `just ci` |
+| Core Rust code | Focused checks or targeted tests while iterating | `just ci` |
+| Mixed focused surfaces without core Rust | Run each matching focused validator once | Run each matching focused validator once |
+| Mixed core Rust plus tests/benches/examples/docs/config | Focused checks while iterating | `just ci` |
 
-Do not run `just ci` merely because documentation, configuration, or Python
-files changed. Do not run `just ci` merely because a Rust file changed if the
-diff only touches unit tests, integration tests, examples, or benchmarks and
-the focused validator covers the changed surface. Run `just ci` before final
-handoff when non-test Rust code changed or when the maintainer explicitly asks
-for full CI.
+Do not run `just ci` merely because documentation, configuration, Python,
+notebook, or test-only Rust files changed. Do not run `just test` when a single
+focused test bucket covers the change unless you intentionally want the full
+default test suite. When a diff touches multiple focused test surfaces, compose
+the matching recipes once each; for example, run `just test-doc` and
+`just test-integration` for doctest plus integration-test changes. Broad Rust
+correctness workflows such as `just test-rust` and `just ci` use
+`just test-rust-ci`, which runs Rust lib unit tests and integration tests
+together in one release-profile nextest invocation.
+
+During fast code-writing cycles, start with the smallest changed test or
+doctest rather than the whole focused bucket. For single-item rustdoc edits, run
+`cargo test --doc <item-or-module-filter>`; for unit-test edits, run
+`cargo test --lib <test-or-module-filter>`; for integration-test crate edits,
+run the changed crate with `cargo nextest run --test <crate>`. Cargo's built-in
+test-name filter accepts one filter per invocation, so run separate filtered
+commands for unrelated changed tests or choose one shared module/name prefix
+that covers the intended small group. Use `just test-doc`, `just test-unit`, or
+`just test-integration` for final bucket validation or broad changes.
+
+Focused validators own one target class. Avoid adding a compile-only smoke
+recipe before a recipe that already compiles and runs the same target class.
 
 For benchmark-only changes, run the changed benchmark with
 `cargo bench --profile perf --bench <name>` when the change affects measured
@@ -148,8 +174,10 @@ examples, or benchmarks.
 just check-fast
 ```
 
-`just check` runs the default checks plus an `--all-features` pass. DenseSlotMap
-is the only supported storage backend.
+`rust-core-check` runs core library Clippy in the default and all-features
+configurations. `clippy-all-targets` is available as an optional broad sweep,
+but it is not part of `just ci` because tests, examples, and benchmark harnesses
+own their own validation buckets.
 
 ---
 
@@ -173,7 +201,7 @@ cargo doc
 
 ## Full CI Validation
 
-Before large Rust changes, broad API/test/benchmark changes, release-style
+Before core Rust changes, broad API-affecting changes, release-style
 validation, or explicit maintainer requests, run the full CI command:
 
 ```bash
@@ -183,11 +211,17 @@ just ci
 This runs:
 
 - formatting checks
-- lint checks
-- benchmark and release-test compile checks using Cargo's default release profile
-- unit tests
-- integration tests
-- documentation builds
+- GitHub Actions checks
+- Markdown checks
+- JSON/TOML/YAML/CFF checks
+- Python lint/typecheck
+- notebook hygiene and fast headless execution
+- Rust core lint, documentation, and Semgrep checks
+- benchmark harness compile checks
+- Rust lib unit tests
+- Rust doctests
+- Rust release integration tests
+- Python tests
 - example builds
 
 ---
@@ -199,15 +233,30 @@ For performance-sensitive code changes, follow
 when none covers the hot path, benchmark after editing, and preserve
 correctness invariants throughout.
 
-`just ci` is the comprehensive error-catching validation path. It runs the
-`check`, `test`, and `examples` recipes. The `test` recipe already depends on
-`bench-test-compile`, so CI compiles benchmark harnesses and release tests
-through that path; `bench-compile` is a standalone recipe that is **not**
-executed by `just ci`:
+`just ci` is the comprehensive error-catching validation path used by GitHub
+Actions. It is a flat union of leaf validators rather than a nested call to
+`just check`. The target classes are kept separate: `rust-core-check` covers
+formatting, core library Clippy, rustdoc, and Semgrep; `bench-compile` compiles
+benchmark harnesses once; `test-rust-ci` compiles and runs Rust lib unit tests
+and release integration tests in one release-profile nextest invocation;
+`test-doc` compiles and runs Rust doctests; `notebook-check` lints notebooks
+and executes fast notebooks headlessly once.
+
+`just test` is tests-only. `test-integration-compile` and `bench-test-compile`
+are explicit no-run smoke recipes for cases where a compile-only check is the
+desired validator; do not run them before `test-integration` unless you
+intentionally want a separate compile-only pass. `test-unit` and
+`test-integration` stay focused for targeted local validation; broad test and
+CI workflows use `test-rust-ci` to avoid a debug-plus-release profile split.
 
 ```bash
 just ci
-just test              # includes just bench-test-compile
+just test
+just rust-core-check
+just test-rust-ci
+just notebook-check
+just bench-compile
+just test-integration-compile
 just bench-test-compile
 ```
 
@@ -232,7 +281,7 @@ Use `just bench-smoke` only for quick harness validation with minimal samples;
 do not treat smoke output as performance data.
 
 Workspace-wide benchmark recipes (`just bench`, `just bench-smoke`,
-`just bench-compile`, and the benchmark compile step inside `just test`) enable
+`just bench-compile`, and the benchmark compile step inside `just ci`) enable
 `--features bench` so feature-gated benchmark fixtures are compiled.
 
 Some repair benchmarks need feature-gated fixtures that deliberately construct
@@ -399,6 +448,31 @@ under:
 
 ---
 
+## Notebook Validation
+
+Notebook source files should not commit generated outputs or execution counts.
+Notebook code is extracted and checked with Ruff and ty so `.ipynb` cells follow
+the same Python standards as repository scripts.
+
+Commands:
+
+```bash
+just notebook-lint
+just notebook-check
+just notebook-check-slow
+just notebook-clear-outputs-all
+```
+
+`notebook-check` runs notebook hygiene and fast headless execution. Headless
+execution writes executed notebooks under `target/notebooks/` and leaves source
+notebooks unchanged. Slow notebooks should be named `*_slow.ipynb` or placed
+under `notebooks/slow/`; those run through `notebook-check-slow`.
+
+Before notebooks exist, these recipes are clean no-ops so the CI shape can stay
+stable ahead of notebook work.
+
+---
+
 ## Markdown Checks
 
 Markdown files are checked and fixed with rumdl. Keep the non-mutating check
@@ -507,14 +581,22 @@ just action-lint
 | Fast compile check | `just check-fast` |
 | Check formatting | `just fmt-check` |
 | Apply formatters/auto-fixes | `just fix` |
-| Validate documentation/config-only changes | `just check` |
-| Validate Python-only changes | `just python-check` |
-| Run tests + compile smoke | `just test` |
-| Run unit/doc tests only | `just test-unit` |
+| Validate Markdown-only changes | `just markdown-check` |
+| Validate configuration-only changes | `just lint-config` |
+| Validate Python scripts/tests | `just python-check` and `just test-python` |
+| Validate notebook changes | `just notebook-check` |
+| Validate core Rust checks | `just rust-core-check` |
+| Run all default test buckets | `just test` |
+| Run Rust tests only | `just test-rust` |
+| Run Rust CI nextest bucket | `just test-rust-ci` |
+| Run Rust lib unit tests only | `just test-unit` |
+| Run doctests only | `just test-doc` |
 | Run integration tests | `just test-integration` |
 | Run all tests | `just test-all` |
+| Compile benchmark harnesses | `just bench-compile` |
+| Compile release integration tests without running | `just test-integration-compile` |
 | Run examples | `just examples` |
-| Run full CI | `just ci` |
+| Run full GitHub-equivalent CI | `just ci` |
 | Run perf-profile benchmarks | `just bench` |
 
 ---
@@ -523,20 +605,24 @@ just action-lint
 
 CI enforces:
 
-- formatting
-- clippy lints
-- documentation build
-- tests
+- GitHub Actions checks
+- Markdown, JSON, TOML, YAML, CFF, and spell checks
+- Python lint, type checks, and tests
+- notebook hygiene and fast headless execution
+- core Rust formatting, Clippy, rustdoc, and Semgrep checks
+- Rust unit, doctest, and integration tests
+- benchmark harness compilation
+- examples
 
 Rust warnings are denied by the manifest lint policy and Clippy warnings are
-denied by the `just clippy` invocations. Keep any intentional warning-level
+denied by the `just clippy-core` invocations. Keep any intentional warning-level
 exceptions explicit in `Cargo.toml`.
 
 Agents must ensure changes pass the appropriate local validator before
-proposing patches. Rust/Cargo/example/benchmark/test changes should pass
-`just ci` for final handoff validation; documentation/config-only changes
-should normally pass `just check`, and Python-only changes should normally pass
-`just python-check`.
+proposing patches. Use the validation matrix above for final handoff: core
+Rust/Cargo changes require `just ci`, while documentation, configuration,
+Python, test-only, benchmark-only, and example-only changes use their focused
+validators and compose them once each when multiple surfaces changed.
 
 ---
 

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -67,12 +67,12 @@ changed surface.
 
 | Touched surface | Iteration validation | Final validation |
 |-----|-----|-----|
-| Markdown documentation (`*.md`) | `just markdown-check` | `just markdown-check` |
+| Markdown documentation (`*.md`) | `just markdown-check` | `just markdown-ci` |
 | Python under `scripts/` | Targeted pytest or `just test-python`; add `just python-check` for logic/style | `just python-check` and `just test-python` |
 | Jupyter notebooks (`notebooks/**/*.ipynb`) | `just notebook-lint` | `just notebook-check` |
 | Configuration only (JSON, TOML, YAML, CFF, workflows) | Matching config validator | `just lint-config` |
 | Rust unit tests only (`#[cfg(test)]` in `src/**`) | Targeted `cargo test --lib <filter>` or `just test-unit` | `just test-unit` |
-| Rust doctests only (`///` examples or crate docs) | Targeted `cargo test --doc <filter>` or `just test-doc` | `just test-doc` |
+| Rust doctests only (`///` examples or crate docs) | Targeted `cargo test --doc --release <filter>` or `just test-doc` | `just test-doc` |
 | Rust integration tests only (`tests/**`) | Targeted `cargo nextest run --test <name>` or `just test-integration-fast` | `just test-integration` |
 | Rust benchmark files only (`benches/**`) | Targeted benchmark command or `just bench-smoke` | Matching benchmark validator |
 | Rust examples only (`examples/**`) | Targeted `cargo run --example <name>` or `just examples` | `just examples` |
@@ -92,7 +92,7 @@ together in one release-profile nextest invocation.
 
 During fast code-writing cycles, start with the smallest changed test or
 doctest rather than the whole focused bucket. For single-item rustdoc edits, run
-`cargo test --doc <item-or-module-filter>`; for unit-test edits, run
+`cargo test --doc --release <item-or-module-filter>`; for unit-test edits, run
 `cargo test --lib <test-or-module-filter>`; for integration-test crate edits,
 run the changed crate with `cargo nextest run --test <crate>`. Cargo's built-in
 test-name filter accepts one filter per invocation, so run separate filtered
@@ -239,8 +239,8 @@ Actions. It is a flat union of leaf validators rather than a nested call to
 formatting, core library Clippy, rustdoc, and Semgrep; `bench-compile` compiles
 benchmark harnesses once; `test-rust-ci` compiles and runs Rust lib unit tests
 and release integration tests in one release-profile nextest invocation;
-`test-doc` compiles and runs Rust doctests; `notebook-check` lints notebooks
-and executes fast notebooks headlessly once.
+`test-doc` compiles and runs Rust doctests once in release profile;
+`notebook-check` lints notebooks and executes fast notebooks headlessly once.
 
 `just test` is tests-only. `test-integration-compile` and `bench-test-compile`
 are explicit no-run smoke recipes for cases where a compile-only check is the
@@ -475,12 +475,13 @@ stable ahead of notebook work.
 
 ## Markdown Checks
 
-Markdown files are checked and fixed with rumdl. Keep the non-mutating check
-before the mutating fixer in user-facing command examples.
+Markdown files are checked with rumdl and spell-checking for handoff. Keep the
+non-mutating check before the mutating fixer in user-facing command examples.
 
 Commands:
 
 ```bash
+just markdown-ci
 just markdown-check
 just markdown-fix
 ```
@@ -581,7 +582,7 @@ just action-lint
 | Fast compile check | `just check-fast` |
 | Check formatting | `just fmt-check` |
 | Apply formatters/auto-fixes | `just fix` |
-| Validate Markdown-only changes | `just markdown-check` |
+| Validate Markdown-only changes | `just markdown-ci` |
 | Validate configuration-only changes | `just lint-config` |
 | Validate Python scripts/tests | `just python-check` and `just test-python` |
 | Validate notebook changes | `just notebook-check` |

--- a/docs/dev/python.md
+++ b/docs/dev/python.md
@@ -15,16 +15,22 @@ Run the Python validators through the repository toolchain:
 
 ```bash
 just python-check
-just python-typecheck
 just test-python
 ```
 
-`just python-typecheck` runs `ty check scripts/ --error all`, which is the
-type-checking authority. Prefer reducing untyped surfaces in code and tests
-over adding more `ty` configuration.
+`just python-check` runs Ruff formatting checks, Ruff linting, and
+`just python-typecheck`. `just python-typecheck` runs
+`ty check scripts/ --error all`, which is the type-checking authority. Prefer
+reducing untyped surfaces in code and tests over adding more `ty`
+configuration.
 
 `just check` also runs Python formatting checks, Ruff, and `ty` as part of the
 normal repository validation bundle.
+
+Jupyter notebooks are validated separately through `just notebook-lint` and
+`just notebook-check`. Notebook cells are extracted and checked with Ruff and
+ty, but notebook edits should use the notebook validators rather than treating
+`.ipynb` files as ordinary Python scripts.
 
 ---
 

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -888,12 +888,15 @@ isolation.
 Use focused tests while iterating on Rust changes, for example:
 
 ```bash
-just test
+just test-unit
+just test-doc
 just test-integration
 ```
 
-For final handoff validation after Rust/Cargo/example/benchmark/test changes,
-run `just ci`; see [`commands.md`](commands.md) for the full command matrix.
+For final handoff validation, core Rust/Cargo changes require `just ci`.
+Doctest-only, unit-test-only, integration-test-only, benchmark-only, and
+example-only changes use the focused validators in
+[`commands.md`](commands.md).
 
 Property tests are preferred for geometric invariants such as:
 
@@ -949,7 +952,7 @@ Before adding a dependency, consider:
 Code must pass non-mutating checks:
 
 ```bash
-just check
+just rust-core-check
 ```
 
 Apply formatters and auto-fixes after reviewing check output:

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -371,6 +371,29 @@ The test suite has two routine correctness buckets:
   Gate these with `#[cfg(feature = "slow-tests")]` and run them through
   `just test-slow`.
 
+Default test recipes are split by target class:
+
+- `just test-unit` runs Rust lib unit tests.
+- `just test-doc` runs Rust doctests.
+- `just test-integration` runs Rust integration tests.
+- `just test-python` runs Python tests.
+
+For test-only changes, run only the matching focused recipe. If multiple test
+target classes changed, compose those focused recipes once each. Use
+`just test` when you intentionally want the full default test suite; broad Rust
+test workflows use `just test-rust-ci` so lib unit tests and integration tests
+compile together under the release profile rather than as separate
+debug/release nextest passes.
+During iteration, prefer the targeted changed-test commands in
+[`commands.md`](commands.md); reserve full focused recipes such as
+`just test-doc`, `just test-unit`, and `just test-integration` for final bucket
+validation or broad changes.
+
+Notebook validation is separate from `just test`. Use `just notebook-lint` for
+notebook hygiene and extracted-code checks, `just notebook-check` for fast
+headless execution, and `just notebook-check-slow` for notebooks that exceed
+the routine execution budget.
+
 Do not mark deterministic slow correctness tests with `#[ignore]`; that makes
 them invisible to `just test-slow`. Benchmark-style tests should live in
 `benches/`, not as `#[cfg(feature = "bench")]` unit tests. Feature-gated
@@ -380,16 +403,40 @@ Those helpers should still have focused unit tests for their fixture contract.
 Known limitations should be asserted explicitly or tracked outside the routine
 test suite rather than hidden behind `#[ignore]`.
 
-Run standard tests:
+Run all default test buckets:
 
 ```bash
 just test
+```
+
+Run Rust lib unit tests and integration tests in the CI release-profile nextest bucket:
+
+```bash
+just test-rust-ci
+```
+
+Run Rust lib unit tests:
+
+```bash
+just test-unit
+```
+
+Run Rust doctests:
+
+```bash
+just test-doc
 ```
 
 Run integration tests:
 
 ```bash
 just test-integration
+```
+
+Run Python tests:
+
+```bash
+just test-python
 ```
 
 Run all tests:

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -374,7 +374,7 @@ The test suite has two routine correctness buckets:
 Default test recipes are split by target class:
 
 - `just test-unit` runs Rust lib unit tests.
-- `just test-doc` runs Rust doctests.
+- `just test-doc` runs Rust doctests in release profile.
 - `just test-integration` runs Rust integration tests.
 - `just test-python` runs Python tests.
 
@@ -460,13 +460,13 @@ Public documentation examples must compile.
 Validate with:
 
 ```bash
-just doc-check
+just test-doc
 ```
 
 or:
 
 ```bash
-cargo test --doc
+cargo test --doc --release
 ```
 
 ---

--- a/docs/mesh_export.md
+++ b/docs/mesh_export.md
@@ -1,0 +1,165 @@
+# Mesh Export Schema
+
+`delaunay` exposes a generic simplicial-complex export model for analysis,
+visualization, notebooks, ML pipelines, and downstream crates. The API lives in
+`delaunay::io::visualization` and is also available through
+`delaunay::prelude::export`.
+
+This format is distinct from the internal `Tds` serde snapshot. Use `Tds` /
+`DelaunayTriangulation` serde when you need validated Rust round-trip
+persistence. Use mesh export when another tool needs stable ids, coordinates,
+connectivity, and adjacency without depending on private handle formatting. A
+mesh export is an owned, detached interchange snapshot; regenerate it after
+mutating the source triangulation.
+
+## Rust API
+
+Call `DelaunayTriangulation::to_mesh_export()` for the default schema, or
+`DelaunayTriangulation::to_visualization_data()` when the generic
+visualization name communicates the workflow more clearly.
+
+```rust
+use delaunay::prelude::construction::{
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+};
+use delaunay::prelude::export::{
+    MeshExport, MeshExportError, MeshExportValidationError, ValidatedMeshExport,
+};
+use delaunay::prelude::geometry::CoordinateConversionError;
+
+#[derive(Debug, thiserror::Error)]
+enum ExampleError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Coordinate(#[from] CoordinateConversionError),
+    #[error(transparent)]
+    Export(#[from] MeshExportError),
+    #[error(transparent)]
+    Validation(#[from] MeshExportValidationError),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+fn main() -> Result<(), ExampleError> {
+    let vertices = vec![
+        vertex![0.0, 0.0]?,
+        vertex![1.0, 0.0]?,
+        vertex![0.0, 1.0]?,
+    ];
+    let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    let export = triangulation.to_mesh_export()?;
+    let json = serde_json::to_string_pretty(&export)?;
+    let decoded: MeshExport<2> = serde_json::from_str(&json)?;
+    let validated: ValidatedMeshExport<2> = decoded.into_validated()?;
+
+    assert!(json.contains("delaunay.simplicial_complex"));
+    assert_eq!(validated.vertices().len(), 3);
+    Ok(())
+}
+```
+
+## JSON Shape
+
+The v1 schema has four top-level fields:
+
+- `metadata`: schema name, schema version, producer, dimension, counts,
+  topology kind, and topology guarantee. In Rust, the topology fields are
+  typed schema enums that serde round-trips as the JSON strings shown below.
+- `vertices`: stable vertex UUID and coordinate array.
+- `simplices`: stable simplex UUID and ordered vertex UUID membership.
+- `adjacency`: one record per simplex facet, with nullable neighbor simplex
+  UUIDs for boundary facets.
+
+Example, abbreviated:
+
+```json
+{
+  "metadata": {
+    "schema": "delaunay.simplicial_complex",
+    "schema_version": 1,
+    "producer": "delaunay",
+    "dimension": 2,
+    "vertex_count": 3,
+    "simplex_count": 1,
+    "topology_kind": "Euclidean",
+    "topology_guarantee": "PLManifold"
+  },
+  "vertices": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "coordinates": [0.0, 0.0]
+    }
+  ],
+  "simplices": [
+    {
+      "id": "00000000-0000-0000-0000-000000000010",
+      "vertex_ids": [
+        "00000000-0000-0000-0000-000000000001",
+        "00000000-0000-0000-0000-000000000002",
+        "00000000-0000-0000-0000-000000000003"
+      ]
+    }
+  ],
+  "adjacency": [
+    {
+      "simplex_id": "00000000-0000-0000-0000-000000000010",
+      "facet_index": 0,
+      "neighbor_simplex_id": null
+    }
+  ]
+}
+```
+
+## Stability Contract
+
+Entity ids are UUIDs stored on vertices and simplices. They are stable across
+ordinary JSON serde round trips of the TDS snapshot and are safe for external
+tools to store. Runtime `VertexKey` and `SimplexKey` values are intentionally
+absent because they are storage-local handles.
+
+The export sorts vertices and simplices by UUID for deterministic output.
+Simplex `vertex_ids` preserve the simplex's stored vertex order because that
+order carries orientation and facet-slot meaning.
+
+`adjacency[*].facet_index` is aligned with the simplex's vertex list: facet
+`i` is opposite `simplices[*].vertex_ids[i]`. A `null` neighbor marks a
+boundary facet.
+
+After deserializing JSON from another process or file, call `into_validated()`
+before handing records to topology-aware code. It parses the raw DTO into a
+`ValidatedMeshExport` proof-bearing wrapper; use `validate()` only when a
+one-off check is enough. Validation checks schema metadata, topology category
+strings, dimensional arity, counts, non-nil and duplicate ids, finite coordinate
+values, connectivity references, one adjacency record per simplex facet, and
+reciprocal non-boundary adjacency whose neighbor actually contains the source
+facet vertices. It does not turn the records into canonical Rust `Tds` storage,
+but the validated wrapper does canonicalize detached record order by stable ids
+for deterministic serialization. Use triangulation/TDS serde when the goal is
+validated Rust hydration.
+
+## Downstream Extension
+
+The Rust records are generic over optional attribute payloads:
+
+```rust
+use delaunay::prelude::export::VisualizationData;
+
+struct CausalVertexAttributes {
+    time_slice: usize,
+}
+
+type CausalExport<const D: usize> = VisualizationData<D, CausalVertexAttributes>;
+```
+
+Downstream crates can also wrap the base export with additional tables for
+foliation, simplex types, causal adjacency, simulation step, or observables
+without changing the common plotting primitives.
+
+## Non-Goals
+
+- This export is not a native GUI or plotting layer.
+- This export is not the canonical hydration format for reconstructing a
+  validated Rust `Tds`.
+- Arrow or Parquet exports, if added later, should remain optional analytical
+  formats and should not affect the default build.

--- a/justfile
+++ b/justfile
@@ -359,7 +359,7 @@ help-workflows:
     @echo "  just test-rust         # Rust unit, doctest, and integration tests"
     @echo "  just test-rust-ci      # CI Rust unit + integration tests in one release nextest run"
     @echo "  just test-unit         # Rust lib unit tests only"
-    @echo "  just test-doc          # Rust doctests only"
+    @echo "  just test-doc          # Rust doctests only, in release profile"
     @echo "  just test-integration  # All integration tests (includes proptests)"
     @echo "  just test-integration-fast # Integration tests (skips proptests)"
     @echo "  just test-integration-compile # Compile integration tests without running"
@@ -486,7 +486,7 @@ notebook notebook="notebooks/00_quickstart.ipynb": _ensure-uv
     set -euo pipefail
     notebook_cache="$(pwd)/target/notebooks"
     mkdir -p "$notebook_cache/.ipython" "$notebook_cache/.matplotlib"
-    MPLBACKEND=Agg IPYTHONDIR="$notebook_cache/.ipython" MPLCONFIGDIR="$notebook_cache/.matplotlib" uv run --group notebooks jupyter lab --ServerApp.open_browser=True --LabApp.open_browser=True "{{notebook}}"
+    MPLBACKEND=Agg IPYTHONDIR="$notebook_cache/.ipython" MPLCONFIGDIR="$notebook_cache/.matplotlib" uv run --group notebooks jupyter lab --ServerApp.open_browser=True --LabApp.open_browser=True "{{ notebook }}"
 
 notebook-check: notebook-lint notebook-execute-fast
     @echo "📓 Notebook checks complete!"
@@ -495,7 +495,7 @@ notebook-check-slow: notebook-check notebook-execute-slow
     @echo "📓 Slow notebook checks complete!"
 
 notebook-clear-outputs notebook="notebooks/00_quickstart.ipynb": _ensure-uv
-    uv run --group notebooks jupyter nbconvert --clear-output --inplace "{{notebook}}"
+    uv run --group notebooks jupyter nbconvert --clear-output --inplace "{{ notebook }}"
 
 notebook-clear-outputs-all: _ensure-uv
     #!/usr/bin/env bash
@@ -516,9 +516,9 @@ notebook-clear-outputs-all: _ensure-uv
 notebook-execute notebook="notebooks/00_quickstart.ipynb" output_dir="target/notebooks": _ensure-uv
     #!/usr/bin/env bash
     set -euo pipefail
-    output_path="$(pwd)/{{output_dir}}"
+    output_path="$(pwd)/{{ output_dir }}"
     mkdir -p "$output_path/.ipython" "$output_path/.matplotlib"
-    MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{output_dir}}" "{{notebook}}"
+    MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{ output_dir }}" "{{ notebook }}"
 
 notebook-execute-fast output_dir="target/notebooks": _ensure-uv
     #!/usr/bin/env bash
@@ -527,12 +527,12 @@ notebook-execute-fast output_dir="target/notebooks": _ensure-uv
         echo "No fast notebooks found to execute."
         exit 0
     fi
-    output_path="$(pwd)/{{output_dir}}"
+    output_path="$(pwd)/{{ output_dir }}"
     mkdir -p "$output_path/.ipython" "$output_path/.matplotlib"
     found=0
     while IFS= read -r notebook; do
         found=1
-        MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{output_dir}}" "$notebook"
+        MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{ output_dir }}" "$notebook"
     done < <(find notebooks -type f -name '*.ipynb' ! -path '*/.ipynb_checkpoints/*' ! -path 'notebooks/slow/*' ! -name '*_slow.ipynb' | sort)
     if [ "$found" -eq 0 ]; then
         echo "No fast notebooks found to execute."
@@ -545,12 +545,12 @@ notebook-execute-slow output_dir="target/notebooks": _ensure-uv
         echo "No slow notebooks found to execute."
         exit 0
     fi
-    output_path="$(pwd)/{{output_dir}}"
+    output_path="$(pwd)/{{ output_dir }}"
     mkdir -p "$output_path/.ipython" "$output_path/.matplotlib"
     found=0
     while IFS= read -r notebook; do
         found=1
-        MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=1800 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{output_dir}}" "$notebook"
+        MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=1800 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{ output_dir }}" "$notebook"
     done < <(find notebooks -type f \( -path 'notebooks/slow/*' -o -name '*_slow.ipynb' \) ! -path '*/.ipynb_checkpoints/*' | sort)
     if [ "$found" -eq 0 ]; then
         echo "No slow notebooks found to execute."
@@ -1209,9 +1209,9 @@ test-allocation: _ensure-nextest
 test-diagnostics: _ensure-nextest
     cargo nextest run --profile ci --test circumsphere_debug_tools --features diagnostics -- --nocapture
 
-# test-doc: runs Rust doctests.
+# test-doc: runs Rust doctests in release profile.
 test-doc:
-    cargo test --doc --verbose
+    cargo test --doc --release --verbose
 
 # test-integration: runs all default integration tests under the 10s per-test budget.
 test-integration: _ensure-nextest
@@ -1233,8 +1233,7 @@ test-integration-fast: _ensure-nextest
 test-python: _ensure-uv
     uv run pytest
 
-test-release: test-rust-ci
-    cargo test --doc --release
+test-release: test-rust-ci test-doc
 
 # test-rust: runs each default Rust correctness target class once.
 test-rust: test-rust-ci test-doc

--- a/justfile
+++ b/justfile
@@ -201,8 +201,7 @@ bench-allocations:
 bench-ci:
     cargo bench --profile perf --bench ci_performance_suite
 
-# Compile benchmarks without running them. Manifest lints enforce the warning
-# policy without using RUSTFLAGS that fragment Cargo artifact caches.
+# Compile benchmark harnesses without running them.
 bench-compile:
     cargo bench --workspace --no-run --features bench
 
@@ -215,12 +214,8 @@ bench-perf-summary: _ensure-uv
 bench-smoke:
     CRIT_SAMPLE_SIZE=10 CRIT_MEASUREMENT_MS=500 CRIT_WARMUP_MS=200 cargo bench --workspace --profile perf --features bench
 
-# Compile benchmarks and integration tests without running. This catches
-# release-profile-only warnings (e.g. cfg-gated unused-mut) that debug-mode
-# clippy/test won't see.
-bench-test-compile: _ensure-nextest
-    cargo bench --workspace --no-run --features bench
-    cargo nextest run --release --tests --no-run
+# Compile benchmarks and release integration tests without running.
+bench-test-compile: bench-compile test-integration-compile
 
 # Build commands
 build:
@@ -254,7 +249,7 @@ changelog-update: changelog
     @echo "To create a git tag with changelog content for a specific version, run:"
     @echo "  just tag <version>  # e.g., just tag v0.4.2"
 
-# Check (non-mutating): run all linters/validators.
+# Check (non-mutating): run non-test validators.
 check: lint
     @echo "✅ Checks complete!"
 
@@ -263,8 +258,7 @@ check-fast:
     cargo check
 
 # CI simulation: comprehensive validation.
-# Runs: checks + test workflow + examples
-ci: check test examples
+ci: github-actions-check markdown-ci json-check toml-ci yaml-ci python-ci notebook-check rust-core-check test-rust-ci test-doc bench-compile examples
     @echo "🎯 CI checks complete!"
 
 # CI followed by an explicit persistent local baseline refresh.
@@ -288,13 +282,15 @@ clean:
     rm -rf coverage
 
 # Code quality and formatting
-clippy:
-    cargo clippy --workspace --all-targets -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+clippy: clippy-core
 
-    # All features, split by target class so feature-gated benchmark/example
-    # code stays covered without rebuilding every target in one oversized graph.
-    cargo clippy --workspace --lib --tests --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
-    cargo clippy --workspace --benches --examples --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+clippy-all-targets:
+    cargo clippy --workspace --all-targets -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+    cargo clippy --workspace --all-targets --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+
+clippy-core:
+    cargo clippy --workspace --lib -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
+    cargo clippy --workspace --lib --all-features -- -D warnings -W clippy::pedantic -W clippy::nursery -W clippy::cargo
 
 # Coverage analysis for local development (HTML output)
 coverage: _ensure-cargo-llvm-cov
@@ -340,20 +336,43 @@ fmt:
 fmt-check:
     cargo fmt --all -- --check
 
+github-actions-check: action-lint zizmor
+    @echo "✅ GitHub Actions checks complete!"
+
 help-workflows:
     @echo "Recommended Just workflow:"
     @echo "  just check             # Run all non-mutating lints/validators"
     @echo "  just fix               # Apply formatters/auto-fixes (mutating)"
-    @echo "  just test              # Run tests + default-profile benchmark/release compile smoke"
-    @echo "  just ci                # Comprehensive checks + tests + examples"
+    @echo "  just test              # Run default test buckets"
+    @echo "  just ci                # GitHub-equivalent union of every validation bucket"
+    @echo ""
+    @echo "Focused validation:"
+    @echo "  just rust-core-check   # Formatting, core clippy, docs, and Semgrep"
+    @echo "  just python-ci         # Python lint/typecheck + pytest"
+    @echo "  just notebook-check    # Notebook hygiene + fast headless execution"
+    @echo "  just markdown-ci       # Markdown lint + spell check"
+    @echo "  just toml-ci           # TOML parse/lint/format checks"
+    @echo "  just yaml-ci           # YAML/CFF format/lint/citation checks"
+    @echo "  just github-actions-check # actionlint + zizmor"
     @echo ""
     @echo "Focused testing:"
-    @echo "  just test-unit         # Lib and doc tests only"
+    @echo "  just test-rust         # Rust unit, doctest, and integration tests"
+    @echo "  just test-rust-ci      # CI Rust unit + integration tests in one release nextest run"
+    @echo "  just test-unit         # Rust lib unit tests only"
+    @echo "  just test-doc          # Rust doctests only"
     @echo "  just test-integration  # All integration tests (includes proptests)"
     @echo "  just test-integration-fast # Integration tests (skips proptests)"
+    @echo "  just test-integration-compile # Compile integration tests without running"
     @echo "  just test-python       # Python tests only (pytest)"
     @echo "  just test-slow         # Run correctness tests over the 10s default-suite budget"
     @echo "  just examples          # Run all examples"
+    @echo ""
+    @echo "Notebook workflows:"
+    @echo "  just notebook          # Launch the default notebook with uv-managed dependencies"
+    @echo "  just notebook-lint     # Validate notebook JSON, output hygiene, and extracted code"
+    @echo "  just notebook-check    # Lint notebooks and execute fast notebooks under target/notebooks"
+    @echo "  just notebook-check-slow # Include slow notebook execution"
+    @echo "  just notebook-clear-outputs-all # Clear source notebook outputs"
     @echo ""
     @echo "Active large-scale debugging:"
     @echo "  just test-diagnostics      # Run diagnostics tools with output"
@@ -363,6 +382,7 @@ help-workflows:
     @echo "  just debug-large-scale-5d [n] [repair_every] # Issue #342: 5D feasibility (defaults n=140, repair_every=1)"
     @echo ""
     @echo "Benchmark workflows:"
+    @echo "  just bench-compile      # Compile benchmark harnesses without running"
     @echo "  just bench-smoke        # Smoke-test benchmark harnesses (minimal samples)"
     @echo "  just bench              # Run all benchmarks with perf profile (ThinLTO)"
     @echo "  just bench-ci           # CI regression benchmarks with perf profile (~5-10 min)"
@@ -396,16 +416,16 @@ json-check: _ensure-jq
     fi
 
 # All linting: code + documentation + configuration
-lint: lint-code lint-docs lint-config
+lint: github-actions-check markdown-ci json-check toml-ci yaml-ci python-check notebook-lint rust-core-check shell-lint
 
-# Code linting: Rust (fmt-check, clippy, docs, Semgrep) + Python (Ruff, Ty) + Shell scripts
-lint-code: fmt-check clippy doc-check semgrep semgrep-test python-lint shell-lint
+# Code linting: Rust, Python, notebooks, and shell scripts.
+lint-code: rust-core-check python-check notebook-lint shell-lint
 
 # Configuration checks: JSON, TOML, YAML/CFF, GitHub Actions workflows
-lint-config: json-check toml-check toml-lint toml-fmt-check yaml-check citation-check action-lint zizmor
+lint-config: json-check toml-ci yaml-ci github-actions-check
 
 # Documentation linting: Markdown + spell checking
-lint-docs: markdown-check spell-check
+lint-docs: markdown-ci
 
 markdown-check: _ensure-rumdl
     #!/usr/bin/env bash
@@ -438,6 +458,9 @@ markdown-check: _ensure-rumdl
         echo "No markdown files found to check."
     fi
 
+markdown-ci: markdown-check spell-check
+    @echo "✅ Markdown checks complete!"
+
 # Shell, markdown, and YAML quality
 markdown-fix: _ensure-rumdl
     #!/usr/bin/env bash
@@ -457,6 +480,90 @@ markdown-fix: _ensure-rumdl
     fi
 
 markdown-lint: markdown-check
+
+notebook notebook="notebooks/00_quickstart.ipynb": _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    notebook_cache="$(pwd)/target/notebooks"
+    mkdir -p "$notebook_cache/.ipython" "$notebook_cache/.matplotlib"
+    MPLBACKEND=Agg IPYTHONDIR="$notebook_cache/.ipython" MPLCONFIGDIR="$notebook_cache/.matplotlib" uv run --group notebooks jupyter lab --ServerApp.open_browser=True --LabApp.open_browser=True "{{notebook}}"
+
+notebook-check: notebook-lint notebook-execute-fast
+    @echo "📓 Notebook checks complete!"
+
+notebook-check-slow: notebook-check notebook-execute-slow
+    @echo "📓 Slow notebook checks complete!"
+
+notebook-clear-outputs notebook="notebooks/00_quickstart.ipynb": _ensure-uv
+    uv run --group notebooks jupyter nbconvert --clear-output --inplace "{{notebook}}"
+
+notebook-clear-outputs-all: _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d notebooks ]; then
+        echo "No notebooks found to clear."
+        exit 0
+    fi
+    found=0
+    while IFS= read -r notebook; do
+        found=1
+        uv run --group notebooks jupyter nbconvert --clear-output --inplace "$notebook"
+    done < <(find notebooks -type f -name '*.ipynb' ! -path '*/.ipynb_checkpoints/*' | sort)
+    if [ "$found" -eq 0 ]; then
+        echo "No notebooks found to clear."
+    fi
+
+notebook-execute notebook="notebooks/00_quickstart.ipynb" output_dir="target/notebooks": _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    output_path="$(pwd)/{{output_dir}}"
+    mkdir -p "$output_path/.ipython" "$output_path/.matplotlib"
+    MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{output_dir}}" "{{notebook}}"
+
+notebook-execute-fast output_dir="target/notebooks": _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d notebooks ]; then
+        echo "No fast notebooks found to execute."
+        exit 0
+    fi
+    output_path="$(pwd)/{{output_dir}}"
+    mkdir -p "$output_path/.ipython" "$output_path/.matplotlib"
+    found=0
+    while IFS= read -r notebook; do
+        found=1
+        MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=600 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{output_dir}}" "$notebook"
+    done < <(find notebooks -type f -name '*.ipynb' ! -path '*/.ipynb_checkpoints/*' ! -path 'notebooks/slow/*' ! -name '*_slow.ipynb' | sort)
+    if [ "$found" -eq 0 ]; then
+        echo "No fast notebooks found to execute."
+    fi
+
+notebook-execute-slow output_dir="target/notebooks": _ensure-uv
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [ ! -d notebooks ]; then
+        echo "No slow notebooks found to execute."
+        exit 0
+    fi
+    output_path="$(pwd)/{{output_dir}}"
+    mkdir -p "$output_path/.ipython" "$output_path/.matplotlib"
+    found=0
+    while IFS= read -r notebook; do
+        found=1
+        MPLBACKEND=Agg IPYTHONDIR="$output_path/.ipython" MPLCONFIGDIR="$output_path/.matplotlib" uv run --group notebooks jupyter nbconvert --execute --ExecutePreprocessor.timeout=1800 --ExecutePreprocessor.shutdown_kernel=immediate --to notebook --output-dir "{{output_dir}}" "$notebook"
+    done < <(find notebooks -type f \( -path 'notebooks/slow/*' -o -name '*_slow.ipynb' \) ! -path '*/.ipynb_checkpoints/*' | sort)
+    if [ "$found" -eq 0 ]; then
+        echo "No slow notebooks found to execute."
+    fi
+
+notebook-lint: _ensure-uv
+    uv run --group dev --group notebooks notebook-check lint --repo-root .
+
+notebook-output-check: _ensure-uv
+    uv run --group dev --group notebooks notebook-check lint --repo-root . --no-ruff --no-format --no-ty
+
+notebook-setup: _ensure-uv
+    uv sync --group notebooks
 
 # Generate a same-machine dev-mode baseline for a GitHub ref.
 perf-baseline ref="main": _ensure-uv
@@ -767,6 +874,9 @@ python-check: _ensure-uv
     uv run ruff check scripts/
     just python-typecheck
 
+python-ci: python-check test-python
+    @echo "✅ Python checks complete!"
+
 # Python code quality
 python-fix: _ensure-uv
     uv run ruff check scripts/ --fix
@@ -779,6 +889,9 @@ python-sync: _ensure-uv
 
 python-typecheck: _ensure-uv
     uv run ty check scripts/ --error all
+
+rust-core-check: fmt-check clippy-core doc-check semgrep semgrep-test
+    @echo "✅ Rust core checks complete!"
 
 # Repository-owned Semgrep rules for project-specific Rust diagnostics.
 semgrep: _ensure-uv
@@ -1082,12 +1195,12 @@ tag-force version: python-sync
     uv run tag-release {{ version }} --force
 
 # Testing
-# test: runs default-profile benchmark/release compile checks plus all tests.
-test: bench-test-compile test-all
+# test: runs each default test bucket once.
+test: test-all
     @echo "✅ Test workflow passed!"
 
-# test-all: runs lib, doc, integration, and Python tests (comprehensive)
-test-all: test-unit test-integration test-python
+# test-all: runs Rust and Python tests.
+test-all: test-rust test-python
     @echo "✅ All tests passed!"
 
 test-allocation: _ensure-nextest
@@ -1096,9 +1209,17 @@ test-allocation: _ensure-nextest
 test-diagnostics: _ensure-nextest
     cargo nextest run --profile ci --test circumsphere_debug_tools --features diagnostics -- --nocapture
 
+# test-doc: runs Rust doctests.
+test-doc:
+    cargo test --doc --verbose
+
 # test-integration: runs all default integration tests under the 10s per-test budget.
 test-integration: _ensure-nextest
     cargo nextest run --release --profile ci --tests
+
+# Compile release integration tests without running them.
+test-integration-compile: _ensure-nextest
+    cargo nextest run --release --tests --no-run
 
 # test-integration-fast: runs integration tests but skips proptests (tests prefixed with `prop_`)
 #
@@ -1112,9 +1233,16 @@ test-integration-fast: _ensure-nextest
 test-python: _ensure-uv
     uv run pytest
 
-test-release: _ensure-nextest
-    cargo nextest run --release --profile ci
+test-release: test-rust-ci
     cargo test --doc --release
+
+# test-rust: runs each default Rust correctness target class once.
+test-rust: test-rust-ci test-doc
+    @echo "✅ Rust tests passed!"
+
+# test-rust-ci: runs Rust lib unit tests and integration tests in one release-profile nextest invocation.
+test-rust-ci: _ensure-nextest
+    cargo nextest run --release --profile ci --lib --tests
 
 # Run correctness tests that exceed the 10s default-suite budget.
 # Slow tests run in release mode because debug exact-predicate paths can turn
@@ -1125,10 +1253,9 @@ test-slow: _ensure-nextest
 
 test-slow-release: test-slow
 
-# test-unit: runs lib and doc tests.
+# test-unit: runs Rust lib unit tests.
 test-unit: _ensure-nextest
     cargo nextest run --profile ci --lib
-    cargo test --doc --verbose
 
 # Check TOML files parse cleanly.
 toml-check: _ensure-uv
@@ -1143,6 +1270,9 @@ toml-check: _ensure-uv
     else
         echo "No TOML files found to check."
     fi
+
+toml-ci: toml-check toml-lint toml-fmt-check
+    @echo "✅ TOML checks complete!"
 
 toml-fix: toml-fmt
 
@@ -1213,6 +1343,9 @@ verify-expect-counts:
     check_count 'src/**/*.rs doc-comment .expect(' 0 '^\s*//[/!].*\.expect\(' src
 
 yaml-check: yaml-fmt-check yaml-lint
+
+yaml-ci: yaml-check citation-check
+    @echo "✅ YAML/CFF checks complete!"
 
 yaml-fix: _ensure-dprint
     #!/usr/bin/env bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [ "packaging" ]
 archive-changelog = "archive_changelog:main"
 benchmark-utils = "benchmark_utils:main"
 hardware-utils = "hardware_utils:main"
+notebook-check = "notebook_check:main"
 postprocess-changelog = "postprocess_changelog:main"
 tag-release = "tag_release:main"
 
@@ -48,6 +49,7 @@ py-modules = [
     "archive_changelog",
     "benchmark_utils",
     "hardware_utils",
+    "notebook_check",
     "postprocess_changelog",
     "subprocess_utils",
     "tag_release",
@@ -169,6 +171,7 @@ known-first-party = [
     "archive_changelog",
     "benchmark_utils",
     "hardware_utils",
+    "notebook_check",
     "postprocess_changelog",
     "subprocess_utils",
     "tag_release",
@@ -229,4 +232,14 @@ dev = [
     "shfmt-py==4.0.0",
     "ty==0.0.49",
     "yamllint==1.38.0",
+]
+notebooks = [
+    "ipykernel>=7.1.0",
+    "jupyterlab>=4.5.1",
+    "matplotlib>=3.10.8",
+    "nbclient>=0.10.2",
+    "nbconvert>=7.17.1",
+    "nbformat>=5.10.4",
+    "polars>=1.36.1",
+    "plotly>=6.5.0",
 ]

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -39,6 +39,19 @@ Use `just changelog-unreleased vX.Y.Z` while preparing a release PR before the
 final tag exists. Use `just tag vX.Y.Z` after the release PR is merged to
 create the annotated release tag from the matching changelog section.
 
+### Notebook utilities
+
+```bash
+just notebook-lint
+just notebook-check
+uv run --group dev --group notebooks notebook-check --help
+```
+
+`notebook-check` validates notebook JSON, rejects committed outputs and
+execution counts, extracts code cells for Ruff and ty, and can execute notebooks
+headlessly. The `just notebook-check` recipe writes executed notebooks under
+`target/notebooks/` and leaves source notebooks unchanged.
+
 ### Benchmark utilities
 
 ```bash

--- a/scripts/notebook_check.py
+++ b/scripts/notebook_check.py
@@ -15,16 +15,33 @@ import tempfile
 from dataclasses import dataclass
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Literal, override
+from typing import TYPE_CHECKING, Any, Literal, override
 
 from subprocess_utils import run_safe_command
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 RUFF_EXTEND_IGNORE = "INP001"
 RUFF_LOCATION_RE = re.compile(r"\s*-->\s+.+?:(?P<line>\d+):(?P<column>\d+)")
+RUFF_INLINE_LOCATION_RE = re.compile(r"^.+?:(?P<line>\d+):(?P<column>\d+):")
 TY_LOCATION_RE = re.compile(r"^.+?:(?P<line>\d+):(?P<column>\d+): (?P<message>.+)$")
 
 type CellType = Literal["code", "markdown", "raw"]
 VALID_CELL_TYPES: set[CellType] = {"code", "markdown", "raw"}
+
+
+class NotebookExecutionError(RuntimeError):
+    """Raised when optional notebook execution dependencies or runtime fail."""
+
+
+@dataclass(frozen=True, slots=True)
+class NotebookExecutionBackend:
+    """Validated optional notebook execution imports."""
+
+    client_factory: Callable[..., Any]
+    read_notebook: Callable[..., Any]
+    runtime_error_types: tuple[type[BaseException], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,6 +122,15 @@ def parse_positive_int(value: str) -> int:
         msg = f"expected a positive integer, got {value!r}"
         raise argparse.ArgumentTypeError(msg)
     return parsed
+
+
+def resolve_repo_root(path: Path) -> Path:
+    """Resolve and validate the repository root path."""
+    repo_root = path.resolve()
+    if not repo_root.is_dir():
+        msg = f"repository root does not exist or is not a directory: {repo_root}"
+        raise FileNotFoundError(msg)
+    return repo_root
 
 
 def parse_cell_source(source: Any, *, path: Path, index: int) -> str:
@@ -348,7 +374,19 @@ def extract_code(notebook: NotebookDocument) -> CodeSnapshot:
     return CodeSnapshot(source="".join(chunks), line_to_cell=line_to_cell)
 
 
-def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagnostic]:
+def diagnostic_cell_from_ruff_line(line: str, snapshot: CodeSnapshot) -> int | None:
+    """Return the notebook cell for either Ruff diagnostic location format."""
+    match = RUFF_LOCATION_RE.match(line) or RUFF_INLINE_LOCATION_RE.match(line)
+    if match is None:
+        return None
+    return snapshot.line_to_cell.get(int(match.group("line")), 0)
+
+
+def ruff_lint_diagnostics(
+    path: Path,
+    notebook: NotebookDocument,
+    project_root: Path,
+) -> list[Diagnostic]:
     """Run Ruff lint checks on extracted notebook code when Ruff is available."""
     snapshot = extract_code(notebook)
     command = [
@@ -364,6 +402,7 @@ def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagno
         result = run_safe_command(
             command[0],
             command[1:],
+            cwd=project_root,
             input=snapshot.source,
             timeout=30,
             check=False,
@@ -384,15 +423,19 @@ def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagno
             continue
         cell = 0
         for line in lines:
-            match = RUFF_LOCATION_RE.match(line)
-            if match is not None:
-                cell = snapshot.line_to_cell.get(int(match.group("line")), 0)
+            parsed_cell = diagnostic_cell_from_ruff_line(line, snapshot)
+            if parsed_cell is not None:
+                cell = parsed_cell
                 break
         diagnostics.append(Diagnostic("error", cell, f"ruff check: {lines[0]}"))
     return diagnostics
 
 
-def ruff_format_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagnostic]:
+def ruff_format_diagnostics(
+    path: Path,
+    notebook: NotebookDocument,
+    project_root: Path,
+) -> list[Diagnostic]:
     """Run Ruff format check on extracted notebook code when Ruff is available."""
     snapshot = extract_code(notebook)
     command = ["ruff", "format", "--check", "--stdin-filename", f"{path.stem}_notebook.py", "-"]
@@ -400,6 +443,7 @@ def ruff_format_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diag
         result = run_safe_command(
             command[0],
             command[1:],
+            cwd=project_root,
             input=snapshot.source,
             timeout=30,
             check=False,
@@ -481,19 +525,20 @@ def code_cell_diagnostics(path: Path, notebook: NotebookDocument, options: LintO
 def external_tool_diagnostics(path: Path, notebook: NotebookDocument, options: LintOptions) -> list[Diagnostic]:
     """Return diagnostics from Ruff and ty checks over extracted notebook code."""
     diagnostics: list[Diagnostic] = []
+    project_root = options.project_root or Path.cwd()
     if options.run_ruff or options.run_format:
         if shutil.which("ruff") is None:
             diagnostics.append(Diagnostic("error", 0, "ruff is required for notebook linting; run through `uv run` or install Ruff"))
         else:
             if options.run_ruff:
-                diagnostics.extend(ruff_lint_diagnostics(path, notebook))
+                diagnostics.extend(ruff_lint_diagnostics(path, notebook, project_root))
             if options.run_format:
-                diagnostics.extend(ruff_format_diagnostics(path, notebook))
+                diagnostics.extend(ruff_format_diagnostics(path, notebook, project_root))
     if options.run_ty:
         if shutil.which("ty") is None:
             diagnostics.append(Diagnostic("error", 0, "ty is required for notebook linting; run through `uv run` or install ty"))
         else:
-            diagnostics.extend(ty_diagnostics(path, notebook, options.project_root or Path.cwd()))
+            diagnostics.extend(ty_diagnostics(path, notebook, project_root))
     return diagnostics
 
 
@@ -517,21 +562,85 @@ def lint(path: Path, options: LintOptions) -> int:
     return 0
 
 
+def compact_exception(error: BaseException) -> str:
+    """Render an exception as a single-line diagnostic fragment."""
+    detail = " ".join(str(error).split())
+    if not detail:
+        return type(error).__name__
+    return f"{type(error).__name__}: {detail}"
+
+
+def nbclient_error_types(exceptions_module: Any) -> tuple[type[BaseException], ...]:
+    """Return nbclient runtime error classes available in the installed version."""
+    names = (
+        "CellExecutionError",
+        "CellTimeoutError",
+        "DeadKernelError",
+        "NotebookClientError",
+    )
+    error_types: list[type[BaseException]] = []
+    for name in names:
+        error_type = getattr(exceptions_module, name, None)
+        if isinstance(error_type, type) and issubclass(error_type, BaseException):
+            error_types.append(error_type)
+    return tuple(error_types)
+
+
+def load_notebook_execution_backend(path: Path) -> NotebookExecutionBackend:
+    """Load and validate optional notebook execution dependencies."""
+    try:
+        nbclient = import_module("nbclient")
+        nbclient_exceptions = import_module("nbclient.exceptions")
+        nbformat = import_module("nbformat")
+    except ModuleNotFoundError as error:
+        dependency = error.name or "notebook execution dependency"
+        msg = f"{path}: execute(): missing optional dependency {dependency!r}; run through `uv run`"
+        raise NotebookExecutionError(msg) from error
+
+    client_factory = getattr(nbclient, "NotebookClient", None)
+    if not callable(client_factory):
+        msg = f"{path}: execute(): nbclient.NotebookClient is unavailable"
+        raise NotebookExecutionError(msg)
+
+    read_notebook = getattr(nbformat, "read", None)
+    if not callable(read_notebook):
+        msg = f"{path}: execute(): nbformat.read is unavailable"
+        raise NotebookExecutionError(msg)
+
+    runtime_error_types = nbclient_error_types(nbclient_exceptions)
+    if not runtime_error_types:
+        msg = f"{path}: execute(): nbclient runtime exception types are unavailable"
+        raise NotebookExecutionError(msg)
+
+    return NotebookExecutionBackend(
+        client_factory=client_factory,
+        read_notebook=read_notebook,
+        runtime_error_types=runtime_error_types,
+    )
+
+
 def execute(path: Path, repo_root: Path, timeout: int) -> None:
     """Execute a notebook in memory without modifying it on disk."""
-    nbclient = import_module("nbclient")
-    nbformat = import_module("nbformat")
+    backend = load_notebook_execution_backend(path)
 
     os.environ.setdefault("MPLBACKEND", "Agg")
     with path.open(encoding="utf-8") as handle:
-        notebook = nbformat.read(handle, as_version=4)
-    client = nbclient.NotebookClient(
-        notebook,
-        timeout=timeout,
-        kernel_name="python3",
-        resources={"metadata": {"path": str(repo_root)}},
-    )
-    client.execute()
+        notebook = backend.read_notebook(handle, as_version=4)
+    try:
+        client = backend.client_factory(
+            notebook,
+            timeout=timeout,
+            kernel_name="python3",
+            resources={"metadata": {"path": str(repo_root)}},
+        )
+    except (AttributeError, TypeError, ValueError) as error:
+        msg = f"{path}: execute(): NotebookClient creation failed: {compact_exception(error)}"
+        raise NotebookExecutionError(msg) from error
+    try:
+        client.execute()
+    except backend.runtime_error_types as error:
+        msg = f"{path}: execute(): NotebookClient execution failed: {compact_exception(error)}"
+        raise NotebookExecutionError(msg) from error
     print(f"OK executed {path}")
 
 
@@ -575,7 +684,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
 
 def run(args: argparse.Namespace) -> int:
     """Run notebook checker actions for parsed arguments."""
-    repo_root = args.repo_root.resolve()
+    repo_root = resolve_repo_root(args.repo_root)
     paths = selected_notebooks(args.notebooks, repo_root)
     if not paths:
         print("No notebooks found.")
@@ -605,7 +714,14 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     try:
         return run(args)
-    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError, ValueError) as error:
+    except (
+        FileNotFoundError,
+        json.JSONDecodeError,
+        NotebookExecutionError,
+        OSError,
+        TypeError,
+        ValueError,
+    ) as error:
         print(f"error: {error}", file=sys.stderr)
         return 1
 

--- a/scripts/notebook_check.py
+++ b/scripts/notebook_check.py
@@ -623,7 +623,7 @@ def execute(path: Path, repo_root: Path, timeout: int) -> None:
     """Execute a notebook in memory without modifying it on disk."""
     backend = load_notebook_execution_backend(path)
 
-    os.environ.setdefault("MPLBACKEND", "Agg")
+    os.environ["MPLBACKEND"] = "Agg"
     with path.open(encoding="utf-8") as handle:
         notebook = backend.read_notebook(handle, as_version=4)
     try:

--- a/scripts/notebook_check.py
+++ b/scripts/notebook_check.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Inspect, lint, and optionally execute Jupyter notebooks."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from importlib import import_module
+from pathlib import Path
+from typing import Any, Literal, override
+
+from subprocess_utils import run_safe_command
+
+RUFF_EXTEND_IGNORE = "INP001"
+RUFF_LOCATION_RE = re.compile(r"\s*-->\s+.+?:(?P<line>\d+):(?P<column>\d+)")
+TY_LOCATION_RE = re.compile(r"^.+?:(?P<line>\d+):(?P<column>\d+): (?P<message>.+)$")
+
+type CellType = Literal["code", "markdown", "raw"]
+VALID_CELL_TYPES: set[CellType] = {"code", "markdown", "raw"}
+
+
+@dataclass(frozen=True, slots=True)
+class Diagnostic:
+    """Notebook lint diagnostic."""
+
+    severity: str
+    cell: int
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class CodeSnapshot:
+    """Notebook code extracted into a Python-like source string."""
+
+    source: str
+    line_to_cell: dict[int, int]
+
+
+@dataclass(frozen=True, slots=True)
+class LintOptions:
+    """Options that control notebook linting."""
+
+    allow_outputs: bool = False
+    strict: bool = False
+    run_ruff: bool = True
+    run_format: bool = True
+    run_ty: bool = True
+    project_root: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class NotebookCell:
+    """Validated notebook cell metadata used by linting."""
+
+    index: int
+    cell_type: CellType
+    source: str
+    output_count: int
+    execution_count: int | None
+
+    @property
+    def is_code(self) -> bool:
+        """Return whether this is a Python code cell."""
+        return self.cell_type == "code"
+
+
+@dataclass(frozen=True, slots=True)
+class NotebookDocument:
+    """Validated notebook structure loaded from nbformat JSON."""
+
+    path: Path
+    nbformat: int
+    nbformat_minor: int | None
+    cells: tuple[NotebookCell, ...]
+
+
+def parse_cell_type(value: Any, *, path: Path, index: int) -> CellType:
+    """Parse a notebook cell type."""
+    if not isinstance(value, str):
+        msg = f"{path}: cell {index}: expected cell_type to be a string"
+        raise TypeError(msg)
+    if value not in VALID_CELL_TYPES:
+        expected = ", ".join(sorted(VALID_CELL_TYPES))
+        msg = f"{path}: cell {index}: expected cell_type to be one of {expected}; got {value!r}"
+        raise ValueError(msg)
+    return value
+
+
+def parse_positive_int(value: str) -> int:
+    """Parse a positive integer command-line argument."""
+    try:
+        parsed = int(value)
+    except ValueError as error:
+        msg = f"expected a positive integer, got {value!r}"
+        raise argparse.ArgumentTypeError(msg) from error
+    if parsed <= 0:
+        msg = f"expected a positive integer, got {value!r}"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
+def parse_cell_source(source: Any, *, path: Path, index: int) -> str:
+    """Parse a notebook cell source as joined text."""
+    if isinstance(source, list):
+        if not all(isinstance(part, str) for part in source):
+            msg = f"{path}: cell {index}: source list must contain only strings"
+            raise TypeError(msg)
+        return "".join(source)
+    if isinstance(source, str):
+        return source
+    msg = f"{path}: cell {index}: source must be a string or list of strings, got {type(source).__name__}"
+    raise TypeError(msg)
+
+
+def parse_output_count(value: Any, *, path: Path, index: int) -> int:
+    """Parse a notebook cell output list into its validated count."""
+    if value is None:
+        return 0
+    if not isinstance(value, list):
+        msg = f"{path}: cell {index}: outputs must be a list"
+        raise TypeError(msg)
+    return len(value)
+
+
+def parse_execution_count(value: Any, *, path: Path, index: int) -> int | None:
+    """Parse a notebook code-cell execution count."""
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    msg = f"{path}: cell {index}: execution_count must be an integer or null"
+    raise TypeError(msg)
+
+
+def parse_notebook_cell(raw_cell: Any, *, path: Path, index: int) -> NotebookCell:
+    """Parse a raw nbformat cell into validated notebook metadata."""
+    if not isinstance(raw_cell, dict):
+        msg = f"{path}: cell {index}: expected cell to be an object"
+        raise TypeError(msg)
+    return NotebookCell(
+        index=index,
+        cell_type=parse_cell_type(raw_cell.get("cell_type"), path=path, index=index),
+        source=parse_cell_source(raw_cell.get("source", ""), path=path, index=index),
+        output_count=parse_output_count(raw_cell.get("outputs"), path=path, index=index),
+        execution_count=parse_execution_count(raw_cell.get("execution_count"), path=path, index=index),
+    )
+
+
+def load_notebook(path: Path) -> NotebookDocument:
+    """Load a notebook as plain JSON."""
+    if not path.is_file():
+        msg = f"notebook does not exist or is not a file: {path}"
+        raise FileNotFoundError(msg)
+    with path.open(encoding="utf-8") as handle:
+        notebook = json.load(handle)
+    if not isinstance(notebook, dict):
+        msg = f"{path}: expected notebook JSON to be an object"
+        raise TypeError(msg)
+    if notebook.get("nbformat") != 4:
+        msg = f"{path}: expected nbformat 4, got {notebook.get('nbformat')!r}"
+        raise ValueError(msg)
+    cells = notebook.get("cells")
+    if not isinstance(cells, list):
+        msg = f"{path}: expected notebook cells to be a list"
+        raise TypeError(msg)
+    nbformat_minor = notebook.get("nbformat_minor")
+    if nbformat_minor is not None and not isinstance(nbformat_minor, int):
+        msg = f"{path}: expected nbformat_minor to be an integer or null"
+        raise TypeError(msg)
+    return NotebookDocument(
+        path=path,
+        nbformat=4,
+        nbformat_minor=nbformat_minor,
+        cells=tuple(parse_notebook_cell(cell, path=path, index=index) for index, cell in enumerate(cells, start=1)),
+    )
+
+
+def discover_notebooks(repo_root: Path) -> list[Path]:
+    """Return notebooks under the conventional notebooks directory."""
+    notebook_root = repo_root / "notebooks"
+    if not notebook_root.is_dir():
+        return []
+    return sorted(path for path in notebook_root.glob("**/*.ipynb") if ".ipynb_checkpoints" not in path.parts)
+
+
+def code_cells(notebook: NotebookDocument) -> list[NotebookCell]:
+    """Return code cells with one-based cell numbers and joined source."""
+    return [cell for cell in notebook.cells if cell.is_code]
+
+
+def summarize(path: Path) -> None:
+    """Print a compact notebook inventory."""
+    notebook = load_notebook(path)
+    print(f"{path}")
+    print(f"  nbformat: {notebook.nbformat}.{notebook.nbformat_minor}")
+    for cell in notebook.cells:
+        first_line = next((line.strip() for line in cell.source.splitlines() if line.strip()), "")
+        outputs = cell.output_count if cell.is_code else 0
+        execution_count = cell.execution_count if cell.is_code else ""
+        print(
+            f"  cell {cell.index:03d} {cell.cell_type:<8} "
+            f"lines={len(cell.source.splitlines()):<3} outputs={outputs:<2} exec={execution_count!s:<4} {first_line[:100]}",
+        )
+
+
+class NotebookVisitor(ast.NodeVisitor):
+    """Collect notebook-specific Python quality diagnostics."""
+
+    def __init__(self, cell: int) -> None:
+        """Initialize a visitor for a one-based notebook cell number."""
+        self.cell = cell
+        self.diagnostics: list[Diagnostic] = []
+
+    @override
+    def visit_Import(self, node: ast.Import) -> None:
+        """Warn on imports that are usually poor notebook defaults."""
+        for alias in node.names:
+            if alias.name == "pandas":
+                self.diagnostics.append(Diagnostic("warning", self.cell, "imports pandas; prefer Polars unless pandas is required"))
+            if alias.name == "csv":
+                self.diagnostics.append(Diagnostic("warning", self.cell, "imports csv; prefer Polars for dataframe-shaped CSV analysis"))
+        self.generic_visit(node)
+
+    @override
+    def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        """Warn on from-imports that are usually poor notebook defaults."""
+        if node.module == "pandas":
+            self.diagnostics.append(Diagnostic("warning", self.cell, "imports pandas; prefer Polars unless pandas is required"))
+        if node.module == "csv":
+            self.diagnostics.append(Diagnostic("warning", self.cell, "imports csv; prefer Polars for dataframe-shaped CSV analysis"))
+        self.generic_visit(node)
+
+    @override
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        """Check regular function definitions for annotations."""
+        self._check_function_annotations(node)
+        self.generic_visit(node)
+
+    @override
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        """Check async function definitions for annotations."""
+        self._check_function_annotations(node)
+        self.generic_visit(node)
+
+    @override
+    def visit_ExceptHandler(self, node: ast.ExceptHandler) -> None:
+        """Warn on broad exception handling in notebook code."""
+        if node.type is None:
+            self.diagnostics.append(Diagnostic("warning", self.cell, "uses bare except; catch specific exceptions"))
+        elif isinstance(node.type, ast.Name) and node.type.id in {"Exception", "BaseException"}:
+            self.diagnostics.append(Diagnostic("warning", self.cell, f"catches broad {node.type.id}; catch specific recoverable errors"))
+        self.generic_visit(node)
+
+    @override
+    def visit_Call(self, node: ast.Call) -> None:
+        """Check subprocess calls for shell and timeout hazards."""
+        call_name = dotted_name(node.func)
+        if call_name in {"subprocess.run", "subprocess.Popen"}:
+            if keyword_bool(node, "shell"):
+                self.diagnostics.append(Diagnostic("error", self.cell, f"{call_name} uses shell=True"))
+            if call_name == "subprocess.run" and not has_keyword(node, "timeout"):
+                self.diagnostics.append(Diagnostic("warning", self.cell, "subprocess.run lacks timeout; add one or document why it can run unbounded"))
+            if call_name == "subprocess.Popen" and not has_wait_timeout(node):
+                self.diagnostics.append(
+                    Diagnostic("warning", self.cell, "subprocess.Popen stream lacks timeout; ensure tutorial commands cannot hang indefinitely"),
+                )
+        self.generic_visit(node)
+
+    def _check_function_annotations(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        missing_args = [
+            argument.arg
+            for argument in [*node.args.posonlyargs, *node.args.args, *node.args.kwonlyargs]
+            if argument.arg not in {"self", "cls"} and argument.annotation is None
+        ]
+        if node.args.vararg is not None and node.args.vararg.annotation is None:
+            missing_args.append(f"*{node.args.vararg.arg}")
+        if node.args.kwarg is not None and node.args.kwarg.annotation is None:
+            missing_args.append(f"**{node.args.kwarg.arg}")
+        if missing_args:
+            self.diagnostics.append(Diagnostic("warning", self.cell, f"function {node.name} lacks parameter annotations: {', '.join(missing_args)}"))
+        if node.returns is None:
+            self.diagnostics.append(Diagnostic("warning", self.cell, f"function {node.name} lacks return annotation"))
+
+
+def dotted_name(node: ast.AST) -> str:
+    """Return a dotted expression name when statically knowable."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        parent = dotted_name(node.value)
+        return f"{parent}.{node.attr}" if parent else node.attr
+    return ""
+
+
+def has_keyword(node: ast.Call, name: str) -> bool:
+    """Return whether a call has a named keyword argument."""
+    return any(keyword.arg == name for keyword in node.keywords)
+
+
+def keyword_bool(node: ast.Call, name: str) -> bool:
+    """Return a boolean keyword value when it is statically true."""
+    for keyword in node.keywords:
+        if keyword.arg == name and isinstance(keyword.value, ast.Constant):
+            return keyword.value.value is True
+    return False
+
+
+def has_wait_timeout(node: ast.Call) -> bool:
+    """Return whether a Popen call obviously wraps a timeout in the same call."""
+    return has_keyword(node, "timeout")
+
+
+def extract_code(notebook: NotebookDocument) -> CodeSnapshot:
+    """Extract code cells into one source string and retain line-to-cell mapping."""
+    chunks: list[str] = []
+    line_to_cell: dict[int, int] = {}
+    current_line = 1
+    cells = code_cells(notebook)
+    for cell_position, cell in enumerate(cells):
+        chunks.append(f"# %% notebook cell {cell.index}\n")
+        line_to_cell[current_line] = cell.index
+        current_line += 1
+        source_lines = cell.source.splitlines(keepends=True)
+        if not source_lines:
+            chunks.append("\n")
+            line_to_cell[current_line] = cell.index
+            current_line += 1
+        for source_line in source_lines:
+            chunks.append(source_line)
+            line_to_cell[current_line] = cell.index
+            current_line += 1
+        if source_lines and not source_lines[-1].endswith(("\n", "\r")):
+            chunks.append("\n")
+            line_to_cell[current_line] = cell.index
+            current_line += 1
+        if cell_position < len(cells) - 1:
+            chunks.append("\n")
+            line_to_cell[current_line] = cell.index
+            current_line += 1
+    return CodeSnapshot(source="".join(chunks), line_to_cell=line_to_cell)
+
+
+def ruff_lint_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagnostic]:
+    """Run Ruff lint checks on extracted notebook code when Ruff is available."""
+    snapshot = extract_code(notebook)
+    command = [
+        "ruff",
+        "check",
+        "--stdin-filename",
+        f"{path.stem}_notebook.py",
+        "--extend-ignore",
+        RUFF_EXTEND_IGNORE,
+        "-",
+    ]
+    try:
+        result = run_safe_command(
+            command[0],
+            command[1:],
+            input=snapshot.source,
+            timeout=30,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        return [Diagnostic("error", 0, f"ruff timed out after {error.timeout} seconds")]
+
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    if result.returncode == 0:
+        return []
+    if result.returncode != 1:
+        return [Diagnostic("error", 0, f"ruff failed with exit code {result.returncode}:\n{output}")]
+
+    diagnostics: list[Diagnostic] = []
+    for block in output.split("\n\n"):
+        lines = [line for line in block.splitlines() if line.strip()]
+        if not lines or lines[0].startswith("Found "):
+            continue
+        cell = 0
+        for line in lines:
+            match = RUFF_LOCATION_RE.match(line)
+            if match is not None:
+                cell = snapshot.line_to_cell.get(int(match.group("line")), 0)
+                break
+        diagnostics.append(Diagnostic("error", cell, f"ruff check: {lines[0]}"))
+    return diagnostics
+
+
+def ruff_format_diagnostics(path: Path, notebook: NotebookDocument) -> list[Diagnostic]:
+    """Run Ruff format check on extracted notebook code when Ruff is available."""
+    snapshot = extract_code(notebook)
+    command = ["ruff", "format", "--check", "--stdin-filename", f"{path.stem}_notebook.py", "-"]
+    try:
+        result = run_safe_command(
+            command[0],
+            command[1:],
+            input=snapshot.source,
+            timeout=30,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as error:
+        return [Diagnostic("error", 0, f"ruff format timed out after {error.timeout} seconds")]
+
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
+    if result.returncode == 0:
+        return []
+    if result.returncode != 1:
+        return [Diagnostic("error", 0, f"ruff format failed with exit code {result.returncode}:\n{output}")]
+    return [Diagnostic("error", 0, f"ruff format: extracted notebook code is not formatted\n{output}")]
+
+
+def ty_diagnostics(path: Path, notebook: NotebookDocument, project_root: Path) -> list[Diagnostic]:
+    """Run ty on extracted notebook code when ty is available."""
+    snapshot = extract_code(notebook)
+    with tempfile.TemporaryDirectory(prefix="notebook-check-") as temporary_directory:
+        extracted_path = Path(temporary_directory) / f"{path.stem}_notebook.py"
+        extracted_path.write_text(snapshot.source, encoding="utf-8")
+        command = [
+            "ty",
+            "check",
+            "--project",
+            str(project_root),
+            "--output-format",
+            "concise",
+            str(extracted_path),
+        ]
+        try:
+            result = run_safe_command(
+                command[0],
+                command[1:],
+                timeout=30,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as error:
+            return [Diagnostic("error", 0, f"ty timed out after {error.timeout} seconds")]
+
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    if result.returncode == 0:
+        return []
+    if result.returncode not in {1, 2}:
+        return [Diagnostic("error", 0, f"ty failed with exit code {result.returncode}:\n{output}")]
+
+    diagnostics: list[Diagnostic] = []
+    for line in output.splitlines():
+        if not line.strip() or line.startswith("Found ") or line == "All checks passed!":
+            continue
+        match = TY_LOCATION_RE.match(line)
+        if match is None:
+            diagnostics.append(Diagnostic("error", 0, f"ty: {line}"))
+            continue
+        cell = snapshot.line_to_cell.get(int(match.group("line")), 0)
+        diagnostics.append(Diagnostic("error", cell, f"ty: {match.group('message')}"))
+    return diagnostics
+
+
+def code_cell_diagnostics(path: Path, notebook: NotebookDocument, options: LintOptions) -> list[Diagnostic]:
+    """Return diagnostics from AST parsing and notebook output hygiene."""
+    diagnostics: list[Diagnostic] = []
+    for cell in code_cells(notebook):
+        try:
+            tree = ast.parse(cell.source, filename=f"{path}:cell-{cell.index}")
+        except SyntaxError as error:
+            diagnostics.append(Diagnostic("error", cell.index, f"syntax error: {error}"))
+            continue
+        visitor = NotebookVisitor(cell.index)
+        visitor.visit(tree)
+        diagnostics.extend(visitor.diagnostics)
+        if cell.output_count > 0 and not options.allow_outputs:
+            diagnostics.append(Diagnostic("error", cell.index, f"has {cell.output_count} output block(s); clear outputs before committing"))
+        if cell.execution_count is not None and not options.allow_outputs:
+            diagnostics.append(Diagnostic("error", cell.index, f"execution_count={cell.execution_count}; clear execution counts"))
+    return diagnostics
+
+
+def external_tool_diagnostics(path: Path, notebook: NotebookDocument, options: LintOptions) -> list[Diagnostic]:
+    """Return diagnostics from Ruff and ty checks over extracted notebook code."""
+    diagnostics: list[Diagnostic] = []
+    if options.run_ruff or options.run_format:
+        if shutil.which("ruff") is None:
+            diagnostics.append(Diagnostic("error", 0, "ruff is required for notebook linting; run through `uv run` or install Ruff"))
+        else:
+            if options.run_ruff:
+                diagnostics.extend(ruff_lint_diagnostics(path, notebook))
+            if options.run_format:
+                diagnostics.extend(ruff_format_diagnostics(path, notebook))
+    if options.run_ty:
+        if shutil.which("ty") is None:
+            diagnostics.append(Diagnostic("error", 0, "ty is required for notebook linting; run through `uv run` or install ty"))
+        else:
+            diagnostics.extend(ty_diagnostics(path, notebook, options.project_root or Path.cwd()))
+    return diagnostics
+
+
+def lint(path: Path, options: LintOptions) -> int:
+    """Validate notebook JSON, compile code cells, and run Python lint checks."""
+    notebook = load_notebook(path)
+    diagnostics = [
+        *code_cell_diagnostics(path, notebook, options),
+        *external_tool_diagnostics(path, notebook, options),
+    ]
+
+    for diagnostic in diagnostics:
+        stream = sys.stderr if diagnostic.severity == "error" else sys.stdout
+        location = f"cell {diagnostic.cell}" if diagnostic.cell > 0 else "notebook"
+        print(f"{path}: {location}: {diagnostic.severity}: {diagnostic.message}", file=stream)
+
+    if any(diagnostic.severity == "error" for diagnostic in diagnostics):
+        return 1
+    if options.strict and diagnostics:
+        return 1
+    return 0
+
+
+def execute(path: Path, repo_root: Path, timeout: int) -> None:
+    """Execute a notebook in memory without modifying it on disk."""
+    nbclient = import_module("nbclient")
+    nbformat = import_module("nbformat")
+
+    os.environ.setdefault("MPLBACKEND", "Agg")
+    with path.open(encoding="utf-8") as handle:
+        notebook = nbformat.read(handle, as_version=4)
+    client = nbclient.NotebookClient(
+        notebook,
+        timeout=timeout,
+        kernel_name="python3",
+        resources={"metadata": {"path": str(repo_root)}},
+    )
+    client.execute()
+    print(f"OK executed {path}")
+
+
+def lint_notebooks(paths: list[Path], options: LintOptions) -> int:
+    """Lint every notebook in `paths`."""
+    status = 0
+    for path in paths:
+        status = max(status, lint(path, options))
+        if status == 0:
+            print(f"OK linted {path}")
+    return status
+
+
+def execute_notebooks(paths: list[Path], repo_root: Path, timeout: int) -> None:
+    """Execute every notebook in `paths`."""
+    for path in paths:
+        execute(path, repo_root, timeout)
+
+
+def selected_notebooks(paths: list[Path], repo_root: Path) -> list[Path]:
+    """Return explicit notebook paths or discover notebooks under the repo root."""
+    if paths:
+        return [path if path.is_absolute() else repo_root / path for path in paths]
+    return discover_notebooks(repo_root)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=["summary", "lint", "execute"], help="notebook check mode")
+    parser.add_argument("notebooks", nargs="*", type=Path, help="notebooks to check; defaults to notebooks/**/*.ipynb")
+    parser.add_argument("--allow-outputs", action="store_true", help="do not fail lint when code cells contain outputs or execution counts")
+    parser.add_argument("--strict", action="store_true", help="treat warning diagnostics as lint failures")
+    parser.add_argument("--no-ruff", action="store_true", help="skip Ruff lint checks for extracted notebook code")
+    parser.add_argument("--no-format", action="store_true", help="skip Ruff format checks for extracted notebook code")
+    parser.add_argument("--no-ty", action="store_true", help="skip ty checks for extracted notebook code")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="repository root for discovery and execution")
+    parser.add_argument("--timeout", type=parse_positive_int, default=120, help="per-cell execution timeout in seconds")
+    return parser.parse_args(argv)
+
+
+def run(args: argparse.Namespace) -> int:
+    """Run notebook checker actions for parsed arguments."""
+    repo_root = args.repo_root.resolve()
+    paths = selected_notebooks(args.notebooks, repo_root)
+    if not paths:
+        print("No notebooks found.")
+        return 0
+    if args.mode == "summary":
+        for path in paths:
+            summarize(path)
+        return 0
+    if args.mode == "lint":
+        return lint_notebooks(
+            paths,
+            LintOptions(
+                allow_outputs=args.allow_outputs,
+                strict=args.strict,
+                run_ruff=not args.no_ruff,
+                run_format=not args.no_format,
+                run_ty=not args.no_ty,
+                project_root=repo_root,
+            ),
+        )
+    execute_notebooks(paths, repo_root, args.timeout)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the requested notebook check."""
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        return run(args)
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_notebook_check.py
+++ b/scripts/tests/test_notebook_check.py
@@ -462,7 +462,7 @@ def test_execute_notebooks_uses_headless_kernel_context(
         msg = f"unexpected import {name}"
         raise AssertionError(msg)
 
-    monkeypatch.delenv("MPLBACKEND", raising=False)
+    monkeypatch.setenv("MPLBACKEND", "TkAgg")
     monkeypatch.setattr("notebook_check.import_module", fake_import)
 
     execute_notebooks([notebook], repo_root, timeout=123)

--- a/scripts/tests/test_notebook_check.py
+++ b/scripts/tests/test_notebook_check.py
@@ -1,0 +1,315 @@
+"""Tests for notebook_check.py notebook linting diagnostics."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from notebook_check import (
+    LintOptions,
+    NotebookDocument,
+    code_cell_diagnostics,
+    discover_notebooks,
+    execute_notebooks,
+    external_tool_diagnostics,
+    extract_code,
+    lint,
+    load_notebook,
+    main,
+)
+
+
+def write_notebook(path: Path, cells: list[dict[str, Any]]) -> None:
+    """Write a minimal nbformat v4 notebook fixture."""
+    notebook = {
+        "cells": cells,
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(notebook), encoding="utf-8")
+
+
+def load_notebook_fixture(tmp_path: Path, name: str, cells: list[dict[str, Any]]) -> NotebookDocument:
+    """Write and load a minimal notebook through the real parser."""
+    path = tmp_path / name
+    write_notebook(path, cells)
+    return load_notebook(path)
+
+
+def code_cell(source: Any, *, outputs: Any = None, execution_count: Any = None) -> dict[str, Any]:
+    """Return a minimal code cell fixture."""
+    return {
+        "cell_type": "code",
+        "execution_count": execution_count,
+        "metadata": {},
+        "outputs": [] if outputs is None else outputs,
+        "source": source,
+    }
+
+
+def test_discover_notebooks_excludes_checkpoints(tmp_path: Path) -> None:
+    """Notebook discovery should stay under notebooks/ and skip checkpoint files."""
+    notebooks = tmp_path / "notebooks"
+    checkpoints = notebooks / ".ipynb_checkpoints"
+    nested = notebooks / "nested"
+    checkpoints.mkdir(parents=True)
+    nested.mkdir()
+    first = notebooks / "a.ipynb"
+    second = nested / "b.ipynb"
+    checkpoint = checkpoints / "a-checkpoint.ipynb"
+    elsewhere = tmp_path / "outside.ipynb"
+    for path in [first, second, checkpoint, elsewhere]:
+        path.write_text("{}", encoding="utf-8")
+
+    assert discover_notebooks(tmp_path) == [first, second]
+
+
+def test_discover_notebooks_returns_empty_list_without_notebook_directory(tmp_path: Path) -> None:
+    """Repositories without notebooks should still pass notebook validation."""
+    assert discover_notebooks(tmp_path) == []
+
+
+def test_load_notebook_rejects_missing_cells(tmp_path: Path) -> None:
+    """Notebook JSON must contain a cells list."""
+    notebook = tmp_path / "missing-cells.ipynb"
+    notebook.write_text('{"nbformat": 4, "nbformat_minor": 5, "metadata": {}}', encoding="utf-8")
+
+    with pytest.raises(TypeError, match="expected notebook cells to be a list"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_non_object_json(tmp_path: Path) -> None:
+    """Notebook root JSON must be an object."""
+    notebook = tmp_path / "list.ipynb"
+    notebook.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(TypeError, match="expected notebook JSON to be an object"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_wrong_nbformat(tmp_path: Path) -> None:
+    """Only nbformat v4 notebooks are supported."""
+    notebook = tmp_path / "old-format.ipynb"
+    notebook.write_text('{"cells": [], "nbformat": 3, "nbformat_minor": 0, "metadata": {}}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="expected nbformat 4"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_bad_cell_source(tmp_path: Path) -> None:
+    """Cell source lists must contain only strings."""
+    notebook = tmp_path / "bad-source.ipynb"
+    write_notebook(notebook, [code_cell(["valid", 5])])
+
+    with pytest.raises(TypeError, match="source list must contain only strings"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_unknown_cell_type(tmp_path: Path) -> None:
+    """Only standard nbformat cell types are accepted."""
+    notebook = tmp_path / "bad-cell-type.ipynb"
+    write_notebook(notebook, [{**code_cell("x = 1"), "cell_type": "python"}])
+
+    with pytest.raises(ValueError, match="expected cell_type to be one of"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_bad_execution_count(tmp_path: Path) -> None:
+    """Code cell execution counts must be integers or null."""
+    notebook = tmp_path / "bad-execution-count.ipynb"
+    write_notebook(notebook, [code_cell("x = 1", execution_count="1")])
+
+    with pytest.raises(TypeError, match="execution_count must be an integer or null"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_bad_outputs_shape(tmp_path: Path) -> None:
+    """Code cell outputs must be a list."""
+    notebook = tmp_path / "bad-outputs.ipynb"
+    write_notebook(notebook, [code_cell("x = 1", outputs={"output_type": "stream"})])
+
+    with pytest.raises(TypeError, match="outputs must be a list"):
+        load_notebook(notebook)
+
+
+def test_code_cell_diagnostics_report_dirty_outputs_and_syntax(tmp_path: Path) -> None:
+    """Dirty outputs and syntax errors should be reported before commit."""
+    notebook_path = tmp_path / "dirty.ipynb"
+    write_notebook(
+        notebook_path,
+        [
+            code_cell("x = 1", outputs=[{"output_type": "stream", "name": "stdout", "text": "1"}], execution_count=7),
+            code_cell("def broken(:\n    pass"),
+        ],
+    )
+    notebook = load_notebook(notebook_path)
+
+    diagnostics = code_cell_diagnostics(notebook_path, notebook, LintOptions(run_ruff=False, run_format=False, run_ty=False))
+
+    messages = [diagnostic.message for diagnostic in diagnostics]
+    assert "has 1 output block(s); clear outputs before committing" in messages
+    assert "execution_count=7; clear execution counts" in messages
+    assert any(message.startswith("syntax error:") for message in messages)
+
+
+def test_lint_allow_outputs_accepts_rendered_notebook(tmp_path: Path) -> None:
+    """Rendered notebooks can be allowed explicitly."""
+    notebook = tmp_path / "rendered.ipynb"
+    write_notebook(notebook, [code_cell("x = 1", outputs=[{"output_type": "stream", "name": "stdout", "text": "1"}], execution_count=1)])
+
+    result = lint(notebook, LintOptions(allow_outputs=True, run_ruff=False, run_format=False, run_ty=False))
+
+    assert result == 0
+
+
+def test_lint_strict_fails_on_notebook_warnings(tmp_path: Path) -> None:
+    """Strict mode should promote advisory notebook warnings to failures."""
+    notebook = tmp_path / "warnings.ipynb"
+    write_notebook(notebook, [code_cell("import pandas\n\ndef helper(value):\n    return value\n")])
+
+    result = lint(notebook, LintOptions(strict=True, run_ruff=False, run_format=False, run_ty=False))
+
+    assert result == 1
+
+
+def test_lint_without_external_tools_passes_clean_notebook(tmp_path: Path) -> None:
+    """A clean notebook should pass when external tool checks are disabled."""
+    notebook = tmp_path / "clean.ipynb"
+    write_notebook(notebook, [code_cell("def helper(value: int) -> int:\n    return value + 1\n")])
+
+    result = lint(notebook, LintOptions(run_ruff=False, run_format=False, run_ty=False))
+
+    assert result == 0
+
+
+def test_external_tool_diagnostics_report_missing_tools(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing Ruff or ty should be explicit notebook diagnostics."""
+    monkeypatch.setattr("notebook_check.shutil.which", lambda _command: None)
+    notebook = NotebookDocument(path=Path("missing-tools.ipynb"), nbformat=4, nbformat_minor=5, cells=())
+
+    diagnostics = external_tool_diagnostics(Path("missing-tools.ipynb"), notebook, LintOptions())
+
+    messages = [diagnostic.message for diagnostic in diagnostics]
+    assert "ruff is required for notebook linting; run through `uv run` or install Ruff" in messages
+    assert "ty is required for notebook linting; run through `uv run` or install ty" in messages
+
+
+def test_main_lint_reports_errors_to_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI lint errors should be concise and actionable."""
+    notebook = tmp_path / "dirty.ipynb"
+    write_notebook(notebook, [code_cell("x = 1", outputs=[{"output_type": "stream", "name": "stdout", "text": "1"}], execution_count=3)])
+
+    result = main(["lint", "--no-ruff", "--no-format", "--no-ty", str(notebook)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert f"{notebook}: cell 1: error: has 1 output block(s); clear outputs before committing" in captured.err
+    assert f"{notebook}: cell 1: error: execution_count=3; clear execution counts" in captured.err
+
+
+def test_main_reports_missing_notebook_without_traceback(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Missing notebook paths should not print a traceback."""
+    missing_notebook = tmp_path / "missing.ipynb"
+
+    result = main(["summary", str(missing_notebook)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert "error: notebook does not exist or is not a file:" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_rejects_non_positive_timeout(capsys: pytest.CaptureFixture[str]) -> None:
+    """Execution timeouts must be positive."""
+    with pytest.raises(SystemExit) as exc_info:
+        main(["execute", "--timeout", "0", "notebook.ipynb"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "expected a positive integer" in captured.err
+
+
+def test_main_returns_success_when_no_notebooks_are_found(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """Notebook validation should be a clean no-op before notebooks are added."""
+    monkeypatch.chdir(tmp_path)
+
+    assert main(["lint"]) == 0
+
+    assert "No notebooks found." in capsys.readouterr().out
+
+
+def test_extract_code_maps_lines_to_source_cells(tmp_path: Path) -> None:
+    """Extracted Python should retain enough mapping for diagnostics."""
+    notebook = load_notebook_fixture(
+        tmp_path,
+        "line-map.ipynb",
+        [
+            {"cell_type": "markdown", "metadata": {}, "source": "context"},
+            code_cell("first = 1\nsecond = 2\n"),
+            code_cell("third = 3"),
+        ],
+    )
+
+    snapshot = extract_code(notebook)
+
+    assert "# %% notebook cell 2" in snapshot.source
+    assert "# %% notebook cell 3" in snapshot.source
+    assert snapshot.line_to_cell[2] == 2
+    assert snapshot.line_to_cell[5] == 3
+
+
+def test_execute_notebooks_uses_headless_kernel_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Notebook execution should run headlessly from the repository root."""
+    repo_root = tmp_path
+    notebook = tmp_path / "notebooks" / "valid.ipynb"
+    notebook.parent.mkdir()
+    notebook.write_text("{}", encoding="utf-8")
+    calls: dict[str, Any] = {}
+
+    fake_nbformat = SimpleNamespace(read=lambda handle, as_version: {"handle": handle.name, "as_version": as_version})
+
+    class FakeNotebookClient:
+        """Capture nbclient construction without starting a real kernel."""
+
+        def __init__(self, notebook_value: dict[str, Any], **kwargs: Any) -> None:
+            calls["notebook"] = notebook_value
+            calls["kwargs"] = kwargs
+
+        def execute(self) -> None:
+            """Record notebook execution."""
+            calls["executed"] = True
+
+    fake_nbclient = SimpleNamespace(NotebookClient=FakeNotebookClient)
+
+    def fake_import(name: str) -> SimpleNamespace:
+        if name == "nbformat":
+            return fake_nbformat
+        if name == "nbclient":
+            return fake_nbclient
+        msg = f"unexpected import {name}"
+        raise AssertionError(msg)
+
+    monkeypatch.delenv("MPLBACKEND", raising=False)
+    monkeypatch.setattr("notebook_check.import_module", fake_import)
+
+    execute_notebooks([notebook], repo_root, timeout=123)
+
+    assert calls["notebook"]["as_version"] == 4
+    assert calls["kwargs"]["timeout"] == 123
+    assert calls["kwargs"]["kernel_name"] == "python3"
+    assert calls["kwargs"]["resources"] == {"metadata": {"path": str(repo_root)}}
+    assert calls["executed"] is True
+    assert os.environ["MPLBACKEND"] == "Agg"
+    assert f"OK executed {notebook}" in capsys.readouterr().out

--- a/scripts/tests/test_notebook_check.py
+++ b/scripts/tests/test_notebook_check.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -21,6 +22,7 @@ from notebook_check import (
     lint,
     load_notebook,
     main,
+    ruff_lint_diagnostics,
 )
 
 
@@ -51,6 +53,16 @@ def code_cell(source: Any, *, outputs: Any = None, execution_count: Any = None) 
         "outputs": [] if outputs is None else outputs,
         "source": source,
     }
+
+
+def completed_process(
+    stdout: str = "",
+    stderr: str = "",
+    *,
+    returncode: int = 0,
+) -> subprocess.CompletedProcess[str]:
+    """Return a typed subprocess result for notebook checker command mocks."""
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
 
 
 def test_discover_notebooks_excludes_checkpoints(tmp_path: Path) -> None:
@@ -200,6 +212,79 @@ def test_external_tool_diagnostics_report_missing_tools(monkeypatch: pytest.Monk
     assert "ty is required for notebook linting; run through `uv run` or install ty" in messages
 
 
+def test_ruff_diagnostics_use_configured_project_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ruff checks should resolve configuration from the requested repo root."""
+    project_root = tmp_path / "repo"
+    project_root.mkdir()
+    notebook_path = tmp_path / "clean.ipynb"
+    notebook = load_notebook_fixture(tmp_path, "clean.ipynb", [code_cell("value = 1\n")])
+    calls: list[Path | None] = []
+
+    def fake_run_safe_command(
+        command: str,
+        args: list[str],
+        cwd: Path | None = None,
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(cwd)
+        assert command == "ruff"
+        assert kwargs["input"]
+        return completed_process()
+
+    monkeypatch.setattr("notebook_check.shutil.which", lambda command: f"/bin/{command}")
+    monkeypatch.setattr("notebook_check.run_safe_command", fake_run_safe_command)
+
+    diagnostics = external_tool_diagnostics(
+        notebook_path,
+        notebook,
+        LintOptions(run_ty=False, project_root=project_root),
+    )
+
+    assert diagnostics == []
+    assert calls == [project_root, project_root]
+
+
+def test_ruff_inline_locations_map_to_notebook_cells(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ruff path:line:column diagnostics should map to the owning notebook cell."""
+    notebook_path = tmp_path / "inline.ipynb"
+    notebook = load_notebook_fixture(
+        tmp_path,
+        "inline.ipynb",
+        [
+            code_cell("first = 1\n"),
+            code_cell("import os\n"),
+        ],
+    )
+
+    def fake_run_safe_command(
+        command: str,
+        args: list[str],
+        cwd: Path | None = None,
+        **kwargs: Any,
+    ) -> subprocess.CompletedProcess[str]:
+        assert command == "ruff"
+        assert cwd == tmp_path
+        assert kwargs["input"]
+        return completed_process(
+            stdout="inline_notebook.py:5:1: F401 `os` imported but unused\nFound 1 error.\n",
+            returncode=1,
+        )
+
+    monkeypatch.setattr("notebook_check.run_safe_command", fake_run_safe_command)
+
+    diagnostics = ruff_lint_diagnostics(notebook_path, notebook, tmp_path)
+
+    assert len(diagnostics) == 1
+    assert diagnostics[0].cell == 2
+    assert diagnostics[0].message.startswith("ruff check: inline_notebook.py:5:1:")
+
+
 def test_main_lint_reports_errors_to_stderr(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """CLI lint errors should be concise and actionable."""
     notebook = tmp_path / "dirty.ipynb"
@@ -227,6 +312,62 @@ def test_main_reports_missing_notebook_without_traceback(tmp_path: Path, capsys:
     assert "Traceback" not in captured.err
 
 
+def test_main_execute_reports_missing_nbclient_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Missing optional execution dependencies should produce one-line errors."""
+    notebook = tmp_path / "valid.ipynb"
+    write_notebook(notebook, [code_cell("value = 1\n")])
+
+    def fake_import(name: str) -> SimpleNamespace:
+        raise ModuleNotFoundError(f"No module named {name!r}", name=name)
+
+    monkeypatch.setattr("notebook_check.import_module", fake_import)
+
+    result = main(["execute", "--repo-root", str(tmp_path), str(notebook)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert f"error: {notebook}: execute(): missing optional dependency 'nbclient'" in captured.err
+    assert "Traceback" not in captured.err
+
+
+def test_main_execute_reports_invalid_nbclient_backend_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Execution dependency shape errors should stay concise."""
+    notebook = tmp_path / "valid.ipynb"
+    write_notebook(notebook, [code_cell("value = 1\n")])
+    fake_nbformat = SimpleNamespace(read=lambda handle, as_version: {"handle": handle.name, "as_version": as_version})
+    fake_nbclient = SimpleNamespace(NotebookClient=object)
+    fake_nbclient_exceptions = SimpleNamespace()
+
+    def fake_import(name: str) -> SimpleNamespace:
+        if name == "nbformat":
+            return fake_nbformat
+        if name == "nbclient":
+            return fake_nbclient
+        if name == "nbclient.exceptions":
+            return fake_nbclient_exceptions
+        msg = f"unexpected import {name}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("notebook_check.import_module", fake_import)
+
+    result = main(["execute", "--repo-root", str(tmp_path), str(notebook)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert f"error: {notebook}: execute(): nbclient runtime exception types are unavailable" in captured.err
+    assert "Traceback" not in captured.err
+
+
 def test_main_rejects_non_positive_timeout(capsys: pytest.CaptureFixture[str]) -> None:
     """Execution timeouts must be positive."""
     with pytest.raises(SystemExit) as exc_info:
@@ -244,6 +385,19 @@ def test_main_returns_success_when_no_notebooks_are_found(tmp_path: Path, monkey
     assert main(["lint"]) == 0
 
     assert "No notebooks found." in capsys.readouterr().out
+
+
+def test_main_rejects_missing_repo_root(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Invalid repo roots should fail before notebook discovery."""
+    missing_repo_root = tmp_path / "missing-repo"
+
+    result = main(["lint", "--repo-root", str(missing_repo_root)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert "error: repository root does not exist or is not a directory:" in captured.err
+    assert "No notebooks found." not in captured.out
 
 
 def test_extract_code_maps_lines_to_source_cells(tmp_path: Path) -> None:
@@ -293,11 +447,18 @@ def test_execute_notebooks_uses_headless_kernel_context(
 
     fake_nbclient = SimpleNamespace(NotebookClient=FakeNotebookClient)
 
+    class FakeNotebookClientError(Exception):
+        """Fake nbclient base error."""
+
+    fake_nbclient_exceptions = SimpleNamespace(NotebookClientError=FakeNotebookClientError)
+
     def fake_import(name: str) -> SimpleNamespace:
         if name == "nbformat":
             return fake_nbformat
         if name == "nbclient":
             return fake_nbclient
+        if name == "nbclient.exceptions":
+            return fake_nbclient_exceptions
         msg = f"unexpected import {name}"
         raise AssertionError(msg)
 
@@ -313,3 +474,53 @@ def test_execute_notebooks_uses_headless_kernel_context(
     assert calls["executed"] is True
     assert os.environ["MPLBACKEND"] == "Agg"
     assert f"OK executed {notebook}" in capsys.readouterr().out
+
+
+def test_main_execute_reports_nbclient_failures_without_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Notebook runtime failures should stay concise for CI logs."""
+    notebook = tmp_path / "notebooks" / "failing.ipynb"
+    notebook.parent.mkdir()
+    write_notebook(notebook, [code_cell("raise RuntimeError('boom')\n")])
+
+    class FakeCellExecutionError(Exception):
+        """Fake nbclient execution error."""
+
+    class FakeNotebookClient:
+        """Raise a fake execution failure from NotebookClient.execute."""
+
+        def __init__(self, notebook_value: dict[str, Any], **kwargs: Any) -> None:
+            self.notebook_value = notebook_value
+            self.kwargs = kwargs
+
+        def execute(self) -> None:
+            """Simulate a notebook cell failure."""
+            message = "cell failed\ntraceback line"
+            raise FakeCellExecutionError(message)
+
+    fake_nbformat = SimpleNamespace(read=lambda handle, as_version: {"handle": handle.name, "as_version": as_version})
+    fake_nbclient = SimpleNamespace(NotebookClient=FakeNotebookClient)
+    fake_nbclient_exceptions = SimpleNamespace(CellExecutionError=FakeCellExecutionError)
+
+    def fake_import(name: str) -> SimpleNamespace:
+        if name == "nbformat":
+            return fake_nbformat
+        if name == "nbclient":
+            return fake_nbclient
+        if name == "nbclient.exceptions":
+            return fake_nbclient_exceptions
+        msg = f"unexpected import {name}"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("notebook_check.import_module", fake_import)
+
+    result = main(["execute", "--repo-root", str(tmp_path), str(notebook)])
+
+    captured = capsys.readouterr()
+    assert result == 1
+    assert captured.out == ""
+    assert (f"error: {notebook}: execute(): NotebookClient execution failed: FakeCellExecutionError: cell failed traceback line") in captured.err
+    assert "Traceback" not in captured.err

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -214,6 +214,8 @@ pub(crate) mod test_hooks {
 /// data, and validating the export schema. More specialized workflows such as
 /// convex hull extraction, repair, and delaunayize continue to expose their
 /// narrower error types directly.
+/// Each variant keeps the concrete typed source error behind a box so the
+/// umbrella result stays small without erasing matchable failure details.
 ///
 /// # Examples
 ///
@@ -245,92 +247,180 @@ pub(crate) mod test_hooks {
 #[non_exhaustive]
 pub enum DelaunayError {
     /// Delaunay triangulation construction failed.
-    #[error(transparent)]
+    #[error("{source}")]
     Construction {
         /// Underlying construction failure.
-        #[from]
-        source: DelaunayTriangulationConstructionError,
+        #[source]
+        source: Box<DelaunayTriangulationConstructionError>,
     },
 
     /// Coordinate conversion or validation failed before construction.
-    #[error(transparent)]
+    #[error("{source}")]
     CoordinateConversion {
         /// Underlying coordinate conversion failure.
-        #[from]
-        source: CoordinateConversionError,
+        #[source]
+        source: Box<CoordinateConversionError>,
     },
 
     /// Incremental Delaunay insertion failed.
-    #[error(transparent)]
+    #[error("{source}")]
     Insertion {
         /// Underlying insertion failure.
-        #[from]
-        source: InsertionError,
+        #[source]
+        source: Box<InsertionError>,
     },
 
     /// Delaunay vertex deletion failed.
-    #[error(transparent)]
+    #[error("{source}")]
     DeleteVertex {
         /// Underlying vertex-deletion failure.
-        #[from]
-        source: DeleteVertexError,
+        #[source]
+        source: Box<DeleteVertexError>,
     },
 
     /// Explicit bistellar flip or Pachner move dispatch failed.
-    #[error(transparent)]
+    #[error("{source}")]
     Flip {
         /// Underlying flip failure.
-        #[from]
-        source: FlipError,
+        #[source]
+        source: Box<FlipError>,
     },
 
     /// User-data mutation through a checked TDS key failed.
-    #[error(transparent)]
+    #[error("{source}")]
     TdsMutation {
         /// Underlying TDS mutation failure.
-        #[from]
-        source: TdsMutationError,
+        #[source]
+        source: Box<TdsMutationError>,
     },
 
     /// Validation policy configuration failed.
-    #[error(transparent)]
+    #[error("{source}")]
     ValidationConfiguration {
         /// Underlying validation configuration failure.
-        #[from]
-        source: ValidationConfigurationError,
+        #[source]
+        source: Box<ValidationConfigurationError>,
     },
 
     /// Delaunay triangulation validation failed.
-    #[error(transparent)]
+    #[error("{source}")]
     Validation {
         /// Underlying validation failure.
-        #[from]
-        source: DelaunayTriangulationValidationError,
+        #[source]
+        source: Box<DelaunayTriangulationValidationError>,
     },
 
     /// Visualization or mesh export failed.
-    #[error(transparent)]
+    #[error("{source}")]
     VisualizationExport {
         /// Underlying visualization export failure.
-        #[from]
-        source: VisualizationExportError,
+        #[source]
+        source: Box<VisualizationExportError>,
     },
 
     /// Visualization or mesh export schema validation failed.
-    #[error(transparent)]
+    #[error("{source}")]
     VisualizationDataValidation {
         /// Underlying visualization data validation failure.
-        #[from]
-        source: VisualizationDataValidationError,
+        #[source]
+        source: Box<VisualizationDataValidationError>,
     },
 
     /// Toroidal-domain setup failed.
-    #[error(transparent)]
+    #[error("{source}")]
     ToroidalDomain {
         /// Underlying toroidal-domain validation failure.
-        #[from]
-        source: ToroidalDomainError,
+        #[source]
+        source: Box<ToroidalDomainError>,
     },
+}
+
+impl From<DelaunayTriangulationConstructionError> for DelaunayError {
+    fn from(source: DelaunayTriangulationConstructionError) -> Self {
+        Self::Construction {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<CoordinateConversionError> for DelaunayError {
+    fn from(source: CoordinateConversionError) -> Self {
+        Self::CoordinateConversion {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<InsertionError> for DelaunayError {
+    fn from(source: InsertionError) -> Self {
+        Self::Insertion {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<DeleteVertexError> for DelaunayError {
+    fn from(source: DeleteVertexError) -> Self {
+        Self::DeleteVertex {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<FlipError> for DelaunayError {
+    fn from(source: FlipError) -> Self {
+        Self::Flip {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<TdsMutationError> for DelaunayError {
+    fn from(source: TdsMutationError) -> Self {
+        Self::TdsMutation {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<ValidationConfigurationError> for DelaunayError {
+    fn from(source: ValidationConfigurationError) -> Self {
+        Self::ValidationConfiguration {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<DelaunayTriangulationValidationError> for DelaunayError {
+    fn from(source: DelaunayTriangulationValidationError) -> Self {
+        Self::Validation {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<VisualizationExportError> for DelaunayError {
+    fn from(source: VisualizationExportError) -> Self {
+        Self::VisualizationExport {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<VisualizationDataValidationError> for DelaunayError {
+    fn from(source: VisualizationDataValidationError) -> Self {
+        Self::VisualizationDataValidation {
+            source: Box::new(source),
+        }
+    }
+}
+
+impl From<ToroidalDomainError> for DelaunayError {
+    fn from(source: ToroidalDomainError) -> Self {
+        Self::ToroidalDomain {
+            source: Box::new(source),
+        }
+    }
 }
 
 /// Result alias for common user-facing Delaunay triangulation workflows.

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -90,6 +90,7 @@ use crate::geometry::traits::coordinate::{
     CoordinateConversionError, CoordinateValidationError, CoordinateValues,
 };
 use crate::geometry::util::{RandomPointGenerationError, safe_usize_to_scalar, simplex_volume};
+use crate::io::visualization::{VisualizationDataValidationError, VisualizationExportError};
 use crate::locality::{
     accumulate_live_simplex_seeds, clear_simplex_seed_set, retain_live_simplex_seeds,
 };
@@ -209,16 +210,17 @@ pub(crate) mod test_hooks {
 /// converting caller coordinates into vertices, constructing a
 /// [`DelaunayTriangulation`], editing it through the Delaunay insertion/deletion
 /// API or explicit flip/Pachner APIs, updating auxiliary vertex/simplex data
-/// through checked keys, and validating its Delaunay invariants. More specialized
-/// workflows such as convex hull extraction, repair, and delaunayize continue
-/// to expose their narrower error types directly.
+/// through checked keys, validating its Delaunay invariants, exporting mesh
+/// data, and validating the export schema. More specialized workflows such as
+/// convex hull extraction, repair, and delaunayize continue to expose their
+/// narrower error types directly.
 ///
 /// # Examples
 ///
 /// Use [`DelaunayResult`] for examples, binaries, and quick workflows whose
 /// fallible operations stay inside coordinate conversion, construction,
 /// checked auxiliary-data mutation, insertion/deletion, explicit flip editing,
-/// and validation:
+/// validation, mesh export, and export-schema validation:
 ///
 /// ```rust
 /// use delaunay::prelude::construction::{
@@ -306,6 +308,22 @@ pub enum DelaunayError {
         source: DelaunayTriangulationValidationError,
     },
 
+    /// Visualization or mesh export failed.
+    #[error(transparent)]
+    VisualizationExport {
+        /// Underlying visualization export failure.
+        #[from]
+        source: VisualizationExportError,
+    },
+
+    /// Visualization or mesh export schema validation failed.
+    #[error(transparent)]
+    VisualizationDataValidation {
+        /// Underlying visualization data validation failure.
+        #[from]
+        source: VisualizationDataValidationError,
+    },
+
     /// Toroidal-domain setup failed.
     #[error(transparent)]
     ToroidalDomain {
@@ -320,7 +338,8 @@ pub enum DelaunayError {
 /// This is equivalent to `Result<T, DelaunayError>` with [`DelaunayError`] as
 /// the error type, and is intended for caller-facing examples and applications
 /// that use the standard construction, checked auxiliary-data mutation,
-/// insertion/deletion, explicit flip editing, and validation APIs.
+/// insertion/deletion, explicit flip editing, validation, mesh export, and
+/// export-schema validation APIs.
 pub type DelaunayResult<T> = Result<T, DelaunayError>;
 
 /// Errors that can occur during Delaunay triangulation construction.

--- a/src/io/visualization.rs
+++ b/src/io/visualization.rs
@@ -1,0 +1,1263 @@
+//! Generic simplicial-complex export data for notebooks and downstream tools.
+//!
+//! This module owns a downstream-facing schema distinct from the internal TDS
+//! persistence format. It uses stable vertex and simplex UUIDs for entity
+//! identity so consumers do not depend on storage-local slotmap keys.
+
+#![forbid(unsafe_code)]
+
+use crate::core::collections::NeighborBuffer;
+use crate::core::simplex::NeighborSlot;
+use crate::core::tds::{SimplexKey, Tds, VertexKey};
+use crate::core::validation::TopologyGuarantee;
+use crate::core::vertex::Vertex;
+use crate::geometry::traits::coordinate::InvalidCoordinateValue;
+use crate::topology::traits::topological_space::TopologyKind;
+use crate::triangulation::DelaunayTriangulation;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt,
+};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Supplies absent optional attributes during deserialization without requiring
+/// the attribute payload type to implement `Default`.
+const fn no_attributes<Attributes>() -> Option<Attributes> {
+    None
+}
+
+/// Schema name used by [`VisualizationData`].
+pub const VISUALIZATION_SCHEMA: &str = "delaunay.simplicial_complex";
+
+/// Current [`VisualizationData`] schema version.
+pub const VISUALIZATION_SCHEMA_VERSION: u32 = 1;
+
+/// Compatibility schema name used by the mesh-export alias.
+pub const MESH_EXPORT_SCHEMA: &str = VISUALIZATION_SCHEMA;
+
+/// Compatibility schema version used by the mesh-export alias.
+pub const MESH_EXPORT_SCHEMA_VERSION: u32 = VISUALIZATION_SCHEMA_VERSION;
+
+/// Stable topology-kind schema category used by [`VisualizationMetadata`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum VisualizationTopologyKind {
+    /// Euclidean topology.
+    Euclidean,
+    /// Toroidal topology.
+    Toroidal,
+    /// Spherical topology.
+    Spherical,
+    /// Hyperbolic topology.
+    Hyperbolic,
+    /// Unknown topology-kind text from an external JSON producer.
+    Unknown {
+        /// Raw schema text that did not match a known v1 topology kind.
+        actual: String,
+    },
+}
+
+impl VisualizationTopologyKind {
+    /// Returns the v1 JSON schema spelling for this topology-kind category.
+    fn schema_name(&self) -> &str {
+        match self {
+            Self::Euclidean => "Euclidean",
+            Self::Toroidal => "Toroidal",
+            Self::Spherical => "Spherical",
+            Self::Hyperbolic => "Hyperbolic",
+            Self::Unknown { actual } => actual,
+        }
+    }
+
+    /// Reports whether this topology-kind value is part of the v1 schema.
+    const fn is_supported(&self) -> bool {
+        match self {
+            Self::Euclidean | Self::Toroidal | Self::Spherical | Self::Hyperbolic => true,
+            Self::Unknown { .. } => false,
+        }
+    }
+}
+
+impl From<TopologyKind> for VisualizationTopologyKind {
+    fn from(kind: TopologyKind) -> Self {
+        match kind {
+            TopologyKind::Euclidean => Self::Euclidean,
+            TopologyKind::Toroidal => Self::Toroidal,
+            TopologyKind::Spherical => Self::Spherical,
+            TopologyKind::Hyperbolic => Self::Hyperbolic,
+        }
+    }
+}
+
+impl fmt::Display for VisualizationTopologyKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.schema_name())
+    }
+}
+
+impl Serialize for VisualizationTopologyKind {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.schema_name())
+    }
+}
+
+impl<'de> Deserialize<'de> for VisualizationTopologyKind {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let actual = String::deserialize(deserializer)?;
+        Ok(match actual.as_str() {
+            "Euclidean" => Self::Euclidean,
+            "Toroidal" => Self::Toroidal,
+            "Spherical" => Self::Spherical,
+            "Hyperbolic" => Self::Hyperbolic,
+            _ => Self::Unknown { actual },
+        })
+    }
+}
+
+/// Stable topology-guarantee schema category used by [`VisualizationMetadata`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum VisualizationTopologyGuarantee {
+    /// Pseudomanifold guarantee.
+    Pseudomanifold,
+    /// PL-manifold guarantee.
+    PLManifold,
+    /// Strict PL-manifold guarantee.
+    PLManifoldStrict,
+    /// Unknown topology-guarantee text from an external JSON producer.
+    Unknown {
+        /// Raw schema text that did not match a known v1 topology guarantee.
+        actual: String,
+    },
+}
+
+impl VisualizationTopologyGuarantee {
+    /// Returns the v1 JSON schema spelling for this topology-guarantee category.
+    fn schema_name(&self) -> &str {
+        match self {
+            Self::Pseudomanifold => "Pseudomanifold",
+            Self::PLManifold => "PLManifold",
+            Self::PLManifoldStrict => "PLManifoldStrict",
+            Self::Unknown { actual } => actual,
+        }
+    }
+
+    /// Reports whether this topology-guarantee value is part of the v1 schema.
+    const fn is_supported(&self) -> bool {
+        match self {
+            Self::Pseudomanifold | Self::PLManifold | Self::PLManifoldStrict => true,
+            Self::Unknown { .. } => false,
+        }
+    }
+}
+
+impl From<TopologyGuarantee> for VisualizationTopologyGuarantee {
+    fn from(guarantee: TopologyGuarantee) -> Self {
+        match guarantee {
+            TopologyGuarantee::Pseudomanifold => Self::Pseudomanifold,
+            TopologyGuarantee::PLManifold => Self::PLManifold,
+            TopologyGuarantee::PLManifoldStrict => Self::PLManifoldStrict,
+        }
+    }
+}
+
+impl fmt::Display for VisualizationTopologyGuarantee {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.schema_name())
+    }
+}
+
+impl Serialize for VisualizationTopologyGuarantee {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.schema_name())
+    }
+}
+
+impl<'de> Deserialize<'de> for VisualizationTopologyGuarantee {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let actual = String::deserialize(deserializer)?;
+        Ok(match actual.as_str() {
+            "Pseudomanifold" => Self::Pseudomanifold,
+            "PLManifold" => Self::PLManifold,
+            "PLManifoldStrict" => Self::PLManifoldStrict,
+            _ => Self::Unknown { actual },
+        })
+    }
+}
+
+/// Generic simplicial-complex data for analysis, notebooks, and interchange.
+///
+/// The JSON shape is intentionally separate from `Tds` serde persistence. It
+/// exposes common visualization primitives: schema metadata, stable vertex and
+/// simplex ids, coordinates, simplex vertex membership, and facet-neighbor
+/// adjacency by stable simplex id. Attribute type parameters let downstream
+/// crates wrap or extend the base records with domain-specific metadata.
+/// The value is an owned, detached interchange snapshot rather than a live
+/// borrowed view over a triangulation; regenerate it after mutating the source
+/// triangulation.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::prelude::construction::{
+///     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
+/// };
+/// use delaunay::prelude::export::VisualizationExportError;
+/// use delaunay::prelude::geometry::CoordinateConversionError;
+///
+/// # #[derive(Debug, thiserror::Error)]
+/// # enum ExampleError {
+/// #     #[error(transparent)]
+/// #     Construction(#[from] DelaunayTriangulationConstructionError),
+/// #     #[error(transparent)]
+/// #     Coordinate(#[from] CoordinateConversionError),
+/// #     #[error(transparent)]
+/// #     Export(#[from] VisualizationExportError),
+/// #     #[error(transparent)]
+/// #     Serde(#[from] serde_json::Error),
+/// # }
+/// # fn main() -> Result<(), ExampleError> {
+/// let vertices = vec![
+///     vertex![0.0, 0.0]?,
+///     vertex![1.0, 0.0]?,
+///     vertex![0.0, 1.0]?,
+/// ];
+/// let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+///
+/// let export = triangulation.to_visualization_data()?;
+/// let json = serde_json::to_string(&export)?;
+///
+/// assert!(json.contains("\"schema\":\"delaunay.simplicial_complex\""));
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct VisualizationData<
+    const D: usize,
+    VertexAttributes = (),
+    SimplexAttributes = (),
+    AdjacencyAttributes = (),
+    GlobalAttributes = (),
+> {
+    /// Global schema and producer metadata.
+    pub metadata: VisualizationMetadata<GlobalAttributes>,
+    /// Vertices sorted by stable UUID for deterministic output.
+    pub vertices: Vec<VertexRecord<D, VertexAttributes>>,
+    /// Maximal simplices sorted by stable UUID for deterministic output.
+    pub simplices: Vec<SimplexRecord<SimplexAttributes>>,
+    /// Facet-neighbor adjacency records sorted by simplex id and facet index.
+    pub adjacency: Vec<AdjacencyRecord<AdjacencyAttributes>>,
+}
+
+impl<const D: usize, VertexAttributes, SimplexAttributes, AdjacencyAttributes, GlobalAttributes>
+    VisualizationData<D, VertexAttributes, SimplexAttributes, AdjacencyAttributes, GlobalAttributes>
+{
+    /// Parses this raw visualization/interchange value into a validated wrapper.
+    ///
+    /// This consumes the raw DTO and returns a proof-bearing value whose
+    /// borrowed accessors can be used without repeating schema validation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisualizationDataValidationError`] when schema metadata,
+    /// coordinate values or arity, non-nil ids, connectivity, facet coverage,
+    /// or reciprocal facet-compatible adjacency are inconsistent.
+    pub fn into_validated(
+        self,
+    ) -> Result<
+        ValidatedVisualizationData<
+            D,
+            VertexAttributes,
+            SimplexAttributes,
+            AdjacencyAttributes,
+            GlobalAttributes,
+        >,
+        VisualizationDataValidationError,
+    > {
+        ValidatedVisualizationData::try_from_raw(self)
+    }
+
+    /// Validates this raw visualization/interchange value against the v1 schema.
+    ///
+    /// This is the boundary to use after deserializing untrusted JSON. Produced
+    /// values from [`DelaunayTriangulation::to_visualization_data`] should
+    /// already satisfy these invariants. Validation does not convert the value
+    /// into canonical `Tds` storage; use [`Self::into_validated`] when callers
+    /// need to carry validation evidence inward, or use triangulation/TDS serde
+    /// for validated Rust hydration.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisualizationDataValidationError`] when schema metadata,
+    /// coordinate values or arity, non-nil ids, connectivity, facet coverage,
+    /// or reciprocal facet-compatible adjacency are inconsistent.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, vertex,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     vertex![0.0, 0.0]?,
+    ///     vertex![1.0, 0.0]?,
+    ///     vertex![0.0, 1.0]?,
+    /// ];
+    /// let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let export = triangulation.to_mesh_export()?;
+    ///
+    /// export.validate()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn validate(&self) -> Result<(), VisualizationDataValidationError> {
+        validate_metadata::<D, GlobalAttributes>(
+            &self.metadata,
+            self.vertices.len(),
+            self.simplices.len(),
+        )?;
+
+        let mut vertex_ids = HashSet::with_capacity(self.vertices.len());
+        for (vertex_index, vertex) in self.vertices.iter().enumerate() {
+            if vertex.id.is_nil() {
+                return Err(VisualizationDataValidationError::NilVertexId { vertex_index });
+            }
+            if vertex.coordinates.len() != D {
+                return Err(
+                    VisualizationDataValidationError::InvalidVertexCoordinateCount {
+                        vertex_id: vertex.id,
+                        expected: D,
+                        actual: vertex.coordinates.len(),
+                    },
+                );
+            }
+            for (coordinate_index, coordinate) in vertex.coordinates.iter().enumerate() {
+                if !coordinate.is_finite() {
+                    return Err(
+                        VisualizationDataValidationError::InvalidVertexCoordinateValue {
+                            vertex_id: vertex.id,
+                            coordinate_index,
+                            value: InvalidCoordinateValue::from_debug(coordinate),
+                        },
+                    );
+                }
+            }
+            if !vertex_ids.insert(vertex.id) {
+                return Err(VisualizationDataValidationError::DuplicateVertexId {
+                    vertex_id: vertex.id,
+                });
+            }
+        }
+
+        let expected_simplex_vertices = D + 1;
+        let mut simplex_ids = HashSet::with_capacity(self.simplices.len());
+        for (simplex_index, simplex) in self.simplices.iter().enumerate() {
+            if simplex.id.is_nil() {
+                return Err(VisualizationDataValidationError::NilSimplexId { simplex_index });
+            }
+            if !simplex_ids.insert(simplex.id) {
+                return Err(VisualizationDataValidationError::DuplicateSimplexId {
+                    simplex_id: simplex.id,
+                });
+            }
+            if simplex.vertex_ids.len() != expected_simplex_vertices {
+                return Err(
+                    VisualizationDataValidationError::InvalidSimplexVertexCount {
+                        simplex_id: simplex.id,
+                        expected: expected_simplex_vertices,
+                        actual: simplex.vertex_ids.len(),
+                    },
+                );
+            }
+
+            let mut local_vertex_ids = HashSet::with_capacity(simplex.vertex_ids.len());
+            for vertex_id in &simplex.vertex_ids {
+                if !vertex_ids.contains(vertex_id) {
+                    return Err(VisualizationDataValidationError::MissingSimplexVertex {
+                        simplex_id: simplex.id,
+                        vertex_id: *vertex_id,
+                    });
+                }
+                if !local_vertex_ids.insert(*vertex_id) {
+                    return Err(VisualizationDataValidationError::DuplicateSimplexVertex {
+                        simplex_id: simplex.id,
+                        vertex_id: *vertex_id,
+                    });
+                }
+            }
+        }
+
+        validate_adjacency::<D, _, _>(&self.adjacency, &self.simplices)
+    }
+}
+
+/// Proof-bearing wrapper for a validated [`VisualizationData`] value.
+///
+/// Raw visualization data keeps public fields for serde, external JSON, and
+/// fixtures. This wrapper is the parsed form to pass inward once schema
+/// metadata, finite coordinate values, dimensions, non-nil ids, connectivity,
+/// and facet-compatible adjacency have been checked. Parsing canonicalizes
+/// record order by stable ids so serialized validated values remain
+/// deterministic. This remains an owned, detached snapshot; its accessors
+/// borrow records from the validated snapshot, not from the source
+/// triangulation.
+#[derive(Clone, Debug, PartialEq, Serialize)]
+#[serde(transparent)]
+pub struct ValidatedVisualizationData<
+    const D: usize,
+    VertexAttributes = (),
+    SimplexAttributes = (),
+    AdjacencyAttributes = (),
+    GlobalAttributes = (),
+> {
+    inner: VisualizationData<
+        D,
+        VertexAttributes,
+        SimplexAttributes,
+        AdjacencyAttributes,
+        GlobalAttributes,
+    >,
+}
+
+impl<const D: usize, VertexAttributes, SimplexAttributes, AdjacencyAttributes, GlobalAttributes>
+    ValidatedVisualizationData<
+        D,
+        VertexAttributes,
+        SimplexAttributes,
+        AdjacencyAttributes,
+        GlobalAttributes,
+    >
+{
+    /// Parses a raw visualization/interchange DTO into a validated wrapper.
+    /// Valid inputs are canonicalized by stable ids before storage.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisualizationDataValidationError`] when schema metadata,
+    /// coordinate values or arity, non-nil ids, connectivity, facet coverage,
+    /// or reciprocal facet-compatible adjacency are inconsistent.
+    pub fn try_from_raw(
+        mut raw: VisualizationData<
+            D,
+            VertexAttributes,
+            SimplexAttributes,
+            AdjacencyAttributes,
+            GlobalAttributes,
+        >,
+    ) -> Result<Self, VisualizationDataValidationError> {
+        raw.validate()?;
+        canonicalize_record_order(&mut raw);
+        Ok(Self { inner: raw })
+    }
+
+    /// Returns the validated raw DTO without exposing mutable access.
+    pub const fn as_raw(
+        &self,
+    ) -> &VisualizationData<
+        D,
+        VertexAttributes,
+        SimplexAttributes,
+        AdjacencyAttributes,
+        GlobalAttributes,
+    > {
+        &self.inner
+    }
+
+    /// Consumes the wrapper and returns the raw DTO, discarding validation proof.
+    pub fn into_raw(
+        self,
+    ) -> VisualizationData<
+        D,
+        VertexAttributes,
+        SimplexAttributes,
+        AdjacencyAttributes,
+        GlobalAttributes,
+    > {
+        self.inner
+    }
+
+    /// Returns validated schema and producer metadata.
+    pub const fn metadata(&self) -> &VisualizationMetadata<GlobalAttributes> {
+        &self.inner.metadata
+    }
+
+    /// Returns validated vertex records.
+    pub fn vertices(&self) -> &[VertexRecord<D, VertexAttributes>] {
+        &self.inner.vertices
+    }
+
+    /// Returns validated simplex records.
+    pub fn simplices(&self) -> &[SimplexRecord<SimplexAttributes>] {
+        &self.inner.simplices
+    }
+
+    /// Returns validated adjacency records.
+    pub fn adjacency(&self) -> &[AdjacencyRecord<AdjacencyAttributes>] {
+        &self.inner.adjacency
+    }
+}
+
+impl<const D: usize, VertexAttributes, SimplexAttributes, AdjacencyAttributes, GlobalAttributes>
+    TryFrom<
+        VisualizationData<
+            D,
+            VertexAttributes,
+            SimplexAttributes,
+            AdjacencyAttributes,
+            GlobalAttributes,
+        >,
+    >
+    for ValidatedVisualizationData<
+        D,
+        VertexAttributes,
+        SimplexAttributes,
+        AdjacencyAttributes,
+        GlobalAttributes,
+    >
+{
+    type Error = VisualizationDataValidationError;
+
+    fn try_from(
+        raw: VisualizationData<
+            D,
+            VertexAttributes,
+            SimplexAttributes,
+            AdjacencyAttributes,
+            GlobalAttributes,
+        >,
+    ) -> Result<Self, Self::Error> {
+        Self::try_from_raw(raw)
+    }
+}
+
+/// Global metadata for [`VisualizationData`].
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct VisualizationMetadata<Attributes = ()> {
+    /// Stable schema name for downstream format dispatch.
+    pub schema: String,
+    /// Integer schema version for compatibility checks.
+    pub schema_version: u32,
+    /// Name of the crate or tool that produced this export.
+    pub producer: String,
+    /// Compile-time triangulation dimension recorded for non-Rust consumers.
+    pub dimension: usize,
+    /// Number of exported vertex records.
+    pub vertex_count: usize,
+    /// Number of exported simplex records.
+    pub simplex_count: usize,
+    /// Topological-space kind recorded as a stable schema category.
+    pub topology_kind: VisualizationTopologyKind,
+    /// Validation/topology guarantee recorded as a stable schema category.
+    pub topology_guarantee: VisualizationTopologyGuarantee,
+    /// Optional downstream global metadata.
+    #[serde(default = "no_attributes", skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<Attributes>,
+}
+
+/// Vertex record in [`VisualizationData`].
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct VertexRecord<const D: usize, Attributes = ()> {
+    /// Stable vertex id.
+    pub id: Uuid,
+    /// Vertex coordinates in triangulation dimension order.
+    pub coordinates: Vec<f64>,
+    /// Optional downstream per-vertex metadata.
+    #[serde(default = "no_attributes", skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<Attributes>,
+}
+
+/// Simplex record in [`VisualizationData`].
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct SimplexRecord<Attributes = ()> {
+    /// Stable simplex id.
+    pub id: Uuid,
+    /// Stable vertex ids in the simplex's stored orientation/order.
+    pub vertex_ids: Vec<Uuid>,
+    /// Optional downstream per-simplex metadata.
+    #[serde(default = "no_attributes", skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<Attributes>,
+}
+
+/// Facet-neighbor adjacency record in [`VisualizationData`].
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+pub struct AdjacencyRecord<Attributes = ()> {
+    /// Stable simplex id for the source simplex.
+    pub simplex_id: Uuid,
+    /// Local facet index, opposite `SimplexRecord::vertex_ids[facet_index]`.
+    pub facet_index: usize,
+    /// Stable id of the neighboring simplex across this facet.
+    ///
+    /// `None` denotes a boundary facet.
+    pub neighbor_simplex_id: Option<Uuid>,
+    /// Optional downstream per-adjacency metadata.
+    #[serde(default = "no_attributes", skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<Attributes>,
+}
+
+/// Default mesh-export alias for callers that do not need extra attributes.
+///
+/// This is an owned, detached interchange snapshot, not a live borrowed view
+/// over the source triangulation.
+pub type MeshExport<const D: usize> = VisualizationData<D>;
+
+/// Validated mesh-export alias for callers that do not need extra attributes.
+pub type ValidatedMeshExport<const D: usize> = ValidatedVisualizationData<D>;
+
+/// Default vertex-record alias for callers that do not need extra attributes.
+pub type MeshVertexRecord<const D: usize> = VertexRecord<D>;
+
+/// Default simplex-record alias for callers that do not need extra attributes.
+pub type MeshSimplexRecord = SimplexRecord;
+
+/// Default adjacency-record alias for callers that do not need extra attributes.
+pub type MeshAdjacencyRecord = AdjacencyRecord;
+
+/// Compatibility error alias for mesh export callers.
+pub type MeshExportError = VisualizationExportError;
+
+/// Compatibility validation-error alias for mesh export callers.
+pub type MeshExportValidationError = VisualizationDataValidationError;
+
+/// Errors that can occur while exporting visualization data.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum VisualizationExportError {
+    /// A simplex referenced a vertex key that is not present in the TDS.
+    #[error("simplex {simplex_id} references missing vertex key {vertex_key:?}")]
+    MissingVertex {
+        /// Stable id of the simplex containing the bad reference.
+        simplex_id: Uuid,
+        /// Storage-local key that could not be resolved.
+        vertex_key: VertexKey,
+    },
+    /// A simplex has no assigned neighbor buffer.
+    #[error("simplex {simplex_id} has no assigned neighbor buffer")]
+    UnassignedNeighborBuffer {
+        /// Stable id of the simplex with no neighbor buffer.
+        simplex_id: Uuid,
+    },
+    /// A simplex neighbor buffer length does not match the simplex dimension.
+    #[error("simplex {simplex_id} has {actual} neighbor slots; expected {expected}")]
+    InvalidNeighborCount {
+        /// Stable id of the simplex with malformed neighbor slots.
+        simplex_id: Uuid,
+        /// Expected number of neighbor slots.
+        expected: usize,
+        /// Actual number of neighbor slots.
+        actual: usize,
+    },
+    /// A simplex has an explicit unassigned neighbor slot.
+    #[error("simplex {simplex_id} has an unassigned neighbor slot at facet {facet_index}")]
+    UnassignedNeighborSlot {
+        /// Stable id of the simplex with an unassigned slot.
+        simplex_id: Uuid,
+        /// Facet index containing the unassigned slot.
+        facet_index: usize,
+    },
+    /// A simplex neighbor key does not resolve to a simplex.
+    #[error(
+        "simplex {simplex_id} facet {facet_index} references missing neighbor key {neighbor_key:?}"
+    )]
+    MissingNeighbor {
+        /// Stable id of the simplex containing the bad neighbor reference.
+        simplex_id: Uuid,
+        /// Facet index containing the neighbor key.
+        facet_index: usize,
+        /// Storage-local neighbor key that could not be resolved.
+        neighbor_key: SimplexKey,
+    },
+}
+
+/// Errors found when validating deserialized visualization data.
+#[derive(Clone, Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum VisualizationDataValidationError {
+    /// The schema name is not supported by this validator.
+    #[error("unsupported visualization schema {actual:?}; expected {expected:?}")]
+    InvalidSchema {
+        /// Expected schema name.
+        expected: &'static str,
+        /// Actual schema name.
+        actual: String,
+    },
+    /// The schema version is not supported by this validator.
+    #[error("unsupported visualization schema version {actual}; expected {expected}")]
+    InvalidSchemaVersion {
+        /// Expected schema version.
+        expected: u32,
+        /// Actual schema version.
+        actual: u32,
+    },
+    /// Metadata dimension does not match the const-generic export dimension.
+    #[error("metadata dimension {actual} does not match export dimension {expected}")]
+    DimensionMismatch {
+        /// Expected const-generic dimension.
+        expected: usize,
+        /// Actual metadata dimension.
+        actual: usize,
+    },
+    /// Metadata vertex count does not match the vertex table length.
+    #[error("metadata vertex_count {expected} does not match {actual} vertex records")]
+    VertexCountMismatch {
+        /// Metadata vertex count.
+        expected: usize,
+        /// Actual vertex table length.
+        actual: usize,
+    },
+    /// Metadata simplex count does not match the simplex table length.
+    #[error("metadata simplex_count {expected} does not match {actual} simplex records")]
+    SimplexCountMismatch {
+        /// Metadata simplex count.
+        expected: usize,
+        /// Actual simplex table length.
+        actual: usize,
+    },
+    /// Metadata topology kind is not one of the v1 schema names.
+    #[error(
+        "unsupported topology kind {actual}; expected one of Euclidean, Toroidal, Spherical, Hyperbolic"
+    )]
+    InvalidTopologyKind {
+        /// Actual topology-kind schema category.
+        actual: VisualizationTopologyKind,
+    },
+    /// Metadata topology guarantee is not one of the v1 schema names.
+    #[error(
+        "unsupported topology guarantee {actual}; expected one of Pseudomanifold, PLManifold, PLManifoldStrict"
+    )]
+    InvalidTopologyGuarantee {
+        /// Actual topology-guarantee schema category.
+        actual: VisualizationTopologyGuarantee,
+    },
+    /// A vertex record uses the nil UUID rather than a stable entity id.
+    #[error("vertex record {vertex_index} uses nil UUID")]
+    NilVertexId {
+        /// Position of the invalid vertex record in the raw vertex table.
+        vertex_index: usize,
+    },
+    /// A vertex has the wrong coordinate arity.
+    #[error("vertex {vertex_id} has {actual} coordinates; expected {expected}")]
+    InvalidVertexCoordinateCount {
+        /// Stable vertex id.
+        vertex_id: Uuid,
+        /// Expected coordinate count.
+        expected: usize,
+        /// Actual coordinate count.
+        actual: usize,
+    },
+    /// A vertex coordinate is not finite.
+    #[error("vertex {vertex_id} coordinate {coordinate_index} is non-finite: {value}")]
+    InvalidVertexCoordinateValue {
+        /// Stable vertex id.
+        vertex_id: Uuid,
+        /// Coordinate index containing the non-finite value.
+        coordinate_index: usize,
+        /// Non-finite coordinate category.
+        value: InvalidCoordinateValue,
+    },
+    /// The vertex table contains a duplicate stable id.
+    #[error("duplicate vertex id {vertex_id}")]
+    DuplicateVertexId {
+        /// Duplicated stable vertex id.
+        vertex_id: Uuid,
+    },
+    /// A simplex record uses the nil UUID rather than a stable entity id.
+    #[error("simplex record {simplex_index} uses nil UUID")]
+    NilSimplexId {
+        /// Position of the invalid simplex record in the raw simplex table.
+        simplex_index: usize,
+    },
+    /// A simplex has the wrong vertex arity.
+    #[error("simplex {simplex_id} has {actual} vertex ids; expected {expected}")]
+    InvalidSimplexVertexCount {
+        /// Stable simplex id.
+        simplex_id: Uuid,
+        /// Expected vertex id count.
+        expected: usize,
+        /// Actual vertex id count.
+        actual: usize,
+    },
+    /// The simplex table contains a duplicate stable id.
+    #[error("duplicate simplex id {simplex_id}")]
+    DuplicateSimplexId {
+        /// Duplicated stable simplex id.
+        simplex_id: Uuid,
+    },
+    /// A simplex references a vertex id absent from the vertex table.
+    #[error("simplex {simplex_id} references missing vertex id {vertex_id}")]
+    MissingSimplexVertex {
+        /// Stable simplex id.
+        simplex_id: Uuid,
+        /// Missing stable vertex id.
+        vertex_id: Uuid,
+    },
+    /// A simplex repeats a vertex id.
+    #[error("simplex {simplex_id} repeats vertex id {vertex_id}")]
+    DuplicateSimplexVertex {
+        /// Stable simplex id.
+        simplex_id: Uuid,
+        /// Repeated stable vertex id.
+        vertex_id: Uuid,
+    },
+    /// An adjacency record references an absent source simplex id.
+    #[error("adjacency references missing source simplex id {simplex_id}")]
+    MissingAdjacencySimplex {
+        /// Missing stable source simplex id.
+        simplex_id: Uuid,
+    },
+    /// An adjacency record uses an invalid facet index.
+    #[error(
+        "adjacency for simplex {simplex_id} has facet index {facet_index}; expected less than {max_exclusive}"
+    )]
+    InvalidAdjacencyFacetIndex {
+        /// Stable source simplex id.
+        simplex_id: Uuid,
+        /// Invalid facet index.
+        facet_index: usize,
+        /// Exclusive upper bound for valid facet indices.
+        max_exclusive: usize,
+    },
+    /// An adjacency record references an absent neighbor simplex id.
+    #[error(
+        "adjacency for simplex {simplex_id} facet {facet_index} references missing neighbor simplex id {neighbor_simplex_id}"
+    )]
+    MissingAdjacencyNeighbor {
+        /// Stable source simplex id.
+        simplex_id: Uuid,
+        /// Facet index for the bad neighbor reference.
+        facet_index: usize,
+        /// Missing stable neighbor simplex id.
+        neighbor_simplex_id: Uuid,
+    },
+    /// A non-boundary adjacency record points at a neighbor that does not share the source facet.
+    #[error(
+        "adjacency for simplex {simplex_id} facet {facet_index} references neighbor {neighbor_simplex_id}, but source facet vertex {missing_vertex_id} is absent from the neighbor"
+    )]
+    InvalidAdjacencyFacetSharing {
+        /// Stable source simplex id.
+        simplex_id: Uuid,
+        /// Facet index for the invalid neighbor reference.
+        facet_index: usize,
+        /// Neighbor simplex id that does not contain the source facet.
+        neighbor_simplex_id: Uuid,
+        /// Source-facet vertex that the neighbor simplex does not contain.
+        missing_vertex_id: Uuid,
+    },
+    /// The adjacency table has multiple records for one simplex facet.
+    #[error("duplicate adjacency record for simplex {simplex_id} facet {facet_index}")]
+    DuplicateAdjacency {
+        /// Stable source simplex id.
+        simplex_id: Uuid,
+        /// Duplicated facet index.
+        facet_index: usize,
+    },
+    /// The adjacency table is missing a required simplex-facet record.
+    #[error("missing adjacency record for simplex {simplex_id} facet {facet_index}")]
+    MissingAdjacency {
+        /// Stable source simplex id.
+        simplex_id: Uuid,
+        /// Missing facet index.
+        facet_index: usize,
+    },
+    /// A non-boundary adjacency record is not reciprocated by the neighbor simplex.
+    #[error(
+        "adjacency for simplex {simplex_id} facet {facet_index} references neighbor {neighbor_simplex_id}, but the neighbor does not reference it back"
+    )]
+    AsymmetricAdjacency {
+        /// Stable source simplex id.
+        simplex_id: Uuid,
+        /// Facet index for the asymmetric neighbor reference.
+        facet_index: usize,
+        /// Neighbor simplex id that does not reciprocate the link.
+        neighbor_simplex_id: Uuid,
+    },
+}
+
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
+    /// Exports this triangulation as generic visualization/interchange data.
+    ///
+    /// The returned value implements [`Serialize`] and [`Deserialize`] so callers
+    /// can write JSON with `serde_json`, feed the schema to notebooks or ML
+    /// pipelines, or adapt it for visualization and external editing tools.
+    /// Entity ids are vertex/simplex UUIDs, not runtime `VertexKey` or
+    /// `SimplexKey` debug strings.
+    ///
+    /// The returned value is an owned, detached snapshot of the triangulation's
+    /// current UUIDs, coordinates, simplex membership, and facet adjacency.
+    /// Mutating the triangulation later does not update this export; regenerate
+    /// the value when consumers need a fresh view of the topology.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisualizationExportError`] if the stored topology has missing
+    /// vertex references, missing neighbor references, or unassigned neighbor
+    /// slots. Valid constructed triangulations should export without error.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, vertex,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     vertex![0.0, 0.0, 0.0]?,
+    ///     vertex![1.0, 0.0, 0.0]?,
+    ///     vertex![0.0, 1.0, 0.0]?,
+    ///     vertex![0.0, 0.0, 1.0]?,
+    /// ];
+    /// let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    ///
+    /// let export = triangulation.to_visualization_data()?;
+    ///
+    /// assert_eq!(export.metadata.schema, "delaunay.simplicial_complex");
+    /// assert_eq!(export.metadata.dimension, 3);
+    /// assert_eq!(export.vertices.len(), 4);
+    /// assert_eq!(export.simplices.len(), 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn to_visualization_data(&self) -> Result<VisualizationData<D>, VisualizationExportError> {
+        let tds = self.tds();
+        let mut vertices: Vec<_> = tds
+            .vertices()
+            .map(|(_, vertex)| VertexRecord {
+                id: vertex.uuid(),
+                coordinates: vertex.point().coords().to_vec(),
+                attributes: None,
+            })
+            .collect();
+        vertices.sort_by_key(|record| record.id);
+
+        let mut simplices = Vec::with_capacity(tds.number_of_simplices());
+        let mut adjacency = Vec::with_capacity(tds.number_of_simplices().saturating_mul(D + 1));
+        for (_, simplex) in tds.simplices() {
+            let simplex_id = simplex.uuid();
+            let vertex_ids = simplex
+                .vertices()
+                .iter()
+                .copied()
+                .map(|vertex_key| {
+                    tds.vertex(vertex_key).map(Vertex::uuid).ok_or(
+                        VisualizationExportError::MissingVertex {
+                            simplex_id,
+                            vertex_key,
+                        },
+                    )
+                })
+                .collect::<Result<Vec<_>, _>>()?;
+
+            simplices.push(SimplexRecord {
+                id: simplex_id,
+                vertex_ids,
+                attributes: None,
+            });
+            push_adjacency_records(
+                tds,
+                simplex_id,
+                simplex.neighbor_slots().map(NeighborBuffer::as_slice),
+                &mut adjacency,
+            )?;
+        }
+        simplices.sort_by_key(|record| record.id);
+        adjacency.sort_by_key(|record| (record.simplex_id, record.facet_index));
+
+        Ok(VisualizationData {
+            metadata: VisualizationMetadata {
+                schema: VISUALIZATION_SCHEMA.to_owned(),
+                schema_version: VISUALIZATION_SCHEMA_VERSION,
+                producer: env!("CARGO_PKG_NAME").to_owned(),
+                dimension: D,
+                vertex_count: vertices.len(),
+                simplex_count: simplices.len(),
+                topology_kind: VisualizationTopologyKind::from(self.topology_kind()),
+                topology_guarantee: VisualizationTopologyGuarantee::from(self.topology_guarantee()),
+                attributes: None,
+            },
+            vertices,
+            simplices,
+            adjacency,
+        })
+    }
+
+    /// Exports this triangulation as the default stable mesh interchange value.
+    ///
+    /// This is an ergonomic alias for [`to_visualization_data`](Self::to_visualization_data)
+    /// when callers want the v1 generic simplicial-complex schema without extra
+    /// downstream attributes.
+    ///
+    /// Like [`to_visualization_data`](Self::to_visualization_data), this returns
+    /// an owned, detached snapshot. Mutating the source triangulation after
+    /// export does not update the mesh export.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`MeshExportError`] under the same conditions as
+    /// [`to_visualization_data`](Self::to_visualization_data).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, vertex,
+    /// };
+    /// use delaunay::prelude::export::MESH_EXPORT_SCHEMA;
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     vertex![0.0, 0.0, 0.0]?,
+    ///     vertex![1.0, 0.0, 0.0]?,
+    ///     vertex![0.0, 1.0, 0.0]?,
+    ///     vertex![0.0, 0.0, 1.0]?,
+    /// ];
+    /// let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    ///
+    /// let export = triangulation.to_mesh_export()?;
+    ///
+    /// assert_eq!(export.metadata.schema, MESH_EXPORT_SCHEMA);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn to_mesh_export(&self) -> Result<MeshExport<D>, MeshExportError> {
+        self.to_visualization_data()
+    }
+}
+
+/// Canonicalizes detached record order for deterministic validated exports.
+fn canonicalize_record_order<
+    const D: usize,
+    VertexAttributes,
+    SimplexAttributes,
+    AdjacencyAttributes,
+    GlobalAttributes,
+>(
+    data: &mut VisualizationData<
+        D,
+        VertexAttributes,
+        SimplexAttributes,
+        AdjacencyAttributes,
+        GlobalAttributes,
+    >,
+) {
+    data.vertices.sort_by_key(|record| record.id);
+    data.simplices.sort_by_key(|record| record.id);
+    data.adjacency
+        .sort_by_key(|record| (record.simplex_id, record.facet_index));
+}
+
+/// Validates whole-payload schema metadata before walking entity records.
+fn validate_metadata<const D: usize, Attributes>(
+    metadata: &VisualizationMetadata<Attributes>,
+    vertex_count: usize,
+    simplex_count: usize,
+) -> Result<(), VisualizationDataValidationError> {
+    if metadata.schema != VISUALIZATION_SCHEMA {
+        return Err(VisualizationDataValidationError::InvalidSchema {
+            expected: VISUALIZATION_SCHEMA,
+            actual: metadata.schema.clone(),
+        });
+    }
+    if metadata.schema_version != VISUALIZATION_SCHEMA_VERSION {
+        return Err(VisualizationDataValidationError::InvalidSchemaVersion {
+            expected: VISUALIZATION_SCHEMA_VERSION,
+            actual: metadata.schema_version,
+        });
+    }
+    if metadata.dimension != D {
+        return Err(VisualizationDataValidationError::DimensionMismatch {
+            expected: D,
+            actual: metadata.dimension,
+        });
+    }
+    if metadata.vertex_count != vertex_count {
+        return Err(VisualizationDataValidationError::VertexCountMismatch {
+            expected: metadata.vertex_count,
+            actual: vertex_count,
+        });
+    }
+    if metadata.simplex_count != simplex_count {
+        return Err(VisualizationDataValidationError::SimplexCountMismatch {
+            expected: metadata.simplex_count,
+            actual: simplex_count,
+        });
+    }
+    if !metadata.topology_kind.is_supported() {
+        return Err(VisualizationDataValidationError::InvalidTopologyKind {
+            actual: metadata.topology_kind.clone(),
+        });
+    }
+    if !metadata.topology_guarantee.is_supported() {
+        return Err(VisualizationDataValidationError::InvalidTopologyGuarantee {
+            actual: metadata.topology_guarantee.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Validates that adjacency records reference known simplices, share their
+/// claimed source facet, and cover every facet once.
+fn validate_adjacency<const D: usize, SimplexAttributes, AdjacencyAttributes>(
+    adjacency: &[AdjacencyRecord<AdjacencyAttributes>],
+    simplices: &[SimplexRecord<SimplexAttributes>],
+) -> Result<(), VisualizationDataValidationError> {
+    let simplex_by_id: HashMap<_, _> = simplices
+        .iter()
+        .map(|simplex| (simplex.id, simplex))
+        .collect();
+    let max_exclusive = D + 1;
+    let mut adjacency_slots = HashSet::with_capacity(adjacency.len());
+    let mut neighbor_edges = HashSet::with_capacity(adjacency.len());
+
+    for record in adjacency {
+        let Some(source_simplex) = simplex_by_id.get(&record.simplex_id) else {
+            return Err(VisualizationDataValidationError::MissingAdjacencySimplex {
+                simplex_id: record.simplex_id,
+            });
+        };
+        if record.facet_index >= max_exclusive {
+            return Err(
+                VisualizationDataValidationError::InvalidAdjacencyFacetIndex {
+                    simplex_id: record.simplex_id,
+                    facet_index: record.facet_index,
+                    max_exclusive,
+                },
+            );
+        }
+        if let Some(neighbor_simplex_id) = record.neighbor_simplex_id {
+            let Some(neighbor_simplex) = simplex_by_id.get(&neighbor_simplex_id) else {
+                return Err(VisualizationDataValidationError::MissingAdjacencyNeighbor {
+                    simplex_id: record.simplex_id,
+                    facet_index: record.facet_index,
+                    neighbor_simplex_id,
+                });
+            };
+            if let Some(missing_vertex_id) =
+                missing_source_facet_vertex(source_simplex, neighbor_simplex, record.facet_index)
+            {
+                return Err(
+                    VisualizationDataValidationError::InvalidAdjacencyFacetSharing {
+                        simplex_id: record.simplex_id,
+                        facet_index: record.facet_index,
+                        neighbor_simplex_id,
+                        missing_vertex_id,
+                    },
+                );
+            }
+            neighbor_edges.insert((record.simplex_id, neighbor_simplex_id));
+        }
+        if !adjacency_slots.insert((record.simplex_id, record.facet_index)) {
+            return Err(VisualizationDataValidationError::DuplicateAdjacency {
+                simplex_id: record.simplex_id,
+                facet_index: record.facet_index,
+            });
+        }
+    }
+
+    for simplex in simplices {
+        for facet_index in 0..max_exclusive {
+            if !adjacency_slots.contains(&(simplex.id, facet_index)) {
+                return Err(VisualizationDataValidationError::MissingAdjacency {
+                    simplex_id: simplex.id,
+                    facet_index,
+                });
+            }
+        }
+    }
+
+    for record in adjacency {
+        if let Some(neighbor_simplex_id) = record.neighbor_simplex_id
+            && !neighbor_edges.contains(&(neighbor_simplex_id, record.simplex_id))
+        {
+            return Err(VisualizationDataValidationError::AsymmetricAdjacency {
+                simplex_id: record.simplex_id,
+                facet_index: record.facet_index,
+                neighbor_simplex_id,
+            });
+        }
+    }
+
+    Ok(())
+}
+
+/// Finds the first source-facet vertex absent from the candidate neighbor simplex.
+fn missing_source_facet_vertex<SimplexAttributes>(
+    source_simplex: &SimplexRecord<SimplexAttributes>,
+    neighbor_simplex: &SimplexRecord<SimplexAttributes>,
+    facet_index: usize,
+) -> Option<Uuid> {
+    source_simplex
+        .vertex_ids
+        .iter()
+        .enumerate()
+        .filter(|(vertex_index, _)| *vertex_index != facet_index)
+        .map(|(_, vertex_id)| *vertex_id)
+        .find(|vertex_id| !neighbor_simplex.vertex_ids.contains(vertex_id))
+}
+
+/// Resolves facet-neighbor slots to stable adjacency records.
+fn push_adjacency_records<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    simplex_id: Uuid,
+    neighbor_slots: Option<&[NeighborSlot]>,
+    adjacency: &mut Vec<AdjacencyRecord>,
+) -> Result<(), VisualizationExportError> {
+    let slots =
+        neighbor_slots.ok_or(VisualizationExportError::UnassignedNeighborBuffer { simplex_id })?;
+    if slots.len() != D + 1 {
+        return Err(VisualizationExportError::InvalidNeighborCount {
+            simplex_id,
+            expected: D + 1,
+            actual: slots.len(),
+        });
+    }
+
+    for (facet_index, slot) in slots.iter().copied().enumerate() {
+        let record = match slot {
+            NeighborSlot::Boundary => AdjacencyRecord {
+                simplex_id,
+                facet_index,
+                neighbor_simplex_id: None,
+                attributes: None,
+            },
+            NeighborSlot::Neighbor(neighbor_key) => tds
+                .simplex(neighbor_key)
+                .map(|neighbor| AdjacencyRecord {
+                    simplex_id,
+                    facet_index,
+                    neighbor_simplex_id: Some(neighbor.uuid()),
+                    attributes: None,
+                })
+                .ok_or(VisualizationExportError::MissingNeighbor {
+                    simplex_id,
+                    facet_index,
+                    neighbor_key,
+                })?,
+            NeighborSlot::Unassigned => {
+                return Err(VisualizationExportError::UnassignedNeighborSlot {
+                    simplex_id,
+                    facet_index,
+                });
+            }
+        };
+        adjacency.push(record);
+    }
+
+    Ok(())
+}

--- a/src/io/visualization.rs
+++ b/src/io/visualization.rs
@@ -1296,3 +1296,92 @@ fn push_adjacency_records<U, V, const D: usize>(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use slotmap::KeyData;
+
+    #[test]
+    fn push_adjacency_records_rejects_wrong_neighbor_arity() {
+        let tds: Tds<(), (), 2> = Tds::empty();
+        let simplex_id = Uuid::from_u128(0x3000_0000_0000_0000_0000_0000_0000_0001);
+        let mut adjacency = Vec::new();
+
+        let error = push_adjacency_records(
+            &tds,
+            simplex_id,
+            Some(&[NeighborSlot::Boundary]),
+            &mut adjacency,
+        )
+        .expect_err("neighbor buffers must have one slot per simplex facet");
+
+        assert_eq!(
+            error,
+            VisualizationExportError::InvalidNeighborCount {
+                simplex_id,
+                expected: 3,
+                actual: 1,
+            }
+        );
+        assert!(adjacency.is_empty());
+    }
+
+    #[test]
+    fn push_adjacency_records_rejects_unassigned_neighbor_slot() {
+        let tds: Tds<(), (), 2> = Tds::empty();
+        let simplex_id = Uuid::from_u128(0x3000_0000_0000_0000_0000_0000_0000_0002);
+        let mut adjacency = Vec::new();
+
+        let error = push_adjacency_records(
+            &tds,
+            simplex_id,
+            Some(&[
+                NeighborSlot::Unassigned,
+                NeighborSlot::Boundary,
+                NeighborSlot::Boundary,
+            ]),
+            &mut adjacency,
+        )
+        .expect_err("export must reject explicit unassigned neighbor slots");
+
+        assert_eq!(
+            error,
+            VisualizationExportError::UnassignedNeighborSlot {
+                simplex_id,
+                facet_index: 0,
+            }
+        );
+        assert!(adjacency.is_empty());
+    }
+
+    #[test]
+    fn push_adjacency_records_rejects_dangling_neighbor_key() {
+        let tds: Tds<(), (), 2> = Tds::empty();
+        let simplex_id = Uuid::from_u128(0x3000_0000_0000_0000_0000_0000_0000_0003);
+        let neighbor_key = SimplexKey::from(KeyData::from_ffi(1));
+        let mut adjacency = Vec::new();
+
+        let error = push_adjacency_records(
+            &tds,
+            simplex_id,
+            Some(&[
+                NeighborSlot::Neighbor(neighbor_key),
+                NeighborSlot::Boundary,
+                NeighborSlot::Boundary,
+            ]),
+            &mut adjacency,
+        )
+        .expect_err("export must reject neighbor keys absent from the TDS");
+
+        assert_eq!(
+            error,
+            VisualizationExportError::MissingNeighbor {
+                simplex_id,
+                facet_index: 0,
+                neighbor_key,
+            }
+        );
+        assert!(adjacency.is_empty());
+    }
+}

--- a/src/io/visualization.rs
+++ b/src/io/visualization.rs
@@ -275,7 +275,8 @@ impl<const D: usize, VertexAttributes, SimplexAttributes, AdjacencyAttributes, G
     ///
     /// Returns [`VisualizationDataValidationError`] when schema metadata,
     /// coordinate values or arity, non-nil ids, connectivity, facet coverage,
-    /// or reciprocal facet-compatible adjacency are inconsistent.
+    /// or reciprocal facet-compatible adjacency, including distinct reciprocal
+    /// records for self-neighbor facets, are inconsistent.
     pub fn into_validated(
         self,
     ) -> Result<
@@ -304,7 +305,8 @@ impl<const D: usize, VertexAttributes, SimplexAttributes, AdjacencyAttributes, G
     ///
     /// Returns [`VisualizationDataValidationError`] when schema metadata,
     /// coordinate values or arity, non-nil ids, connectivity, facet coverage,
-    /// or reciprocal facet-compatible adjacency are inconsistent.
+    /// or reciprocal facet-compatible adjacency, including distinct reciprocal
+    /// records for self-neighbor facets, are inconsistent.
     ///
     /// # Examples
     ///
@@ -412,11 +414,12 @@ impl<const D: usize, VertexAttributes, SimplexAttributes, AdjacencyAttributes, G
 /// Raw visualization data keeps public fields for serde, external JSON, and
 /// fixtures. This wrapper is the parsed form to pass inward once schema
 /// metadata, finite coordinate values, dimensions, non-nil ids, connectivity,
-/// and facet-compatible adjacency have been checked. Parsing canonicalizes
-/// record order by stable ids so serialized validated values remain
-/// deterministic. This remains an owned, detached snapshot; its accessors
-/// borrow records from the validated snapshot, not from the source
-/// triangulation.
+/// facet coverage, and reciprocal facet-compatible adjacency have been checked.
+/// Self-neighbor facets require distinct reciprocal records so a one-sided
+/// self-gluing cannot validate as closed topology. Parsing canonicalizes record
+/// order by stable ids so serialized validated values remain deterministic.
+/// This remains an owned, detached snapshot; its accessors borrow records from
+/// the validated snapshot, not from the source triangulation.
 #[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(transparent)]
 pub struct ValidatedVisualizationData<
@@ -451,7 +454,8 @@ impl<const D: usize, VertexAttributes, SimplexAttributes, AdjacencyAttributes, G
     ///
     /// Returns [`VisualizationDataValidationError`] when schema metadata,
     /// coordinate values or arity, non-nil ids, connectivity, facet coverage,
-    /// or reciprocal facet-compatible adjacency are inconsistent.
+    /// or reciprocal facet-compatible adjacency, including distinct reciprocal
+    /// records for self-neighbor facets, are inconsistent.
     pub fn try_from_raw(
         mut raw: VisualizationData<
             D,
@@ -603,7 +607,9 @@ pub struct AdjacencyRecord<Attributes = ()> {
     pub facet_index: usize,
     /// Stable id of the neighboring simplex across this facet.
     ///
-    /// `None` denotes a boundary facet.
+    /// `None` denotes a boundary facet. When this points back to `simplex_id`,
+    /// validation still requires a distinct reciprocal adjacency record for the
+    /// matching self-neighbor facet.
     pub neighbor_simplex_id: Option<Uuid>,
     /// Optional downstream per-adjacency metadata.
     #[serde(default = "no_attributes", skip_serializing_if = "Option::is_none")]
@@ -1112,7 +1118,7 @@ fn validate_metadata<const D: usize, Attributes>(
 }
 
 /// Validates that adjacency records reference known simplices, share their
-/// claimed source facet, and cover every facet once.
+/// claimed source facet, cover every facet once, and reciprocate neighbors.
 fn validate_adjacency<const D: usize, SimplexAttributes, AdjacencyAttributes>(
     adjacency: &[AdjacencyRecord<AdjacencyAttributes>],
     simplices: &[SimplexRecord<SimplexAttributes>],
@@ -1123,7 +1129,7 @@ fn validate_adjacency<const D: usize, SimplexAttributes, AdjacencyAttributes>(
         .collect();
     let max_exclusive = D + 1;
     let mut adjacency_slots = HashSet::with_capacity(adjacency.len());
-    let mut neighbor_edges = HashSet::with_capacity(adjacency.len());
+    let mut neighbor_edge_counts = HashMap::with_capacity(adjacency.len());
 
     for record in adjacency {
         let Some(source_simplex) = simplex_by_id.get(&record.simplex_id) else {
@@ -1160,7 +1166,9 @@ fn validate_adjacency<const D: usize, SimplexAttributes, AdjacencyAttributes>(
                     },
                 );
             }
-            neighbor_edges.insert((record.simplex_id, neighbor_simplex_id));
+            *neighbor_edge_counts
+                .entry((record.simplex_id, neighbor_simplex_id))
+                .or_insert(0) += 1;
         }
         if !adjacency_slots.insert((record.simplex_id, record.facet_index)) {
             return Err(VisualizationDataValidationError::DuplicateAdjacency {
@@ -1183,7 +1191,11 @@ fn validate_adjacency<const D: usize, SimplexAttributes, AdjacencyAttributes>(
 
     for record in adjacency {
         if let Some(neighbor_simplex_id) = record.neighbor_simplex_id
-            && !neighbor_edges.contains(&(neighbor_simplex_id, record.simplex_id))
+            && !has_reciprocal_adjacency(
+                &neighbor_edge_counts,
+                record.simplex_id,
+                neighbor_simplex_id,
+            )
         {
             return Err(VisualizationDataValidationError::AsymmetricAdjacency {
                 simplex_id: record.simplex_id,
@@ -1194,6 +1206,29 @@ fn validate_adjacency<const D: usize, SimplexAttributes, AdjacencyAttributes>(
     }
 
     Ok(())
+}
+
+/// Enforces the exported adjacency reciprocity contract.
+///
+/// Ordinary neighbors reciprocate when the neighbor simplex has any record
+/// pointing back to the source simplex. For self-neighbors, the edge count must
+/// exceed the current record because the record itself cannot satisfy
+/// reciprocity.
+fn has_reciprocal_adjacency(
+    neighbor_edge_counts: &HashMap<(Uuid, Uuid), usize>,
+    simplex_id: Uuid,
+    neighbor_simplex_id: Uuid,
+) -> bool {
+    let reciprocal_count = neighbor_edge_counts
+        .get(&(neighbor_simplex_id, simplex_id))
+        .copied()
+        .unwrap_or(0);
+
+    if neighbor_simplex_id == simplex_id {
+        reciprocal_count > 1
+    } else {
+        reciprocal_count > 0
+    }
 }
 
 /// Finds the first source-facet vertex absent from the candidate neighbor simplex.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -744,6 +744,14 @@ pub(crate) mod triangulation;
 #[path = "delaunay/validation.rs"]
 pub mod validation;
 
+/// I/O and downstream-facing export data models.
+pub mod io {
+    /// Generic simplicial-complex export data for notebooks and downstream tools.
+    pub mod visualization;
+
+    pub use visualization::*;
+}
+
 // Re-export commonly used Delaunay-facing types at the crate root.
 pub use crate::builder::DelaunayTriangulationBuilder;
 pub use crate::construction::{
@@ -785,6 +793,14 @@ pub use crate::core::validation::{
     TopologyGuarantee, TriangulationValidationError, ValidationConfigurationError, ValidationPolicy,
 };
 pub use crate::deletion::DeleteVertexError;
+pub use crate::io::visualization::{
+    AdjacencyRecord, MESH_EXPORT_SCHEMA, MESH_EXPORT_SCHEMA_VERSION, MeshAdjacencyRecord,
+    MeshExport, MeshExportError, MeshExportValidationError, MeshSimplexRecord, MeshVertexRecord,
+    SimplexRecord, VISUALIZATION_SCHEMA, VISUALIZATION_SCHEMA_VERSION, ValidatedMeshExport,
+    ValidatedVisualizationData, VertexRecord, VisualizationData, VisualizationDataValidationError,
+    VisualizationExportError, VisualizationMetadata, VisualizationTopologyGuarantee,
+    VisualizationTopologyKind,
+};
 pub use crate::repair::{
     DelaunayCheckPolicy, DelaunayRepairHeuristicConfig, DelaunayRepairHeuristicSeeds,
     DelaunayRepairOperation, DelaunayRepairOutcome, DelaunayRepairPolicy,
@@ -1708,6 +1724,45 @@ pub mod prelude {
         pub use crate::{
             DelaunayViolationDetail, DelaunayViolationReport, debug_print_first_delaunay_violation,
             delaunay_violation_report,
+        };
+    }
+
+    /// Focused exports for generic simplicial-complex export data.
+    ///
+    /// These records are intended for notebooks, visualization tools, ML
+    /// pipelines, and downstream crates that want stable vertex/simplex ids
+    /// without depending on storage-local TDS handles.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, vertex,
+    /// };
+    /// use delaunay::prelude::export::MESH_EXPORT_SCHEMA;
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     vertex![0.0, 0.0]?,
+    ///     vertex![1.0, 0.0]?,
+    ///     vertex![0.0, 1.0]?,
+    /// ];
+    /// let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    /// let export = triangulation.to_mesh_export()?;
+    ///
+    /// assert_eq!(export.metadata.schema, MESH_EXPORT_SCHEMA);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub mod export {
+        pub use crate::geometry::traits::coordinate::InvalidCoordinateValue;
+        pub use crate::io::visualization::{
+            AdjacencyRecord, MESH_EXPORT_SCHEMA, MESH_EXPORT_SCHEMA_VERSION, MeshAdjacencyRecord,
+            MeshExport, MeshExportError, MeshExportValidationError, MeshSimplexRecord,
+            MeshVertexRecord, SimplexRecord, VISUALIZATION_SCHEMA, VISUALIZATION_SCHEMA_VERSION,
+            ValidatedMeshExport, ValidatedVisualizationData, VertexRecord, VisualizationData,
+            VisualizationDataValidationError, VisualizationExportError, VisualizationMetadata,
+            VisualizationTopologyGuarantee, VisualizationTopologyKind,
         };
     }
 

--- a/tests/mesh_export.rs
+++ b/tests/mesh_export.rs
@@ -11,7 +11,7 @@ use std::{
 use delaunay::geometry::CoordinateConversionError;
 use delaunay::prelude::construction::{
     DelaunayError, DelaunayResult, DelaunayTriangulationBuilder,
-    DelaunayTriangulationConstructionError, Vertex, vertex,
+    DelaunayTriangulationConstructionError, TopologyGuarantee, Vertex, vertex,
 };
 use delaunay::prelude::export::{
     AdjacencyRecord, InvalidCoordinateValue, MESH_EXPORT_SCHEMA, MESH_EXPORT_SCHEMA_VERSION,
@@ -19,6 +19,7 @@ use delaunay::prelude::export::{
     VertexRecord, VisualizationData, VisualizationDataValidationError, VisualizationExportError,
     VisualizationMetadata, VisualizationTopologyGuarantee, VisualizationTopologyKind,
 };
+use delaunay::prelude::topology::spaces::TopologyKind;
 use uuid::Uuid;
 
 #[derive(Debug, thiserror::Error)]
@@ -275,6 +276,72 @@ fn mesh_export_round_trips_for_dimensions_2_through_5() -> Result<(), MeshExport
     assert_mesh_export_round_trip_for_dimension::<3>()?;
     assert_mesh_export_round_trip_for_dimension::<4>()?;
     assert_mesh_export_round_trip_for_dimension::<5>()?;
+    Ok(())
+}
+
+#[test]
+fn visualization_topology_schema_categories_are_stable() -> Result<(), MeshExportTestError> {
+    for (source, expected, schema) in [
+        (
+            TopologyKind::Euclidean,
+            VisualizationTopologyKind::Euclidean,
+            "Euclidean",
+        ),
+        (
+            TopologyKind::Toroidal,
+            VisualizationTopologyKind::Toroidal,
+            "Toroidal",
+        ),
+        (
+            TopologyKind::Spherical,
+            VisualizationTopologyKind::Spherical,
+            "Spherical",
+        ),
+        (
+            TopologyKind::Hyperbolic,
+            VisualizationTopologyKind::Hyperbolic,
+            "Hyperbolic",
+        ),
+    ] {
+        let converted = VisualizationTopologyKind::from(source);
+
+        assert_eq!(converted, expected);
+        assert_eq!(converted.to_string(), schema);
+        assert_eq!(serde_json::to_value(&converted)?, serde_json::json!(schema));
+        assert_eq!(
+            serde_json::from_value::<VisualizationTopologyKind>(serde_json::json!(schema))?,
+            expected
+        );
+    }
+
+    for (source, expected, schema) in [
+        (
+            TopologyGuarantee::Pseudomanifold,
+            VisualizationTopologyGuarantee::Pseudomanifold,
+            "Pseudomanifold",
+        ),
+        (
+            TopologyGuarantee::PLManifold,
+            VisualizationTopologyGuarantee::PLManifold,
+            "PLManifold",
+        ),
+        (
+            TopologyGuarantee::PLManifoldStrict,
+            VisualizationTopologyGuarantee::PLManifoldStrict,
+            "PLManifoldStrict",
+        ),
+    ] {
+        let converted = VisualizationTopologyGuarantee::from(source);
+
+        assert_eq!(converted, expected);
+        assert_eq!(converted.to_string(), schema);
+        assert_eq!(serde_json::to_value(&converted)?, serde_json::json!(schema));
+        assert_eq!(
+            serde_json::from_value::<VisualizationTopologyGuarantee>(serde_json::json!(schema))?,
+            expected
+        );
+    }
+
     Ok(())
 }
 
@@ -850,6 +917,27 @@ fn visualization_data_into_validated_carries_validation_proof() -> Result<(), Me
         serde_json::to_value(&export)?
     );
     assert_eq!(validated.into_raw(), export);
+
+    Ok(())
+}
+
+#[test]
+fn visualization_data_try_from_carries_validation_proof() -> Result<(), MeshExportTestError> {
+    let export = sample_export()?;
+    let validated = ValidatedMeshExport::<2>::try_from(export.clone())?;
+
+    assert_eq!(validated.as_raw(), &export);
+
+    let mut invalid = export;
+    let actual = invalid.simplices.len();
+    invalid.metadata.simplex_count = actual + 1;
+    assert_eq!(
+        ValidatedMeshExport::<2>::try_from(invalid),
+        Err(VisualizationDataValidationError::SimplexCountMismatch {
+            expected: actual + 1,
+            actual,
+        })
+    );
 
     Ok(())
 }

--- a/tests/mesh_export.rs
+++ b/tests/mesh_export.rs
@@ -1,0 +1,766 @@
+//! Public mesh and visualization export tests.
+
+#![forbid(unsafe_code)]
+
+use std::{
+    assert_matches,
+    collections::{HashMap, HashSet},
+};
+
+use delaunay::geometry::CoordinateConversionError;
+use delaunay::io::visualization::{
+    AdjacencyRecord, MESH_EXPORT_SCHEMA, MESH_EXPORT_SCHEMA_VERSION, MeshExport, MeshExportError,
+    SimplexRecord, ValidatedMeshExport, ValidatedVisualizationData, VertexRecord,
+    VisualizationData, VisualizationDataValidationError, VisualizationExportError,
+    VisualizationMetadata, VisualizationTopologyGuarantee, VisualizationTopologyKind,
+};
+use delaunay::prelude::construction::{
+    DelaunayError, DelaunayResult, DelaunayTriangulationBuilder,
+    DelaunayTriangulationConstructionError, vertex,
+};
+use delaunay::prelude::geometry::InvalidCoordinateValue;
+use uuid::Uuid;
+
+#[derive(Debug, thiserror::Error)]
+enum MeshExportTestError {
+    #[error(transparent)]
+    Construction(#[from] DelaunayTriangulationConstructionError),
+    #[error(transparent)]
+    Coordinate(#[from] CoordinateConversionError),
+    #[error(transparent)]
+    Export(#[from] MeshExportError),
+    #[error(transparent)]
+    Validation(#[from] VisualizationDataValidationError),
+    #[error(transparent)]
+    Serde(#[from] serde_json::Error),
+}
+
+struct OpaqueAttribute;
+
+#[derive(Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+struct NonDefaultAttribute;
+
+fn sample_export() -> Result<MeshExport<2>, MeshExportTestError> {
+    let vertices = vec![
+        vertex![0.0, 0.0]?,
+        vertex![2.0, 0.0]?,
+        vertex![0.0, 2.0]?,
+        vertex![0.25, 0.25]?,
+    ];
+    let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+
+    Ok(triangulation.to_mesh_export()?)
+}
+
+fn sample_delaunay_result_export() -> DelaunayResult<MeshExport<2>> {
+    let vertices = vec![
+        vertex![0.0, 0.0]?,
+        vertex![2.0, 0.0]?,
+        vertex![0.0, 2.0]?,
+        vertex![0.25, 0.25]?,
+    ];
+    let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+
+    Ok(triangulation.to_mesh_export()?)
+}
+
+fn assert_connectivity_ids_exist<const D: usize>(export: &MeshExport<D>) {
+    let vertex_ids: HashSet<_> = export.vertices.iter().map(|vertex| vertex.id).collect();
+    let simplex_ids: HashSet<_> = export.simplices.iter().map(|simplex| simplex.id).collect();
+
+    assert_eq!(vertex_ids.len(), export.vertices.len());
+    assert_eq!(simplex_ids.len(), export.simplices.len());
+
+    for simplex in &export.simplices {
+        assert_eq!(simplex.vertex_ids.len(), D + 1);
+        for vertex_id in &simplex.vertex_ids {
+            assert!(
+                vertex_ids.contains(vertex_id),
+                "simplex {} references missing vertex {}",
+                simplex.id,
+                vertex_id
+            );
+        }
+    }
+
+    for adjacency in &export.adjacency {
+        assert!(
+            simplex_ids.contains(&adjacency.simplex_id),
+            "adjacency references missing simplex {}",
+            adjacency.simplex_id
+        );
+        assert!(adjacency.facet_index < D + 1);
+        if let Some(neighbor_id) = adjacency.neighbor_simplex_id {
+            assert!(
+                simplex_ids.contains(&neighbor_id),
+                "adjacency references missing neighbor {neighbor_id}"
+            );
+        }
+    }
+}
+
+fn assert_neighbor_links_are_symmetric(export: &MeshExport<2>) {
+    let neighbor_links: HashSet<_> = export
+        .adjacency
+        .iter()
+        .filter_map(|adjacency| {
+            adjacency
+                .neighbor_simplex_id
+                .map(|neighbor_id| (adjacency.simplex_id, neighbor_id))
+        })
+        .collect();
+
+    for &(simplex_id, neighbor_id) in &neighbor_links {
+        assert!(
+            neighbor_links.contains(&(neighbor_id, simplex_id)),
+            "neighbor link {simplex_id} -> {neighbor_id} is not reciprocal"
+        );
+    }
+}
+
+const fn assert_send_sync_unpin<T: Send + Sync + Unpin>() {}
+
+#[test]
+fn mesh_export_json_contains_schema_ids_and_connectivity() -> Result<(), MeshExportTestError> {
+    let export = sample_export()?;
+
+    assert_eq!(export.metadata.schema, MESH_EXPORT_SCHEMA);
+    assert_eq!(export.metadata.schema_version, MESH_EXPORT_SCHEMA_VERSION);
+    assert_eq!(export.metadata.producer, "delaunay");
+    assert_eq!(export.metadata.dimension, 2);
+    assert_eq!(export.metadata.vertex_count, export.vertices.len());
+    assert_eq!(export.metadata.simplex_count, export.simplices.len());
+    export.validate()?;
+    assert_eq!(export.vertices.len(), 4);
+    assert!(!export.simplices.is_empty());
+    assert_eq!(export.adjacency.len(), export.simplices.len() * 3);
+
+    assert_connectivity_ids_exist(&export);
+    assert_neighbor_links_are_symmetric(&export);
+
+    let json = serde_json::to_value(&export)?;
+    assert_eq!(json["metadata"]["schema"], MESH_EXPORT_SCHEMA);
+    assert_eq!(
+        json["metadata"]["schema_version"],
+        MESH_EXPORT_SCHEMA_VERSION
+    );
+    assert_eq!(json["metadata"]["dimension"], 2);
+    assert!(
+        json["vertices"]
+            .as_array()
+            .is_some_and(|vertices| !vertices.is_empty())
+    );
+    assert!(
+        json["simplices"]
+            .as_array()
+            .is_some_and(|simplices| !simplices.is_empty())
+    );
+    assert!(
+        json["adjacency"]
+            .as_array()
+            .is_some_and(|adjacency| !adjacency.is_empty())
+    );
+
+    Ok(())
+}
+
+fn assert_validation_error(
+    export: &MeshExport<2>,
+    expected: VisualizationDataValidationError,
+) -> Result<(), MeshExportTestError> {
+    let json = serde_json::to_string(&export)?;
+    let decoded: MeshExport<2> = serde_json::from_str(&json)?;
+
+    assert_eq!(decoded.validate(), Err(expected));
+    Ok(())
+}
+
+#[test]
+fn mesh_export_validation_rejects_bad_metadata() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    export.metadata.schema = "not.delaunay".to_owned();
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidSchema {
+            expected: MESH_EXPORT_SCHEMA,
+            actual: "not.delaunay".to_owned(),
+        },
+    )?;
+
+    let mut export = sample_export()?;
+    export.metadata.schema_version = 0;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidSchemaVersion {
+            expected: MESH_EXPORT_SCHEMA_VERSION,
+            actual: 0,
+        },
+    )?;
+
+    let mut export = sample_export()?;
+    export.metadata.dimension = 3;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::DimensionMismatch {
+            expected: 2,
+            actual: 3,
+        },
+    )?;
+
+    let mut export = sample_export()?;
+    let actual = export.vertices.len();
+    export.metadata.vertex_count = actual + 1;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::VertexCountMismatch {
+            expected: actual + 1,
+            actual,
+        },
+    )?;
+
+    let mut export = sample_export()?;
+    let actual = export.simplices.len();
+    export.metadata.simplex_count = actual + 1;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::SimplexCountMismatch {
+            expected: actual + 1,
+            actual,
+        },
+    )?;
+
+    let mut export = sample_export()?;
+    export.metadata.topology_kind = VisualizationTopologyKind::Unknown {
+        actual: "Cartesian".to_owned(),
+    };
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidTopologyKind {
+            actual: VisualizationTopologyKind::Unknown {
+                actual: "Cartesian".to_owned(),
+            },
+        },
+    )?;
+
+    let mut export = sample_export()?;
+    export.metadata.topology_guarantee = VisualizationTopologyGuarantee::Unknown {
+        actual: "Triangulation".to_owned(),
+    };
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidTopologyGuarantee {
+            actual: VisualizationTopologyGuarantee::Unknown {
+                actual: "Triangulation".to_owned(),
+            },
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_bad_vertex_arity() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let vertex_id = export.vertices[0].id;
+    export.vertices[0].coordinates.pop();
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidVertexCoordinateCount {
+            vertex_id,
+            expected: 2,
+            actual: 1,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_non_finite_coordinates() -> Result<(), MeshExportTestError> {
+    for (coordinate, expected_value) in [
+        (f64::NAN, InvalidCoordinateValue::Nan),
+        (f64::INFINITY, InvalidCoordinateValue::PositiveInfinity),
+        (f64::NEG_INFINITY, InvalidCoordinateValue::NegativeInfinity),
+    ] {
+        let mut export = sample_export()?;
+        let vertex_id = export.vertices[0].id;
+        export.vertices[0].coordinates[1] = coordinate;
+
+        assert_eq!(
+            export.into_validated(),
+            Err(
+                VisualizationDataValidationError::InvalidVertexCoordinateValue {
+                    vertex_id,
+                    coordinate_index: 1,
+                    value: expected_value,
+                }
+            )
+        );
+    }
+
+    Ok(())
+}
+
+#[test]
+fn mesh_export_validation_rejects_nil_vertex_ids() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    export.vertices[0].id = Uuid::nil();
+
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::NilVertexId { vertex_index: 0 },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_duplicate_vertex_ids() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let vertex_id = export.vertices[0].id;
+    export.vertices[1].id = vertex_id;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::DuplicateVertexId { vertex_id },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_bad_simplex_arity() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let simplex_id = export.simplices[0].id;
+    export.simplices[0].vertex_ids.pop();
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidSimplexVertexCount {
+            simplex_id,
+            expected: 3,
+            actual: 2,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_nil_simplex_ids() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    export.simplices[0].id = Uuid::nil();
+
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::NilSimplexId { simplex_index: 0 },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_duplicate_simplex_ids() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let simplex_id = export.simplices[0].id;
+    export.simplices[1].id = simplex_id;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::DuplicateSimplexId { simplex_id },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_duplicate_simplex_vertices() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let simplex_id = export.simplices[0].id;
+    let vertex_id = export.simplices[0].vertex_ids[0];
+    export.simplices[0].vertex_ids[1] = vertex_id;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::DuplicateSimplexVertex {
+            simplex_id,
+            vertex_id,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_missing_referenced_ids() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let missing_vertex_id = Uuid::nil();
+    let simplex_id = export.simplices[0].id;
+    export.simplices[0].vertex_ids[0] = missing_vertex_id;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::MissingSimplexVertex {
+            simplex_id,
+            vertex_id: missing_vertex_id,
+        },
+    )?;
+
+    let mut export = sample_export()?;
+    let missing_neighbor_id = Uuid::nil();
+    let simplex_id = export.adjacency[0].simplex_id;
+    let facet_index = export.adjacency[0].facet_index;
+    export.adjacency[0].neighbor_simplex_id = Some(missing_neighbor_id);
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::MissingAdjacencyNeighbor {
+            simplex_id,
+            facet_index,
+            neighbor_simplex_id: missing_neighbor_id,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_missing_adjacency_sources() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let simplex_id = Uuid::nil();
+    export.adjacency[0].simplex_id = simplex_id;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::MissingAdjacencySimplex { simplex_id },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_invalid_facet_indices() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let simplex_id = export.adjacency[0].simplex_id;
+    export.adjacency[0].facet_index = 3;
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidAdjacencyFacetIndex {
+            simplex_id,
+            facet_index: 3,
+            max_exclusive: 3,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_duplicate_adjacency() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let duplicate = export.adjacency[0].clone();
+    let simplex_id = duplicate.simplex_id;
+    let facet_index = duplicate.facet_index;
+    export.adjacency.push(duplicate);
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::DuplicateAdjacency {
+            simplex_id,
+            facet_index,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_missing_adjacency() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let removed = export.adjacency.remove(0);
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::MissingAdjacency {
+            simplex_id: removed.simplex_id,
+            facet_index: removed.facet_index,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_wrong_facet_adjacency() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let source_index = export
+        .adjacency
+        .iter()
+        .position(|record| record.neighbor_simplex_id.is_some())
+        .expect("sample export should contain an interior neighbor");
+    let source_simplex_id = export.adjacency[source_index].simplex_id;
+    let source_facet_index = export.adjacency[source_index].facet_index;
+    let neighbor_simplex_id = export.adjacency[source_index]
+        .neighbor_simplex_id
+        .expect("source record should reference a neighbor");
+    let (wrong_facet_index, missing_vertex_id) = {
+        let source_simplex = export
+            .simplices
+            .iter()
+            .find(|simplex| simplex.id == source_simplex_id)
+            .expect("source simplex should exist");
+        let neighbor_simplex = export
+            .simplices
+            .iter()
+            .find(|simplex| simplex.id == neighbor_simplex_id)
+            .expect("neighbor simplex should exist");
+        source_simplex
+            .vertex_ids
+            .iter()
+            .enumerate()
+            .filter(|(facet_index, _)| *facet_index != source_facet_index)
+            .find_map(|(facet_index, _)| {
+                let missing_vertex_id = source_simplex
+                    .vertex_ids
+                    .iter()
+                    .enumerate()
+                    .filter(|(vertex_index, _)| *vertex_index != facet_index)
+                    .map(|(_, vertex_id)| *vertex_id)
+                    .find(|vertex_id| !neighbor_simplex.vertex_ids.contains(vertex_id))?;
+                Some((facet_index, missing_vertex_id))
+            })
+            .expect("sample source should have a facet not shared by the same neighbor")
+    };
+    let swapped_index = export
+        .adjacency
+        .iter()
+        .position(|record| {
+            record.simplex_id == source_simplex_id && record.facet_index == wrong_facet_index
+        })
+        .expect("sample export should contain every source facet");
+    export.adjacency[swapped_index].facet_index = source_facet_index;
+    export.adjacency[source_index].facet_index = wrong_facet_index;
+
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::InvalidAdjacencyFacetSharing {
+            simplex_id: source_simplex_id,
+            facet_index: wrong_facet_index,
+            neighbor_simplex_id,
+            missing_vertex_id,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_rejects_asymmetric_adjacency() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let source = export
+        .adjacency
+        .iter()
+        .find(|record| record.neighbor_simplex_id.is_some())
+        .expect("sample export should contain an interior neighbor");
+    let source_simplex_id = source.simplex_id;
+    let source_facet_index = source.facet_index;
+    let neighbor_simplex_id = source
+        .neighbor_simplex_id
+        .expect("source record should reference a neighbor");
+    let reciprocal = export
+        .adjacency
+        .iter_mut()
+        .find(|record| {
+            record.simplex_id == neighbor_simplex_id
+                && record.neighbor_simplex_id == Some(source_simplex_id)
+        })
+        .expect("sample export should contain the reciprocal neighbor link");
+    reciprocal.neighbor_simplex_id = None;
+
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::AsymmetricAdjacency {
+            simplex_id: source_simplex_id,
+            facet_index: source_facet_index,
+            neighbor_simplex_id,
+        },
+    )
+}
+
+#[test]
+fn delaunay_result_accepts_mesh_export_error_families() -> DelaunayResult<()> {
+    let mut export = sample_delaunay_result_export()?;
+    export.validate()?;
+
+    export.metadata.schema_version = 0;
+    let expected_validation_error = VisualizationDataValidationError::InvalidSchemaVersion {
+        expected: MESH_EXPORT_SCHEMA_VERSION,
+        actual: 0,
+    };
+    let validation_error = export.validate().expect_err("schema version should fail");
+    assert_eq!(validation_error, expected_validation_error);
+    let err = DelaunayError::from(validation_error);
+    assert_matches!(
+        err,
+        DelaunayError::VisualizationDataValidation { source }
+            if source == expected_validation_error
+    );
+
+    let export_error = VisualizationExportError::UnassignedNeighborBuffer {
+        simplex_id: Uuid::nil(),
+    };
+    let err = DelaunayError::from(export_error.clone());
+    assert_matches!(
+        err,
+        DelaunayError::VisualizationExport { source } if source == export_error
+    );
+
+    Ok(())
+}
+
+#[test]
+fn mesh_export_ids_match_triangulation_uuids() -> Result<(), MeshExportTestError> {
+    let vertices = vec![
+        vertex![0.0, 0.0, 0.0]?,
+        vertex![1.0, 0.0, 0.0]?,
+        vertex![0.0, 1.0, 0.0]?,
+        vertex![0.0, 0.0, 1.0]?,
+    ];
+    let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    let export = triangulation.to_mesh_export()?;
+
+    let exported_vertices: HashMap<_, _> = export
+        .vertices
+        .iter()
+        .map(|vertex| (vertex.id, vertex.coordinates.as_slice()))
+        .collect();
+    for (_, vertex) in triangulation.vertices() {
+        assert_eq!(
+            exported_vertices.get(&vertex.uuid()).copied(),
+            Some(vertex.point().coords().as_slice())
+        );
+    }
+
+    let exported_simplices: HashSet<_> =
+        export.simplices.iter().map(|simplex| simplex.id).collect();
+    for (_, simplex) in triangulation.simplices() {
+        assert!(exported_simplices.contains(&simplex.uuid()));
+    }
+
+    Ok(())
+}
+
+#[test]
+fn visualization_records_support_downstream_attributes() {
+    assert_send_sync_unpin::<VisualizationData<3, u8, u16, u32, u64>>();
+    assert_send_sync_unpin::<ValidatedVisualizationData<3, u8, u16, u32, u64>>();
+    assert_send_sync_unpin::<VertexRecord<3, &'static str>>();
+    assert_send_sync_unpin::<SimplexRecord<&'static str>>();
+    assert_send_sync_unpin::<AdjacencyRecord<&'static str>>();
+    assert_send_sync_unpin::<VisualizationMetadata<&'static str>>();
+}
+
+#[test]
+fn visualization_validation_does_not_require_attribute_traits() -> Result<(), MeshExportTestError> {
+    let VisualizationData {
+        metadata,
+        vertices,
+        simplices,
+        adjacency,
+    } = sample_export()?;
+
+    let export: VisualizationData<
+        2,
+        OpaqueAttribute,
+        OpaqueAttribute,
+        OpaqueAttribute,
+        OpaqueAttribute,
+    > = VisualizationData {
+        metadata: VisualizationMetadata {
+            schema: metadata.schema,
+            schema_version: metadata.schema_version,
+            producer: metadata.producer,
+            dimension: metadata.dimension,
+            vertex_count: metadata.vertex_count,
+            simplex_count: metadata.simplex_count,
+            topology_kind: metadata.topology_kind,
+            topology_guarantee: metadata.topology_guarantee,
+            attributes: None,
+        },
+        vertices: vertices
+            .into_iter()
+            .map(|vertex| VertexRecord {
+                id: vertex.id,
+                coordinates: vertex.coordinates,
+                attributes: None,
+            })
+            .collect(),
+        simplices: simplices
+            .into_iter()
+            .map(|simplex| SimplexRecord {
+                id: simplex.id,
+                vertex_ids: simplex.vertex_ids,
+                attributes: None,
+            })
+            .collect(),
+        adjacency: adjacency
+            .into_iter()
+            .map(|record| AdjacencyRecord {
+                simplex_id: record.simplex_id,
+                facet_index: record.facet_index,
+                neighbor_simplex_id: record.neighbor_simplex_id,
+                attributes: None,
+            })
+            .collect(),
+    };
+
+    export.validate()?;
+    Ok(())
+}
+
+#[test]
+fn visualization_data_into_validated_carries_validation_proof() -> Result<(), MeshExportTestError> {
+    let export = sample_export()?;
+    let validated: ValidatedMeshExport<2> = export.clone().into_validated()?;
+
+    assert_eq!(validated.as_raw(), &export);
+    assert_eq!(validated.metadata().schema, MESH_EXPORT_SCHEMA);
+    assert_eq!(validated.vertices().len(), export.vertices.len());
+    assert_eq!(validated.simplices().len(), export.simplices.len());
+    assert_eq!(validated.adjacency().len(), export.adjacency.len());
+    assert_eq!(
+        serde_json::to_value(&validated)?,
+        serde_json::to_value(&export)?
+    );
+    assert_eq!(validated.into_raw(), export);
+
+    Ok(())
+}
+
+#[test]
+fn visualization_data_into_validated_rejects_invalid_raw_dto() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    export.metadata.schema_version = 0;
+
+    assert_eq!(
+        export.into_validated(),
+        Err(VisualizationDataValidationError::InvalidSchemaVersion {
+            expected: MESH_EXPORT_SCHEMA_VERSION,
+            actual: 0,
+        })
+    );
+
+    Ok(())
+}
+
+#[test]
+fn visualization_data_into_validated_canonicalizes_record_order() -> Result<(), MeshExportTestError>
+{
+    let canonical = sample_export()?;
+    let mut raw = canonical.clone();
+    raw.vertices.reverse();
+    raw.simplices.reverse();
+    raw.adjacency.reverse();
+
+    let validated = raw.into_validated()?;
+
+    assert_eq!(validated.as_raw(), &canonical);
+    Ok(())
+}
+
+#[test]
+fn visualization_attributes_deserialize_without_default_bound() -> Result<(), MeshExportTestError> {
+    let json = serde_json::to_string(&sample_export()?)?;
+    let decoded: VisualizationData<
+        2,
+        NonDefaultAttribute,
+        NonDefaultAttribute,
+        NonDefaultAttribute,
+        NonDefaultAttribute,
+    > = serde_json::from_str(&json)?;
+
+    let validated = decoded.into_validated()?;
+    assert!(validated.metadata().attributes.is_none());
+    assert!(
+        validated
+            .vertices()
+            .iter()
+            .all(|vertex| vertex.attributes.is_none())
+    );
+    assert!(
+        validated
+            .simplices()
+            .iter()
+            .all(|simplex| simplex.attributes.is_none())
+    );
+    assert!(
+        validated
+            .adjacency()
+            .iter()
+            .all(|adjacency| adjacency.attributes.is_none())
+    );
+    Ok(())
+}

--- a/tests/mesh_export.rs
+++ b/tests/mesh_export.rs
@@ -5,20 +5,20 @@
 use std::{
     assert_matches,
     collections::{HashMap, HashSet},
+    error::Error as StdError,
 };
 
 use delaunay::geometry::CoordinateConversionError;
-use delaunay::io::visualization::{
-    AdjacencyRecord, MESH_EXPORT_SCHEMA, MESH_EXPORT_SCHEMA_VERSION, MeshExport, MeshExportError,
-    SimplexRecord, ValidatedMeshExport, ValidatedVisualizationData, VertexRecord,
-    VisualizationData, VisualizationDataValidationError, VisualizationExportError,
-    VisualizationMetadata, VisualizationTopologyGuarantee, VisualizationTopologyKind,
-};
 use delaunay::prelude::construction::{
     DelaunayError, DelaunayResult, DelaunayTriangulationBuilder,
-    DelaunayTriangulationConstructionError, vertex,
+    DelaunayTriangulationConstructionError, Vertex, vertex,
 };
-use delaunay::prelude::geometry::InvalidCoordinateValue;
+use delaunay::prelude::export::{
+    AdjacencyRecord, InvalidCoordinateValue, MESH_EXPORT_SCHEMA, MESH_EXPORT_SCHEMA_VERSION,
+    MeshExport, MeshExportError, SimplexRecord, ValidatedMeshExport, ValidatedVisualizationData,
+    VertexRecord, VisualizationData, VisualizationDataValidationError, VisualizationExportError,
+    VisualizationMetadata, VisualizationTopologyGuarantee, VisualizationTopologyKind,
+};
 use uuid::Uuid;
 
 #[derive(Debug, thiserror::Error)]
@@ -62,6 +62,111 @@ fn sample_delaunay_result_export() -> DelaunayResult<MeshExport<2>> {
     let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
 
     Ok(triangulation.to_mesh_export()?)
+}
+
+/// Builds the minimal affinely spanning fixture used by the dimension sweep.
+fn sample_vertices_for_dimension<const D: usize>() -> Result<Vec<Vertex<(), D>>, MeshExportTestError>
+{
+    let mut vertices = Vec::with_capacity(D + 2);
+    vertices.push(vertex!([0.0; D])?);
+    for axis in 0..D {
+        let mut coords = [0.0; D];
+        coords[axis] = 1.0;
+        vertices.push(vertex!(coords)?);
+    }
+    vertices.push(vertex!([0.125; D])?);
+    Ok(vertices)
+}
+
+/// Exports one dimension-sweep fixture through the public builder path.
+fn sample_export_for_dimension<const D: usize>() -> Result<MeshExport<D>, MeshExportTestError> {
+    let vertices = sample_vertices_for_dimension::<D>()?;
+    let triangulation = DelaunayTriangulationBuilder::new(&vertices).build::<()>()?;
+    Ok(triangulation.to_mesh_export()?)
+}
+
+/// Builds a raw DTO where distinct facets reciprocate a self-neighbor link.
+fn reciprocal_self_neighbor_export() -> MeshExport<2> {
+    let vertex_ids = [
+        Uuid::from_u128(0x1000_0000_0000_0000_0000_0000_0000_0001),
+        Uuid::from_u128(0x1000_0000_0000_0000_0000_0000_0000_0002),
+        Uuid::from_u128(0x1000_0000_0000_0000_0000_0000_0000_0003),
+    ];
+    let simplex_id = Uuid::from_u128(0x2000_0000_0000_0000_0000_0000_0000_0001);
+
+    MeshExport {
+        metadata: VisualizationMetadata {
+            schema: MESH_EXPORT_SCHEMA.to_owned(),
+            schema_version: MESH_EXPORT_SCHEMA_VERSION,
+            producer: "delaunay-test".to_owned(),
+            dimension: 2,
+            vertex_count: vertex_ids.len(),
+            simplex_count: 1,
+            topology_kind: VisualizationTopologyKind::Euclidean,
+            topology_guarantee: VisualizationTopologyGuarantee::Pseudomanifold,
+            attributes: None,
+        },
+        vertices: vec![
+            VertexRecord {
+                id: vertex_ids[0],
+                coordinates: vec![0.0, 0.0],
+                attributes: None,
+            },
+            VertexRecord {
+                id: vertex_ids[1],
+                coordinates: vec![1.0, 0.0],
+                attributes: None,
+            },
+            VertexRecord {
+                id: vertex_ids[2],
+                coordinates: vec![0.0, 1.0],
+                attributes: None,
+            },
+        ],
+        simplices: vec![SimplexRecord {
+            id: simplex_id,
+            vertex_ids: vertex_ids.to_vec(),
+            attributes: None,
+        }],
+        adjacency: vec![
+            AdjacencyRecord {
+                simplex_id,
+                facet_index: 0,
+                neighbor_simplex_id: Some(simplex_id),
+                attributes: None,
+            },
+            AdjacencyRecord {
+                simplex_id,
+                facet_index: 1,
+                neighbor_simplex_id: Some(simplex_id),
+                attributes: None,
+            },
+            AdjacencyRecord {
+                simplex_id,
+                facet_index: 2,
+                neighbor_simplex_id: None,
+                attributes: None,
+            },
+        ],
+    }
+}
+
+/// Verifies const-generic export invariants and serde round-trip behavior.
+fn assert_mesh_export_round_trip_for_dimension<const D: usize>() -> Result<(), MeshExportTestError>
+{
+    let export = sample_export_for_dimension::<D>()?;
+    assert_eq!(export.metadata.dimension, D);
+    assert_eq!(export.metadata.vertex_count, export.vertices.len());
+    assert_eq!(export.metadata.simplex_count, export.simplices.len());
+    assert_eq!(export.adjacency.len(), export.simplices.len() * (D + 1));
+    assert_connectivity_ids_exist(&export);
+    export.validate()?;
+
+    let json = serde_json::to_string(&export)?;
+    let decoded: MeshExport<D> = serde_json::from_str(&json)?;
+    assert_connectivity_ids_exist(&decoded);
+    decoded.validate()?;
+    Ok(())
 }
 
 fn assert_connectivity_ids_exist<const D: usize>(export: &MeshExport<D>) {
@@ -161,6 +266,15 @@ fn mesh_export_json_contains_schema_ids_and_connectivity() -> Result<(), MeshExp
             .is_some_and(|adjacency| !adjacency.is_empty())
     );
 
+    Ok(())
+}
+
+#[test]
+fn mesh_export_round_trips_for_dimensions_2_through_5() -> Result<(), MeshExportTestError> {
+    assert_mesh_export_round_trip_for_dimension::<2>()?;
+    assert_mesh_export_round_trip_for_dimension::<3>()?;
+    assert_mesh_export_round_trip_for_dimension::<4>()?;
+    assert_mesh_export_round_trip_for_dimension::<5>()?;
     Ok(())
 }
 
@@ -551,6 +665,45 @@ fn mesh_export_validation_rejects_asymmetric_adjacency() -> Result<(), MeshExpor
 }
 
 #[test]
+fn mesh_export_validation_rejects_one_sided_self_neighbor() -> Result<(), MeshExportTestError> {
+    let mut export = sample_export()?;
+    let boundary = export
+        .adjacency
+        .iter_mut()
+        .find(|record| record.neighbor_simplex_id.is_none())
+        .expect("sample export should contain a boundary facet");
+    let simplex_id = boundary.simplex_id;
+    let facet_index = boundary.facet_index;
+    boundary.neighbor_simplex_id = Some(simplex_id);
+
+    assert_validation_error(
+        &export,
+        VisualizationDataValidationError::AsymmetricAdjacency {
+            simplex_id,
+            facet_index,
+            neighbor_simplex_id: simplex_id,
+        },
+    )
+}
+
+#[test]
+fn mesh_export_validation_accepts_reciprocal_self_neighbor() -> Result<(), MeshExportTestError> {
+    let export = reciprocal_self_neighbor_export();
+
+    let validated = export.into_validated()?;
+
+    assert_eq!(
+        validated
+            .adjacency()
+            .iter()
+            .filter(|record| record.neighbor_simplex_id == Some(record.simplex_id))
+            .count(),
+        2
+    );
+    Ok(())
+}
+
+#[test]
 fn delaunay_result_accepts_mesh_export_error_families() -> DelaunayResult<()> {
     let mut export = sample_delaunay_result_export()?;
     export.validate()?;
@@ -563,20 +716,21 @@ fn delaunay_result_accepts_mesh_export_error_families() -> DelaunayResult<()> {
     let validation_error = export.validate().expect_err("schema version should fail");
     assert_eq!(validation_error, expected_validation_error);
     let err = DelaunayError::from(validation_error);
-    assert_matches!(
-        err,
-        DelaunayError::VisualizationDataValidation { source }
-            if source == expected_validation_error
-    );
+    let source = StdError::source(&err)
+        .and_then(|source| source.downcast_ref::<Box<VisualizationDataValidationError>>())
+        .expect("DelaunayError should expose the typed boxed visualization validation source");
+    assert_eq!(source.as_ref(), &expected_validation_error);
+    assert_matches!(&err, DelaunayError::VisualizationDataValidation { .. });
 
     let export_error = VisualizationExportError::UnassignedNeighborBuffer {
         simplex_id: Uuid::nil(),
     };
     let err = DelaunayError::from(export_error.clone());
-    assert_matches!(
-        err,
-        DelaunayError::VisualizationExport { source } if source == export_error
-    );
+    let source = StdError::source(&err)
+        .and_then(|source| source.downcast_ref::<Box<VisualizationExportError>>())
+        .expect("DelaunayError should expose the typed boxed visualization export source");
+    assert_eq!(source.as_ref(), &export_error);
+    assert_matches!(&err, DelaunayError::VisualizationExport { .. });
 
     Ok(())
 }

--- a/tests/pachner_roundtrip.rs
+++ b/tests/pachner_roundtrip.rs
@@ -102,9 +102,11 @@ fn stale_pachner_error_propagates_through_delaunay_result() {
         .expect_err("stale Pachner failure should propagate through DelaunayResult");
     assert_matches!(
         &err,
-        DelaunayError::Flip {
-            source: FlipError::MissingSimplex { simplex_key },
-        } if *simplex_key == stale_simplex,
+        DelaunayError::Flip { source }
+            if matches!(
+                source.as_ref(),
+                FlipError::MissingSimplex { simplex_key } if *simplex_key == stale_simplex
+            ),
         "unexpected DelaunayResult error for stale Pachner move: {err:?}"
     );
     dt.tds()
@@ -172,10 +174,6 @@ fn edge_to_facet_query_tracks_2d_k2_mutation_freshness() {
 }
 
 /// Attempts a stale k=1 insert through the public `DelaunayResult` alias.
-#[expect(
-    clippy::result_large_err,
-    reason = "test intentionally exercises DelaunayResult error propagation"
-)]
 fn try_stale_k1_insert(
     dt: &mut Dt4,
     stale_simplex: SimplexKey,

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -389,13 +389,13 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
     let focused_error = DelaunayError::from(source.clone());
     assert_matches!(
         focused_error,
-        DelaunayError::CoordinateConversion { source: err } if err == source
+        DelaunayError::CoordinateConversion { source: err } if err.as_ref() == &source
     );
 
     let root_error = RootDelaunayError::from(source.clone());
     assert_matches!(
         root_error,
-        RootDelaunayError::CoordinateConversion { source: err } if err == source
+        RootDelaunayError::CoordinateConversion { source: err } if err.as_ref() == &source
     );
 
     let no_vertices: [Vertex<(), 2>; 0] = [];
@@ -404,11 +404,13 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
         .expect_err("empty Delaunay construction should fail");
     assert_matches!(
         DelaunayError::from(construction),
-        DelaunayError::Construction {
-            source: DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::InsufficientVertices { dimension: 2, .. }
+        DelaunayError::Construction { source }
+            if matches!(
+                source.as_ref(),
+                DelaunayTriangulationConstructionError::Triangulation(
+                    DelaunayConstructionFailure::InsufficientVertices { dimension: 2, .. }
+                )
             )
-        }
     );
 
     let insertion = InsertionError::DuplicateCoordinates {
@@ -416,7 +418,7 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
     };
     assert_matches!(
         DelaunayError::from(insertion.clone()),
-        DelaunayError::Insertion { source: err } if err == insertion
+        DelaunayError::Insertion { source: err } if err.as_ref() == &insertion
     );
 
     let delete_vertex = DeleteVertexError::VertexNotFound {
@@ -424,13 +426,13 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
     };
     assert_matches!(
         DelaunayError::from(delete_vertex.clone()),
-        DelaunayError::DeleteVertex { source: err } if err == delete_vertex
+        DelaunayError::DeleteVertex { source: err } if err.as_ref() == &delete_vertex
     );
 
     let flip = FlipError::DegenerateSimplex;
     assert_matches!(
         DelaunayError::from(flip.clone()),
-        DelaunayError::Flip { source: err } if err == flip
+        DelaunayError::Flip { source: err } if err.as_ref() == &flip
     );
 
     let configuration =
@@ -446,7 +448,7 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
     assert_matches!(
         DelaunayError::from(configuration),
         DelaunayError::ValidationConfiguration { source: err }
-            if err == expected_configuration
+            if err.as_ref() == &expected_configuration
     );
 
     let toroidal_domain = ToroidalDomainError::InvalidPeriod {
@@ -455,9 +457,12 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
     };
     assert_matches!(
         DelaunayError::from(toroidal_domain),
-        DelaunayError::ToroidalDomain {
-            source: ToroidalDomainError::InvalidPeriod { axis, period }
-        } if axis == 0 && period.to_bits() == 0.0_f64.to_bits()
+        DelaunayError::ToroidalDomain { source }
+            if matches!(
+                source.as_ref(),
+                ToroidalDomainError::InvalidPeriod { axis: 0, period }
+                    if period.to_bits() == 0.0_f64.to_bits()
+            )
     );
 
     let simplex_key = SimplexKey::from(KeyData::from_ffi(1));
@@ -468,7 +473,7 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
     };
     assert_matches!(
         DelaunayError::from(validation.clone()),
-        DelaunayError::Validation { source: err } if err == validation
+        DelaunayError::Validation { source: err } if err.as_ref() == &validation
     );
 
     let focused_result: DelaunayResult<()> = Ok(());

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -59,6 +59,17 @@ use delaunay::prelude::diagnostics::{
     debug_print_first_delaunay_violation, delaunay_violation_report,
     verify_conflict_region_completeness,
 };
+use delaunay::prelude::export::{
+    InvalidCoordinateValue as ExportPreludeInvalidCoordinateValue,
+    MESH_EXPORT_SCHEMA as ExportPreludeMeshExportSchema, MeshExport as ExportPreludeMeshExport,
+    MeshExportError as ExportPreludeMeshExportError,
+    MeshExportValidationError as ExportPreludeMeshExportValidationError,
+    ValidatedMeshExport as ExportPreludeValidatedMeshExport,
+    ValidatedVisualizationData as ExportPreludeValidatedVisualizationData,
+    VisualizationData as ExportPreludeVisualizationData,
+    VisualizationTopologyGuarantee as ExportPreludeVisualizationTopologyGuarantee,
+    VisualizationTopologyKind as ExportPreludeVisualizationTopologyKind,
+};
 use delaunay::prelude::generators::{
     CoordinateRange, CoordinateRangeError, InvalidPositiveScalar,
     RandomPointGenerationError as GeneratorRandomPointGenerationError, RandomTriangulationBuilder,
@@ -178,6 +189,15 @@ use delaunay::topology::{
     BoundaryFacetClassification as TopologyBoundaryFacetClassification,
     classify_boundary_facet as topology_classify_boundary_facet,
 };
+use delaunay::{
+    MESH_EXPORT_SCHEMA as RootMeshExportSchema, MeshExport as RootMeshExport,
+    MeshExportError as RootMeshExportError,
+    MeshExportValidationError as RootMeshExportValidationError,
+    ValidatedMeshExport as RootValidatedMeshExport,
+    ValidatedVisualizationData as RootValidatedVisualizationData,
+    VisualizationTopologyGuarantee as RootVisualizationTopologyGuarantee,
+    VisualizationTopologyKind as RootVisualizationTopologyKind,
+};
 #[derive(Debug, thiserror::Error)]
 enum RootApiExportTestError {
     #[error(transparent)]
@@ -190,6 +210,10 @@ enum RootApiExportTestError {
     DelaunayRepair(#[from] delaunay::flips::DelaunayRepairError),
     #[error(transparent)]
     Delaunayize(#[from] delaunay::delaunayize::DelaunayizeError),
+    #[error(transparent)]
+    MeshExport(#[from] RootMeshExportError),
+    #[error(transparent)]
+    MeshExportValidation(#[from] RootMeshExportValidationError),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -212,6 +236,10 @@ enum PreludeExportTestError {
     DelaunayRepair(#[from] DelaunayRepairError),
     #[error(transparent)]
     Delaunayize(#[from] DelaunayizeError),
+    #[error(transparent)]
+    MeshExport(#[from] ExportPreludeMeshExportError),
+    #[error(transparent)]
+    MeshExportValidation(#[from] ExportPreludeMeshExportValidationError),
     #[error(transparent)]
     Insertion(#[from] InsertionError),
     #[error(transparent)]
@@ -700,6 +728,24 @@ fn root_exports_cover_flattened_public_api() -> Result<(), RootApiExportTestErro
 
     let validation_result: Result<(), DelaunayTriangulationValidationError> = dt.validate();
     validation_result?;
+    let root_mesh_export: RootMeshExport<3> = dt.to_mesh_export()?;
+    assert_eq!(root_mesh_export.metadata.schema, RootMeshExportSchema);
+    assert_eq!(
+        root_mesh_export.metadata.topology_kind,
+        RootVisualizationTopologyKind::Euclidean
+    );
+    assert_eq!(
+        root_mesh_export.metadata.topology_guarantee,
+        RootVisualizationTopologyGuarantee::PLManifold
+    );
+    let root_validated_export: RootValidatedMeshExport<3> = root_mesh_export.into_validated()?;
+    assert_eq!(
+        root_validated_export.metadata().schema,
+        RootMeshExportSchema
+    );
+    let root_validated_data: RootValidatedVisualizationData<3> =
+        dt.to_visualization_data()?.into_validated()?;
+    assert_eq!(root_validated_data.metadata().schema, RootMeshExportSchema);
     assert_bistellar_flips(&dt);
     assert_root_bistellar_flips(&dt);
 
@@ -812,6 +858,65 @@ fn assert_facet_incidence_exports(
     Ok(())
 }
 
+fn assert_export_prelude_exports<K, U, V, const D: usize>(
+    dt: &DelaunayTriangulation<K, U, V, D>,
+) -> Result<(), PreludeExportTestError> {
+    let focused_mesh_export: ExportPreludeMeshExport<D> = dt.to_mesh_export()?;
+    let focused_visualization_data: ExportPreludeVisualizationData<D> =
+        dt.to_visualization_data()?;
+    assert_eq!(
+        focused_mesh_export.metadata.schema,
+        ExportPreludeMeshExportSchema
+    );
+    assert_eq!(
+        focused_visualization_data.metadata.schema,
+        ExportPreludeMeshExportSchema
+    );
+    assert_eq!(
+        focused_visualization_data.metadata.topology_kind,
+        ExportPreludeVisualizationTopologyKind::Euclidean
+    );
+    assert_eq!(
+        focused_visualization_data.metadata.topology_guarantee,
+        ExportPreludeVisualizationTopologyGuarantee::PLManifold
+    );
+    let focused_validated_mesh_export: ExportPreludeValidatedMeshExport<D> =
+        focused_mesh_export.into_validated()?;
+    let focused_validated_visualization_data: ExportPreludeValidatedVisualizationData<D> =
+        focused_visualization_data.into_validated()?;
+    assert_eq!(
+        focused_validated_mesh_export.metadata().schema,
+        ExportPreludeMeshExportSchema
+    );
+    assert_eq!(
+        focused_validated_visualization_data.metadata().schema,
+        ExportPreludeMeshExportSchema
+    );
+    assert_eq!(ExportPreludeInvalidCoordinateValue::Nan.to_string(), "NaN");
+    Ok(())
+}
+
+fn assert_insertion_prelude_empty_tds_exports() -> Result<(), PreludeExportTestError> {
+    let mut empty_tds: InsertionTds<(), (), 2> = InsertionTds::empty();
+    let _tds_all_facets: TdsAllFacetsIter<'_, (), (), 2> = empty_tds.facets();
+    let tds_boundary_facets: Option<TdsBoundaryFacetsIter<'static, (), (), 2>> = None;
+    assert!(tds_boundary_facets.is_none());
+    assert_eq!(
+        repair_neighbor_pointers_local(&mut empty_tds, &[], None)?,
+        0
+    );
+    assert_eq!(
+        CavityRepairStage::PrimaryInsertion.to_string(),
+        "primary insertion"
+    );
+    assert_matches!(LocateResult::Outside, LocateResult::Outside);
+    assert_matches!(
+        ValidationCadence::from_optional_every(Some(128)),
+        ValidationCadence::EveryN(every) if every.get() == 128
+    );
+    Ok(())
+}
+
 #[test]
 fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
     let _generated_points: Vec<Point<2>> = try_generate_random_points_seeded(3, (0.0, 1.0), 42)?;
@@ -831,6 +936,7 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
     let dt = DelaunayTriangulation::try_new_with_options(&vertices, options)?;
 
     assert_eq!(dt.topology_guarantee(), TopologyGuarantee::PLManifold);
+    assert_export_prelude_exports(&dt)?;
     let _query_facade_all_facets: QueryFacadeAllFacetsIter<'_, (), (), 3> = dt.facets();
     let _query_facade_boundary_facets: QueryFacadeBoundaryFacetsIter<'_, (), (), 3> =
         dt.boundary_facets()?;
@@ -862,23 +968,7 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
     assert_bistellar_flips(&dt);
     assert_pachner_prelude_exports(&dt, simplex_key)?;
 
-    let mut empty_tds: InsertionTds<(), (), 2> = InsertionTds::empty();
-    let _tds_all_facets: TdsAllFacetsIter<'_, (), (), 2> = empty_tds.facets();
-    let tds_boundary_facets: Option<TdsBoundaryFacetsIter<'static, (), (), 2>> = None;
-    assert!(tds_boundary_facets.is_none());
-    assert_eq!(
-        repair_neighbor_pointers_local(&mut empty_tds, &[], None)?,
-        0
-    );
-    assert_eq!(
-        CavityRepairStage::PrimaryInsertion.to_string(),
-        "primary insertion"
-    );
-    assert_matches!(LocateResult::Outside, LocateResult::Outside);
-    assert_matches!(
-        ValidationCadence::from_optional_every(Some(128)),
-        ValidationCadence::EveryN(every) if every.get() == 128
-    );
+    assert_insertion_prelude_empty_tds_exports()?;
     assert_send_sync_unpin::<TdsMutationError>();
     assert_send_sync_unpin::<NeighborRebuildError>();
     assert_send_sync_unpin::<ConstructionSkipSample>();

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -435,6 +435,15 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
         DelaunayError::Flip { source: err } if err.as_ref() == &flip
     );
 
+    let tds_mutation = TdsMutationError::from(TdsError::SimplexNotFound {
+        simplex_key: SimplexKey::from(KeyData::from_ffi(3)),
+        context: "prelude smoke test".to_owned(),
+    });
+    assert_matches!(
+        DelaunayError::from(tds_mutation.clone()),
+        DelaunayError::TdsMutation { source: err } if err.as_ref() == &tds_mutation
+    );
+
     let configuration =
         FocusedValidationConfigurationError::IncompatibleTopologyAndValidationPolicy {
             topology_guarantee: TopologyGuarantee::PLManifold,

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.13"
+resolution-markers = [
+    "python_full_version >= '3.14'",
+    "python_full_version < '3.14'",
+]
 
 [[package]]
 name = "actionlint-py"
@@ -30,12 +34,134 @@ wheels = [
 ]
 
 [[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
+name = "beautifulsoup4"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/65/318323f98dbee45d42dff61d8f047181bc6f2268a9068cfad035a46be5af/beautifulsoup4-4.15.0.tar.gz", hash = "sha256:288e3ca7d54b06f2ac191970bc275c1939cb46d450b255bf6718b04aa37ab4f7", size = 632571, upload-time = "2026-06-07T16:44:20.453Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl", hash = "sha256:d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9", size = 109924, upload-time = "2026-06-07T16:44:21.566Z" },
+]
+
+[[package]]
+name = "bleach"
+version = "6.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/3c/e12ac860709702bd5ebeb9b56a4fe334f1001246ee1b8f2b7ee28912df7d/bleach-6.4.0.tar.gz", hash = "sha256:4202482733d85cedd04e59fcb2f89f4e4c7c385a78d3c3c23c30446843a37452", size = 204857, upload-time = "2026-06-05T13:01:13.734Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl", hash = "sha256:4b6b6a54fff2e69a3dde9d21cc6301220bee3c3cb792187d11403fd795031081", size = 165109, upload-time = "2026-06-05T13:01:12.504Z" },
+]
+
+[package.optional-dependencies]
+css = [
+    { name = "tinycss2" },
 ]
 
 [[package]]
@@ -201,6 +327,70 @@ wheels = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
+name = "contourpy"
+version = "1.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/35/0167aad910bbdb9599272bd96d01a9ec6852f36b9455cf2ca67bd4cc2d23/contourpy-1.3.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:177fb367556747a686509d6fef71d221a4b198a3905fe824430e5ea0fda54eb5", size = 293257, upload-time = "2025-07-26T12:01:39.367Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e4/7adcd9c8362745b2210728f209bfbcf7d91ba868a2c5f40d8b58f54c509b/contourpy-1.3.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d002b6f00d73d69333dac9d0b8d5e84d9724ff9ef044fd63c5986e62b7c9e1b1", size = 274034, upload-time = "2025-07-26T12:01:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/73/23/90e31ceeed1de63058a02cb04b12f2de4b40e3bef5e082a7c18d9c8ae281/contourpy-1.3.3-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:348ac1f5d4f1d66d3322420f01d42e43122f43616e0f194fc1c9f5d830c5b286", size = 334672, upload-time = "2025-07-26T12:01:41.942Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/93/b43d8acbe67392e659e1d984700e79eb67e2acb2bd7f62012b583a7f1b55/contourpy-1.3.3-cp313-cp313-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:655456777ff65c2c548b7c454af9c6f33f16c8884f11083244b5819cc214f1b5", size = 381234, upload-time = "2025-07-26T12:01:43.499Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3b/bec82a3ea06f66711520f75a40c8fc0b113b2a75edb36aa633eb11c4f50f/contourpy-1.3.3-cp313-cp313-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:644a6853d15b2512d67881586bd03f462c7ab755db95f16f14d7e238f2852c67", size = 385169, upload-time = "2025-07-26T12:01:45.219Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/32/e0f13a1c5b0f8572d0ec6ae2f6c677b7991fafd95da523159c19eff0696a/contourpy-1.3.3-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4debd64f124ca62069f313a9cb86656ff087786016d76927ae2cf37846b006c9", size = 362859, upload-time = "2025-07-26T12:01:46.519Z" },
+    { url = "https://files.pythonhosted.org/packages/33/71/e2a7945b7de4e58af42d708a219f3b2f4cff7386e6b6ab0a0fa0033c49a9/contourpy-1.3.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a15459b0f4615b00bbd1e91f1b9e19b7e63aea7483d03d804186f278c0af2659", size = 1332062, upload-time = "2025-07-26T12:01:48.964Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fc/4e87ac754220ccc0e807284f88e943d6d43b43843614f0a8afa469801db0/contourpy-1.3.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ca0fdcd73925568ca027e0b17ab07aad764be4706d0a925b89227e447d9737b7", size = 1403932, upload-time = "2025-07-26T12:01:51.979Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/2e/adc197a37443f934594112222ac1aa7dc9a98faf9c3842884df9a9d8751d/contourpy-1.3.3-cp313-cp313-win32.whl", hash = "sha256:b20c7c9a3bf701366556e1b1984ed2d0cedf999903c51311417cf5f591d8c78d", size = 185024, upload-time = "2025-07-26T12:01:53.245Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl", hash = "sha256:1cadd8b8969f060ba45ed7c1b714fe69185812ab43bd6b86a9123fe8f99c3263", size = 226578, upload-time = "2025-07-26T12:01:54.422Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/9a/2f6024a0c5995243cd63afdeb3651c984f0d2bc727fd98066d40e141ad73/contourpy-1.3.3-cp313-cp313-win_arm64.whl", hash = "sha256:fd914713266421b7536de2bfa8181aa8c699432b6763a0ea64195ebe28bff6a9", size = 193524, upload-time = "2025-07-26T12:01:55.73Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b3/f8a1a86bd3298513f500e5b1f5fd92b69896449f6cab6a146a5d52715479/contourpy-1.3.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:88df9880d507169449d434c293467418b9f6cbe82edd19284aa0409e7fdb933d", size = 306730, upload-time = "2025-07-26T12:01:57.051Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/11/4780db94ae62fc0c2053909b65dc3246bd7cecfc4f8a20d957ad43aa4ad8/contourpy-1.3.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:d06bb1f751ba5d417047db62bca3c8fde202b8c11fb50742ab3ab962c81e8216", size = 287897, upload-time = "2025-07-26T12:01:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/15/e59f5f3ffdd6f3d4daa3e47114c53daabcb18574a26c21f03dc9e4e42ff0/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e4e6b05a45525357e382909a4c1600444e2a45b4795163d3b22669285591c1ae", size = 326751, upload-time = "2025-07-26T12:02:00.343Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/81/03b45cfad088e4770b1dcf72ea78d3802d04200009fb364d18a493857210/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ab3074b48c4e2cf1a960e6bbeb7f04566bf36b1861d5c9d4d8ac04b82e38ba20", size = 375486, upload-time = "2025-07-26T12:02:02.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/ba/49923366492ffbdd4486e970d421b289a670ae8cf539c1ea9a09822b371a/contourpy-1.3.3-cp313-cp313t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6c3d53c796f8647d6deb1abe867daeb66dcc8a97e8455efa729516b997b8ed99", size = 388106, upload-time = "2025-07-26T12:02:03.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/52/5b00ea89525f8f143651f9f03a0df371d3cbd2fccd21ca9b768c7a6500c2/contourpy-1.3.3-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:50ed930df7289ff2a8d7afeb9603f8289e5704755c7e5c3bbd929c90c817164b", size = 352548, upload-time = "2025-07-26T12:02:05.165Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1d/a209ec1a3a3452d490f6b14dd92e72280c99ae3d1e73da74f8277d4ee08f/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:4feffb6537d64b84877da813a5c30f1422ea5739566abf0bd18065ac040e120a", size = 1322297, upload-time = "2025-07-26T12:02:07.379Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/9e/46f0e8ebdd884ca0e8877e46a3f4e633f6c9c8c4f3f6e72be3fe075994aa/contourpy-1.3.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2b7e9480ffe2b0cd2e787e4df64270e3a0440d9db8dc823312e2c940c167df7e", size = 1391023, upload-time = "2025-07-26T12:02:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/70/f308384a3ae9cd2209e0849f33c913f658d3326900d0ff5d378d6a1422d2/contourpy-1.3.3-cp313-cp313t-win32.whl", hash = "sha256:283edd842a01e3dcd435b1c5116798d661378d83d36d337b8dde1d16a5fc9ba3", size = 196157, upload-time = "2025-07-26T12:02:11.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dd/880f890a6663b84d9e34a6f88cded89d78f0091e0045a284427cb6b18521/contourpy-1.3.3-cp313-cp313t-win_amd64.whl", hash = "sha256:87acf5963fc2b34825e5b6b048f40e3635dd547f590b04d2ab317c2619ef7ae8", size = 240570, upload-time = "2025-07-26T12:02:12.754Z" },
+    { url = "https://files.pythonhosted.org/packages/80/99/2adc7d8ffead633234817ef8e9a87115c8a11927a94478f6bb3d3f4d4f7d/contourpy-1.3.3-cp313-cp313t-win_arm64.whl", hash = "sha256:3c30273eb2a55024ff31ba7d052dde990d7d8e5450f4bbb6e913558b3d6c2301", size = 199713, upload-time = "2025-07-26T12:02:14.4Z" },
+    { url = "https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fde6c716d51c04b1c25d0b90364d0be954624a0ee9d60e23e850e8d48353d07a", size = 292189, upload-time = "2025-07-26T12:02:16.095Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cbedb772ed74ff5be440fa8eee9bd49f64f6e3fc09436d9c7d8f1c287b121d77", size = 273251, upload-time = "2025-07-26T12:02:17.524Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:22e9b1bd7a9b1d652cd77388465dc358dafcd2e217d35552424aa4f996f524f5", size = 335810, upload-time = "2025-07-26T12:02:18.9Z" },
+    { url = "https://files.pythonhosted.org/packages/91/f9/e35f4c1c93f9275d4e38681a80506b5510e9327350c51f8d4a5a724d178c/contourpy-1.3.3-cp314-cp314-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a22738912262aa3e254e4f3cb079a95a67132fc5a063890e224393596902f5a4", size = 382871, upload-time = "2025-07-26T12:02:20.418Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/71/47b512f936f66a0a900d81c396a7e60d73419868fba959c61efed7a8ab46/contourpy-1.3.3-cp314-cp314-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:afe5a512f31ee6bd7d0dda52ec9864c984ca3d66664444f2d72e0dc4eb832e36", size = 386264, upload-time = "2025-07-26T12:02:21.916Z" },
+    { url = "https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f64836de09927cba6f79dcd00fdd7d5329f3fccc633468507079c829ca4db4e3", size = 363819, upload-time = "2025-07-26T12:02:23.759Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a6/0b185d4cc480ee494945cde102cb0149ae830b5fa17bf855b95f2e70ad13/contourpy-1.3.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1fd43c3be4c8e5fd6e4f2baeae35ae18176cf2e5cced681cca908addf1cdd53b", size = 1333650, upload-time = "2025-07-26T12:02:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/43/d7/afdc95580ca56f30fbcd3060250f66cedbde69b4547028863abd8aa3b47e/contourpy-1.3.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:6afc576f7b33cf00996e5c1102dc2a8f7cc89e39c0b55df93a0b78c1bd992b36", size = 1404833, upload-time = "2025-07-26T12:02:28.782Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e2/366af18a6d386f41132a48f033cbd2102e9b0cf6345d35ff0826cd984566/contourpy-1.3.3-cp314-cp314-win32.whl", hash = "sha256:66c8a43a4f7b8df8b71ee1840e4211a3c8d93b214b213f590e18a1beca458f7d", size = 189692, upload-time = "2025-07-26T12:02:30.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl", hash = "sha256:cf9022ef053f2694e31d630feaacb21ea24224be1c3ad0520b13d844274614fd", size = 232424, upload-time = "2025-07-26T12:02:31.395Z" },
+    { url = "https://files.pythonhosted.org/packages/18/79/a9416650df9b525737ab521aa181ccc42d56016d2123ddcb7b58e926a42c/contourpy-1.3.3-cp314-cp314-win_arm64.whl", hash = "sha256:95b181891b4c71de4bb404c6621e7e2390745f887f2a026b2d99e92c17892339", size = 198300, upload-time = "2025-07-26T12:02:32.956Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/42/38c159a7d0f2b7b9c04c64ab317042bb6952b713ba875c1681529a2932fe/contourpy-1.3.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:33c82d0138c0a062380332c861387650c82e4cf1747aaa6938b9b6516762e772", size = 306769, upload-time = "2025-07-26T12:02:34.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/6c/26a8205f24bca10974e77460de68d3d7c63e282e23782f1239f226fcae6f/contourpy-1.3.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ea37e7b45949df430fe649e5de8351c423430046a2af20b1c1961cae3afcda77", size = 287892, upload-time = "2025-07-26T12:02:35.807Z" },
+    { url = "https://files.pythonhosted.org/packages/66/06/8a475c8ab718ebfd7925661747dbb3c3ee9c82ac834ccb3570be49d129f4/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d304906ecc71672e9c89e87c4675dc5c2645e1f4269a5063b99b0bb29f232d13", size = 326748, upload-time = "2025-07-26T12:02:37.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a3/c5ca9f010a44c223f098fccd8b158bb1cb287378a31ac141f04730dc49be/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ca658cd1a680a5c9ea96dc61cdbae1e85c8f25849843aa799dfd3cb370ad4fbe", size = 375554, upload-time = "2025-07-26T12:02:38.894Z" },
+    { url = "https://files.pythonhosted.org/packages/80/5b/68bd33ae63fac658a4145088c1e894405e07584a316738710b636c6d0333/contourpy-1.3.3-cp314-cp314t-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ab2fd90904c503739a75b7c8c5c01160130ba67944a7b77bbf36ef8054576e7f", size = 388118, upload-time = "2025-07-26T12:02:40.642Z" },
+    { url = "https://files.pythonhosted.org/packages/40/52/4c285a6435940ae25d7410a6c36bda5145839bc3f0beb20c707cda18b9d2/contourpy-1.3.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b7301b89040075c30e5768810bc96a8e8d78085b47d8be6e4c3f5a0b4ed478a0", size = 352555, upload-time = "2025-07-26T12:02:42.25Z" },
+    { url = "https://files.pythonhosted.org/packages/24/ee/3e81e1dd174f5c7fefe50e85d0892de05ca4e26ef1c9a59c2a57e43b865a/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2a2a8b627d5cc6b7c41a4beff6c5ad5eb848c88255fda4a8745f7e901b32d8e4", size = 1322295, upload-time = "2025-07-26T12:02:44.668Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b2/6d913d4d04e14379de429057cd169e5e00f6c2af3bb13e1710bcbdb5da12/contourpy-1.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:fd6ec6be509c787f1caf6b247f0b1ca598bef13f4ddeaa126b7658215529ba0f", size = 1391027, upload-time = "2025-07-26T12:02:47.09Z" },
+    { url = "https://files.pythonhosted.org/packages/93/8a/68a4ec5c55a2971213d29a9374913f7e9f18581945a7a31d1a39b5d2dfe5/contourpy-1.3.3-cp314-cp314t-win32.whl", hash = "sha256:e74a9a0f5e3fff48fb5a7f2fd2b9b70a3fe014a67522f79b7cca4c0c7e43c9ae", size = 202428, upload-time = "2025-07-26T12:02:48.691Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/96/fd9f641ffedc4fa3ace923af73b9d07e869496c9cc7a459103e6e978992f/contourpy-1.3.3-cp314-cp314t-win_amd64.whl", hash = "sha256:13b68d6a62db8eafaebb8039218921399baf6e47bf85006fd8529f2a08ef33fc", size = 250331, upload-time = "2025-07-26T12:02:50.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8c/469afb6465b853afff216f9528ffda78a915ff880ed58813ba4faf4ba0b6/contourpy-1.3.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b7448cb5a725bb1e35ce88771b86fba35ef418952474492cf7c764059933ff8b", size = 203831, upload-time = "2025-07-26T12:02:51.449Z" },
+]
+
+[[package]]
 name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -251,6 +441,50 @@ wheels = [
 ]
 
 [[package]]
+name = "cycler"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/95/a3dbbb5028f35eafb79008e7522a75244477d2838f38cbb722248dabc2a8/cycler-0.12.1.tar.gz", hash = "sha256:88bb128f02ba341da8ef447245a9e138fae777f6a23943da4540077d3601eb1c", size = 7615, upload-time = "2023-10-07T05:32:18.335Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl", hash = "sha256:85cef7cff222d8644161529808465972e51340599459b8ac3ccbac5a854e0d30", size = 8321, upload-time = "2023-10-07T05:32:16.783Z" },
+]
+
+[[package]]
+name = "debugpy"
+version = "1.8.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
+]
+
+[[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "delaunay-scripts"
 version = "0.7.8"
 source = { editable = "." }
@@ -269,6 +503,16 @@ dev = [
     { name = "ty" },
     { name = "yamllint" },
 ]
+notebooks = [
+    { name = "ipykernel" },
+    { name = "jupyterlab" },
+    { name = "matplotlib" },
+    { name = "nbclient" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "plotly" },
+    { name = "polars" },
+]
 
 [package.metadata]
 requires-dist = [{ name = "packaging" }]
@@ -284,6 +528,16 @@ dev = [
     { name = "ty", specifier = "==0.0.49" },
     { name = "yamllint", specifier = "==1.38.0" },
 ]
+notebooks = [
+    { name = "ipykernel", specifier = ">=7.1.0" },
+    { name = "jupyterlab", specifier = ">=4.5.1" },
+    { name = "matplotlib", specifier = ">=3.10.8" },
+    { name = "nbclient", specifier = ">=0.10.2" },
+    { name = "nbconvert", specifier = ">=7.17.1" },
+    { name = "nbformat", specifier = ">=5.10.4" },
+    { name = "plotly", specifier = ">=6.5.0" },
+    { name = "polars", specifier = ">=1.36.1" },
+]
 
 [[package]]
 name = "exceptiongroup"
@@ -292,6 +546,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/09/35/2495c4ac46b980e4ca1f6ad6db102322ef3ad2410b79fdde159a4b0f3b92/exceptiongroup-1.2.2.tar.gz", hash = "sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc", size = 28883, upload-time = "2024-07-12T22:26:00.161Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/02/cc/b7e31358aac6ed1ef2bb790a9746ac2c69bcb3c8588b41616914eb106eaf/exceptiongroup-1.2.2-py3-none-any.whl", hash = "sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b", size = 16453, upload-time = "2024-07-12T22:25:58.476Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -304,6 +567,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/fd/f84f0600bd72953d5a322f0dedbd4f900e2cedab718e6b6a093ae2d16aae/face-26.0.1.tar.gz", hash = "sha256:8183d94bc248baaea855a9f8445f97a22a9988908e60abddccc6e251da77c4c6", size = 51754, upload-time = "2026-06-17T23:14:39.938Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0a/24/0159c48d19c8b05e6969ee809bbbecc5a5c863f7e38c9327e2c63cb06f0f/face-26.0.1-py3-none-any.whl", hash = "sha256:ab0a83c37c9789dce658a67a9a80eafaa113c9ec37c5a9d950ff5480542a062d", size = 57572, upload-time = "2026-06-17T23:14:38.711Z" },
+]
+
+[[package]]
+name = "fastjsonschema"
+version = "2.21.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/b5/23b216d9d985a956623b6bd12d4086b60f0059b27799f23016af04a74ea1/fastjsonschema-2.21.2.tar.gz", hash = "sha256:b1eb43748041c880796cd077f1a07c3d94e93ae84bba5ed36800a33554ae05de", size = 374130, upload-time = "2025-08-14T18:49:36.666Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/a8/20d0723294217e47de6d9e2e40fd4a9d2f7c4b6ef974babd482a59743694/fastjsonschema-2.21.2-py3-none-any.whl", hash = "sha256:1c797122d0a86c5cace2e54bf4e819c36223b552017172f32c5c024a6b77e463", size = 24024, upload-time = "2025-08-14T18:49:34.776Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.63.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/69/c97f2c18e0db87d2c7b15da1974dace76ae938f1cfa22e2727a648b7ed43/fonttools-4.63.0.tar.gz", hash = "sha256:caeb583deeb5168e694b65cda8b4ee62abedfa66cf88488734466f2366b9c4e0", size = 3597189, upload-time = "2026-05-14T12:04:30.958Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/8d/d8fec3dcde2963f8c908fb315e5ff2cd0ac34f82394bbbf73a2aa5145ce3/fonttools-4.63.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:cd7e9857e5e63738b9d9fd707bc1f59c8b09e5177726d23664db393c59bb08bd", size = 2876062, upload-time = "2026-05-14T12:03:32.554Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/71/d935dc54e4ff121bfdd11e08702db63a7e6f25af21d8a3d7b7212df53641/fonttools-4.63.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c2a2a42198b696a6f48fad91709afb55176e66a5e566131219dba372fb7f8c59", size = 2424594, upload-time = "2026-05-14T12:03:34.86Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/40/e76320afa1df918e146155ef239b1719ee266092e96f5423bfd075affba1/fonttools-4.63.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e874792a8212b44583ea02189d9e693906b2f78b261f372f95d6c563210ac1d", size = 5024840, upload-time = "2026-05-14T12:03:36.745Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/36/0b805d8c485f872f65a509cbe3b58a5d0d17bee855333b54a150c79d3061/fonttools-4.63.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:22135da48a348785c5e2d5d2d9d6bec5ed44adacbaeb9db12d9493bf6c6bfa68", size = 4975801, upload-time = "2026-05-14T12:03:38.833Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/26/2cee03d0aa083ab022da5c07aff9ed3f689da1defb81ad6917c9627896da/fonttools-4.63.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ccf41f2efdf56994d22d73bef4ced1052161958169428d06ba9724ea9e9a64be", size = 4965009, upload-time = "2026-05-14T12:03:41.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/48/cc4b66d9058c0d0982c833fad10127c4b0e9324606aafa41382295ca4102/fonttools-4.63.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9ced0bd02ac751dd6319b0da88aaef24414e3b0dbc32bb4f24944821a3741a27", size = 5105892, upload-time = "2026-05-14T12:03:43.525Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/1f/a98a30a814b9ddef3a2e706025f90b9e0bc94890e6cb15254bc86547d11a/fonttools-4.63.0-cp313-cp313-win32.whl", hash = "sha256:85be818f5506e8a7753153def2c9550178f0ecae6a47b5e0e8dbb23f7cc90380", size = 2291313, upload-time = "2026-05-14T12:03:45.594Z" },
+    { url = "https://files.pythonhosted.org/packages/92/46/5177b01f3b4abfdd4409f31cca4ab279c9343a26efbe9ec78c97fc612e02/fonttools-4.63.0-cp313-cp313-win_amd64.whl", hash = "sha256:ba04cb5891d4c0c21b6da95eda8d7b090021508a294fff33464fc7d241e0856b", size = 2342299, upload-time = "2026-05-14T12:03:47.414Z" },
+    { url = "https://files.pythonhosted.org/packages/27/d2/23d25e3f247b328be58d04a4c9f894178a0d1eda7d42867cfb388adaf416/fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fd1e3094f42d806d3d7c79162fc59e5910fcbe3a7360c385b8da969bc4493745", size = 2875338, upload-time = "2026-05-14T12:03:50.052Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/58/7dfa0c761cb3b2964e2a84c4dc986c926a87de0cb9fb60d5b28ded3f2914/fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6e528da43bc3791085f8cb6141b1d13e459226790240340fcbb4625649238b03", size = 2422661, upload-time = "2026-05-14T12:03:52.154Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/87/64cfa18a7a1621d17b7f4502b2b0ed8a135a90c3db51ea590ee99043e76b/fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6b2248c5decb223562f7902ff6325077a073f608ee8e33e88ad88db734eb9f49", size = 5010526, upload-time = "2026-05-14T12:03:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/36/e1/a8933a72c45a87177fbde2696e0d0755c8c9062f8c077a961c6215fa27b1/fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:308f957cdeaf8abe4e5f2f124902ef405448af92c90f80e302a3b771c2e6116b", size = 4923946, upload-time = "2026-05-14T12:03:56.984Z" },
+    { url = "https://files.pythonhosted.org/packages/27/60/872e6e233b8c5e8b41413796ff18b7fe479661bd40147e071b450dfad7a1/fonttools-4.63.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:bf00f21eb5fb721dbaf73d1e9da6d02a1af7768f2ebcf9798be98beab8ba90f6", size = 4962489, upload-time = "2026-05-14T12:03:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/30/c4/83c24f2ec38b90cfda84bf4b1a1f49df80e84a1db4e7ac6e0d41bf23bc39/fonttools-4.63.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c1aaa4b9c75798400ac043ce04d74e7830376c85095a5a6ed7cba2f17a266bf4", size = 5071870, upload-time = "2026-05-14T12:04:02.122Z" },
+    { url = "https://files.pythonhosted.org/packages/de/40/3ae22b60ff1d41ce0bd044b31238cdc72cef99f28b976f1e128ebd618c9b/fonttools-4.63.0-cp314-cp314-win32.whl", hash = "sha256:22693918177bd9ceabec4736d338045f357769416fc6b0b2508eefef75b08616", size = 2295026, upload-time = "2026-05-14T12:04:04.47Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl", hash = "sha256:7d782fac32985914c351556f68ac0855391572bcd87de50e05970d3cd4c96fc5", size = 2347454, upload-time = "2026-05-14T12:04:06.752Z" },
+    { url = "https://files.pythonhosted.org/packages/49/4e/652d1580c5f4e39f7d103b0c793e4773129ad633dce4addd0cf4dfebde02/fonttools-4.63.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:6db5140a60a5d731d21ec076745b40a310607731b0a565b50776393188649001", size = 2958152, upload-time = "2026-05-14T12:04:08.706Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/55/ad864c9a9b219f552eb46b32cd7906c466e5a578ba0c3abfcc0fe7413eb6/fonttools-4.63.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7d76edbff9014094dbf03bd2d074709dfa6ec7aba13d838c937a2b33d2d6a86e", size = 2460809, upload-time = "2026-05-14T12:04:10.783Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/2b/0aa8db70f18cf52e49b4ed5ecec68547f981160bf5ded3b5aed6faa0a6f9/fonttools-4.63.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0eac00b9118c3c2f87d272e45341871c5b3066baa3c86897fa634a7c3fb59096", size = 5148649, upload-time = "2026-05-14T12:04:12.747Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/63/18e4369c25043096f1048e0c9915951adc4f842bd81c6b18155824d6fa99/fonttools-4.63.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:51394295f1a51de8b5f30bdb1e1b9a4231536c7064ef5c6e211eec19fa36036f", size = 4932147, upload-time = "2026-05-14T12:04:14.806Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/3f/67f3eac2ffd8a98446c5022f8ed3864eac878a5ff7af8df4c8286dba16cc/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9e12f105d2b6342c559c298afb674006bb2893afc7102dcf8a1b55b0486b4e40", size = 5027237, upload-time = "2026-05-14T12:04:17.675Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/ba/4e6214cb38a7b04779e97bb7636de9a5c7f20af7018d03dee0b64c08510a/fonttools-4.63.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:796f27556dbe094c4824f75ca85267e4df776c79036c8441469a4df37038c196", size = 5053933, upload-time = "2026-05-14T12:04:20.818Z" },
+    { url = "https://files.pythonhosted.org/packages/34/3b/214dcc19ee31d3d38fb5ad2755c11ef0514e5dc300bbaf41c0b69f393799/fonttools-4.63.0-cp314-cp314t-win32.whl", hash = "sha256:948428a275741f0b64b113c955425a953314f4b9ab9997f73a72c83e68e569c8", size = 2359326, upload-time = "2026-05-14T12:04:24.22Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/1e/3ff1a9b523058c2eeb6a9d50f5574e2a738200d0d94107d5bc4105e8da3f/fonttools-4.63.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6d4741eb179121cab9eea4cb2393d24492373a260d7945006358c08cfbf45419", size = 2425829, upload-time = "2026-05-14T12:04:26.829Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/47/c99d5268f354002ce80f8d029cd9d7d872969da1de8b93d32de4dc56d6f4/fonttools-4.63.0-py3-none-any.whl", hash = "sha256:445af2eab030a16b9171ea8bdda7ebf7d96bda2df88ee182a464252f6e05e20d", size = 1164562, upload-time = "2026-05-14T12:04:29.092Z" },
+]
+
+[[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
 ]
 
 [[package]]
@@ -409,6 +723,118 @@ wheels = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/22/58818a63eaf8982b67632b1bc20585c811611b15a8da19d6012323dc76a5/ipython-9.14.1-py3-none-any.whl", hash = "sha256:5d4a9ecaa3b10e6e5f269dd0948bdb58ca9cb851899cd23e07c320d3eb11613c", size = 627770, upload-time = "2026-06-05T08:12:33.045Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -421,6 +847,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/74/69/f7185de793a29082a9f3c7728268ffb31cb5095131a9c139a74078e27336/jsonschema-4.25.1.tar.gz", hash = "sha256:e4a9655ce0da0c0b67a085847e00a3a51449e1157f4f75e9fb5aa545e122eb85", size = 357342, upload-time = "2025-08-18T17:03:50.038Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/9c/8c95d856233c1f82500c2450b8c68576b4cf1c871db3afac5c34ff84e6fd/jsonschema-4.25.1-py3-none-any.whl", hash = "sha256:3fba0169e345c7175110351d456342c364814cfcf3b964ba4587f22915230a63", size = 90040, upload-time = "2025-08-18T17:03:48.373Z" },
+]
+
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
 ]
 
 [[package]]
@@ -436,6 +875,249 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-builder"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
+]
+
+[[package]]
+name = "jupyter-client"
+version = "8.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "python-dateutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
+]
+
+[[package]]
+name = "jupyter-core"
+version = "5.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/49/9d1284d0dc65e2c757b74c6687b6d319b02f822ad039e5c512df9194d9dd/jupyter_core-5.9.1.tar.gz", hash = "sha256:4d09aaff303b9566c3ce657f580bd089ff5c91f5f89cf7d8846c3cdf465b5508", size = 89814, upload-time = "2025-10-16T19:19:18.444Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/e7/80988e32bf6f73919a113473a604f5a8f09094de312b9d52b79c2df7612b/jupyter_core-5.9.1-py3-none-any.whl", hash = "sha256:ebf87fdc6073d142e114c72c9e29a9d7ca03fad818c5d300ce2adc1fb0743407", size = 29032, upload-time = "2025-10-16T19:19:16.783Z" },
+]
+
+[[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-builder" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/3c/1ebd737b860cdbe61eed71536d06aab4e1781fbdcf07ecd5a1afe05b8adf/jupyterlab-4.6.0.tar.gz", hash = "sha256:6a8b88f2aae7ed4d012c634fc957c1a27f3aa217c32f0ced0175fac9ee17f9e5", size = 28181861, upload-time = "2026-06-18T13:52:56.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/eb/aa48075d0aa3d0188db34ba2704f53791757743c0bb02e18c4eef989b6de/jupyterlab-4.6.0-py3-none-any.whl", hash = "sha256:b6938cb8a1ef3d43860ff4745a680c62cc0a9385f9672295bb56cd2e7cfeebe2", size = 17143447, upload-time = "2026-06-18T13:52:51.42Z" },
+]
+
+[[package]]
+name = "jupyterlab-pygments"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+]
+
+[[package]]
+name = "kiwisolver"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/67/9c61eccb13f0bdca9307614e782fec49ffdde0f7a2314935d489fa93cd9c/kiwisolver-1.5.0.tar.gz", hash = "sha256:d4193f3d9dc3f6f79aaed0e5637f45d98850ebf01f7ca20e69457f3e8946b66a", size = 103482, upload-time = "2026-03-09T13:15:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/69/024d6711d5ba575aa65d5538042e99964104e97fa153a9f10bc369182bc2/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:fd40bb9cd0891c4c3cb1ddf83f8bbfa15731a248fdc8162669405451e2724b09", size = 123166, upload-time = "2026-03-09T13:13:48.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/adbb40df306f587054a348831220812b9b1d787aff714cfbc8556e38fccd/kiwisolver-1.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c0e1403fd7c26d77c1f03e096dc58a5c726503fa0db0456678b8668f76f521e3", size = 66395, upload-time = "2026-03-09T13:13:49.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/3a/d0a972b34e1c63e2409413104216cd1caa02c5a37cb668d1687d466c1c45/kiwisolver-1.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dda366d548e89a90d88a86c692377d18d8bd64b39c1fb2b92cb31370e2896bbd", size = 64065, upload-time = "2026-03-09T13:13:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0a/7b98e1e119878a27ba8618ca1e18b14f992ff1eda40f47bccccf4de44121/kiwisolver-1.5.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:332b4f0145c30b5f5ad9374881133e5aa64320428a57c2c2b61e9d891a51c2f3", size = 1477903, upload-time = "2026-03-09T13:13:52.084Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d8/55638d89ffd27799d5cc3d8aa28e12f4ce7a64d67b285114dbedc8ea4136/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0c50b89ffd3e1a911c69a1dd3de7173c0cd10b130f56222e57898683841e4f96", size = 1278751, upload-time = "2026-03-09T13:13:54.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/97/b4c8d0d18421ecceba20ad8701358453b88e32414e6f6950b5a4bad54e65/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4db576bb8c3ef9365f8b40fe0f671644de6736ae2c27a2c62d7d8a1b4329f099", size = 1296793, upload-time = "2026-03-09T13:13:56.287Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/f862f94b6389d8957448ec9df59450b81bec4abb318805375c401a1e6892/kiwisolver-1.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:0b85aad90cea8ac6797a53b5d5f2e967334fa4d1149f031c4537569972596cb8", size = 1346041, upload-time = "2026-03-09T13:13:58.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/6a/f1650af35821eaf09de398ec0bc2aefc8f211f0cda50204c9f1673741ba9/kiwisolver-1.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:d36ca54cb4c6c4686f7cbb7b817f66f5911c12ddb519450bbe86707155028f87", size = 987292, upload-time = "2026-03-09T13:13:59.871Z" },
+    { url = "https://files.pythonhosted.org/packages/de/19/d7fb82984b9238115fe629c915007be608ebd23dc8629703d917dbfaffd4/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:38f4a703656f493b0ad185211ccfca7f0386120f022066b018eb5296d8613e23", size = 2227865, upload-time = "2026-03-09T13:14:01.401Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/b9/46b7f386589fd222dac9e9de9c956ce5bcefe2ee73b4e79891381dda8654/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:3ac2360e93cb41be81121755c6462cff3beaa9967188c866e5fce5cf13170859", size = 2324369, upload-time = "2026-03-09T13:14:02.972Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8b/95e237cf3d9c642960153c769ddcbe278f182c8affb20cecc1cc983e7cc5/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:c95cab08d1965db3d84a121f1c7ce7479bdd4072c9b3dafd8fecce48a2e6b902", size = 1977989, upload-time = "2026-03-09T13:14:04.503Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/95/980c9df53501892784997820136c01f62bc1865e31b82b9560f980c0e649/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc20894c3d21194d8041a28b65622d5b86db786da6e3cfe73f0c762951a61167", size = 2491645, upload-time = "2026-03-09T13:14:06.106Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/32/900647fd0840abebe1561792c6b31e6a7c0e278fc3973d30572a965ca14c/kiwisolver-1.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7a32f72973f0f950c1920475d5c5ea3d971b81b6f0ec53b8d0a956cc965f22e0", size = 2295237, upload-time = "2026-03-09T13:14:08.891Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8a/be60e3bbcf513cc5a50f4a3e88e1dcecebb79c1ad607a7222877becaa101/kiwisolver-1.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:0bf3acf1419fa93064a4c2189ac0b58e3be7872bf6ee6177b0d4c63dc4cea276", size = 73573, upload-time = "2026-03-09T13:14:12.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/d2/64be2e429eb4fca7f7e1c52a91b12663aeaf25de3895e5cca0f47ef2a8d0/kiwisolver-1.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:fa8eb9ecdb7efb0b226acec134e0d709e87a909fa4971a54c0c4f6e88635484c", size = 64998, upload-time = "2026-03-09T13:14:13.469Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/69/ce68dd0c85755ae2de490bf015b62f2cea5f6b14ff00a463f9d0774449ff/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:db485b3847d182b908b483b2ed133c66d88d49cacf98fd278fadafe11b4478d1", size = 125700, upload-time = "2026-03-09T13:14:14.636Z" },
+    { url = "https://files.pythonhosted.org/packages/74/aa/937aac021cf9d4349990d47eb319309a51355ed1dbdc9c077cdc9224cb11/kiwisolver-1.5.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:be12f931839a3bdfe28b584db0e640a65a8bcbc24560ae3fdb025a449b3d754e", size = 67537, upload-time = "2026-03-09T13:14:15.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/20/3a87fbece2c40ad0f6f0aefa93542559159c5f99831d596050e8afae7a9f/kiwisolver-1.5.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:16b85d37c2cbb3253226d26e64663f755d88a03439a9c47df6246b35defbdfb7", size = 65514, upload-time = "2026-03-09T13:14:18.035Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7f/f943879cda9007c45e1f7dba216d705c3a18d6b35830e488b6c6a4e7cdf0/kiwisolver-1.5.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4432b835675f0ea7414aab3d37d119f7226d24869b7a829caeab49ebda407b0c", size = 1584848, upload-time = "2026-03-09T13:14:19.745Z" },
+    { url = "https://files.pythonhosted.org/packages/37/f8/4d4f85cc1870c127c88d950913370dd76138482161cd07eabbc450deff01/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b0feb50971481a2cc44d94e88bdb02cdd497618252ae226b8eb1201b957e368", size = 1391542, upload-time = "2026-03-09T13:14:21.54Z" },
+    { url = "https://files.pythonhosted.org/packages/04/0b/65dd2916c84d252b244bd405303220f729e7c17c9d7d33dca6feeff9ffc4/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:56fa888f10d0f367155e76ce849fa1166fc9730d13bd2d65a2aa13b6f5424489", size = 1404447, upload-time = "2026-03-09T13:14:23.205Z" },
+    { url = "https://files.pythonhosted.org/packages/39/5c/2606a373247babce9b1d056c03a04b65f3cf5290a8eac5d7bdead0a17e21/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:940dda65d5e764406b9fb92761cbf462e4e63f712ab60ed98f70552e496f3bf1", size = 1455918, upload-time = "2026-03-09T13:14:24.74Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d1/c6078b5756670658e9192a2ef11e939c92918833d2745f85cd14a6004bdf/kiwisolver-1.5.0-cp313-cp313t-manylinux_2_39_riscv64.whl", hash = "sha256:89fc958c702ee9a745e4700378f5d23fddbc46ff89e8fdbf5395c24d5c1452a3", size = 1072856, upload-time = "2026-03-09T13:14:26.597Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/c8/7def6ddf16eb2b3741d8b172bdaa9af882b03c78e9b0772975408801fa63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9027d773c4ff81487181a925945743413f6069634d0b122d0b37684ccf4f1e18", size = 2333580, upload-time = "2026-03-09T13:14:28.237Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/87/2ac1fce0eb1e616fcd3c35caa23e665e9b1948bb984f4764790924594128/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:5b233ea3e165e43e35dba1d2b8ecc21cf070b45b65ae17dd2747d2713d942021", size = 2423018, upload-time = "2026-03-09T13:14:30.018Z" },
+    { url = "https://files.pythonhosted.org/packages/67/13/c6700ccc6cc218716bfcda4935e4b2997039869b4ad8a94f364c5a3b8e63/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ce9bf03dad3b46408c08649c6fbd6ca28a9fce0eb32fdfffa6775a13103b5310", size = 2062804, upload-time = "2026-03-09T13:14:32.888Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/bd/877056304626943ff0f1f44c08f584300c199b887cb3176cd7e34f1515f1/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:fc4d3f1fb9ca0ae9f97b095963bc6326f1dbfd3779d6679a1e016b9baaa153d3", size = 2597482, upload-time = "2026-03-09T13:14:34.971Z" },
+    { url = "https://files.pythonhosted.org/packages/75/19/c60626c47bf0f8ac5dcf72c6c98e266d714f2fbbfd50cf6dab5ede3aaa50/kiwisolver-1.5.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f443b4825c50a51ee68585522ab4a1d1257fac65896f282b4c6763337ac9f5d2", size = 2394328, upload-time = "2026-03-09T13:14:36.816Z" },
+    { url = "https://files.pythonhosted.org/packages/47/84/6a6d5e5bb8273756c27b7d810d47f7ef2f1f9b9fd23c9ee9a3f8c75c9cef/kiwisolver-1.5.0-cp313-cp313t-win_arm64.whl", hash = "sha256:893ff3a711d1b515ba9da14ee090519bad4610ed1962fbe298a434e8c5f8db53", size = 68410, upload-time = "2026-03-09T13:14:38.695Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/060f45052f2a01ad5762c8fdecd6d7a752b43400dc29ff75cd47225a40fd/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8df31fe574b8b3993cc61764f40941111b25c2d9fea13d3ce24a49907cd2d615", size = 123231, upload-time = "2026-03-09T13:14:41.323Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/a7/78da680eadd06ff35edef6ef68a1ad273bad3e2a0936c9a885103230aece/kiwisolver-1.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1d49a49ac4cbfb7c1375301cd1ec90169dfeae55ff84710d782260ce77a75a02", size = 66489, upload-time = "2026-03-09T13:14:42.534Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b2/97980f3ad4fae37dd7fe31626e2bf75fbf8bdf5d303950ec1fab39a12da8/kiwisolver-1.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0cbe94b69b819209a62cb27bdfa5dc2a8977d8de2f89dfd97ba4f53ed3af754e", size = 64063, upload-time = "2026-03-09T13:14:44.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/f9/b06c934a6aa8bc91f566bd2a214fd04c30506c2d9e2b6b171953216a65b6/kiwisolver-1.5.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:80aa065ffd378ff784822a6d7c3212f2d5f5e9c3589614b5c228b311fd3063ac", size = 1475913, upload-time = "2026-03-09T13:14:46.247Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/f0/f768ae564a710135630672981231320bc403cf9152b5596ec5289de0f106/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e7f886f47ab881692f278ae901039a234e4025a68e6dfab514263a0b1c4ae05", size = 1282782, upload-time = "2026-03-09T13:14:48.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/9f/1de7aad00697325f05238a5f2eafbd487fb637cc27a558b5367a5f37fb7f/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:5060731cc3ed12ca3a8b57acd4aeca5bbc2f49216dd0bec1650a1acd89486bcd", size = 1300815, upload-time = "2026-03-09T13:14:50.721Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/c2/297f25141d2e468e0ce7f7a7b92e0cf8918143a0cbd3422c1ad627e85a06/kiwisolver-1.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7a4aa69609f40fce3cbc3f87b2061f042eee32f94b8f11db707b66a26461591a", size = 1347925, upload-time = "2026-03-09T13:14:52.304Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d3/f4c73a02eb41520c47610207b21afa8cdd18fdbf64ffd94674ae21c4812d/kiwisolver-1.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:d168fda2dbff7b9b5f38e693182d792a938c31db4dac3a80a4888de603c99554", size = 991322, upload-time = "2026-03-09T13:14:54.637Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/46/d3f2efef7732fcda98d22bf4ad5d3d71d545167a852ca710a494f4c15343/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:413b820229730d358efd838ecbab79902fe97094565fdc80ddb6b0a18c18a581", size = 2232857, upload-time = "2026-03-09T13:14:56.471Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/2d9756bf2b6d26ae4349b8d3662fb3993f16d80c1f971c179ce862b9dbae/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5124d1ea754509b09e53738ec185584cc609aae4a3b510aaf4ed6aa047ef9303", size = 2329376, upload-time = "2026-03-09T13:14:58.072Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9f/876a0a0f2260f1bde92e002b3019a5fabc35e0939c7d945e0fa66185eb20/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e4415a8db000bf49a6dd1c478bf70062eaacff0f462b92b0ba68791a905861f9", size = 1982549, upload-time = "2026-03-09T13:14:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/ba3624dfac23a64d54ac4179832860cb537c1b0af06024936e82ca4154a0/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d618fd27420381a4f6044faa71f46d8bfd911bd077c555f7138ed88729bfbe79", size = 2494680, upload-time = "2026-03-09T13:15:01.364Z" },
+    { url = "https://files.pythonhosted.org/packages/39/b7/97716b190ab98911b20d10bf92eca469121ec483b8ce0edd314f51bc85af/kiwisolver-1.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5092eb5b1172947f57d6ea7d89b2f29650414e4293c47707eb499ec07a0ac796", size = 2297905, upload-time = "2026-03-09T13:15:03.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/36/4e551e8aa55c9188bca9abb5096805edbf7431072b76e2298e34fd3a3008/kiwisolver-1.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:d76e2d8c75051d58177e762164d2e9ab92886534e3a12e795f103524f221dd8e", size = 75086, upload-time = "2026-03-09T13:15:07.775Z" },
+    { url = "https://files.pythonhosted.org/packages/70/15/9b90f7df0e31a003c71649cf66ef61c3c1b862f48c81007fa2383c8bd8d7/kiwisolver-1.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:fa6248cd194edff41d7ea9425ced8ca3a6f838bfb295f6f1d6e6bb694a8518df", size = 66577, upload-time = "2026-03-09T13:15:09.139Z" },
+    { url = "https://files.pythonhosted.org/packages/17/01/7dc8c5443ff42b38e72731643ed7cf1ed9bf01691ae5cdca98501999ed83/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:d1ffeb80b5676463d7a7d56acbe8e37a20ce725570e09549fe738e02ca6b7e1e", size = 125794, upload-time = "2026-03-09T13:15:10.525Z" },
+    { url = "https://files.pythonhosted.org/packages/46/8a/b4ebe46ebaac6a303417fab10c2e165c557ddaff558f9699d302b256bc53/kiwisolver-1.5.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bc4d8e252f532ab46a1de9349e2d27b91fce46736a9eedaa37beaca66f574ed4", size = 67646, upload-time = "2026-03-09T13:15:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/60/35/10a844afc5f19d6f567359bf4789e26661755a2f36200d5d1ed8ad0126e5/kiwisolver-1.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6783e069732715ad0c3ce96dbf21dbc2235ab0593f2baf6338101f70371f4028", size = 65511, upload-time = "2026-03-09T13:15:13.311Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/8a/685b297052dd041dcebce8e8787b58923b6e78acc6115a0dc9189011c44b/kiwisolver-1.5.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e7c4c09a490dc4d4a7f8cbee56c606a320f9dc28cf92a7157a39d1ce7676a657", size = 1584858, upload-time = "2026-03-09T13:15:15.103Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/80/04865e3d4638ac5bddec28908916df4a3075b8c6cc101786a96803188b96/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a075bd7bd19c70cf67c8badfa36cf7c5d8de3c9ddb8420c51e10d9c50e94920", size = 1392539, upload-time = "2026-03-09T13:15:16.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/01/77a19cacc0893fa13fafa46d1bba06fb4dc2360b3292baf4b56d8e067b24/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bdd3e53429ff02aa319ba59dfe4ceeec345bf46cf180ec2cf6fd5b942e7975e9", size = 1405310, upload-time = "2026-03-09T13:15:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/53/39/bcaf5d0cca50e604cfa9b4e3ae1d64b50ca1ae5b754122396084599ef903/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3cdcb35dc9d807259c981a85531048ede628eabcffb3239adf3d17463518992d", size = 1456244, upload-time = "2026-03-09T13:15:20.444Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/7a/72c187abc6975f6978c3e39b7cf67aeb8b3c0a8f9790aa7fd412855e9e1f/kiwisolver-1.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:70d593af6a6ca332d1df73d519fddb5148edb15cd90d5f0155e3746a6d4fcc65", size = 1073154, upload-time = "2026-03-09T13:15:22.039Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ca/cf5b25783ebbd59143b4371ed0c8428a278abe68d6d0104b01865b1bbd0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:377815a8616074cabbf3f53354e1d040c35815a134e01d7614b7692e4bf8acfa", size = 2334377, upload-time = "2026-03-09T13:15:23.741Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/e5/b1f492adc516796e88751282276745340e2a72dcd0d36cf7173e0daf3210/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0255a027391d52944eae1dbb5d4cc5903f57092f3674e8e544cdd2622826b3f0", size = 2425288, upload-time = "2026-03-09T13:15:25.789Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/e5/9b21fbe91a61b8f409d74a26498706e97a48008bfcd1864373d32a6ba31c/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:012b1eb16e28718fa782b5e61dc6f2da1f0792ca73bd05d54de6cb9561665fc9", size = 2063158, upload-time = "2026-03-09T13:15:27.63Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/02/83f47986138310f95ea95531f851b2a62227c11cbc3e690ae1374fe49f0f/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e3aafb33aed7479377e5e9a82e9d4bf87063741fc99fc7ae48b0f16e32bdd6f", size = 2597260, upload-time = "2026-03-09T13:15:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
+    { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -445,6 +1127,117 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "matplotlib"
+version = "3.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "contourpy" },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/41/aa47f156b061d14c98b906f76c428507397708ec63ff94f410ae1752b426/matplotlib-3.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:6ce3b839b34ae1f430b4616893a2945a2999debaa7e94e7e29a2a8bbf286f7b5", size = 9450532, upload-time = "2026-06-12T02:28:06.769Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/4f/5a9eb0375e81413953febf8af7b012a6b6357f53438a15c4f5ad86c6bbb5/matplotlib-3.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:373db8f91214e8ccaf35ac833cc1dd59dd961e148bbd55dd027141591dde1313", size = 9279760, upload-time = "2026-06-12T02:28:09.152Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/c0/1117d53077e3ac3152503a84e9cf7a5c239576805ee71276e80c2aaa7471/matplotlib-3.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:be152b7570324dc8d01574cc9474dd2d803237acf528bcbb5b211fa347461a09", size = 10031623, upload-time = "2026-06-12T02:28:11.26Z" },
+    { url = "https://files.pythonhosted.org/packages/92/7e/e937138daffad65b71bf831a377809dcbc830fb4f31a31e067dc1faa2575/matplotlib-3.11.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:126f256df600652d7e4b394cf3164ff75210a00038f287c95a012a6f58d0e83f", size = 10839372, upload-time = "2026-06-12T02:28:14.102Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/c2/438ecc197ffb8023b6b9922915542f2172f5fd45b76703b0b4fc47322243/matplotlib-3.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:03acfeddf87b0dddb11b081ef7740ad445a3ca8bcb6b8e3011b08f2cf802b75c", size = 10924099, upload-time = "2026-06-12T02:28:16.383Z" },
+    { url = "https://files.pythonhosted.org/packages/40/2e/395883da416f378b3ed2c9f3e843ac477eae1ce731b671b79adaa6f0bacd/matplotlib-3.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:ab3722f04f3ff34c23b5012c5873d2894174e06c3822fcdac3610965a5ac7d06", size = 9329727, upload-time = "2026-06-12T02:28:18.581Z" },
+    { url = "https://files.pythonhosted.org/packages/61/82/2c388956abf8bf392dfb5b8917c502f1082df6a941b781ab8c8e5ba2474b/matplotlib-3.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:c945824670fb8915b4ac879e5e61f3c58e0913022f70a0de4c082b17372f8771", size = 9003506, upload-time = "2026-06-12T02:28:20.474Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c1/34454baa44da7975ada82e9aea37105ec47059514dc967d3be14426ba8dc/matplotlib-3.11.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:3489c3dc487669b4a980bc3068f87856de7a1564248d3f6c629efb2a58b03f24", size = 9499838, upload-time = "2026-06-12T02:28:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/c3/98fe79a398cf232219f090163a7fa7e6766e9f2e0ad26df54d6f8934d8ee/matplotlib-3.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:6a98f5476ce784a50ce09998f4ae1e6a9f25043cef8a480c98949902eda74620", size = 9332298, upload-time = "2026-06-12T02:28:24.796Z" },
+    { url = "https://files.pythonhosted.org/packages/95/e4/b4b7c33151e74e5c802f3cde1ba807ebfc38401e329b44e215a5888dd76d/matplotlib-3.11.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:565af866fd63e4bd3f987d580afe27c44c2552a3b3305f4ecbb85133601ea6f3", size = 10045491, upload-time = "2026-06-12T02:28:27.141Z" },
+    { url = "https://files.pythonhosted.org/packages/71/28/394548efd68354110c1a1be11fe6b6e559e06d1a23da35908a0e316c55a9/matplotlib-3.11.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e6b3e64dea5062c570f04358e2711859f3531b459f29516274fbad889079e4f3", size = 10857059, upload-time = "2026-06-12T02:28:29.222Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/44/e7922e6e2a4d63bdfbc9dc4a53e3850ab438d46cf42e6779bb15ec92c948/matplotlib-3.11.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:942b37c5db1899610bd1543ce8e13e4ecff9a4633e7f63bb6aa9205d2644ebd1", size = 10939576, upload-time = "2026-06-12T02:28:31.66Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/be/b1ca96003a441d619b727fee21d671fdff7a5ce2f1bb797b2521aa2f679a/matplotlib-3.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c08e649a6313e1291e713623b97a38e5bb4aa580b2a100a94a3309bc6b9c8eb3", size = 9379519, upload-time = "2026-06-12T02:28:33.888Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/72/4bf3b91821c34596dd6a7bdac5836d94f744144c8208939ef49d8ec43f7e/matplotlib-3.11.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2746cd2c113742ff6ce37a864c5ac5fd7aa644568f445e66166e457ac78e40e0", size = 9055456, upload-time = "2026-06-12T02:28:35.878Z" },
+    { url = "https://files.pythonhosted.org/packages/57/52/a94102ac99eb78e2fe9b826674f9ef9ee23327110ea6ab4776c1b4eb6209/matplotlib-3.11.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3338e3e3de128cf50d0d2fb92a122815daf9c755bd882a474343c05f8fd7ec79", size = 9452137, upload-time = "2026-06-12T02:28:37.93Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/03/b8cdb625a21f710dfa11bbca1f48fb4057d2c0286975f8b415bf80942c99/matplotlib-3.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:25c2e5455efd8d99f41fb79871a31feb7d301569642e332ec58d72cfe9282bc3", size = 9281514, upload-time = "2026-06-12T02:28:40.028Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/2d/4e1240ea82ee197dfb3851e71f71c87eeeb975f1753b56a0588e4e80739a/matplotlib-3.11.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9695457a467ff86d23f35037a43deb6f1134dd6d3e2ac8ce1e2087cff09ffb9", size = 10843005, upload-time = "2026-06-12T02:28:42.39Z" },
+    { url = "https://files.pythonhosted.org/packages/29/dc/6377ecfaa5fef79430f74a1a16638b4e2aa30d4692bae2c19f9d76fe3b01/matplotlib-3.11.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19c16c61dea63b3582918503e6b294193961261d9daa806d4ae2151f1ad05430", size = 11127459, upload-time = "2026-06-12T02:28:44.483Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/41/795c405aa7560443a3b01309424cde4a1113b85c90b8a63417444a749617/matplotlib-3.11.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2d72ea8b7924f3cb955e61518d21e43b3df1e6c8a793b480a0c1214f185d30ba", size = 10925160, upload-time = "2026-06-12T02:28:46.564Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/f7/3a9e6389a7cfaeff76c56e40c2dabcb13110e21e82f837228c834ebe748c/matplotlib-3.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:1c02da0a629dfa9debf52725ea06866b74c1fb70a895bae05e4493d34074f9f2", size = 9485186, upload-time = "2026-06-12T02:28:49.344Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/c0/396478ee7cf2091d182db8b4a8695f6a37f1ddb978989cf9dbb84cd5c123/matplotlib-3.11.0-cp314-cp314-win_arm64.whl", hash = "sha256:aa55d73b3117d4b07f959cd9eb6f69b375d8df3414139c479388e551aa5d999d", size = 9160349, upload-time = "2026-06-12T02:28:51.382Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/6f/1c3bd51bb2b34eaacdcf3c3d859dbb357f952fc8020c617dc118ad7c9e38/matplotlib-3.11.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a9d8c6e7cd2f0ddf11d8d92e520dd1d9d2abb0cf6ac8831e338666c81e905847", size = 9500921, upload-time = "2026-06-12T02:28:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/4d861d0121840cb1a3fd4a10deb211efd6fccd481ed23e553f31f4f4da4a/matplotlib-3.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:be050fcf32f729eda99f7f75a80bf67612ce16ab9ac1c23a387dcaede95cb70e", size = 9332190, upload-time = "2026-06-12T02:28:55.623Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/cb/22f6bc35711a0b5639a784e74e653e77c86210bd4304449dd399a482f74e/matplotlib-3.11.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfabef0230d0697aa0d717385194dd41162e00207a68bf4abf94c2bf4c27dca0", size = 10854181, upload-time = "2026-06-12T02:28:57.856Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/7e/9a9eaca731a2939589da520f0ebe8fd8753d0f51fca98c7d20af6dbe261a/matplotlib-3.11.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1644db30e759199443493ac5e5caec24fdb775a8f6123021f85ba47c4133c3cb", size = 11137715, upload-time = "2026-06-12T02:29:00.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/f9/9b030b6088354acb0296871bb624b25befc1c42509d3c6cd17420c83a5b8/matplotlib-3.11.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:15b0d160079cb10699a0e98b5989c70677b2df7cacdc62af67c30f2facec46d9", size = 10939427, upload-time = "2026-06-12T02:29:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/59/94/6b273eaee4ee250863567d100865da61a5c1527fa67f527b7ed22e0dd29c/matplotlib-3.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:446307e6b04b57b1f1239e228a1ec2af0d589a1008cebc3dfa3f5441d095cfb6", size = 9535809, upload-time = "2026-06-12T02:29:04.994Z" },
+    { url = "https://files.pythonhosted.org/packages/60/95/1d36bddf2b7e2692c1540e78a6e5bc88bc1496b137e3e35a611f91b65ac3/matplotlib-3.11.0-cp314-cp314t-win_arm64.whl", hash = "sha256:652fb5696271d4c50f196d22a5ff4f8e4444c74f847423570d7dc0aa2bbd0159", size = 9209226, upload-time = "2026-06-12T02:29:07.033Z" },
+]
+
+[[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
 ]
 
 [[package]]
@@ -479,6 +1272,140 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mistune"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/5f/007786743f962224423753b78f7d7acb0f2ade46d1604f2e0fa2bedf9020/mistune-3.3.2.tar.gz", hash = "sha256:e12ee4f1e74336e91aa1141e35f913b337c40bdf7c0cc49f21fb853a27e8b62f", size = 111284, upload-time = "2026-06-23T00:29:28.568Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/43/894c2cbbcbdf53b57d1257a249811abe2ee9ab7ef76af301b40f1c054533/mistune-3.3.2-py3-none-any.whl", hash = "sha256:a678a56387d487db7368ede4647cb2ba1deff22ce61f92343e4ebe0ddfce4f2d", size = 61554, upload-time = "2026-06-23T00:29:27.088Z" },
+]
+
+[[package]]
+name = "narwhals"
+version = "2.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/3c/c4ef2164a71c1a63d7f1ae411c4082c5fa872405106db60a4b7114989ad7/narwhals-2.22.1.tar.gz", hash = "sha256:d62920805a0a43b7ff8b54b0c0d3142d796f8a9301836ada37e573d6a33cbcd9", size = 647493, upload-time = "2026-06-05T12:34:34.051Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/ca/36339329c4604adbcc99c899b7eb1ce1a555c499b6a6860757dc9bfed36d/narwhals-2.22.1-py3-none-any.whl", hash = "sha256:60567d774edf77db53906f89d9fbd164e66e56d66d388e1e6990f17ac33cfb53", size = 454815, upload-time = "2026-06-05T12:34:32.289Z" },
+]
+
+[[package]]
+name = "nbclient"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "nbformat" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/a5/b3bae4b590c0cbcada2c63a34f7580024e834a8ba213e949a2f906705787/nbclient-0.11.0.tar.gz", hash = "sha256:04a134a5b087f2c5887f228aca155db50169b8cd9334dee6942c8e927e56081a", size = 62535, upload-time = "2026-06-05T07:52:41.746Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/c9/94d73e5a01c5b926c3fa2496e97d7a8dc28ed5a77c0b2ed712f1a62e6694/nbclient-0.11.0-py3-none-any.whl", hash = "sha256:ef7fa0d59d6e1d41103933d8a445a18d5de860ca6b613b87b8574accdb3c2895", size = 25288, upload-time = "2026-06-05T07:52:40.115Z" },
+]
+
+[[package]]
+name = "nbconvert"
+version = "7.17.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "bleach", extra = ["css"] },
+    { name = "defusedxml" },
+    { name = "jinja2" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab-pygments" },
+    { name = "markupsafe" },
+    { name = "mistune" },
+    { name = "nbclient" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pandocfilters" },
+    { name = "pygments" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/b1/708e53fe2e429c103c6e6e159106bcf0357ac41aa4c28772bd8402339051/nbconvert-7.17.1.tar.gz", hash = "sha256:34d0d0a7e73ce3cbab6c5aae8f4f468797280b01fd8bd2ca746da8569eddd7d2", size = 865311, upload-time = "2026-04-08T00:44:14.914Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/f8/bb0a9d5f46819c821dc1f004aa2cc29b1d91453297dbf5ff20470f00f193/nbconvert-7.17.1-py3-none-any.whl", hash = "sha256:aa85c087b435e7bf1ffd03319f658e285f2b89eccab33bc1ba7025495ab3e7c8", size = 261927, upload-time = "2026-04-08T00:44:12.845Z" },
+]
+
+[[package]]
+name = "nbformat"
+version = "5.10.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastjsonschema" },
+    { name = "jsonschema" },
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fd/91545e604bc3dad7dca9ed03284086039b294c6b3d75c0d2fa45f9e9caf3/nbformat-5.10.4.tar.gz", hash = "sha256:322168b14f937a5d11362988ecac2a4952d3d8e3a2cbeb2319584631226d5b3a", size = 142749, upload-time = "2024-04-04T11:20:37.371Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/82/0340caa499416c78e5d8f5f05947ae4bc3cba53c9f038ab6e9ed964e22f1/nbformat-5.10.4-py3-none-any.whl", hash = "sha256:3b48d6c8fbca4b299bf3982ea7db1af21580e4fec269ad087b9e81588891200b", size = 78454, upload-time = "2024-04-04T11:20:34.895Z" },
+]
+
+[[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+]
+
+[[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
+]
+
+[[package]]
+name = "numpy"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/05/3d27272d30698dc0ecb7fdfaa41ad70303b444f81722bb99bce1d818638a/numpy-2.5.0.tar.gz", hash = "sha256:5a129578019311b6e56bdd714250f19b518f7dceeeb8d1af5490f4942d3f891c", size = 20652461, upload-time = "2026-06-21T20:57:51.95Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/33/07675aaad7f26ea013d5e884d9a0d784b79c6bd7566c333f5a52fa3c610b/numpy-2.5.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:520e6b8be0a4b65840ac8090d4f51cef4bed66e2b0894d5a520f099adc24a9b2", size = 16784890, upload-time = "2026-06-21T20:56:40.799Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4b/953118a730ee3b35e28645e0eb4cf9beec5bdbb954e1ac2f5fcefba6bbc3/numpy-2.5.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:146b81cdd3967fdb6beca8ba25f00c58741d8f3cbd797f55af0fbe0bfec3469c", size = 11754584, upload-time = "2026-06-21T20:56:43.094Z" },
+    { url = "https://files.pythonhosted.org/packages/44/9b/56dd530c367c74ae17411027cea4135ca57e1e0583bf5594cee18bd83217/numpy-2.5.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:126b88d95e8ff9b00c9e717aa540469f21d6180162f84c0caec51b16215d49cd", size = 5313904, upload-time = "2026-06-21T20:56:45.503Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b0/bcd672edad27ecca7da1f7bb0ce72cd1706a4f2d79ae94990afc97c13e1c/numpy-2.5.0-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:d4313cef1594c5ce46c31b6e54e918338f63f16ee9322304e8c9114d6d81c8bd", size = 6648504, upload-time = "2026-06-21T20:56:47.567Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9e/15cdfcbd30a1544a46c9e487a00df331c4672450216538705a9e51fa6710/numpy-2.5.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:750fb097caf26fa878746d9d119f6f9da12dedcbff1eea966c3e3447647c4a9e", size = 15150086, upload-time = "2026-06-21T20:56:49.352Z" },
+    { url = "https://files.pythonhosted.org/packages/32/4e/8d7656ccaab3e81e97258b8a9bc5f0c8502513a92fb4ceb0a2cbfebc17bf/numpy-2.5.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3893adc2dc7c0412ba76777db55a049215d99c9aa3113003be8f49f4f1290ab9", size = 16647250, upload-time = "2026-06-21T20:56:51.542Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/81/97060281b602ed07f21b12f4ec409eac1f75a2f91fbc829ed8b2becf3ad4/numpy-2.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:835e454dd99b238cdc5a3f63bce2371296f5ebc53ca1e0f8e6ddbb6d92a29aab", size = 16512864, upload-time = "2026-06-21T20:56:55.401Z" },
+    { url = "https://files.pythonhosted.org/packages/33/ab/4496208146911f8d8ddb54f68a972aafa6c8d44babcb2ea03b0e5cc87c9d/numpy-2.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6f9836778081a0a3c02a6a21493f3e9f5b311f8d2541934f31f05583dc999ea4", size = 18408407, upload-time = "2026-06-21T20:56:57.75Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/9f/a4df67c181e4ee8b467aa3332dc2db10fd5c515136831302f3ca48bc0a01/numpy-2.5.0-cp313-cp313-win32.whl", hash = "sha256:0b525be4744b60bb0557ac872d53ef07d085b5f39622bc579c98d3809d05b988", size = 6054431, upload-time = "2026-06-21T20:57:00.016Z" },
+    { url = "https://files.pythonhosted.org/packages/30/53/491e1c47c55b62ccc6a63c1c5b8635c73fc2258dddeb9bda27cae4a0ae96/numpy-2.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:44353e2878930039db472b99dc353d749826e4010bd4d2a7f835e94a97a5c748", size = 12414420, upload-time = "2026-06-21T20:57:01.815Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/4a/25c2906f541e9d9f4c5769764db732e6627be91a13f4724fa10634d77db4/numpy-2.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:48f54b00711f83a5f796b70c518e8c2b3c5848dda03a54911f23eb68519b9b60", size = 10339533, upload-time = "2026-06-21T20:57:03.961Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ad/abc44aaceaf7b17ee1edde2bbb4458da591bc79574cffff50c4bb35f00d1/numpy-2.5.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f27582c55ba4c750b7c58c8faf021d2cd9324a662b466229db8a417b41368af9", size = 16783807, upload-time = "2026-06-21T20:57:06.253Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/39/b72e168daf9c00fb20c9fc996d00437ccecdef3102387775d29d7a62576d/numpy-2.5.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:28e7137057d551e4a83c4ae414e3451f50568409db7569aacc7f9811ee06a446", size = 11765215, upload-time = "2026-06-21T20:57:08.547Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/8400a9c0e3625182347593f5e1f57da9a617a534794805c8df5518154ddc/numpy-2.5.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:e1da54b53e75cd9fcfc23efcc7edab2c6aecf97b6037566d8a0fe804af8ec57c", size = 5324493, upload-time = "2026-06-21T20:57:11.012Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/8c/0d104deaa0401c93395a629ec902891618a2eff76d19229139cb5a887bfc/numpy-2.5.0-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:694d8f74e156f7fd01179f1aa8faa2f648ab6ae0f70b6c3fe57a03249aea2303", size = 6645211, upload-time = "2026-06-21T20:57:12.919Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d9/4a4a628c812750363786afc3d33492709a5cd64b215469c16b0f6c7bb811/numpy-2.5.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1a7569a7b53c77716f036bb28cb1c91f166a26ec7d9502cd1e4bdfe502fdec22", size = 15166004, upload-time = "2026-06-21T20:57:14.717Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/5e/2a902317d7fc4aa93236e80c932662dadfc459b323d758329e01775125e1/numpy-2.5.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:39a0433bd4086ebd462960cf375e19195bb07b53dc1d87dd5fcf47ad78576f03", size = 16650797, upload-time = "2026-06-21T20:57:16.906Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/a0/a0090e6329f4ca5992c07847bb579c5259a19953dc57255bb08793142ffb/numpy-2.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:929f0c79ac38bcbd7154fe631dc907abfeddbcc5027a896bd1f7767323271e7a", size = 16524647, upload-time = "2026-06-21T20:57:19.165Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/7d/6caf27734c42b65837e7461ed0dbbd6b6fc835060c9714ec59d673bb383a/numpy-2.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cc4f247a47bbf070bfd70be53ccdcf47b800af563535e7bbe172322197c30e21", size = 18411841, upload-time = "2026-06-21T20:57:21.638Z" },
+    { url = "https://files.pythonhosted.org/packages/13/dc/26edadbd812536769a82c2e9e002234e33feb5da43061d47a044f6d309b7/numpy-2.5.0-cp314-cp314-win32.whl", hash = "sha256:5dc71423499fab3f46f7a7201155ade1669ea101f2f429d332df9e72f8161731", size = 6106361, upload-time = "2026-06-21T20:57:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/9e/4dd1459282229a72d92dece2ae9138e5cac94a72263a7ceb48f37434c925/numpy-2.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:ebb81d9d5443e0309d6c54894c3fbed74ad7da0714352a67b6d773cd189eae73", size = 12551749, upload-time = "2026-06-21T20:57:25.945Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a7/6bc6384c080b86c7f6c85c5bc5b540b24f4f679cd144791d99574e90d462/numpy-2.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:3b94d0d0deceebfad3e67ae5c0e5eb87371e8f7a0581cd04a779928c2450cf1e", size = 10617072, upload-time = "2026-06-21T20:57:28.175Z" },
+    { url = "https://files.pythonhosted.org/packages/86/6b/4a2b71d66ada5608ae02b63f150dfad520f6940721cb7f029ad270befc0e/numpy-2.5.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:22f3d43e362d650bc39db1f17851302874a148ca95ba6981c1dfb5fa6862f35b", size = 11881067, upload-time = "2026-06-21T20:57:30.104Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/d365eb40a20efb49d67e9feb90494ed8511282ee1f5fa16006675c65397d/numpy-2.5.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:243563efb4cd7528a264567e9fd206c87826457322521d06206a00bfa316c927", size = 5440290, upload-time = "2026-06-21T20:57:32.193Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5e/e9c03188de5f9b767e46a8fe988bcfd3efad066a4a3fda8b9cb11a93f895/numpy-2.5.0-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:84881d825ca75249b189bbee875fcfe3238aa5c479e6100893cda566e8e86826", size = 6748371, upload-time = "2026-06-21T20:57:33.933Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1d/68c186a38a5027bae2c4ddd5ea681fdaf8b4d30fb7301def6d8ad270390f/numpy-2.5.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cda12aa4779d42b8771180aba759c96f527d43446d8f380ab59e2b35e8489efd", size = 15214643, upload-time = "2026-06-21T20:57:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/73f67b7c7e20635baae9c4c3ead4ae7326a005900297a6110971abd62eb5/numpy-2.5.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c0121101093d2bd74981b10f8837d78e794a8ff57834eb27179f49e1ba11ac6", size = 16690128, upload-time = "2026-06-21T20:57:38.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/05/d4c1fb0c46d02a27d6b2b8b319a78c90937acec8631c1641874670b31e6f/numpy-2.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:d371c92cfa09da00022f501ab67fafaea813d752eb30ac44336d45b1e5b0268a", size = 16577902, upload-time = "2026-06-21T20:57:40.447Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1d/771c797d50fa26e4888989cccf1d50ee51f530d4e455ad2692dcb64fa711/numpy-2.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9990713e9c38154c6861e7547f1e3fc7a87e75ff09bab24ef1cc81d81c2835e9", size = 18452814, upload-time = "2026-06-21T20:57:42.875Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/46/52fc0d2a68d7643f0f149eeea5a5d8ea2a3507056ac8afa83c9212606e8b/numpy-2.5.0-cp314-cp314t-win32.whl", hash = "sha256:edadfbd4794b1086c0d822f81863e8a68fc129d132fd0bb9e31e955d7fbbbdb7", size = 6253168, upload-time = "2026-06-21T20:57:45.101Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/be/6c8d1118b5f13b2881dc095d5b345de19c6638b8959c17409b6eff84c8aa/numpy-2.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f7e5fa4382967ae6548bd2f174219afb908e294b0d5f625af01166edd5f7d9aa", size = 12736286, upload-time = "2026-06-21T20:57:46.935Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6a/d3a169aaf8536cf228d56a09e04bcb713a2fe4410d4e2105b9419b5a9c89/numpy-2.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:016623417bb330d719d579daf2d6b9a01ddc52e41a9ed61a47f39fde46dcd865", size = 10686451, upload-time = "2026-06-21T20:57:49.313Z" },
 ]
 
 [[package]]
@@ -626,6 +1553,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pandocfilters"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/6f/3dd4940bbe001c06a65f88e36bad298bc7a0de5036115639926b0c5c0458/pandocfilters-1.5.1.tar.gz", hash = "sha256:002b4a555ee4ebc03f8b66307e287fa492e4a77b4ea14d3f934328297bb4939e", size = 8454, upload-time = "2024-01-18T20:08:13.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/af/4fbc8cab944db5d21b7e2a5b8e9211a03a79852b1157e2c102fcc61ac440/pandocfilters-1.5.1-py2.py3-none-any.whl", hash = "sha256:93be382804a9cdb0a7267585f157e5d1731bbe5545a85b268d6f5fe6232de2bc", size = 8663, upload-time = "2024-01-18T20:08:11.28Z" },
+]
+
+[[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
 name = "pathspec"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -644,12 +1589,153 @@ wheels = [
 ]
 
 [[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
+]
+
+[[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/01/53d10cf0dbad820a8db274d259a37ba50b88b24768ddccec07355382d5ad/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:8297651f5b5679c19968abefd6bb84d95fe30ef712eb1b2d9b2d31ca61267f4c", size = 4100837, upload-time = "2026-04-01T14:43:41.506Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/98/f3a6657ecb698c937f6c76ee564882945f29b79bad496abcba0e84659ec5/pillow-12.2.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:50d8520da2a6ce0af445fa6d648c4273c3eeefbc32d7ce049f22e8b5c3daecc2", size = 4176528, upload-time = "2026-04-01T14:43:43.773Z" },
+    { url = "https://files.pythonhosted.org/packages/69/bc/8986948f05e3ea490b8442ea1c1d4d990b24a7e43d8a51b2c7d8b1dced36/pillow-12.2.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:766cef22385fa1091258ad7e6216792b156dc16d8d3fa607e7545b2b72061f1c", size = 3640401, upload-time = "2026-04-01T14:43:45.87Z" },
+    { url = "https://files.pythonhosted.org/packages/34/46/6c717baadcd62bc8ed51d238d521ab651eaa74838291bda1f86fe1f864c9/pillow-12.2.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5d2fd0fa6b5d9d1de415060363433f28da8b1526c1c129020435e186794b3795", size = 5308094, upload-time = "2026-04-01T14:43:48.438Z" },
+    { url = "https://files.pythonhosted.org/packages/71/43/905a14a8b17fdb1ccb58d282454490662d2cb89a6bfec26af6d3520da5ec/pillow-12.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:56b25336f502b6ed02e889f4ece894a72612fe885889a6e8c4c80239ff6e5f5f", size = 4695402, upload-time = "2026-04-01T14:43:51.292Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed", size = 6280005, upload-time = "2026-04-01T14:43:54.242Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9", size = 8090669, upload-time = "2026-04-01T14:43:57.335Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/3ccb54ce8ec4ddd1accd2d89004308b7b0b21c4ac3d20fa70af4760a4330/pillow-12.2.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5cdfebd752ec52bf5bb4e35d9c64b40826bc5b40a13df7c3cda20a2c03a0f5ed", size = 6395194, upload-time = "2026-04-01T14:43:59.864Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ee/21d4e8536afd1a328f01b359b4d3997b291ffd35a237c877b331c1c3b71c/pillow-12.2.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eedf4b74eda2b5a4b2b2fb4c006d6295df3bf29e459e198c90ea48e130dc75c3", size = 7082423, upload-time = "2026-04-01T14:44:02.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/5f/e9f86ab0146464e8c133fe85df987ed9e77e08b29d8d35f9f9f4d6f917ba/pillow-12.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:00a2865911330191c0b818c59103b58a5e697cae67042366970a6b6f1b20b7f9", size = 6505667, upload-time = "2026-04-01T14:44:05.381Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/1e/409007f56a2fdce61584fd3acbc2bbc259857d555196cedcadc68c015c82/pillow-12.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1e1757442ed87f4912397c6d35a0db6a7b52592156014706f17658ff58bbf795", size = 7208580, upload-time = "2026-04-01T14:44:08.39Z" },
+    { url = "https://files.pythonhosted.org/packages/23/c4/7349421080b12fb35414607b8871e9534546c128a11965fd4a7002ccfbee/pillow-12.2.0-cp313-cp313-win32.whl", hash = "sha256:144748b3af2d1b358d41286056d0003f47cb339b8c43a9ea42f5fea4d8c66b6e", size = 6375896, upload-time = "2026-04-01T14:44:11.197Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/82/8a3739a5e470b3c6cbb1d21d315800d8e16bff503d1f16b03a4ec3212786/pillow-12.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:390ede346628ccc626e5730107cde16c42d3836b89662a115a921f28440e6a3b", size = 7081266, upload-time = "2026-04-01T14:44:13.947Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/25/f968f618a062574294592f668218f8af564830ccebdd1fa6200f598e65c5/pillow-12.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:8023abc91fba39036dbce14a7d6535632f99c0b857807cbbbf21ecc9f4717f06", size = 2463508, upload-time = "2026-04-01T14:44:16.312Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a4/b342930964e3cb4dce5038ae34b0eab4653334995336cd486c5a8c25a00c/pillow-12.2.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:042db20a421b9bafecc4b84a8b6e444686bd9d836c7fd24542db3e7df7baad9b", size = 5309927, upload-time = "2026-04-01T14:44:18.89Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/de/23198e0a65a9cf06123f5435a5d95cea62a635697f8f03d134d3f3a96151/pillow-12.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:dd025009355c926a84a612fecf58bb315a3f6814b17ead51a8e48d3823d9087f", size = 4698624, upload-time = "2026-04-01T14:44:21.115Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a6/1265e977f17d93ea37aa28aa81bad4fa597933879fac2520d24e021c8da3/pillow-12.2.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88ddbc66737e277852913bd1e07c150cc7bb124539f94c4e2df5344494e0a612", size = 6321252, upload-time = "2026-04-01T14:44:23.663Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/83/5982eb4a285967baa70340320be9f88e57665a387e3a53a7f0db8231a0cd/pillow-12.2.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d362d1878f00c142b7e1a16e6e5e780f02be8195123f164edf7eddd911eefe7c", size = 8126550, upload-time = "2026-04-01T14:44:26.772Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/48/6ffc514adce69f6050d0753b1a18fd920fce8cac87620d5a31231b04bfc5/pillow-12.2.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2c727a6d53cb0018aadd8018c2b938376af27914a68a492f59dfcaca650d5eea", size = 6433114, upload-time = "2026-04-01T14:44:29.615Z" },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f9a77144231fb8d40ee27107b4463e205fa4677e2ca2548e14da5cf18dce/pillow-12.2.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd8c21c98c5cc60653bcb311bef2ce0401642b7ce9d09e03a7da87c878289d4", size = 7115667, upload-time = "2026-04-01T14:44:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fc/ac4ee3041e7d5a565e1c4fd72a113f03b6394cc72ab7089d27608f8aaccb/pillow-12.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9f08483a632889536b8139663db60f6724bfcb443c96f1b18855860d7d5c0fd4", size = 6538966, upload-time = "2026-04-01T14:44:35.252Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a8/27fb307055087f3668f6d0a8ccb636e7431d56ed0750e07a60547b1e083e/pillow-12.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dac8d77255a37e81a2efcbd1fc05f1c15ee82200e6c240d7e127e25e365c39ea", size = 7238241, upload-time = "2026-04-01T14:44:37.875Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/4b/926ab182c07fccae9fcb120043464e1ff1564775ec8864f21a0ebce6ac25/pillow-12.2.0-cp313-cp313t-win32.whl", hash = "sha256:ee3120ae9dff32f121610bb08e4313be87e03efeadfc6c0d18f89127e24d0c24", size = 6379592, upload-time = "2026-04-01T14:44:40.336Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c4/f9e476451a098181b30050cc4c9a3556b64c02cf6497ea421ac047e89e4b/pillow-12.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:325ca0528c6788d2a6c3d40e3568639398137346c3d6e66bb61db96b96511c98", size = 7085542, upload-time = "2026-04-01T14:44:43.251Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a4/285f12aeacbe2d6dc36c407dfbbe9e96d4a80b0fb710a337f6d2ad978c75/pillow-12.2.0-cp313-cp313t-win_arm64.whl", hash = "sha256:2e5a76d03a6c6dcef67edabda7a52494afa4035021a79c8558e14af25313d453", size = 2465765, upload-time = "2026-04-01T14:44:45.996Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/98/4595daa2365416a86cb0d495248a393dfc84e96d62ad080c8546256cb9c0/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:3adc9215e8be0448ed6e814966ecf3d9952f0ea40eb14e89a102b87f450660d8", size = 4100848, upload-time = "2026-04-01T14:44:48.48Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/79/40184d464cf89f6663e18dfcf7ca21aae2491fff1a16127681bf1fa9b8cf/pillow-12.2.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:6a9adfc6d24b10f89588096364cc726174118c62130c817c2837c60cf08a392b", size = 4176515, upload-time = "2026-04-01T14:44:51.353Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/63/703f86fd4c422a9cf722833670f4f71418fb116b2853ff7da722ea43f184/pillow-12.2.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:6a6e67ea2e6feda684ed370f9a1c52e7a243631c025ba42149a2cc5934dec295", size = 3640159, upload-time = "2026-04-01T14:44:53.588Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/fb22f797187d0be2270f83500aab851536101b254bfa1eae10795709d283/pillow-12.2.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:2bb4a8d594eacdfc59d9e5ad972aa8afdd48d584ffd5f13a937a664c3e7db0ed", size = 5312185, upload-time = "2026-04-01T14:44:56.039Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/1a9e46228571de18f8e28f16fabdfc20212a5d019f3e3303452b3f0a580d/pillow-12.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:80b2da48193b2f33ed0c32c38140f9d3186583ce7d516526d462645fd98660ae", size = 4695386, upload-time = "2026-04-01T14:44:58.663Z" },
+    { url = "https://files.pythonhosted.org/packages/70/62/98f6b7f0c88b9addd0e87c217ded307b36be024d4ff8869a812b241d1345/pillow-12.2.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:22db17c68434de69d8ecfc2fe821569195c0c373b25cccb9cbdacf2c6e53c601", size = 6280384, upload-time = "2026-04-01T14:45:01.5Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/03/688747d2e91cfbe0e64f316cd2e8005698f76ada3130d0194664174fa5de/pillow-12.2.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7b14cc0106cd9aecda615dd6903840a058b4700fcb817687d0ee4fc8b6e389be", size = 8091599, upload-time = "2026-04-01T14:45:04.5Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/35/577e22b936fcdd66537329b33af0b4ccfefaeabd8aec04b266528cddb33c/pillow-12.2.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cbeb542b2ebc6fcdacabf8aca8c1a97c9b3ad3927d46b8723f9d4f033288a0f", size = 6396021, upload-time = "2026-04-01T14:45:07.117Z" },
+    { url = "https://files.pythonhosted.org/packages/11/8d/d2532ad2a603ca2b93ad9f5135732124e57811d0168155852f37fbce2458/pillow-12.2.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4bfd07bc812fbd20395212969e41931001fd59eb55a60658b0e5710872e95286", size = 7083360, upload-time = "2026-04-01T14:45:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/26/d325f9f56c7e039034897e7380e9cc202b1e368bfd04d4cbe6a441f02885/pillow-12.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9aba9a17b623ef750a4d11b742cbafffeb48a869821252b30ee21b5e91392c50", size = 6507628, upload-time = "2026-04-01T14:45:12.378Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f7/769d5632ffb0988f1c5e7660b3e731e30f7f8ec4318e94d0a5d674eb65a4/pillow-12.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:deede7c263feb25dba4e82ea23058a235dcc2fe1f6021025dc71f2b618e26104", size = 7209321, upload-time = "2026-04-01T14:45:15.122Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/7a/c253e3c645cd47f1aceea6a8bacdba9991bf45bb7dfe927f7c893e89c93c/pillow-12.2.0-cp314-cp314-win32.whl", hash = "sha256:632ff19b2778e43162304d50da0181ce24ac5bb8180122cbe1bf4673428328c7", size = 6479723, upload-time = "2026-04-01T14:45:17.797Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8b/601e6566b957ca50e28725cb6c355c59c2c8609751efbecd980db44e0349/pillow-12.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:4e6c62e9d237e9b65fac06857d511e90d8461a32adcc1b9065ea0c0fa3a28150", size = 7217400, upload-time = "2026-04-01T14:45:20.529Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/94/220e46c73065c3e2951bb91c11a1fb636c8c9ad427ac3ce7d7f3359b9b2f/pillow-12.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:b1c1fbd8a5a1af3412a0810d060a78b5136ec0836c8a4ef9aa11807f2a22f4e1", size = 2554835, upload-time = "2026-04-01T14:45:23.162Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ab/1b426a3974cb0e7da5c29ccff4807871d48110933a57207b5a676cccc155/pillow-12.2.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:57850958fe9c751670e49b2cecf6294acc99e562531f4bd317fa5ddee2068463", size = 5314225, upload-time = "2026-04-01T14:45:25.637Z" },
+    { url = "https://files.pythonhosted.org/packages/19/1e/dce46f371be2438eecfee2a1960ee2a243bbe5e961890146d2dee1ff0f12/pillow-12.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:d5d38f1411c0ed9f97bcb49b7bd59b6b7c314e0e27420e34d99d844b9ce3b6f3", size = 4698541, upload-time = "2026-04-01T14:45:28.355Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c3/7fbecf70adb3a0c33b77a300dc52e424dc22ad8cdc06557a2e49523b703d/pillow-12.2.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5c0a9f29ca8e79f09de89293f82fc9b0270bb4af1d58bc98f540cc4aedf03166", size = 6322251, upload-time = "2026-04-01T14:45:30.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/7fbc17cfb7e4fe0ef1642e0abc17fc6c94c9f7a16be41498e12e2ba60408/pillow-12.2.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1610dd6c61621ae1cf811bef44d77e149ce3f7b95afe66a4512f8c59f25d9ebe", size = 8127807, upload-time = "2026-04-01T14:45:33.908Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c3/a8ae14d6defd2e448493ff512fae903b1e9bd40b72efb6ec55ce0048c8ce/pillow-12.2.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0a34329707af4f73cf1782a36cd2289c0368880654a2c11f027bcee9052d35dd", size = 6433935, upload-time = "2026-04-01T14:45:36.623Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/32/2880fb3a074847ac159d8f902cb43278a61e85f681661e7419e6596803ed/pillow-12.2.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e9c4f5b3c546fa3458a29ab22646c1c6c787ea8f5ef51300e5a60300736905e", size = 7116720, upload-time = "2026-04-01T14:45:39.258Z" },
+    { url = "https://files.pythonhosted.org/packages/46/87/495cc9c30e0129501643f24d320076f4cc54f718341df18cc70ec94c44e1/pillow-12.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fb043ee2f06b41473269765c2feae53fc2e2fbf96e5e22ca94fb5ad677856f06", size = 6540498, upload-time = "2026-04-01T14:45:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/18/53/773f5edca692009d883a72211b60fdaf8871cbef075eaa9d577f0a2f989e/pillow-12.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f278f034eb75b4e8a13a54a876cc4a5ab39173d2cdd93a638e1b467fc545ac43", size = 7239413, upload-time = "2026-04-01T14:45:44.705Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/fd/d72c292d78aadb93d1a9bcd76bf3c678271040c7cf10abe5788b33040a39/plotly-6.8.0.tar.gz", hash = "sha256:e088e7ddc68d4f70e3d66659224727a45296d71d2b8284181862d3d8f1f0d88f", size = 6915161, upload-time = "2026-06-03T18:33:40.226Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/14/abe5ce876ab5b66ee3c691bf537fcd43d037aea55d447aacf74630a8f31e/plotly-6.8.0-py3-none-any.whl", hash = "sha256:13c5c4a0f70b74cab1913eda0de49b826df5931708eb6f9c3010040614700ec8", size = 9902055, upload-time = "2026-06-03T18:33:34.26Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polars"
+version = "1.42.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cb/91/a1d7809a6d399f0aa78d4d3a4f4daf411cb97ccfe7f236c08a01be5fc8a5/polars-1.42.0.tar.gz", hash = "sha256:283ddc923e47857924fbef36580d2e98d984a47c962bae4cbce9c0ebcc98989c", size = 740984, upload-time = "2026-06-24T05:20:13.727Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/4d/094819d251f2248999cb722125fd4e44ee79b753fe535338cbf442fbf45d/polars-1.42.0-py3-none-any.whl", hash = "sha256:ab10cac3f2d28a6e22e22bcac69c0e51fb33cd25aee1f45105782d4fe55a3e6a", size = 836855, upload-time = "2026-06-24T05:18:18.204Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.42.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/67/20759e9abbc61910cf948f5c28986ab25ef9e8009099b469d64d6a34a478/polars_runtime_32-1.42.0.tar.gz", hash = "sha256:c927e1930881fe0bf9629d12e5d44ebd4ecef2bfa02374dfc79feaa24054394f", size = 3042711, upload-time = "2026-06-24T05:20:15.715Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/62/8b83fca67d478e4a2b88cbba2fbff4d533052938ff96d598b7915fd9d235/polars_runtime_32-1.42.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:d235a5e8349797c16b70ad573fb9ddbd7f162796884bcbd25260908f8408affc", size = 53112358, upload-time = "2026-06-24T05:18:22.275Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/72/06d3d78b7e8e8d3c72ea9eee310950334d50986462b3c1d40f82972495a5/polars_runtime_32-1.42.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:e7923db3bcb57e0edecde3be28629e0411414a15ef1a4c10c783ac5eadab2e1e", size = 47443757, upload-time = "2026-06-24T05:18:26.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/77/20241aaf919a0f63b946fb702bc14447db290ef918e2c2943ed90d50fcc1/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42e27e2eb5909abcedb4ab4cc04ee67c5ec2b73a5640ebd8739b1b719383fa68", size = 51360855, upload-time = "2026-06-24T05:18:30.709Z" },
+    { url = "https://files.pythonhosted.org/packages/46/5c/ca14606a42628b04d82ac6ae5742ed24048bd43fbf48ae87fc4f4b9e759d/polars_runtime_32-1.42.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a3c43d4a76360bf912f8772b5ac1c23d5a8efef71408c63bba1bb0b4897a8ea", size = 57299346, upload-time = "2026-06-24T05:18:35.374Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/af/3ad0de43bbb97e91d605d7d76acb30be36269b8a8402890ab4f9892b6e26/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:542a77b2b969e5157939bfb76cd0f372c4f42db6ccd58636fcefe0011162a418", size = 51512143, upload-time = "2026-06-24T05:18:39.771Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/a5/d1133ba9d005532a6fb94544f5da09e497a8fe42c04e37c3da6faa80bd67/polars_runtime_32-1.42.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a13949abfce319de7fc4c1abee43bc9d4a4ed4d96bcc1a6037d022e4e9561d9f", size = 55214521, upload-time = "2026-06-24T05:18:43.916Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/54/0b8355ab29669560608b2864a5e54674dd78bbd48c04976607516e081107/polars_runtime_32-1.42.0-cp310-abi3-win_amd64.whl", hash = "sha256:91a07bd852c1d1ea19b3e27c974bc7b1b29ac948fdb2e785da3a6ec0f0683cad", size = 52718509, upload-time = "2026-06-24T05:18:48.202Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/b9/7c46fdbd1dbbaaf77f9512d7665609d7e4c4d8c8849edb9a16c471041075/polars_runtime_32-1.42.0-cp310-abi3-win_arm64.whl", hash = "sha256:b7c5d7721b7bb2563d72785050ac099da1e2000d412f9c72a0cfb7b07779e75d", size = 46728464, upload-time = "2026-06-24T05:18:52.505Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]
@@ -665,6 +1751,52 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
     { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
     { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -785,6 +1917,15 @@ crypto = [
 ]
 
 [[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -801,12 +1942,33 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
 ]
 
 [[package]]
@@ -829,6 +1991,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
 ]
 
 [[package]]
@@ -868,6 +2046,49 @@ wheels = [
 ]
 
 [[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
+    { url = "https://files.pythonhosted.org/packages/60/cb/84a13459c51da6cec1b7b1dc1a47e6db6da50b77ad7fd9c145842750a011/pyzmq-27.1.0-cp313-cp313-android_24_arm64_v8a.whl", hash = "sha256:93ad4b0855a664229559e45c8d23797ceac03183c7b6f5b4428152a6b06684a5", size = 1122436, upload-time = "2025-09-08T23:08:20.801Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b6/94414759a69a26c3dd674570a81813c46a078767d931a6c70ad29fc585cb/pyzmq-27.1.0-cp313-cp313-android_24_x86_64.whl", hash = "sha256:fbb4f2400bfda24f12f009cba62ad5734148569ff4949b1b6ec3b519444342e6", size = 1156301, upload-time = "2025-09-08T23:08:22.47Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ad/15906493fd40c316377fd8a8f6b1f93104f97a752667763c9b9c1b71d42d/pyzmq-27.1.0-cp313-cp313t-macosx_10_15_universal2.whl", hash = "sha256:e343d067f7b151cfe4eb3bb796a7752c9d369eed007b91231e817071d2c2fec7", size = 1341197, upload-time = "2025-09-08T23:08:24.286Z" },
+    { url = "https://files.pythonhosted.org/packages/14/1d/d343f3ce13db53a54cb8946594e567410b2125394dafcc0268d8dda027e0/pyzmq-27.1.0-cp313-cp313t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:08363b2011dec81c354d694bdecaef4770e0ae96b9afea70b3f47b973655cc05", size = 897275, upload-time = "2025-09-08T23:08:26.063Z" },
+    { url = "https://files.pythonhosted.org/packages/69/2d/d83dd6d7ca929a2fc67d2c3005415cdf322af7751d773524809f9e585129/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d54530c8c8b5b8ddb3318f481297441af102517602b569146185fa10b63f4fa9", size = 660469, upload-time = "2025-09-08T23:08:27.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/cd/9822a7af117f4bc0f1952dbe9ef8358eb50a24928efd5edf54210b850259/pyzmq-27.1.0-cp313-cp313t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3afa12c392f0a44a2414056d730eebc33ec0926aae92b5ad5cf26ebb6cc128", size = 847961, upload-time = "2025-09-08T23:08:29.672Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/12/f003e824a19ed73be15542f172fd0ec4ad0b60cf37436652c93b9df7c585/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c65047adafe573ff023b3187bb93faa583151627bc9c51fc4fb2c561ed689d39", size = 1650282, upload-time = "2025-09-08T23:08:31.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/4a/e82d788ed58e9a23995cee70dbc20c9aded3d13a92d30d57ec2291f1e8a3/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:90e6e9441c946a8b0a667356f7078d96411391a3b8f80980315455574177ec97", size = 2024468, upload-time = "2025-09-08T23:08:33.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/94/2da0a60841f757481e402b34bf4c8bf57fa54a5466b965de791b1e6f747d/pyzmq-27.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:add071b2d25f84e8189aaf0882d39a285b42fa3853016ebab234a5e78c7a43db", size = 1885394, upload-time = "2025-09-08T23:08:35.51Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/6f/55c10e2e49ad52d080dc24e37adb215e5b0d64990b57598abc2e3f01725b/pyzmq-27.1.0-cp313-cp313t-win32.whl", hash = "sha256:7ccc0700cfdf7bd487bea8d850ec38f204478681ea02a582a8da8171b7f90a1c", size = 574964, upload-time = "2025-09-08T23:08:37.178Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4d/2534970ba63dd7c522d8ca80fb92777f362c0f321900667c615e2067cb29/pyzmq-27.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:8085a9fba668216b9b4323be338ee5437a235fe275b9d1610e422ccc279733e2", size = 641029, upload-time = "2025-09-08T23:08:40.595Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/fa/f8aea7a28b0641f31d40dea42d7ef003fded31e184ef47db696bc74cd610/pyzmq-27.1.0-cp313-cp313t-win_arm64.whl", hash = "sha256:6bb54ca21bcfe361e445256c15eedf083f153811c37be87e0514934d6913061e", size = 561541, upload-time = "2025-09-08T23:08:42.668Z" },
+    { url = "https://files.pythonhosted.org/packages/87/45/19efbb3000956e82d0331bafca5d9ac19ea2857722fa2caacefb6042f39d/pyzmq-27.1.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ce980af330231615756acd5154f29813d553ea555485ae712c491cd483df6b7a", size = 1341197, upload-time = "2025-09-08T23:08:44.973Z" },
+    { url = "https://files.pythonhosted.org/packages/48/43/d72ccdbf0d73d1343936296665826350cb1e825f92f2db9db3e61c2162a2/pyzmq-27.1.0-cp314-cp314t-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1779be8c549e54a1c38f805e56d2a2e5c009d26de10921d7d51cfd1c8d4632ea", size = 897175, upload-time = "2025-09-08T23:08:46.601Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/2e/a483f73a10b65a9ef0161e817321d39a770b2acf8bcf3004a28d90d14a94/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7200bb0f03345515df50d99d3db206a0a6bee1955fbb8c453c76f5bf0e08fb96", size = 660427, upload-time = "2025-09-08T23:08:48.187Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/d2/5f36552c2d3e5685abe60dfa56f91169f7a2d99bbaf67c5271022ab40863/pyzmq-27.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01c0e07d558b06a60773744ea6251f769cd79a41a97d11b8bf4ab8f034b0424d", size = 847929, upload-time = "2025-09-08T23:08:49.76Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/2a/404b331f2b7bf3198e9945f75c4c521f0c6a3a23b51f7a4a401b94a13833/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:80d834abee71f65253c91540445d37c4c561e293ba6e741b992f20a105d69146", size = 1650193, upload-time = "2025-09-08T23:08:51.7Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/0b/f4107e33f62a5acf60e3ded67ed33d79b4ce18de432625ce2fc5093d6388/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:544b4e3b7198dde4a62b8ff6685e9802a9a1ebf47e77478a5eb88eca2a82f2fd", size = 2024388, upload-time = "2025-09-08T23:08:53.393Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/01/add31fe76512642fd6e40e3a3bd21f4b47e242c8ba33efb6809e37076d9b/pyzmq-27.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cedc4c68178e59a4046f97eca31b148ddcf51e88677de1ef4e78cf06c5376c9a", size = 1885316, upload-time = "2025-09-08T23:08:55.702Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/59/a5f38970f9bf07cee96128de79590bb354917914a9be11272cfc7ff26af0/pyzmq-27.1.0-cp314-cp314t-win32.whl", hash = "sha256:1f0b2a577fd770aa6f053211a55d1c47901f4d537389a034c690291485e5fe92", size = 587472, upload-time = "2025-09-08T23:08:58.18Z" },
+    { url = "https://files.pythonhosted.org/packages/70/d8/78b1bad170f93fcf5e3536e70e8fadac55030002275c9a29e8f5719185de/pyzmq-27.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19c9468ae0437f8074af379e986c5d3d7d7bfe033506af442e8c879732bedbe0", size = 661401, upload-time = "2025-09-08T23:08:59.802Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d6/4bfbb40c9a0b42fc53c7cf442f6385db70b40f74a783130c5d0a5aa62228/pyzmq-27.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:dc5dbf68a7857b59473f7df42650c621d7e8923fb03fa74a526890f4d33cc4d7", size = 575170, upload-time = "2025-09-08T23:09:01.418Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -893,6 +2114,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
 ]
 
 [[package]]
@@ -1119,6 +2373,15 @@ wheels = [
 ]
 
 [[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
 name = "shellcheck-py"
 version = "0.11.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1144,6 +2407,24 @@ wheels = [
 ]
 
 [[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
+]
+
+[[package]]
 name = "sse-starlette"
 version = "3.4.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1157,6 +2438,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1166,6 +2461,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+]
+
+[[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
 ]
 
 [[package]]
@@ -1202,6 +2523,32 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
     { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
     { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "tornado"
+version = "6.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/64/24/95ec527ad67b76d59299e5465b3935d05e4294b7e0290a3924b7487df30b/tornado-6.5.7.tar.gz", hash = "sha256:66c513a76cda70d53907bc27cf1447557699c2e95aa48ba27a442ff61c3ddfc2", size = 519252, upload-time = "2026-06-08T17:34:51.232Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/dc/c7043cab6fed8ae159fc1923ce829ada35c4dbd797d408a43858ffaf9639/tornado-6.5.7-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:148b2eb15c2c765a50796172c1e499649b35f30d2e3c3d3e15913cfa56bfb163", size = 448543, upload-time = "2026-06-08T17:34:38.052Z" },
+    { url = "https://files.pythonhosted.org/packages/92/4f/090b1431e5a43df696feceffc268c5383cc079ecb5f08ce58f917109aafe/tornado-6.5.7-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:9da38de27f1da3b78a966f0dae12b5a1ea9afe72ca805d84ff06508272ddf100", size = 446707, upload-time = "2026-06-08T17:34:39.594Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d8/ef374952fd5da67d4463122c2b8e5a96536ec10b4b339254c6dcde81d01c/tornado-6.5.7-cp39-abi3-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8d759e71906ee783f8867b93bf26a265743da4c1e2f4a018464c1ba019862972", size = 449774, upload-time = "2026-06-08T17:34:41.204Z" },
+    { url = "https://files.pythonhosted.org/packages/35/37/d434c73f4c6e014b745b9b37085f34f40c022f007efff3d7fe65991899f3/tornado-6.5.7-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8a46347a18f23fb92b396beebe0fb78f61dda0cc302445202c16203d8a18848b", size = 450745, upload-time = "2026-06-08T17:34:42.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/2b/56b9aff361d7f1ab728a805ec7d7ea835f8807afa9f5cc690ea0e630efb9/tornado-6.5.7-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7778b30bef919231265e91c69963ce0f49a1e9c07ac900bbe75b19ce2575ba92", size = 450578, upload-time = "2026-06-08T17:34:43.787Z" },
+    { url = "https://files.pythonhosted.org/packages/02/30/a7444fb23aa76860a14198fab96ac79f1866b0a6e19e26c4381b0938e50f/tornado-6.5.7-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:e726f0c75da7726eec023aa62751ff8878bd2737e34fbdd33b1ae5897d2200f5", size = 449985, upload-time = "2026-06-08T17:34:45.326Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/42/5f0e56c01e8d9d36f4e23f367b85ae6cae0c1ecddd5e6977d8388ad27488/tornado-6.5.7-cp39-abi3-win32.whl", hash = "sha256:f8de3bf12d3efdd0cbe7c8887868198f8a91415e3f29fcf258d9b8eb7b1d9ae4", size = 451047, upload-time = "2026-06-08T17:34:46.784Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/b393076ffb21b469eec5b328a0534cf03a3b90bfc6b1f09507cdd075d938/tornado-6.5.7-cp39-abi3-win_amd64.whl", hash = "sha256:de942f843533a039ef9fa3d9c88c7cd8a7c94553fb5ad0154270989b3d99a2c4", size = 451485, upload-time = "2026-06-08T17:34:48.248Z" },
+    { url = "https://files.pythonhosted.org/packages/71/2e/7b1c769803121b809112cf9a00681c472eae1d80e32d7ec0e0bd61d0d0e1/tornado-6.5.7-cp39-abi3-win_arm64.whl", hash = "sha256:ff934fce95643af5f11efdae618eaa73d469dc588641e5c8d19295a0c65c4796", size = 450506, upload-time = "2026-06-08T17:34:49.702Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
 ]
 
 [[package]]
@@ -1251,6 +2598,24 @@ wheels = [
 ]
 
 [[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1282,6 +2647,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ea/c4/55e0d36da61d7b8b2a49fd273e6b296fd5e8471c72ebbe438635d1af3968/wcmatch-8.5.2.tar.gz", hash = "sha256:a70222b86dea82fb382dd87b73278c10756c138bd6f8f714e2183128887b9eb2", size = 114983, upload-time = "2024-05-15T12:51:08.054Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/78/533ef890536e5ba0fd4f7df37482b5800ecaaceae9afc30978a1a7f88ff1/wcmatch-8.5.2-py3-none-any.whl", hash = "sha256:17d3ad3758f9d0b5b4dedc770b65420d4dac62e680229c287bf24c9db856a478", size = 39397, upload-time = "2024-05-15T12:51:06.2Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
+]
+
+[[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Add stable UUID-based visualization and mesh export DTOs with validated wrappers, typed topology schema values, and structured export/validation errors.
- Expose `to_visualization_data` and `to_mesh_export` through crate-root and focused export prelude APIs, with DelaunayResult-compatible error conversions.
- Document the mesh export JSON contract, validation boundary, and downstream attribute extension model.
- Add reusable notebook hygiene tooling and flatten `just ci` into orthogonal validation buckets with one release-profile Rust nextest pass.

Closes #446