### PR TITLE
fix(rollback): make topology mutations failure-atomic

### DIFF
--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -243,7 +243,7 @@ loose `(snapshot, restore)` pairs. Use the TDS rollback primitives in
 methods that need to call back into `self` during the rollback window. Both
 compose through the same TDS snapshot primitive, restore on drop unless
 committed explicitly, and use rollback-preserving clone semantics for retries.
-Higher level
+Higher-level
 `DelaunayTriangulation` operations must use the Delaunay-level rollback guard
 when they also mutate insertion hints, spatial indexes, or repair bookkeeping;
 the guard must restore or intentionally invalidate that auxiliary state

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -236,6 +236,27 @@ live. Inside the mutable scope, collapse short-lived views into validated
 `*Handle`/`*Key` commit identifiers before mutating; a live view must not span a
 topology mutation.
 
+For failure-atomic topology mutation windows, prefer scoped rollback guards over
+loose `(snapshot, restore)` pairs. Use the TDS rollback primitives in
+`core::tds::rollback` for free functions that already own a `&mut Tds`, and use
+`TriangulationRollbackTransaction` from `core::rollback` for `Triangulation`
+methods that need to call back into `self` during the rollback window. Both
+compose through the same TDS snapshot primitive, restore on drop unless
+committed explicitly, and use rollback-preserving clone semantics for retries.
+Higher level
+`DelaunayTriangulation` operations must use the Delaunay-level rollback guard
+when they also mutate insertion hints, spatial indexes, or repair bookkeeping;
+the guard must restore or intentionally invalidate that auxiliary state
+alongside the TDS. Do not wrap only the TDS when owner-coupled state can change.
+Issue #364 tracks this rollback-infrastructure coverage; issue #448 remains the
+separate `remove_vertex` orientation-correctness follow-up and should not be
+folded into infrastructure-only cleanup.
+
+Detached trial/scratch workspaces are a separate pattern: they may use
+`clone_for_rollback`/`clone_from_for_rollback` directly when the canonical owner
+is not mutated until the detached trial has validated and is swapped into place.
+Examples include flip trial workspaces and copy-on-success cleanup operations.
+
 Keep runtime identity or generation checks for detached handles, separately
 supplied indexes, serialization boundaries, and tests that intentionally corrupt
 metadata. Those checks complement lifetimes at API boundaries where Rust cannot

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -43,7 +43,8 @@ use crate::core::facet::{AllFacetsIter, FacetError, FacetHandle, facet_key_from_
 use crate::core::operations::TopologicalOperation;
 use crate::core::simplex::{NeighborSlot, Simplex, SimplexValidationError};
 use crate::core::tds::{
-    EntityKind, NeighborValidationError, SimplexKey, Tds, TdsMutationError, VertexKey,
+    EntityKind, NeighborValidationError, SimplexKey, Tds, TdsMutationError, TdsRollbackTransaction,
+    VertexKey,
 };
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
@@ -6658,42 +6659,41 @@ where
 }
 
 fn run_full_reseed_retry<K, U, V, const D: usize>(
-    tds: &mut Tds<U, V, D>,
+    transaction: &mut TdsRollbackTransaction<'_, U, V, D>,
     kernel: &K,
     config: &RepairAttemptConfig,
-    snapshot: Tds<U, V, D>,
 ) -> Result<DelaunayRepairRun, DelaunayRepairError>
 where
     K: Kernel<D, Scalar = f64>,
     U: DataType,
     V: DataType,
 {
-    *tds = snapshot.clone_for_rollback();
+    transaction.restore();
     let retry_seed_simplices = None;
     let attempt_result = if D == 2 {
-        repair_delaunay_with_flips_k2_attempt(tds, kernel, retry_seed_simplices, config)
-    } else {
-        repair_delaunay_with_flips_k2_k3_attempt(tds, kernel, retry_seed_simplices, config)
-    };
-
-    match attempt_result {
-        Ok(outcome) => match verify_repair_postcondition(
-            tds,
+        repair_delaunay_with_flips_k2_attempt(
+            transaction.tds_mut(),
             kernel,
             retry_seed_simplices,
-            outcome.last_applied_flip.as_ref(),
-        ) {
-            Ok(()) => Ok(repair_run_from_attempt(outcome)),
-            Err(err) => {
-                *tds = snapshot;
-                Err(err)
-            }
-        },
-        Err(err) => {
-            *tds = snapshot;
-            Err(err)
-        }
-    }
+            config,
+        )
+    } else {
+        repair_delaunay_with_flips_k2_k3_attempt(
+            transaction.tds_mut(),
+            kernel,
+            retry_seed_simplices,
+            config,
+        )
+    };
+
+    let outcome = attempt_result?;
+    verify_repair_postcondition(
+        transaction.tds_mut(),
+        kernel,
+        retry_seed_simplices,
+        outcome.last_applied_flip.as_ref(),
+    )?;
+    Ok(repair_run_from_attempt(outcome))
 }
 
 /// Repair Delaunay violations and return the final validation frontier.
@@ -6744,34 +6744,43 @@ where
     };
 
     // Snapshot the pre-repair state so a failed attempt doesn't poison retries.
-    let tds_snapshot = tds.clone_for_rollback();
+    let mut transaction = TdsRollbackTransaction::begin(tds);
 
     let attempt1_result = if D == 2 {
-        repair_delaunay_with_flips_k2_attempt(tds, kernel, seed_simplices, &attempt1)
+        repair_delaunay_with_flips_k2_attempt(
+            transaction.tds_mut(),
+            kernel,
+            seed_simplices,
+            &attempt1,
+        )
     } else {
-        repair_delaunay_with_flips_k2_k3_attempt(tds, kernel, seed_simplices, &attempt1)
+        repair_delaunay_with_flips_k2_k3_attempt(
+            transaction.tds_mut(),
+            kernel,
+            seed_simplices,
+            &attempt1,
+        )
     };
 
     match attempt1_result {
         Ok(outcome) => {
             if verify_repair_postcondition(
-                tds,
+                transaction.tds_mut(),
                 kernel,
                 seed_simplices,
                 outcome.last_applied_flip.as_ref(),
             )
             .is_ok()
             {
-                return Ok(repair_run_from_attempt(outcome));
+                let run = repair_run_from_attempt(outcome);
+                transaction.commit();
+                return Ok(run);
             }
             if repair_trace_enabled() {
                 tracing::debug!(
                     "[repair] attempt 1 postcondition failed; retrying with LIFO + full reseed"
                 );
             }
-
-            // Postcondition verification failed: rerun with LIFO + full reseed.
-            run_full_reseed_retry(tds, kernel, &attempt2, tds_snapshot)
         }
         Err(DelaunayRepairError::NonConvergent { .. }) => {
             if repair_trace_enabled() {
@@ -6779,11 +6788,21 @@ where
                     "[repair] attempt 1 non-convergent; retrying with LIFO + full reseed"
                 );
             }
-            // Retry with LIFO + full reseed.
-            run_full_reseed_retry(tds, kernel, &attempt2, tds_snapshot)
         }
         Err(err) => {
-            *tds = tds_snapshot;
+            transaction.rollback();
+            return Err(err);
+        }
+    }
+
+    // Retry with LIFO + full reseed.
+    match run_full_reseed_retry(&mut transaction, kernel, &attempt2) {
+        Ok(run) => {
+            transaction.commit();
+            Ok(run)
+        }
+        Err(err) => {
+            transaction.rollback();
             Err(err)
         }
     }
@@ -6863,15 +6882,20 @@ where
     };
     // Snapshot so a failed attempt does not leave the TDS in a partially-modified state.
     let snapshot_started = Instant::now();
-    let tds_snapshot = tds.clone_for_rollback();
+    let mut transaction = TdsRollbackTransaction::begin(tds);
     phase_timing.record_snapshot(snapshot_started.elapsed());
 
     let attempt_started = Instant::now();
     let attempt1_result = if D == 2 {
-        repair_delaunay_with_flips_k2_attempt(tds, kernel, Some(seed_simplices), &attempt1)
+        repair_delaunay_with_flips_k2_attempt(
+            transaction.tds_mut(),
+            kernel,
+            Some(seed_simplices),
+            &attempt1,
+        )
     } else {
         repair_delaunay_with_flips_k2_k3_attempt_timed(
-            tds,
+            transaction.tds_mut(),
             kernel,
             Some(seed_simplices),
             &attempt1,
@@ -6887,22 +6911,26 @@ where
             // the same local queues after every successful repair adds quadratic
             // predicate work without strengthening the final correctness gate.
             if !outcome.postcondition_required || D >= 4 {
+                let stats = outcome.stats;
+                transaction.commit();
                 publish_local_repair_phase_timing(&mut timing, phase_timing);
-                return Ok(outcome.stats);
+                return Ok(stats);
             }
             let postcondition_frontier =
                 local_postcondition_frontier(seed_simplices, &outcome.touched_simplices);
             let postcondition_started = Instant::now();
             let postcondition_result = verify_local_repair_postcondition(
-                tds,
+                transaction.tds_mut(),
                 kernel,
                 &postcondition_frontier,
                 outcome.last_applied_flip.as_ref(),
             );
             phase_timing.record_postcondition(postcondition_started.elapsed());
             if postcondition_result.is_ok() {
+                let stats = outcome.stats;
+                transaction.commit();
                 publish_local_repair_phase_timing(&mut timing, phase_timing);
-                return Ok(outcome.stats);
+                return Ok(stats);
             }
             if repair_trace_enabled() {
                 tracing::debug!("[repair] local attempt 1 postcondition failed; retrying LIFO");
@@ -6915,22 +6943,27 @@ where
         }
         Err(err) => {
             let restore_started = Instant::now();
-            *tds = tds_snapshot;
+            transaction.rollback();
             phase_timing.record_restore(restore_started.elapsed());
             publish_local_repair_phase_timing(&mut timing, phase_timing);
             return Err(err);
         }
     }
     let restore_started = Instant::now();
-    *tds = tds_snapshot.clone_for_rollback();
+    transaction.restore();
     phase_timing.record_restore(restore_started.elapsed());
 
     let attempt_started = Instant::now();
     let attempt2_result = if D == 2 {
-        repair_delaunay_with_flips_k2_attempt(tds, kernel, Some(seed_simplices), &attempt2)
+        repair_delaunay_with_flips_k2_attempt(
+            transaction.tds_mut(),
+            kernel,
+            Some(seed_simplices),
+            &attempt2,
+        )
     } else {
         repair_delaunay_with_flips_k2_k3_attempt_timed(
-            tds,
+            transaction.tds_mut(),
             kernel,
             Some(seed_simplices),
             &attempt2,
@@ -6944,14 +6977,16 @@ where
             // See attempt 1: D>=4 local postconditions are deferred to the
             // construction finalization/validation path.
             if !outcome.postcondition_required || D >= 4 {
+                let stats = outcome.stats;
+                transaction.commit();
                 publish_local_repair_phase_timing(&mut timing, phase_timing);
-                return Ok(outcome.stats);
+                return Ok(stats);
             }
             let postcondition_frontier =
                 local_postcondition_frontier(seed_simplices, &outcome.touched_simplices);
             let postcondition_started = Instant::now();
             let postcondition_result = verify_local_repair_postcondition(
-                tds,
+                transaction.tds_mut(),
                 kernel,
                 &postcondition_frontier,
                 outcome.last_applied_flip.as_ref(),
@@ -6959,14 +6994,16 @@ where
             phase_timing.record_postcondition(postcondition_started.elapsed());
             match postcondition_result {
                 Ok(()) => {
+                    let stats = outcome.stats;
+                    transaction.commit();
                     publish_local_repair_phase_timing(&mut timing, phase_timing);
-                    Ok(outcome.stats)
+                    Ok(stats)
                 }
                 Err(verifier_err) => {
                     // Postcondition failed: restore the TDS so callers that
                     // soft-fail receive a structurally valid triangulation.
                     let restore_started = Instant::now();
-                    *tds = tds_snapshot;
+                    transaction.rollback();
                     phase_timing.record_restore(restore_started.elapsed());
                     publish_local_repair_phase_timing(&mut timing, phase_timing);
                     Err(verifier_err)
@@ -6978,7 +7015,7 @@ where
             // soft-fail (e.g. D≥4 bulk construction) receive a structurally valid
             // triangulation rather than a partially-modified one.
             let restore_started = Instant::now();
-            *tds = tds_snapshot;
+            transaction.rollback();
             phase_timing.record_restore(restore_started.elapsed());
             publish_local_repair_phase_timing(&mut timing, phase_timing);
             Err(err)

--- a/src/core/insertion.rs
+++ b/src/core/insertion.rs
@@ -4,6 +4,8 @@
 //! detection, perturbation retry, conflict-region shaping, cavity insertion,
 //! and insertion telemetry for [`Triangulation`](crate::prelude::triangulation::Triangulation).
 
+#![forbid(unsafe_code)]
+
 use crate::core::algorithms::incremental_insertion::{
     CavityFillingError, CavityRepairStage, HullExtensionReason, InsertionError, extend_hull,
     external_facets_for_boundary, fill_cavity_replacing_simplices, wire_cavity_neighbors,
@@ -25,9 +27,10 @@ use crate::core::operations::{
     InsertionOutcome, InsertionResult, InsertionStatistics, InsertionTelemetry,
     InsertionTelemetryMode, SuspicionFlags,
 };
+use crate::core::rollback::TriangulationRollbackTransaction;
 #[cfg(debug_assertions)]
 use crate::core::simplex::Simplex;
-use crate::core::tds::{InvariantError, SimplexKey, Tds, TdsError, VertexKey};
+use crate::core::tds::{InvariantError, SimplexKey, TdsError, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
 use crate::core::vertex::Vertex;
@@ -618,8 +621,7 @@ where
             let simplices_before_attempt = self.tds.number_of_simplices();
             let vertices_before_attempt = self.tds.number_of_vertices();
 
-            // Clone TDS for rollback (transactional semantics)
-            let tds_snapshot = self.tds.clone_for_rollback();
+            let mut transaction = TriangulationRollbackTransaction::begin(self);
 
             // Try insertion.
             //
@@ -635,23 +637,23 @@ where
                     simplex_count: 3,
                 })
             } else {
-                self.try_insert_with_topology_safety_net(
+                Self::try_insert_with_topology_safety_net(
+                    &mut transaction,
                     current_vertex,
                     conflict_simplices,
                     hint,
                     attempt,
-                    &tds_snapshot,
                     &mut telemetry,
                     telemetry_mode,
                 )
             };
             #[cfg(not(test))]
-            let result = self.try_insert_with_topology_safety_net(
+            let result = Self::try_insert_with_topology_safety_net(
+                &mut transaction,
                 current_vertex,
                 conflict_simplices,
                 hint,
                 attempt,
-                &tds_snapshot,
                 &mut telemetry,
                 telemetry_mode,
             );
@@ -674,6 +676,7 @@ where
                     }
 
                     let (vertex_key, hint) = inserted;
+                    transaction.commit();
                     // Only the committed attempt updates the duplicate index. Earlier
                     // retries all rolled back to the pre-attempt triangulation state.
                     if let Some(index) = index.as_deref_mut()
@@ -691,8 +694,7 @@ where
                     });
                 }
                 Err(e) => {
-                    // Any error - rollback to snapshot
-                    self.tds = tds_snapshot;
+                    transaction.rollback();
 
                     // Handle duplicate coordinates specially - skip immediately without retry
                     if matches!(e, InsertionError::DuplicateCoordinates { .. }) {
@@ -1088,22 +1090,22 @@ where
 
     /// Attempt an insertion, and if Level 3 validation fails, roll back and try a
     /// conservative star-split fallback of the containing simplex.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "Topology safety net needs transactional rollback context plus telemetry mode"
-    )]
     fn try_insert_with_topology_safety_net(
-        &mut self,
+        transaction: &mut TriangulationRollbackTransaction<'_, K, U, V, D>,
         vertex: Vertex<U, D>,
         conflict_simplices: Option<&SimplexKeyBuffer>,
         hint: Option<SimplexKey>,
         attempt: usize,
-        tds_snapshot: &Tds<U, V, D>,
         telemetry: &mut InsertionTelemetry,
         telemetry_mode: InsertionTelemetryMode,
     ) -> Result<TryInsertImplOk, InsertionError> {
-        let mut insert_ok =
-            self.try_insert_impl(vertex, conflict_simplices, hint, telemetry, telemetry_mode)?;
+        let mut insert_ok = transaction.triangulation_mut().try_insert_impl(
+            vertex,
+            conflict_simplices,
+            hint,
+            telemetry,
+            telemetry_mode,
+        )?;
 
         if attempt > 0 {
             insert_ok.suspicion.perturbation_used = true;
@@ -1113,27 +1115,31 @@ where
         }
 
         // Skip Level 3 validation during bootstrap (vertices but no simplices yet).
-        if self.tds.number_of_simplices() == 0 {
+        if transaction.triangulation_mut().tds.number_of_simplices() == 0 {
             return Ok(insert_ok);
         }
 
-        let validation_result = self.validate_after_insertion_and_record_telemetry(
-            insert_ok.suspicion,
-            &insert_ok.repair_seed_simplices,
-            telemetry,
-            telemetry_mode,
-        );
-        if let Err(validation_err) = validation_result {
-            // Roll back to snapshot and attempt a star-split fallback for interior points.
-            self.tds = tds_snapshot.clone_for_rollback();
-            return self.try_star_split_fallback_after_topology_failure(
-                vertex,
-                hint,
-                attempt,
-                validation_err,
+        let validation_result = transaction
+            .triangulation_mut()
+            .validate_after_insertion_and_record_telemetry(
+                insert_ok.suspicion,
+                &insert_ok.repair_seed_simplices,
                 telemetry,
                 telemetry_mode,
             );
+        if let Err(validation_err) = validation_result {
+            // Roll back to snapshot and attempt a star-split fallback for interior points.
+            transaction.restore();
+            return transaction
+                .triangulation_mut()
+                .try_star_split_fallback_after_topology_failure(
+                    vertex,
+                    hint,
+                    attempt,
+                    validation_err,
+                    telemetry,
+                    telemetry_mode,
+                );
         }
 
         Ok(insert_ok)

--- a/src/core/repair.rs
+++ b/src/core/repair.rs
@@ -3,6 +3,8 @@
 //! This module owns local facet issue detection/repair, stale incident-simplex
 //! repair, and vertex-removal cavity retriangulation for [`Triangulation`](crate::prelude::triangulation::Triangulation).
 
+#![forbid(unsafe_code)]
+
 use crate::core::algorithms::incremental_insertion::{
     CavityFillingError, CavityRepairStage, InsertionError, InsertionTopologyValidationContext,
     external_facets_for_boundary, fill_cavity_replacing_simplices, repair_neighbor_pointers,
@@ -14,6 +16,7 @@ use crate::core::collections::{
     SimplexKeyBuffer, SimplexKeySet, SmallBuffer, VertexKeySet, fast_hash_set_with_capacity,
 };
 use crate::core::facet::FacetHandle;
+use crate::core::rollback::TriangulationRollbackTransaction;
 use crate::core::tds::{InvariantError, SimplexKey, TdsError, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
@@ -468,83 +471,95 @@ where
         affected_vertices: &VertexKeySet,
         apex_vertex_key: VertexKey,
     ) -> Result<VertexRemovalOutcome, InvariantError> {
-        // Snapshot before destructive retriangulation edits so we can roll back if any
-        // subsequent orientation/finalization step fails.
-        let tds_snapshot = self.tds.clone_for_rollback();
-        let retriangulation_result = (|| -> Result<VertexRemovalOutcome, InvariantError> {
-            // Fill cavity with fan triangulation BEFORE removing old simplices
-            // Use fan triangulation that skips boundary facets which already include the apex
-            let new_simplices = self
-                .fan_fill_cavity(apex_vertex_key, boundary_facets)
-                .map_err(|e| insertion_error_to_invariant_error(e, "Fan triangulation failed"))?;
-            self.canonicalize_positive_orientation_for_simplices(&new_simplices)
-                .map_err(|e| {
-                    insertion_error_to_invariant_error(
-                        e,
-                        "Orientation canonicalization failed after fan filling",
-                    )
-                })?;
-
-            // Wire neighbors for the new simplices (while both old and new simplices exist)
-            let external_facets =
-                external_facets_for_boundary(&self.tds, simplices_to_remove, boundary_facets)
+        let mut transaction = TriangulationRollbackTransaction::begin(self);
+        let retriangulation_result = {
+            let tri = transaction.triangulation_mut();
+            (|| -> Result<VertexRemovalOutcome, InvariantError> {
+                // Fill cavity with fan triangulation BEFORE removing old simplices
+                // Use fan triangulation that skips boundary facets which already include the apex
+                let new_simplices = tri
+                    .fan_fill_cavity(apex_vertex_key, boundary_facets)
                     .map_err(|e| {
-                        insertion_error_to_invariant_error(e, "External-facet collection failed")
+                        insertion_error_to_invariant_error(e, "Fan triangulation failed")
                     })?;
-            wire_cavity_neighbors(
-                &mut self.tds,
-                &new_simplices,
-                external_facets.iter().copied(),
-                Some(simplices_to_remove),
-            )
-            .map_err(|e| insertion_error_to_invariant_error(e, "Neighbor wiring failed"))?;
+                tri.canonicalize_positive_orientation_for_simplices(&new_simplices)
+                    .map_err(|e| {
+                        insertion_error_to_invariant_error(
+                            e,
+                            "Orientation canonicalization failed after fan filling",
+                        )
+                    })?;
 
-            // Remove the simplices containing the vertex (now that new simplices are wired up)
-            // Note: remove_simplices_by_keys() automatically clears neighbor pointers in surviving
-            // simplices that reference removed simplices (sets them to None/boundary)
-            let mut simplices_removed = self
-                .tds
-                .remove_simplices_by_keys(simplices_to_remove)
-                .map_err(|e| InvariantError::Tds(e.into_inner()))?;
-            let max_repair_simplices_removed = simplices_to_remove.len();
-            let mut post_repair_frontier = SimplexKeyBuffer::new();
+                // Wire neighbors for the new simplices (while both old and new simplices exist)
+                let external_facets =
+                    external_facets_for_boundary(&tri.tds, simplices_to_remove, boundary_facets)
+                        .map_err(|e| {
+                            insertion_error_to_invariant_error(
+                                e,
+                                "External-facet collection failed",
+                            )
+                        })?;
+                wire_cavity_neighbors(
+                    &mut tri.tds,
+                    &new_simplices,
+                    external_facets.iter().copied(),
+                    Some(simplices_to_remove),
+                )
+                .map_err(|e| insertion_error_to_invariant_error(e, "Neighbor wiring failed"))?;
 
-            self.repair_vertex_removal_facet_issues(
-                &new_simplices,
-                &mut simplices_removed,
-                &mut post_repair_frontier,
-                max_repair_simplices_removed,
-            )?;
+                // Remove the simplices containing the vertex (now that new simplices are wired up)
+                // Note: remove_simplices_by_keys() automatically clears neighbor pointers in surviving
+                // simplices that reference removed simplices (sets them to None/boundary)
+                let mut simplices_removed = tri
+                    .tds
+                    .remove_simplices_by_keys(simplices_to_remove)
+                    .map_err(|e| InvariantError::Tds(e.into_inner()))?;
+                let max_repair_simplices_removed = simplices_to_remove.len();
+                let mut post_repair_frontier = SimplexKeyBuffer::new();
 
-            self.tds
-                .remove_vertex(vertex_key)
-                .map_err(|e| InvariantError::Tds(e.into_inner()))?;
+                tri.repair_vertex_removal_facet_issues(
+                    &new_simplices,
+                    &mut simplices_removed,
+                    &mut post_repair_frontier,
+                    max_repair_simplices_removed,
+                )?;
 
-            let surviving_new_simplices = self.live_simplices_from(&new_simplices);
-            let validation_scope = self.vertex_removal_validation_scope(
-                &new_simplices,
-                &external_facets,
-                &post_repair_frontier,
-            );
-            self.normalize_vertex_removal_orientation(&validation_scope)?;
-            self.repair_affected_vertex_incidence_from_scope(affected_vertices, &validation_scope)?;
-            self.validate_vertex_removal_postconditions(
-                vertex_key,
-                affected_vertices,
-                &surviving_new_simplices,
-                &validation_scope,
-            )?;
+                tri.tds
+                    .remove_vertex(vertex_key)
+                    .map_err(|e| InvariantError::Tds(e.into_inner()))?;
 
-            Ok(VertexRemovalOutcome::with_repair_seed_simplices(
-                simplices_removed,
-                validation_scope,
-            ))
-        })();
+                let surviving_new_simplices = tri.live_simplices_from(&new_simplices);
+                let validation_scope = tri.vertex_removal_validation_scope(
+                    &new_simplices,
+                    &external_facets,
+                    &post_repair_frontier,
+                );
+                tri.normalize_vertex_removal_orientation(&validation_scope)?;
+                tri.repair_affected_vertex_incidence_from_scope(
+                    affected_vertices,
+                    &validation_scope,
+                )?;
+                tri.validate_vertex_removal_postconditions(
+                    vertex_key,
+                    affected_vertices,
+                    &surviving_new_simplices,
+                    &validation_scope,
+                )?;
+
+                Ok(VertexRemovalOutcome::with_repair_seed_simplices(
+                    simplices_removed,
+                    validation_scope,
+                ))
+            })()
+        };
 
         match retriangulation_result {
-            Ok(outcome) => Ok(outcome),
+            Ok(outcome) => {
+                transaction.commit();
+                Ok(outcome)
+            }
             Err(error) => {
-                self.tds = tds_snapshot;
+                transaction.rollback();
                 Err(error)
             }
         }
@@ -707,21 +722,27 @@ where
         &mut self,
         vertex_key: VertexKey,
     ) -> Result<usize, InvariantError> {
-        let tds_snapshot = self.tds.clone_for_rollback();
-        let result = (|| -> Result<usize, InvariantError> {
-            let simplices_removed = self
-                .tds
-                .remove_vertex(vertex_key)
-                .map_err(|e| InvariantError::Tds(e.into_inner()))?;
-            self.tds.is_valid().map_err(InvariantError::Tds)?;
-            self.is_valid()?;
-            Ok(simplices_removed)
-        })();
+        let mut transaction = TriangulationRollbackTransaction::begin(self);
+        let result = {
+            let tri = transaction.triangulation_mut();
+            (|| -> Result<usize, InvariantError> {
+                let simplices_removed = tri
+                    .tds
+                    .remove_vertex(vertex_key)
+                    .map_err(|e| InvariantError::Tds(e.into_inner()))?;
+                tri.tds.is_valid().map_err(InvariantError::Tds)?;
+                tri.is_valid()?;
+                Ok(simplices_removed)
+            })()
+        };
 
         match result {
-            Ok(simplices_removed) => Ok(simplices_removed),
+            Ok(simplices_removed) => {
+                transaction.commit();
+                Ok(simplices_removed)
+            }
             Err(error) => {
-                self.tds = tds_snapshot;
+                transaction.rollback();
                 Err(error)
             }
         }
@@ -1322,33 +1343,41 @@ where
         issues: &FacetIssuesMap,
         max_simplices_removed: usize,
     ) -> Result<usize, InsertionError> {
-        let tds_snapshot = self.tds.clone_for_rollback();
-        let repair_result = (|| -> Result<usize, InsertionError> {
-            let outcome =
-                self.repair_local_facet_issues_with_frontier(issues, max_simplices_removed)?;
-            if outcome.removed_count == 0 {
-                return Ok(0);
+        let mut transaction = TriangulationRollbackTransaction::begin(self);
+        let repair_result = {
+            let tri = transaction.triangulation_mut();
+            (|| -> Result<usize, InsertionError> {
+                let outcome =
+                    tri.repair_local_facet_issues_with_frontier(issues, max_simplices_removed)?;
+                if outcome.removed_count == 0 {
+                    return Ok(0);
+                }
+
+                let new_simplices = SimplexKeyBuffer::new();
+                tri.repair_neighbors_after_local_simplex_removal(
+                    &new_simplices,
+                    &outcome.frontier_simplices,
+                )?;
+                tri.tds
+                    .assign_incident_simplices()
+                    .map_err(|error| InsertionError::TopologyValidation(error.into_inner()))?;
+                tri.validate()
+                    .map_err(Self::invariant_error_to_insertion_error)?;
+
+                Ok(outcome.removed_count)
+            })()
+        };
+
+        match repair_result {
+            Ok(removed_count) => {
+                transaction.commit();
+                Ok(removed_count)
             }
-
-            let new_simplices = SimplexKeyBuffer::new();
-            self.repair_neighbors_after_local_simplex_removal(
-                &new_simplices,
-                &outcome.frontier_simplices,
-            )?;
-            self.tds
-                .assign_incident_simplices()
-                .map_err(|error| InsertionError::TopologyValidation(error.into_inner()))?;
-            self.validate()
-                .map_err(Self::invariant_error_to_insertion_error)?;
-
-            Ok(outcome.removed_count)
-        })();
-
-        if repair_result.is_err() {
-            self.tds = tds_snapshot;
+            Err(error) => {
+                transaction.rollback();
+                Err(error)
+            }
         }
-
-        repair_result
     }
 }
 

--- a/src/core/repair.rs
+++ b/src/core/repair.rs
@@ -1227,11 +1227,23 @@ where
     }
 
     /// Repair over-shared facets and return the local frontier for neighbor repair.
+    ///
+    /// An empty issue map returns an empty outcome without touching the TDS, which lets the public
+    /// transactional wrapper avoid snapshotting for no-op repairs.
     pub(crate) fn repair_local_facet_issues_with_frontier(
         &mut self,
         issues: &FacetIssuesMap,
         max_simplices_removed: usize,
     ) -> Result<LocalFacetRepairOutcome, InsertionError> {
+        if issues.is_empty() {
+            return Ok(LocalFacetRepairOutcome {
+                removed_count: 0,
+                removed_simplices: SimplexKeyBuffer::new(),
+                frontier_simplices: SimplexKeyBuffer::new(),
+                affected_vertices: IncidentRepairVertexBuffer::new(),
+            });
+        }
+
         let to_remove = self
             .simplices_for_local_facet_issue_repair(issues)
             .map_err(InsertionError::TopologyValidation)?;
@@ -1343,6 +1355,10 @@ where
         issues: &FacetIssuesMap,
         max_simplices_removed: usize,
     ) -> Result<usize, InsertionError> {
+        if issues.is_empty() {
+            return Ok(0);
+        }
+
         let mut transaction = TriangulationRollbackTransaction::begin(self);
         let repair_result = {
             let tri = transaction.triangulation_mut();
@@ -2059,6 +2075,38 @@ mod tests {
         assert!(!tri.tds.contains_vertex_key(isolated_vertex));
         assert_eq!(tri.tds.number_of_simplices(), simplex_count);
         tri.validate().unwrap();
+    }
+
+    #[test]
+    fn test_vertex_removal_outcome_rolls_back_failed_isolated_vertex_removal() {
+        let (mut tri, _, simplex_key) = build_single_tet();
+        let isolated_to_remove = tri
+            .tds
+            .insert_vertex_with_mapping(vertex![0.5, 0.5, 0.5].unwrap())
+            .unwrap();
+        let isolated_survivor = tri
+            .tds
+            .insert_vertex_with_mapping(vertex![0.25, 0.25, 0.25].unwrap())
+            .unwrap();
+        let vertex_count = tri.tds.number_of_vertices();
+        let simplex_count = tri.tds.number_of_simplices();
+
+        let result = tri.remove_vertex_with_repair_seeds(isolated_to_remove);
+
+        assert_matches!(
+            result,
+            Err(InvariantError::Triangulation(
+                TriangulationValidationError::IsolatedVertex {
+                    vertex_key,
+                    ..
+                },
+            )) if vertex_key == isolated_survivor
+        );
+        assert_eq!(tri.tds.number_of_vertices(), vertex_count);
+        assert_eq!(tri.tds.number_of_simplices(), simplex_count);
+        assert!(tri.tds.contains_vertex_key(isolated_to_remove));
+        assert!(tri.tds.contains_vertex_key(isolated_survivor));
+        assert!(tri.tds.contains_simplex(simplex_key));
     }
 
     #[test]

--- a/src/core/rollback.rs
+++ b/src/core/rollback.rs
@@ -1,0 +1,140 @@
+//! Triangulation-level rollback guards for scoped topology mutation windows.
+
+#![forbid(unsafe_code)]
+
+use crate::core::tds::TdsRollbackSnapshot;
+use crate::core::triangulation::Triangulation;
+
+/// Scoped rollback guard for a `Triangulation` mutation that snapshots only
+/// the owned TDS while allowing method-level mutation through the owner.
+#[must_use = "rollback transactions restore on drop unless explicitly committed or rolled back"]
+pub(crate) struct TriangulationRollbackTransaction<'tri, K, U, V, const D: usize>
+where
+    U: Clone,
+    V: Clone,
+{
+    owner: &'tri mut Triangulation<K, U, V, D>,
+    tds_snapshot: TdsRollbackSnapshot<U, V, D>,
+    finished: bool,
+}
+
+impl<'tri, K, U, V, const D: usize> TriangulationRollbackTransaction<'tri, K, U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    /// Begins a rollback window by snapshotting the canonical TDS owner.
+    pub(crate) fn begin(owner: &'tri mut Triangulation<K, U, V, D>) -> Self {
+        let tds_snapshot = TdsRollbackSnapshot::capture(&owner.tds);
+        Self {
+            owner,
+            tds_snapshot,
+            finished: false,
+        }
+    }
+
+    /// Borrows the mutable owner for a mutation step inside the transaction.
+    pub(crate) const fn triangulation_mut(&mut self) -> &mut Triangulation<K, U, V, D> {
+        &mut *self.owner
+    }
+
+    /// Restores the owner TDS to the saved state while keeping the transaction
+    /// open for another attempt.
+    pub(crate) fn restore(&mut self) {
+        self.tds_snapshot.restore_to(&mut self.owner.tds);
+    }
+
+    /// Commits the mutation, preventing the drop guard from restoring the snapshot.
+    pub(crate) fn commit(mut self) {
+        self.finished = true;
+    }
+
+    /// Restores the snapshot and closes the transaction.
+    pub(crate) fn rollback(mut self) {
+        self.restore();
+        self.finished = true;
+    }
+}
+
+impl<K, U, V, const D: usize> Drop for TriangulationRollbackTransaction<'_, K, U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    fn drop(&mut self) {
+        if !self.finished {
+            self.restore();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::tds::Tds;
+    use crate::core::vertex::Vertex;
+    use crate::geometry::kernel::FastKernel;
+    use std::sync::Arc;
+
+    fn insert_test_vertex<const D: usize>(
+        triangulation: &mut Triangulation<FastKernel<f64>, (), (), D>,
+        coordinate: f64,
+    ) {
+        let vertex = Vertex::<(), D>::try_new([coordinate; D]).unwrap();
+        triangulation
+            .tds
+            .insert_vertex_with_mapping(vertex)
+            .unwrap();
+    }
+
+    #[test]
+    fn triangulation_transaction_drop_restores_tds() {
+        let mut triangulation: Triangulation<FastKernel<f64>, (), (), 2> =
+            Triangulation::new_empty(FastKernel::new());
+
+        {
+            let mut transaction = TriangulationRollbackTransaction::begin(&mut triangulation);
+            insert_test_vertex(transaction.triangulation_mut(), 1.0);
+        }
+
+        assert_eq!(triangulation.tds.number_of_vertices(), 0);
+    }
+
+    #[test]
+    fn triangulation_transaction_restore_keeps_window_open() {
+        let mut triangulation: Triangulation<FastKernel<f64>, (), (), 3> =
+            Triangulation::new_empty(FastKernel::new());
+        let mut transaction = TriangulationRollbackTransaction::begin(&mut triangulation);
+
+        insert_test_vertex(transaction.triangulation_mut(), 1.0);
+        transaction.restore();
+        insert_test_vertex(transaction.triangulation_mut(), 2.0);
+        transaction.commit();
+
+        assert_eq!(triangulation.tds.number_of_vertices(), 1);
+    }
+
+    #[test]
+    fn triangulation_transaction_restore_allows_tds_field_replacement() {
+        let mut triangulation: Triangulation<FastKernel<f64>, (), (), 2> =
+            Triangulation::new_empty(FastKernel::new());
+        insert_test_vertex(&mut triangulation, 1.0);
+        let original_identity = Arc::clone(triangulation.tds.identity());
+
+        let mut transaction = TriangulationRollbackTransaction::begin(&mut triangulation);
+        {
+            let owner = transaction.triangulation_mut();
+            owner.tds = Tds::empty();
+            assert_eq!(owner.tds.number_of_vertices(), 0);
+            assert!(!Arc::ptr_eq(&original_identity, owner.tds.identity()));
+        }
+
+        transaction.restore();
+        {
+            let owner = transaction.triangulation_mut();
+            assert_eq!(owner.tds.number_of_vertices(), 1);
+            assert!(Arc::ptr_eq(&original_identity, owner.tds.identity()));
+        }
+        transaction.commit();
+    }
+}

--- a/src/core/rollback.rs
+++ b/src/core/rollback.rs
@@ -2,8 +2,18 @@
 
 #![forbid(unsafe_code)]
 
-use crate::core::tds::TdsRollbackSnapshot;
+use crate::core::tds::{Tds, TdsOwnerRollbackTransaction, TdsRollbackOwner};
 use crate::core::triangulation::Triangulation;
+
+impl<K, U, V, const D: usize> TdsRollbackOwner<U, V, D> for Triangulation<K, U, V, D> {
+    fn rollback_tds(&self) -> &Tds<U, V, D> {
+        &self.tds
+    }
+
+    fn rollback_tds_mut(&mut self) -> &mut Tds<U, V, D> {
+        &mut self.tds
+    }
+}
 
 /// Scoped rollback guard for a `Triangulation` mutation that snapshots only
 /// the owned TDS while allowing method-level mutation through the owner.
@@ -13,9 +23,7 @@ where
     U: Clone,
     V: Clone,
 {
-    owner: &'tri mut Triangulation<K, U, V, D>,
-    tds_snapshot: TdsRollbackSnapshot<U, V, D>,
-    finished: bool,
+    inner: TdsOwnerRollbackTransaction<'tri, Triangulation<K, U, V, D>, U, V, D>,
 }
 
 impl<'tri, K, U, V, const D: usize> TriangulationRollbackTransaction<'tri, K, U, V, D>
@@ -25,46 +33,30 @@ where
 {
     /// Begins a rollback window by snapshotting the canonical TDS owner.
     pub(crate) fn begin(owner: &'tri mut Triangulation<K, U, V, D>) -> Self {
-        let tds_snapshot = TdsRollbackSnapshot::capture(&owner.tds);
         Self {
-            owner,
-            tds_snapshot,
-            finished: false,
+            inner: TdsOwnerRollbackTransaction::begin(owner),
         }
     }
 
     /// Borrows the mutable owner for a mutation step inside the transaction.
     pub(crate) const fn triangulation_mut(&mut self) -> &mut Triangulation<K, U, V, D> {
-        &mut *self.owner
+        self.inner.owner_mut()
     }
 
     /// Restores the owner TDS to the saved state while keeping the transaction
     /// open for another attempt.
     pub(crate) fn restore(&mut self) {
-        self.tds_snapshot.restore_to(&mut self.owner.tds);
+        self.inner.restore();
     }
 
     /// Commits the mutation, preventing the drop guard from restoring the snapshot.
-    pub(crate) fn commit(mut self) {
-        self.finished = true;
+    pub(crate) fn commit(self) {
+        self.inner.commit();
     }
 
     /// Restores the snapshot and closes the transaction.
-    pub(crate) fn rollback(mut self) {
-        self.restore();
-        self.finished = true;
-    }
-}
-
-impl<K, U, V, const D: usize> Drop for TriangulationRollbackTransaction<'_, K, U, V, D>
-where
-    U: Clone,
-    V: Clone,
-{
-    fn drop(&mut self) {
-        if !self.finished {
-            self.restore();
-        }
+    pub(crate) fn rollback(self) {
+        self.inner.rollback();
     }
 }
 
@@ -87,9 +79,17 @@ mod tests {
             .unwrap();
     }
 
-    #[test]
-    fn triangulation_transaction_drop_restores_tds() {
-        let mut triangulation: Triangulation<FastKernel<f64>, (), (), 2> =
+    macro_rules! assert_rollback_dimensions {
+        ($case:ident) => {{
+            $case::<2>();
+            $case::<3>();
+            $case::<4>();
+            $case::<5>();
+        }};
+    }
+
+    fn assert_drop_restores_tds<const D: usize>() {
+        let mut triangulation: Triangulation<FastKernel<f64>, (), (), D> =
             Triangulation::new_empty(FastKernel::new());
 
         {
@@ -100,9 +100,8 @@ mod tests {
         assert_eq!(triangulation.tds.number_of_vertices(), 0);
     }
 
-    #[test]
-    fn triangulation_transaction_restore_keeps_window_open() {
-        let mut triangulation: Triangulation<FastKernel<f64>, (), (), 3> =
+    fn assert_restore_keeps_window_open<const D: usize>() {
+        let mut triangulation: Triangulation<FastKernel<f64>, (), (), D> =
             Triangulation::new_empty(FastKernel::new());
         let mut transaction = TriangulationRollbackTransaction::begin(&mut triangulation);
 
@@ -114,9 +113,8 @@ mod tests {
         assert_eq!(triangulation.tds.number_of_vertices(), 1);
     }
 
-    #[test]
-    fn triangulation_transaction_restore_allows_tds_field_replacement() {
-        let mut triangulation: Triangulation<FastKernel<f64>, (), (), 2> =
+    fn assert_restore_allows_tds_field_replacement<const D: usize>() {
+        let mut triangulation: Triangulation<FastKernel<f64>, (), (), D> =
             Triangulation::new_empty(FastKernel::new());
         insert_test_vertex(&mut triangulation, 1.0);
         let original_identity = Arc::clone(triangulation.tds.identity());
@@ -136,5 +134,20 @@ mod tests {
             assert!(Arc::ptr_eq(&original_identity, owner.tds.identity()));
         }
         transaction.commit();
+    }
+
+    #[test]
+    fn triangulation_transaction_drop_restores_tds() {
+        assert_rollback_dimensions!(assert_drop_restores_tds);
+    }
+
+    #[test]
+    fn triangulation_transaction_restore_keeps_window_open() {
+        assert_rollback_dimensions!(assert_restore_keeps_window_open);
+    }
+
+    #[test]
+    fn triangulation_transaction_restore_allows_tds_field_replacement() {
+        assert_rollback_dimensions!(assert_restore_allows_tds_field_replacement);
     }
 }

--- a/src/core/tds/rollback.rs
+++ b/src/core/tds/rollback.rs
@@ -5,8 +5,27 @@
 use crate::core::tds::Tds;
 use std::ptr;
 
-/// Owned TDS rollback snapshot shared by higher-level transaction guards.
-pub(crate) struct TdsRollbackSnapshot<U, V, const D: usize> {
+/// Owner abstraction for rollback guards that snapshot an embedded canonical [`Tds`].
+pub(crate) trait TdsRollbackOwner<U, V, const D: usize> {
+    /// Returns the canonical [`Tds`] that a rollback transaction snapshots.
+    fn rollback_tds(&self) -> &Tds<U, V, D>;
+
+    /// Returns the canonical [`Tds`] that a rollback transaction restores.
+    fn rollback_tds_mut(&mut self) -> &mut Tds<U, V, D>;
+}
+
+impl<U, V, const D: usize> TdsRollbackOwner<U, V, D> for Tds<U, V, D> {
+    fn rollback_tds(&self) -> &Self {
+        self
+    }
+
+    fn rollback_tds_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+/// Owned TDS rollback snapshot kept private behind owner-bound guards.
+struct TdsRollbackSnapshot<U, V, const D: usize> {
     owner: *const (),
     snapshot: Tds<U, V, D>,
 }
@@ -17,7 +36,7 @@ where
     V: Clone,
 {
     /// Captures a rollback snapshot with rollback-preserving identity semantics.
-    pub(crate) fn capture(tds: &Tds<U, V, D>) -> Self {
+    fn capture(tds: &Tds<U, V, D>) -> Self {
         Self {
             owner: ptr::from_ref(tds).cast::<()>(),
             snapshot: tds.clone_for_rollback(),
@@ -30,7 +49,7 @@ where
     ///
     /// Panics if `tds` is not the canonical owner location this snapshot was
     /// captured from.
-    pub(crate) fn restore_to(&self, tds: &mut Tds<U, V, D>) {
+    fn restore_to(&self, tds: &mut Tds<U, V, D>) {
         let target_owner = ptr::from_ref(tds).cast::<()>();
         assert!(
             ptr::eq(self.owner, target_owner),
@@ -43,25 +62,27 @@ where
 /// Scoped rollback guard for a mutation that must either commit explicitly or
 /// restore the original TDS state.
 #[must_use = "rollback transactions restore on drop unless explicitly committed or rolled back"]
-pub(crate) struct TdsRollbackTransaction<'tds, U, V, const D: usize>
+pub(crate) struct TdsOwnerRollbackTransaction<'owner, O, U, V, const D: usize>
 where
+    O: TdsRollbackOwner<U, V, D>,
     U: Clone,
     V: Clone,
 {
-    owner: &'tds mut Tds<U, V, D>,
+    owner: &'owner mut O,
     snapshot: TdsRollbackSnapshot<U, V, D>,
     finished: bool,
 }
 
-impl<'tds, U, V, const D: usize> TdsRollbackTransaction<'tds, U, V, D>
+impl<'owner, O, U, V, const D: usize> TdsOwnerRollbackTransaction<'owner, O, U, V, D>
 where
+    O: TdsRollbackOwner<U, V, D>,
     U: Clone,
     V: Clone,
 {
-    /// Begins a rollback window by snapshotting the canonical owner while
-    /// retaining the owner's runtime identity for cache provenance.
-    pub(crate) fn begin(owner: &'tds mut Tds<U, V, D>) -> Self {
-        let snapshot = TdsRollbackSnapshot::capture(owner);
+    /// Begins a rollback window by snapshotting the owner's canonical TDS while
+    /// retaining runtime identity for cache provenance.
+    pub(crate) fn begin(owner: &'owner mut O) -> Self {
+        let snapshot = TdsRollbackSnapshot::capture(owner.rollback_tds());
         Self {
             owner,
             snapshot,
@@ -70,14 +91,14 @@ where
     }
 
     /// Borrows the mutable owner for a mutation step inside the transaction.
-    pub(crate) const fn tds_mut(&mut self) -> &mut Tds<U, V, D> {
+    pub(crate) const fn owner_mut(&mut self) -> &mut O {
         &mut *self.owner
     }
 
     /// Restores the owner to the saved state while keeping the transaction open
     /// for another attempt.
     pub(crate) fn restore(&mut self) {
-        self.snapshot.restore_to(self.owner);
+        self.snapshot.restore_to(self.owner.rollback_tds_mut());
     }
 
     /// Commits the mutation, preventing the drop guard from restoring the snapshot.
@@ -90,10 +111,16 @@ where
         self.restore();
         self.finished = true;
     }
+
+    /// Marks the transaction committed for wrapper guards that own their own drop policy.
+    pub(crate) const fn commit_in_place(&mut self) {
+        self.finished = true;
+    }
 }
 
-impl<U, V, const D: usize> Drop for TdsRollbackTransaction<'_, U, V, D>
+impl<O, U, V, const D: usize> Drop for TdsOwnerRollbackTransaction<'_, O, U, V, D>
 where
+    O: TdsRollbackOwner<U, V, D>,
     U: Clone,
     V: Clone,
 {
@@ -101,6 +128,21 @@ where
         if !self.finished {
             self.restore();
         }
+    }
+}
+
+/// Owner-bound rollback guard for functions that mutate a [`Tds`] directly.
+pub(crate) type TdsRollbackTransaction<'tds, U, V, const D: usize> =
+    TdsOwnerRollbackTransaction<'tds, Tds<U, V, D>, U, V, D>;
+
+impl<U, V, const D: usize> TdsOwnerRollbackTransaction<'_, Tds<U, V, D>, U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    /// Borrows the mutable TDS for a mutation step inside the transaction.
+    pub(crate) const fn tds_mut(&mut self) -> &mut Tds<U, V, D> {
+        self.owner_mut()
     }
 }
 

--- a/src/core/tds/rollback.rs
+++ b/src/core/tds/rollback.rs
@@ -1,0 +1,122 @@
+//! TDS rollback snapshots and transactions.
+
+#![forbid(unsafe_code)]
+
+use crate::core::tds::Tds;
+use std::ptr;
+
+/// Owned TDS rollback snapshot shared by higher-level transaction guards.
+pub(crate) struct TdsRollbackSnapshot<U, V, const D: usize> {
+    owner: *const (),
+    snapshot: Tds<U, V, D>,
+}
+
+impl<U, V, const D: usize> TdsRollbackSnapshot<U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    /// Captures a rollback snapshot with rollback-preserving identity semantics.
+    pub(crate) fn capture(tds: &Tds<U, V, D>) -> Self {
+        Self {
+            owner: ptr::from_ref(tds).cast::<()>(),
+            snapshot: tds.clone_for_rollback(),
+        }
+    }
+
+    /// Restores `tds` from this snapshot while preserving rollback identity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `tds` is not the canonical owner location this snapshot was
+    /// captured from.
+    pub(crate) fn restore_to(&self, tds: &mut Tds<U, V, D>) {
+        let target_owner = ptr::from_ref(tds).cast::<()>();
+        assert!(
+            ptr::eq(self.owner, target_owner),
+            "rollback snapshot must be restored to the TDS owner location it was captured from"
+        );
+        tds.clone_from_for_rollback(&self.snapshot);
+    }
+}
+
+/// Scoped rollback guard for a mutation that must either commit explicitly or
+/// restore the original TDS state.
+#[must_use = "rollback transactions restore on drop unless explicitly committed or rolled back"]
+pub(crate) struct TdsRollbackTransaction<'tds, U, V, const D: usize>
+where
+    U: Clone,
+    V: Clone,
+{
+    owner: &'tds mut Tds<U, V, D>,
+    snapshot: TdsRollbackSnapshot<U, V, D>,
+    finished: bool,
+}
+
+impl<'tds, U, V, const D: usize> TdsRollbackTransaction<'tds, U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    /// Begins a rollback window by snapshotting the canonical owner while
+    /// retaining the owner's runtime identity for cache provenance.
+    pub(crate) fn begin(owner: &'tds mut Tds<U, V, D>) -> Self {
+        let snapshot = TdsRollbackSnapshot::capture(owner);
+        Self {
+            owner,
+            snapshot,
+            finished: false,
+        }
+    }
+
+    /// Borrows the mutable owner for a mutation step inside the transaction.
+    pub(crate) const fn tds_mut(&mut self) -> &mut Tds<U, V, D> {
+        &mut *self.owner
+    }
+
+    /// Restores the owner to the saved state while keeping the transaction open
+    /// for another attempt.
+    pub(crate) fn restore(&mut self) {
+        self.snapshot.restore_to(self.owner);
+    }
+
+    /// Commits the mutation, preventing the drop guard from restoring the snapshot.
+    pub(crate) fn commit(mut self) {
+        self.finished = true;
+    }
+
+    /// Restores the snapshot and closes the transaction.
+    pub(crate) fn rollback(mut self) {
+        self.restore();
+        self.finished = true;
+    }
+}
+
+impl<U, V, const D: usize> Drop for TdsRollbackTransaction<'_, U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    fn drop(&mut self) {
+        if !self.finished {
+            self.restore();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic(
+        expected = "rollback snapshot must be restored to the TDS owner location it was captured from"
+    )]
+    fn snapshot_restore_rejects_cross_owner_target() {
+        let source: Tds<(), (), 2> = Tds::empty();
+        let snapshot = TdsRollbackSnapshot::capture(&source);
+        let mut target: Tds<(), (), 2> = Tds::empty();
+
+        snapshot.restore_to(&mut target);
+    }
+}

--- a/src/core/tds/storage.rs
+++ b/src/core/tds/storage.rs
@@ -2427,8 +2427,14 @@ pub(in crate::core::tds) type SimplexUuidSortKey<const D: usize> =
 mod tests {
     use super::*;
     use crate::core::simplex::Simplex;
+    use crate::core::tds::TdsRollbackTransaction;
     use std::assert_matches;
     use std::sync::Arc;
+
+    fn insert_test_vertex<const D: usize>(tds: &mut Tds<(), (), D>, coordinate: f64) -> VertexKey {
+        let vertex = Vertex::<(), _>::try_new([coordinate; D]).unwrap();
+        tds.insert_vertex_with_mapping(vertex).unwrap()
+    }
 
     #[test]
     fn test_empty_initializes_storage_identity_and_counts() {
@@ -2727,6 +2733,77 @@ mod tests {
                             source_generation,
                             "clone_from_for_rollback must keep an independent generation counter"
                         );
+                    }
+
+                    #[test]
+                    fn [<test_rollback_transaction_drop_restores_snapshot_ $dim d>]() {
+                        let mut tds: Tds<(), (), $dim> = Tds::empty();
+                        let source_vertex = insert_test_vertex(&mut tds, 0.0);
+                        let source_generation = tds.generation();
+                        let source_identity = Arc::clone(tds.identity());
+
+                        {
+                            let mut transaction = TdsRollbackTransaction::begin(&mut tds);
+                            let _transient_vertex = insert_test_vertex(transaction.tds_mut(), 1.0);
+                        }
+
+                        assert!(Arc::ptr_eq(&source_identity, tds.identity()));
+                        assert_eq!(tds.generation(), source_generation);
+                        assert_eq!(tds.number_of_vertices(), 1);
+                        assert!(tds.vertex(source_vertex).is_some());
+                    }
+
+                    #[test]
+                    fn [<test_rollback_transaction_explicit_rollback_restores_snapshot_ $dim d>]() {
+                        let mut tds: Tds<(), (), $dim> = Tds::empty();
+                        let source_vertex = insert_test_vertex(&mut tds, 0.0);
+                        let source_generation = tds.generation();
+
+                        {
+                            let mut transaction = TdsRollbackTransaction::begin(&mut tds);
+                            let _transient_vertex = insert_test_vertex(transaction.tds_mut(), 1.0);
+                            transaction.rollback();
+                        }
+
+                        assert_eq!(tds.generation(), source_generation);
+                        assert_eq!(tds.number_of_vertices(), 1);
+                        assert!(tds.vertex(source_vertex).is_some());
+                    }
+
+                    #[test]
+                    fn [<test_rollback_transaction_restore_keeps_transaction_open_ $dim d>]() {
+                        let mut tds: Tds<(), (), $dim> = Tds::empty();
+                        let source_vertex = insert_test_vertex(&mut tds, 0.0);
+
+                        let committed_vertex = {
+                            let mut transaction = TdsRollbackTransaction::begin(&mut tds);
+                            let _transient_vertex = insert_test_vertex(transaction.tds_mut(), 1.0);
+                            transaction.restore();
+                            let committed_vertex = insert_test_vertex(transaction.tds_mut(), 2.0);
+                            transaction.commit();
+                            committed_vertex
+                        };
+
+                        assert_eq!(tds.number_of_vertices(), 2);
+                        assert!(tds.vertex(source_vertex).is_some());
+                        assert!(tds.vertex(committed_vertex).is_some());
+                    }
+
+                    #[test]
+                    fn [<test_rollback_transaction_commit_preserves_mutation_ $dim d>]() {
+                        let mut tds: Tds<(), (), $dim> = Tds::empty();
+                        let source_vertex = insert_test_vertex(&mut tds, 0.0);
+
+                        let committed_vertex = {
+                            let mut transaction = TdsRollbackTransaction::begin(&mut tds);
+                            let committed_vertex = insert_test_vertex(transaction.tds_mut(), 1.0);
+                            transaction.commit();
+                            committed_vertex
+                        };
+
+                        assert_eq!(tds.number_of_vertices(), 2);
+                        assert!(tds.vertex(source_vertex).is_some());
+                        assert!(tds.vertex(committed_vertex).is_some());
                     }
                 )+
             }

--- a/src/delaunay/deletion.rs
+++ b/src/delaunay/deletion.rs
@@ -17,6 +17,7 @@ use crate::core::collections::SimplexKeyBuffer;
 use crate::core::tds::{InvariantError, NeighborValidationError, TdsError, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::validation::insertion_error_to_invariant_error;
+use crate::delaunay_rollback::{DelaunayRollbackTransaction, DelaunaySpatialIndexRollback};
 use crate::geometry::kernel::Kernel;
 use crate::repair::DelaunayRepairOperation;
 use crate::triangulation::DelaunayTriangulation;
@@ -205,95 +206,101 @@ where
             return Err(DeleteVertexError::VertexNotFound { vertex_key });
         };
         let removed_vertex_coords = *removed_vertex.point().coords();
-        let snapshot = (self.tri.tds.clone_for_rollback(), self.insertion_state);
 
-        let result: Result<usize, InvariantError> = (|| {
-            // Fast path: inverse k=1 flip when the vertex star is a simplex.
-            let mut seed_simplices: Option<SimplexKeyBuffer> = None;
-            let simplices_removed =
-                match apply_bistellar_flip_k1_inverse(&mut self.tri.tds, vertex_key) {
-                    Ok(info) => {
-                        seed_simplices = Some(info.new_simplices);
-                        info.removed_simplices.len()
-                    }
-                    Err(FlipError::NeighborWiring { reason }) => {
-                        return Err(TdsError::InvalidNeighbors {
-                            reason: NeighborValidationError::FlipNeighborWiring { reason },
+        let mut transaction =
+            DelaunayRollbackTransaction::begin(self, DelaunaySpatialIndexRollback::Restore);
+        let result: Result<usize, InvariantError> = {
+            let delaunay = transaction.delaunay_mut();
+            (|| {
+                // Fast path: inverse k=1 flip when the vertex star is a simplex.
+                let mut seed_simplices: Option<SimplexKeyBuffer> = None;
+                let simplices_removed =
+                    match apply_bistellar_flip_k1_inverse(&mut delaunay.tri.tds, vertex_key) {
+                        Ok(info) => {
+                            seed_simplices = Some(info.new_simplices);
+                            info.removed_simplices.len()
                         }
-                        .into());
-                    }
-                    Err(_) => {
-                        let outcome = self.tri.remove_vertex_with_repair_seeds(vertex_key)?;
-                        if !outcome.repair_seed_simplices.is_empty() {
-                            seed_simplices = Some(outcome.repair_seed_simplices);
+                        Err(FlipError::NeighborWiring { reason }) => {
+                            return Err(TdsError::InvalidNeighbors {
+                                reason: NeighborValidationError::FlipNeighborWiring { reason },
+                            }
+                            .into());
                         }
-                        outcome.simplices_removed
-                    }
-                };
+                        Err(_) => {
+                            let outcome =
+                                delaunay.tri.remove_vertex_with_repair_seeds(vertex_key)?;
+                            if !outcome.repair_seed_simplices.is_empty() {
+                                seed_simplices = Some(outcome.repair_seed_simplices);
+                            }
+                            outcome.simplices_removed
+                        }
+                    };
 
-            let topology = self.tri.topology_guarantee();
-            if self.should_run_delaunay_repair_after_mutation(topology) {
-                let seed_ref = seed_simplices.as_deref();
-                let repair_seed_count =
-                    seed_ref.map_or_else(|| self.tri.tds.number_of_simplices(), <[_]>::len);
-                let max_flips = local_repair_flip_budget::<D>(repair_seed_count);
-                let repair_result = {
-                    self.invalidate_locate_hint_cache();
-                    let (tds, kernel) = (&mut self.tri.tds, &self.tri.kernel);
-                    repair_delaunay_with_flips_k2_k3(
-                        tds,
-                        kernel,
-                        seed_ref,
-                        topology,
-                        Some(max_flips),
-                    )
-                };
+                let topology = delaunay.tri.topology_guarantee();
+                if delaunay.should_run_delaunay_repair_after_mutation(topology) {
+                    let seed_ref = seed_simplices.as_deref();
+                    let repair_seed_count =
+                        seed_ref.map_or_else(|| delaunay.tri.tds.number_of_simplices(), <[_]>::len);
+                    let max_flips = local_repair_flip_budget::<D>(repair_seed_count);
+                    let repair_result = {
+                        delaunay.invalidate_locate_hint_cache();
+                        let (tds, kernel) = (&mut delaunay.tri.tds, &delaunay.tri.kernel);
+                        repair_delaunay_with_flips_k2_k3(
+                            tds,
+                            kernel,
+                            seed_ref,
+                            topology,
+                            Some(max_flips),
+                        )
+                    };
 
-                #[cfg(test)]
-                let repair_result = if test_hooks::force_repair_nonconvergent_enabled() {
-                    Err(test_hooks::synthetic_nonconvergent_error())
-                } else {
-                    repair_result
-                };
+                    #[cfg(test)]
+                    let repair_result = if test_hooks::force_repair_nonconvergent_enabled() {
+                        Err(test_hooks::synthetic_nonconvergent_error())
+                    } else {
+                        repair_result
+                    };
 
-                repair_result.map_err(|source| {
-                    InvariantError::Delaunay(
-                        DelaunayTriangulationValidationError::RepairOperationFailed {
-                            operation: DelaunayRepairOperation::VertexRemoval,
-                            source: Box::new(source),
-                        },
-                    )
-                })?;
-
-                // Re-canonicalize geometric orientation (#258): flip repair may leave
-                // the global sign negative.
-                self.tri
-                    .normalize_and_promote_positive_orientation()
-                    .map_err(|e| {
-                        insertion_error_to_invariant_error(
-                            e,
-                            "Orientation canonicalization failed after vertex deletion",
+                    repair_result.map_err(|source| {
+                        InvariantError::Delaunay(
+                            DelaunayTriangulationValidationError::RepairOperationFailed {
+                                operation: DelaunayRepairOperation::VertexRemoval,
+                                source: Box::new(source),
+                            },
                         )
                     })?;
-            } else {
-                self.is_valid().map_err(InvariantError::Delaunay)?;
-            }
 
-            Ok(simplices_removed)
-        })();
+                    // Re-canonicalize geometric orientation (#258): flip repair may leave
+                    // the global sign negative.
+                    delaunay
+                        .tri
+                        .normalize_and_promote_positive_orientation()
+                        .map_err(|e| {
+                            insertion_error_to_invariant_error(
+                                e,
+                                "Orientation canonicalization failed after vertex deletion",
+                            )
+                        })?;
+                } else {
+                    delaunay.is_valid().map_err(InvariantError::Delaunay)?;
+                }
+
+                Ok(simplices_removed)
+            })()
+        };
 
         match result {
             Ok(simplices_removed) => {
-                self.insertion_state.last_inserted_simplex = None;
-                if let Some(index) = self.spatial_index.as_mut() {
+                let delaunay = transaction.delaunay_mut();
+                delaunay.insertion_state.last_inserted_simplex = None;
+                if let Some(index) = delaunay.spatial_index.as_mut() {
                     index.remove_vertex(&vertex_key, &removed_vertex_coords);
                 }
+                transaction.commit();
                 Ok(simplices_removed)
             }
             Err(err) => {
-                let (tds, insertion_state) = snapshot;
-                self.tri.tds = tds;
-                self.insertion_state = insertion_state;
+                transaction.rollback();
                 Err(err.into())
             }
         }

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -30,6 +30,7 @@ use crate::core::tds::{SimplexKey, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::validation::{TopologyGuarantee, TriangulationValidationError};
 use crate::core::vertex::Vertex;
+use crate::delaunay_rollback::{DelaunayRollbackTransaction, DelaunaySpatialIndexRollback};
 use crate::geometry::kernel::Kernel;
 use crate::repair::DelaunayRepairPolicy;
 use crate::topology::manifold::{ManifoldError, validate_ridge_links_for_simplices};
@@ -80,12 +81,56 @@ where
         Ok(())
     }
 
+    /// Returns whether the post-insertion repair/check path needs an outer
+    /// Delaunay-level rollback window.
+    fn post_insertion_transaction_required(&self) -> bool {
+        let next_insertion_count = self
+            .insertion_state
+            .delaunay_repair_insertion_count
+            .saturating_add(1);
+        let could_have_simplices_after_insertion = self.tri.tds.number_of_simplices() > 0
+            || self.tri.tds.number_of_vertices().saturating_add(1) > D;
+        could_have_simplices_after_insertion
+            && (self.insertion_state.delaunay_repair_policy != DelaunayRepairPolicy::Never
+                || self
+                    .insertion_state
+                    .delaunay_check_policy
+                    .should_check(next_insertion_count))
+    }
+
+    /// Runs a Delaunay insertion operation with the rollback policy used by
+    /// post-insertion repair/check failures.
+    fn with_post_insertion_rollback<T>(
+        &mut self,
+        operation: impl FnOnce(&mut Self) -> Result<T, InsertionError>,
+    ) -> Result<T, InsertionError> {
+        if !self.post_insertion_transaction_required() {
+            return operation(self);
+        }
+
+        let mut transaction =
+            DelaunayRollbackTransaction::begin(self, DelaunaySpatialIndexRollback::Invalidate);
+        match operation(transaction.delaunay_mut()) {
+            Ok(value) => {
+                transaction.commit();
+                Ok(value)
+            }
+            Err(error) => {
+                transaction.rollback();
+                Err(error)
+            }
+        }
+    }
+
     /// Insert a vertex into the Delaunay triangulation using incremental cavity-based algorithm.
     ///
     /// This method handles all stages of triangulation construction:
     /// - **Bootstrap (< D+1 vertices)**: Accumulates vertices without creating simplices
     /// - **Initial simplex (D+1 vertices)**: Automatically builds the first D-simplex
     /// - **Incremental (> D+1 vertices)**: Uses cavity-based insertion with point location
+    ///
+    /// If post-insertion Delaunay repair or validation fails, the failed insertion is rolled
+    /// back before this method returns the error.
     ///
     /// # Algorithm
     /// 1. Insert vertex into Tds
@@ -185,25 +230,10 @@ where
         //
         // Transactional guard: post-steps (flip repair and/or global Delaunay checks) can fail.
         // If they do, rollback to leave the triangulation unchanged.
-        let next_insertion_count = self
-            .insertion_state
-            .delaunay_repair_insertion_count
-            .saturating_add(1);
-        let could_have_simplices_after_insertion = self.tri.tds.number_of_simplices() > 0
-            || self.tri.tds.number_of_vertices().saturating_add(1) > D;
-        let snapshot_needed = could_have_simplices_after_insertion
-            && (self.insertion_state.delaunay_repair_policy != DelaunayRepairPolicy::Never
-                || self
-                    .insertion_state
-                    .delaunay_check_policy
-                    .should_check(next_insertion_count));
-        let snapshot =
-            snapshot_needed.then(|| (self.tri.tds.clone_for_rollback(), self.insertion_state));
-
-        let insertion_result = (|| {
-            let hint = self.insertion_state.last_inserted_simplex;
+        self.with_post_insertion_rollback(|delaunay| {
+            let hint = delaunay.insertion_state.last_inserted_simplex;
             let insert_detail = {
-                let (tri, spatial_index) = (&mut self.tri, &mut self.spatial_index);
+                let (tri, spatial_index) = (&mut delaunay.tri, &mut delaunay.spatial_index);
                 tri.insert_with_statistics_seeded_indexed_detailed(
                     vertex,
                     None,
@@ -221,32 +251,24 @@ where
                     vertex_key: v_key,
                     hint,
                 } => {
-                    self.insertion_state.last_inserted_simplex = hint;
-                    self.insertion_state.delaunay_repair_insertion_count = self
+                    delaunay.insertion_state.last_inserted_simplex = hint;
+                    delaunay.insertion_state.delaunay_repair_insertion_count = delaunay
                         .insertion_state
                         .delaunay_repair_insertion_count
                         .saturating_add(1);
                     if delaunay_repair_required {
-                        self.maybe_repair_after_insertion(v_key, hint, &repair_seed_simplices)?;
+                        delaunay.maybe_repair_after_insertion(
+                            v_key,
+                            hint,
+                            &repair_seed_simplices,
+                        )?;
                     }
-                    self.maybe_check_after_insertion()?;
+                    delaunay.maybe_check_after_insertion()?;
                     Ok(v_key)
                 }
                 InsertionOutcome::Skipped { error } => Err(error),
             }
-        })();
-
-        match insertion_result {
-            Ok(v_key) => Ok(v_key),
-            Err(err) => {
-                if let Some((tds, insertion_state)) = snapshot {
-                    self.spatial_index = None;
-                    self.tri.tds = tds;
-                    self.insertion_state = insertion_state;
-                }
-                Err(err)
-            }
-        }
+        })
     }
 
     /// Insert a vertex and return the insertion outcome plus statistics.
@@ -256,6 +278,8 @@ where
     /// Unlike [`insert_best_effort_with_statistics`](Self::insert_best_effort_with_statistics),
     /// skipped insertions are reported as [`InsertionError`] values so callers using `?`
     /// cannot accidentally ignore a duplicate or retry-exhausted degeneracy.
+    /// If post-insertion Delaunay repair or validation fails, the failed insertion is rolled
+    /// back before this method returns the error.
     ///
     /// # Errors
     ///
@@ -303,7 +327,9 @@ where
     /// and workloads that deliberately continue after duplicate coordinates or
     /// retry-exhausted geometric degeneracies. A skipped insertion returns
     /// `Ok((InsertionOutcome::Skipped { .. }, stats))`; the triangulation is
-    /// left unchanged for that vertex.
+    /// left unchanged for that vertex. If post-insertion Delaunay repair or
+    /// validation fails, the failed insertion is rolled back before this method
+    /// returns the error.
     ///
     /// # Errors
     ///
@@ -345,25 +371,10 @@ where
 
         // Transactional guard: post-steps (flip repair and/or global Delaunay checks) can fail.
         // If they do, rollback to leave the triangulation unchanged.
-        let next_insertion_count = self
-            .insertion_state
-            .delaunay_repair_insertion_count
-            .saturating_add(1);
-        let could_have_simplices_after_insertion = self.tri.tds.number_of_simplices() > 0
-            || self.tri.tds.number_of_vertices().saturating_add(1) > D;
-        let snapshot_needed = could_have_simplices_after_insertion
-            && (self.insertion_state.delaunay_repair_policy != DelaunayRepairPolicy::Never
-                || self
-                    .insertion_state
-                    .delaunay_check_policy
-                    .should_check(next_insertion_count));
-        let snapshot =
-            snapshot_needed.then(|| (self.tri.tds.clone_for_rollback(), self.insertion_state));
-
-        let insertion_result = (|| {
-            let hint = self.insertion_state.last_inserted_simplex;
+        self.with_post_insertion_rollback(|delaunay| {
+            let hint = delaunay.insertion_state.last_inserted_simplex;
             let insert_detail = {
-                let (tri, spatial_index) = (&mut self.tri, &mut self.spatial_index);
+                let (tri, spatial_index) = (&mut delaunay.tri, &mut delaunay.spatial_index);
                 tri.insert_with_statistics_seeded_indexed_detailed(
                     vertex,
                     None,
@@ -379,38 +390,26 @@ where
 
             let outcome = match insert_detail.outcome {
                 InsertionOutcome::Inserted { vertex_key, hint } => {
-                    self.insertion_state.last_inserted_simplex = hint;
-                    self.insertion_state.delaunay_repair_insertion_count = self
+                    delaunay.insertion_state.last_inserted_simplex = hint;
+                    delaunay.insertion_state.delaunay_repair_insertion_count = delaunay
                         .insertion_state
                         .delaunay_repair_insertion_count
                         .saturating_add(1);
                     if delaunay_repair_required {
-                        self.maybe_repair_after_insertion(
+                        delaunay.maybe_repair_after_insertion(
                             vertex_key,
                             hint,
                             &repair_seed_simplices,
                         )?;
                     }
-                    self.maybe_check_after_insertion()?;
+                    delaunay.maybe_check_after_insertion()?;
                     InsertionOutcome::Inserted { vertex_key, hint }
                 }
                 other @ InsertionOutcome::Skipped { .. } => other,
             };
 
             Ok((outcome, stats))
-        })();
-
-        match insertion_result {
-            Ok((outcome, stats)) => Ok((outcome, stats)),
-            Err(err) => {
-                if let Some((tds, insertion_state)) = snapshot {
-                    self.spatial_index = None;
-                    self.tri.tds = tds;
-                    self.insertion_state = insertion_state;
-                }
-                Err(err)
-            }
-        }
+        })
     }
 
     /// Keeps the default insertion path on the same repair helper as capped
@@ -846,6 +845,62 @@ mod tests {
             })
         );
         assert!(found_inserted_key);
+        assert!(dt.validate().is_ok());
+    }
+
+    #[test]
+    fn post_insertion_rollback_error_restores_state_and_invalidates_spatial_index() {
+        init_tracing();
+        let vertices: Vec<Vertex<(), 2>> = vec![
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
+        ];
+        let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> =
+            DelaunayTriangulation::try_new(&vertices).unwrap();
+        let vertex_count_before = dt.number_of_vertices();
+        let simplex_count_before = dt.number_of_simplices();
+        let hint_before = dt.simplices().next().map(|(key, _)| key);
+        dt.insertion_state.last_inserted_simplex = hint_before;
+
+        let mut spatial_index = HashGridIndex::<2>::try_new(1.0).unwrap();
+        for (vertex_key, vertex) in dt.vertices() {
+            spatial_index.insert_vertex(vertex_key, vertex.point().coords());
+        }
+        dt.spatial_index = Some(spatial_index);
+        assert!(dt.post_insertion_transaction_required());
+
+        let transient_vertex = vertex![0.25, 0.25].unwrap();
+        let transient_uuid = transient_vertex.uuid();
+        let result: Result<(), InsertionError> = dt.with_post_insertion_rollback(|delaunay| {
+            delaunay
+                .tri
+                .tds
+                .insert_vertex_with_mapping(transient_vertex)
+                .unwrap();
+            delaunay.insertion_state.last_inserted_simplex = None;
+            delaunay.spatial_index = Some(HashGridIndex::<2>::try_new(1.0).unwrap());
+            Err(InsertionError::MaxSimplicesRemovedExceeded {
+                max_simplices_removed: 0,
+                attempted: 1,
+            })
+        });
+
+        assert_matches!(
+            result,
+            Err(InsertionError::MaxSimplicesRemovedExceeded {
+                max_simplices_removed: 0,
+                attempted: 1,
+            })
+        );
+        assert_eq!(dt.number_of_vertices(), vertex_count_before);
+        assert_eq!(dt.number_of_simplices(), simplex_count_before);
+        assert_eq!(dt.insertion_state.last_inserted_simplex, hint_before);
+        assert!(
+            dt.spatial_index.is_none(),
+            "post-insertion rollback should invalidate the spatial index"
+        );
+        assert!(!dt.vertices().any(|(_, v)| v.uuid() == transient_uuid));
         assert!(dt.validate().is_ok());
     }
 

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -32,7 +32,6 @@ use crate::core::validation::{TopologyGuarantee, TriangulationValidationError};
 use crate::core::vertex::Vertex;
 use crate::delaunay_rollback::{DelaunayRollbackTransaction, DelaunaySpatialIndexRollback};
 use crate::geometry::kernel::Kernel;
-use crate::repair::DelaunayRepairPolicy;
 use crate::topology::manifold::{ManifoldError, validate_ridge_links_for_simplices};
 use crate::triangulation::DelaunayTriangulation;
 #[cfg(test)]
@@ -81,8 +80,10 @@ where
         Ok(())
     }
 
-    /// Returns whether the post-insertion repair/check path needs an outer
-    /// Delaunay-level rollback window.
+    /// Returns whether the next insertion needs an outer Delaunay-level rollback window.
+    ///
+    /// This mirrors the post-insertion repair and validation cadence so ordinary insertions avoid
+    /// snapshotting when neither scheduled repair nor scheduled Delaunay checking can run.
     fn post_insertion_transaction_required(&self) -> bool {
         let next_insertion_count = self
             .insertion_state
@@ -90,12 +91,13 @@ where
             .saturating_add(1);
         let could_have_simplices_after_insertion = self.tri.tds.number_of_simplices() > 0
             || self.tri.tds.number_of_vertices().saturating_add(1) > D;
-        could_have_simplices_after_insertion
-            && (self.insertion_state.delaunay_repair_policy != DelaunayRepairPolicy::Never
-                || self
-                    .insertion_state
-                    .delaunay_check_policy
-                    .should_check(next_insertion_count))
+        let repair_scheduled = self
+            .should_run_delaunay_repair_for(self.tri.topology_guarantee(), next_insertion_count);
+        let check_scheduled = self
+            .insertion_state
+            .delaunay_check_policy
+            .should_check(next_insertion_count);
+        could_have_simplices_after_insertion && (repair_scheduled || check_scheduled)
     }
 
     /// Runs a Delaunay insertion operation with the rollback policy used by
@@ -620,10 +622,12 @@ mod tests {
     use crate::core::simplex::Simplex;
     use crate::core::tds::{Tds, TdsError};
     use crate::geometry::kernel::{AdaptiveKernel, RobustKernel};
+    use crate::repair::{DelaunayCheckPolicy, DelaunayRepairPolicy};
     use crate::topology::traits::topological_space::GlobalTopology;
     use crate::vertex;
     use slotmap::KeyData;
     use std::assert_matches;
+    use std::num::NonZeroUsize;
     use std::sync::Once;
 
     fn init_tracing() {
@@ -846,6 +850,34 @@ mod tests {
         );
         assert!(found_inserted_key);
         assert!(dt.validate().is_ok());
+    }
+
+    #[test]
+    fn post_insertion_transaction_required_respects_repair_and_check_cadence() {
+        init_tracing();
+        let vertices: Vec<Vertex<(), 2>> = vec![
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
+        ];
+        let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> =
+            DelaunayTriangulation::try_new(&vertices).unwrap();
+
+        dt.set_delaunay_repair_policy(DelaunayRepairPolicy::EveryN(NonZeroUsize::new(3).unwrap()));
+        dt.set_delaunay_check_policy(DelaunayCheckPolicy::EndOnly);
+        dt.insertion_state.delaunay_repair_insertion_count = 0;
+        assert!(!dt.post_insertion_transaction_required());
+
+        dt.insertion_state.delaunay_repair_insertion_count = 2;
+        assert!(dt.post_insertion_transaction_required());
+
+        dt.set_delaunay_repair_policy(DelaunayRepairPolicy::Never);
+        dt.set_delaunay_check_policy(DelaunayCheckPolicy::EveryN(NonZeroUsize::new(2).unwrap()));
+        dt.insertion_state.delaunay_repair_insertion_count = 0;
+        assert!(!dt.post_insertion_transaction_required());
+
+        dt.insertion_state.delaunay_repair_insertion_count = 1;
+        assert!(dt.post_insertion_transaction_required());
     }
 
     #[test]

--- a/src/delaunay/rollback.rs
+++ b/src/delaunay/rollback.rs
@@ -1,0 +1,205 @@
+//! Delaunay-level rollback guards for mutations with owner-coupled caches.
+
+#![forbid(unsafe_code)]
+
+use crate::core::collections::spatial_hash_grid::HashGridIndex;
+use crate::core::operations::DelaunayInsertionState;
+use crate::core::tds::TdsRollbackSnapshot;
+use crate::triangulation::DelaunayTriangulation;
+
+/// Spatial-index policy for a Delaunay-level rollback transaction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DelaunaySpatialIndexRollback {
+    /// Restore the pre-transaction spatial index exactly.
+    Restore,
+    /// Drop the index on rollback so it can be rebuilt lazily.
+    Invalidate,
+}
+
+/// Scoped rollback guard for Delaunay-level mutations that must restore TDS
+/// state together with owner-coupled insertion and cache state.
+#[must_use = "rollback transactions restore on drop unless explicitly committed or rolled back"]
+pub struct DelaunayRollbackTransaction<'dt, K, U, V, const D: usize>
+where
+    U: Clone,
+    V: Clone,
+{
+    owner: &'dt mut DelaunayTriangulation<K, U, V, D>,
+    tds_snapshot: TdsRollbackSnapshot<U, V, D>,
+    insertion_state_snapshot: DelaunayInsertionState,
+    spatial_index_snapshot: Option<HashGridIndex<D>>,
+    spatial_index_rollback: DelaunaySpatialIndexRollback,
+    finished: bool,
+}
+
+impl<'dt, K, U, V, const D: usize> DelaunayRollbackTransaction<'dt, K, U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    /// Begins a Delaunay-level rollback window.
+    pub(super) fn begin(
+        owner: &'dt mut DelaunayTriangulation<K, U, V, D>,
+        spatial_index_rollback: DelaunaySpatialIndexRollback,
+    ) -> Self {
+        let tds_snapshot = TdsRollbackSnapshot::capture(&owner.tri.tds);
+        let insertion_state_snapshot = owner.insertion_state;
+        let spatial_index_snapshot = match spatial_index_rollback {
+            DelaunaySpatialIndexRollback::Restore => owner.spatial_index.clone(),
+            DelaunaySpatialIndexRollback::Invalidate => None,
+        };
+        Self {
+            owner,
+            tds_snapshot,
+            insertion_state_snapshot,
+            spatial_index_snapshot,
+            spatial_index_rollback,
+            finished: false,
+        }
+    }
+
+    /// Borrows the mutable owner for a mutation step inside the transaction.
+    pub(super) const fn delaunay_mut(&mut self) -> &mut DelaunayTriangulation<K, U, V, D> {
+        &mut *self.owner
+    }
+
+    /// Restores all owner-coupled rollback state and keeps the transaction open.
+    pub(super) fn restore(&mut self) {
+        self.tds_snapshot.restore_to(&mut self.owner.tri.tds);
+        self.owner.insertion_state = self.insertion_state_snapshot;
+        self.owner.spatial_index = match self.spatial_index_rollback {
+            DelaunaySpatialIndexRollback::Restore => self.spatial_index_snapshot.clone(),
+            DelaunaySpatialIndexRollback::Invalidate => None,
+        };
+    }
+
+    /// Commits the mutation, preventing the drop guard from restoring the snapshot.
+    pub(super) fn commit(mut self) {
+        self.finished = true;
+    }
+
+    /// Restores the snapshot and closes the transaction.
+    pub(super) fn rollback(mut self) {
+        self.restore();
+        self.finished = true;
+    }
+}
+
+impl<K, U, V, const D: usize> Drop for DelaunayRollbackTransaction<'_, K, U, V, D>
+where
+    U: Clone,
+    V: Clone,
+{
+    fn drop(&mut self) {
+        if !self.finished {
+            self.restore();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::collections::spatial_hash_grid::HashGridIndexSnapshot;
+    use crate::core::vertex::Vertex;
+    use crate::geometry::kernel::AdaptiveKernel;
+    use crate::vertex;
+
+    fn test_triangulation() -> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> {
+        let vertices = [
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
+        ];
+        DelaunayTriangulation::try_new(&vertices).unwrap()
+    }
+
+    fn seed_spatial_index(
+        triangulation: &mut DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2>,
+    ) -> Option<HashGridIndexSnapshot> {
+        let mut index = HashGridIndex::<2>::try_new(1.0).unwrap();
+        for (vertex_key, vertex) in triangulation.vertices() {
+            index.insert_vertex(vertex_key, vertex.point().coords());
+        }
+        triangulation.spatial_index = Some(index);
+        triangulation
+            .spatial_index
+            .as_ref()
+            .map(HashGridIndex::<2>::debug_snapshot)
+    }
+
+    fn insert_uncommitted_vertex(
+        transaction: &mut DelaunayRollbackTransaction<'_, AdaptiveKernel<f64>, (), (), 2>,
+    ) {
+        let vertex = Vertex::<(), 2>::try_new([0.25, 0.25]).unwrap();
+        transaction
+            .delaunay_mut()
+            .tri
+            .tds
+            .insert_vertex_with_mapping(vertex)
+            .unwrap();
+    }
+
+    #[test]
+    fn delaunay_transaction_restore_policy_restores_auxiliary_state() {
+        let mut triangulation = test_triangulation();
+        let hint_before = triangulation.simplices().next().map(|(key, _)| key);
+        triangulation.insertion_state.last_inserted_simplex = hint_before;
+        let spatial_index_before = seed_spatial_index(&mut triangulation);
+        let vertices_before = triangulation.number_of_vertices();
+
+        {
+            let mut transaction = DelaunayRollbackTransaction::begin(
+                &mut triangulation,
+                DelaunaySpatialIndexRollback::Restore,
+            );
+            insert_uncommitted_vertex(&mut transaction);
+            transaction
+                .delaunay_mut()
+                .insertion_state
+                .last_inserted_simplex = None;
+            transaction.delaunay_mut().spatial_index = None;
+        }
+
+        assert_eq!(triangulation.number_of_vertices(), vertices_before);
+        assert_eq!(
+            triangulation.insertion_state.last_inserted_simplex,
+            hint_before
+        );
+        assert_eq!(
+            triangulation
+                .spatial_index
+                .as_ref()
+                .map(HashGridIndex::<2>::debug_snapshot),
+            spatial_index_before
+        );
+    }
+
+    #[test]
+    fn delaunay_transaction_invalidate_policy_drops_spatial_index_on_restore() {
+        let mut triangulation = test_triangulation();
+        let hint_before = triangulation.simplices().next().map(|(key, _)| key);
+        triangulation.insertion_state.last_inserted_simplex = hint_before;
+        let _ = seed_spatial_index(&mut triangulation);
+        let vertices_before = triangulation.number_of_vertices();
+
+        {
+            let mut transaction = DelaunayRollbackTransaction::begin(
+                &mut triangulation,
+                DelaunaySpatialIndexRollback::Invalidate,
+            );
+            insert_uncommitted_vertex(&mut transaction);
+            transaction
+                .delaunay_mut()
+                .insertion_state
+                .last_inserted_simplex = None;
+        }
+
+        assert_eq!(triangulation.number_of_vertices(), vertices_before);
+        assert_eq!(
+            triangulation.insertion_state.last_inserted_simplex,
+            hint_before
+        );
+        assert!(triangulation.spatial_index.is_none());
+    }
+}

--- a/src/delaunay/rollback.rs
+++ b/src/delaunay/rollback.rs
@@ -4,8 +4,18 @@
 
 use crate::core::collections::spatial_hash_grid::HashGridIndex;
 use crate::core::operations::DelaunayInsertionState;
-use crate::core::tds::TdsRollbackSnapshot;
+use crate::core::tds::{Tds, TdsOwnerRollbackTransaction, TdsRollbackOwner};
 use crate::triangulation::DelaunayTriangulation;
+
+impl<K, U, V, const D: usize> TdsRollbackOwner<U, V, D> for DelaunayTriangulation<K, U, V, D> {
+    fn rollback_tds(&self) -> &Tds<U, V, D> {
+        &self.tri.tds
+    }
+
+    fn rollback_tds_mut(&mut self) -> &mut Tds<U, V, D> {
+        &mut self.tri.tds
+    }
+}
 
 /// Spatial-index policy for a Delaunay-level rollback transaction.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -24,8 +34,7 @@ where
     U: Clone,
     V: Clone,
 {
-    owner: &'dt mut DelaunayTriangulation<K, U, V, D>,
-    tds_snapshot: TdsRollbackSnapshot<U, V, D>,
+    tds_transaction: TdsOwnerRollbackTransaction<'dt, DelaunayTriangulation<K, U, V, D>, U, V, D>,
     insertion_state_snapshot: DelaunayInsertionState,
     spatial_index_snapshot: Option<HashGridIndex<D>>,
     spatial_index_rollback: DelaunaySpatialIndexRollback,
@@ -42,15 +51,14 @@ where
         owner: &'dt mut DelaunayTriangulation<K, U, V, D>,
         spatial_index_rollback: DelaunaySpatialIndexRollback,
     ) -> Self {
-        let tds_snapshot = TdsRollbackSnapshot::capture(&owner.tri.tds);
         let insertion_state_snapshot = owner.insertion_state;
         let spatial_index_snapshot = match spatial_index_rollback {
             DelaunaySpatialIndexRollback::Restore => owner.spatial_index.clone(),
             DelaunaySpatialIndexRollback::Invalidate => None,
         };
+        let tds_transaction = TdsOwnerRollbackTransaction::begin(owner);
         Self {
-            owner,
-            tds_snapshot,
+            tds_transaction,
             insertion_state_snapshot,
             spatial_index_snapshot,
             spatial_index_rollback,
@@ -60,14 +68,15 @@ where
 
     /// Borrows the mutable owner for a mutation step inside the transaction.
     pub(super) const fn delaunay_mut(&mut self) -> &mut DelaunayTriangulation<K, U, V, D> {
-        &mut *self.owner
+        self.tds_transaction.owner_mut()
     }
 
     /// Restores all owner-coupled rollback state and keeps the transaction open.
     pub(super) fn restore(&mut self) {
-        self.tds_snapshot.restore_to(&mut self.owner.tri.tds);
-        self.owner.insertion_state = self.insertion_state_snapshot;
-        self.owner.spatial_index = match self.spatial_index_rollback {
+        self.tds_transaction.restore();
+        let owner = self.tds_transaction.owner_mut();
+        owner.insertion_state = self.insertion_state_snapshot;
+        owner.spatial_index = match self.spatial_index_rollback {
             DelaunaySpatialIndexRollback::Restore => self.spatial_index_snapshot.clone(),
             DelaunaySpatialIndexRollback::Invalidate => None,
         };
@@ -75,12 +84,14 @@ where
 
     /// Commits the mutation, preventing the drop guard from restoring the snapshot.
     pub(super) fn commit(mut self) {
+        self.tds_transaction.commit_in_place();
         self.finished = true;
     }
 
     /// Restores the snapshot and closes the transaction.
     pub(super) fn rollback(mut self) {
         self.restore();
+        self.tds_transaction.commit_in_place();
         self.finished = true;
     }
 }
@@ -93,6 +104,7 @@ where
     fn drop(&mut self) {
         if !self.finished {
             self.restore();
+            self.tds_transaction.commit_in_place();
         }
     }
 }
@@ -101,23 +113,31 @@ where
 mod tests {
     use super::*;
     use crate::core::collections::spatial_hash_grid::HashGridIndexSnapshot;
+    use crate::core::tds::VertexKey;
     use crate::core::vertex::Vertex;
     use crate::geometry::kernel::AdaptiveKernel;
-    use crate::vertex;
 
-    fn test_triangulation() -> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> {
-        let vertices = [
-            vertex![0.0, 0.0].unwrap(),
-            vertex![1.0, 0.0].unwrap(),
-            vertex![0.0, 1.0].unwrap(),
-        ];
+    fn simplex_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
+        let mut vertices = Vec::with_capacity(D + 1);
+        vertices.push(Vertex::<(), D>::try_new([0.0; D]).unwrap());
+        for axis in 0..D {
+            let mut coords = [0.0; D];
+            coords[axis] = 1.0;
+            vertices.push(Vertex::<(), D>::try_new(coords).unwrap());
+        }
+        vertices
+    }
+
+    fn test_triangulation<const D: usize>() -> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D>
+    {
+        let vertices = simplex_vertices::<D>();
         DelaunayTriangulation::try_new(&vertices).unwrap()
     }
 
-    fn seed_spatial_index(
-        triangulation: &mut DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2>,
+    fn seed_spatial_index<const D: usize>(
+        triangulation: &mut DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D>,
     ) -> Option<HashGridIndexSnapshot> {
-        let mut index = HashGridIndex::<2>::try_new(1.0).unwrap();
+        let mut index = HashGridIndex::<D>::try_new(1.0).unwrap();
         for (vertex_key, vertex) in triangulation.vertices() {
             index.insert_vertex(vertex_key, vertex.point().coords());
         }
@@ -125,35 +145,44 @@ mod tests {
         triangulation
             .spatial_index
             .as_ref()
-            .map(HashGridIndex::<2>::debug_snapshot)
+            .map(HashGridIndex::<D>::debug_snapshot)
     }
 
-    fn insert_uncommitted_vertex(
-        transaction: &mut DelaunayRollbackTransaction<'_, AdaptiveKernel<f64>, (), (), 2>,
-    ) {
-        let vertex = Vertex::<(), 2>::try_new([0.25, 0.25]).unwrap();
+    fn insert_uncommitted_vertex<const D: usize>(
+        transaction: &mut DelaunayRollbackTransaction<'_, AdaptiveKernel<f64>, (), (), D>,
+    ) -> VertexKey {
+        let vertex = Vertex::<(), D>::try_new([0.25; D]).unwrap();
         transaction
             .delaunay_mut()
             .tri
             .tds
             .insert_vertex_with_mapping(vertex)
-            .unwrap();
+            .unwrap()
     }
 
-    #[test]
-    fn delaunay_transaction_restore_policy_restores_auxiliary_state() {
-        let mut triangulation = test_triangulation();
+    macro_rules! assert_rollback_dimensions {
+        ($case:ident) => {{
+            $case::<2>();
+            $case::<3>();
+            $case::<4>();
+            $case::<5>();
+        }};
+    }
+
+    fn assert_restore_policy_drop_restores_auxiliary_state<const D: usize>() {
+        let mut triangulation = test_triangulation::<D>();
         let hint_before = triangulation.simplices().next().map(|(key, _)| key);
         triangulation.insertion_state.last_inserted_simplex = hint_before;
         let spatial_index_before = seed_spatial_index(&mut triangulation);
         let vertices_before = triangulation.number_of_vertices();
+        let inserted_key;
 
         {
             let mut transaction = DelaunayRollbackTransaction::begin(
                 &mut triangulation,
                 DelaunaySpatialIndexRollback::Restore,
             );
-            insert_uncommitted_vertex(&mut transaction);
+            inserted_key = insert_uncommitted_vertex(&mut transaction);
             transaction
                 .delaunay_mut()
                 .insertion_state
@@ -162,6 +191,7 @@ mod tests {
         }
 
         assert_eq!(triangulation.number_of_vertices(), vertices_before);
+        assert!(!triangulation.tri.tds.contains_vertex_key(inserted_key));
         assert_eq!(
             triangulation.insertion_state.last_inserted_simplex,
             hint_before
@@ -170,25 +200,25 @@ mod tests {
             triangulation
                 .spatial_index
                 .as_ref()
-                .map(HashGridIndex::<2>::debug_snapshot),
+                .map(HashGridIndex::<D>::debug_snapshot),
             spatial_index_before
         );
     }
 
-    #[test]
-    fn delaunay_transaction_invalidate_policy_drops_spatial_index_on_restore() {
-        let mut triangulation = test_triangulation();
+    fn assert_invalidate_policy_drop_drops_spatial_index<const D: usize>() {
+        let mut triangulation = test_triangulation::<D>();
         let hint_before = triangulation.simplices().next().map(|(key, _)| key);
         triangulation.insertion_state.last_inserted_simplex = hint_before;
         let _ = seed_spatial_index(&mut triangulation);
         let vertices_before = triangulation.number_of_vertices();
+        let inserted_key;
 
         {
             let mut transaction = DelaunayRollbackTransaction::begin(
                 &mut triangulation,
                 DelaunaySpatialIndexRollback::Invalidate,
             );
-            insert_uncommitted_vertex(&mut transaction);
+            inserted_key = insert_uncommitted_vertex(&mut transaction);
             transaction
                 .delaunay_mut()
                 .insertion_state
@@ -196,10 +226,95 @@ mod tests {
         }
 
         assert_eq!(triangulation.number_of_vertices(), vertices_before);
+        assert!(!triangulation.tri.tds.contains_vertex_key(inserted_key));
         assert_eq!(
             triangulation.insertion_state.last_inserted_simplex,
             hint_before
         );
         assert!(triangulation.spatial_index.is_none());
+    }
+
+    fn assert_commit_keeps_mutations<const D: usize>() {
+        let mut triangulation = test_triangulation::<D>();
+        let hint_before = triangulation.simplices().next().map(|(key, _)| key);
+        triangulation.insertion_state.last_inserted_simplex = hint_before;
+        let _ = seed_spatial_index(&mut triangulation);
+        let vertices_before = triangulation.number_of_vertices();
+
+        let mut transaction = DelaunayRollbackTransaction::begin(
+            &mut triangulation,
+            DelaunaySpatialIndexRollback::Restore,
+        );
+        let inserted_key = insert_uncommitted_vertex(&mut transaction);
+        transaction
+            .delaunay_mut()
+            .insertion_state
+            .last_inserted_simplex = None;
+        transaction.delaunay_mut().spatial_index = None;
+        transaction.commit();
+
+        assert_eq!(triangulation.number_of_vertices(), vertices_before + 1);
+        assert!(triangulation.tri.tds.contains_vertex_key(inserted_key));
+        assert!(
+            triangulation
+                .insertion_state
+                .last_inserted_simplex
+                .is_none()
+        );
+        assert!(triangulation.spatial_index.is_none());
+    }
+
+    fn assert_explicit_rollback_restores_auxiliary_state<const D: usize>() {
+        let mut triangulation = test_triangulation::<D>();
+        let hint_before = triangulation.simplices().next().map(|(key, _)| key);
+        triangulation.insertion_state.last_inserted_simplex = hint_before;
+        let spatial_index_before = seed_spatial_index(&mut triangulation);
+        let vertices_before = triangulation.number_of_vertices();
+
+        let mut transaction = DelaunayRollbackTransaction::begin(
+            &mut triangulation,
+            DelaunaySpatialIndexRollback::Restore,
+        );
+        let inserted_key = insert_uncommitted_vertex(&mut transaction);
+        transaction
+            .delaunay_mut()
+            .insertion_state
+            .last_inserted_simplex = None;
+        transaction.delaunay_mut().spatial_index = None;
+        transaction.rollback();
+
+        assert_eq!(triangulation.number_of_vertices(), vertices_before);
+        assert!(!triangulation.tri.tds.contains_vertex_key(inserted_key));
+        assert_eq!(
+            triangulation.insertion_state.last_inserted_simplex,
+            hint_before
+        );
+        assert_eq!(
+            triangulation
+                .spatial_index
+                .as_ref()
+                .map(HashGridIndex::<D>::debug_snapshot),
+            spatial_index_before
+        );
+    }
+
+    #[test]
+    fn delaunay_transaction_restore_policy_restores_auxiliary_state() {
+        assert_rollback_dimensions!(assert_restore_policy_drop_restores_auxiliary_state);
+    }
+
+    #[test]
+    fn delaunay_transaction_invalidate_policy_drops_spatial_index_on_restore() {
+        assert_rollback_dimensions!(assert_invalidate_policy_drop_drops_spatial_index);
+    }
+
+    #[test]
+    fn delaunay_transaction_commit_keeps_mutations() {
+        assert_rollback_dimensions!(assert_commit_keeps_mutations);
+    }
+
+    #[test]
+    fn delaunay_transaction_explicit_rollback_restores_auxiliary_state() {
+        assert_rollback_dimensions!(assert_explicit_rollback_restores_auxiliary_state);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,6 +570,8 @@ mod core {
     pub mod query;
     /// Local topology repair for generic triangulations.
     pub mod repair;
+    /// Scoped rollback guards for internal topology mutation windows.
+    pub(crate) mod rollback;
     /// Triangulation data structure internals.
     pub mod tds {
         mod equality;
@@ -577,12 +579,14 @@ mod core {
         pub(crate) mod incidence;
         mod keys;
         mod mutation;
+        pub(crate) mod rollback;
         mod snapshot;
         mod storage;
         mod validation;
 
         pub use errors::*;
         pub use keys::{SimplexKey, VertexKey};
+        pub(crate) use rollback::{TdsRollbackSnapshot, TdsRollbackTransaction};
         pub use storage::Tds;
     }
     /// Generic triangulation combining kernel + Tds.
@@ -711,6 +715,9 @@ pub mod construction;
 /// Read-only Delaunay query, traversal, and accessor methods.
 #[path = "delaunay/query.rs"]
 pub(crate) mod delaunay_query;
+/// Delaunay-level rollback guards for mutation windows with auxiliary state.
+#[path = "delaunay/rollback.rs"]
+pub(crate) mod delaunay_rollback;
 /// End-to-end "repair then delaunayize" workflow.
 #[path = "delaunay/delaunayize.rs"]
 pub mod delaunayize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -586,7 +586,9 @@ mod core {
 
         pub use errors::*;
         pub use keys::{SimplexKey, VertexKey};
-        pub(crate) use rollback::{TdsRollbackSnapshot, TdsRollbackTransaction};
+        pub(crate) use rollback::{
+            TdsOwnerRollbackTransaction, TdsRollbackOwner, TdsRollbackTransaction,
+        };
         pub use storage::Tds;
     }
     /// Generic triangulation combining kernel + Tds.


### PR DESCRIPTION
- Add scoped rollback guards for TDS, generic triangulation, and Delaunay mutation windows.
- Use the guards across insertion, deletion, local facet repair, and flip-repair retry paths.
- Restore insertion state and spatial-index caches according to the Delaunay rollback policy.
- Document rollback ownership rules for future mutation paths.