### PR TITLE
fix(construction): preserve exact 2D layered strip vertices

### DIFF
--- a/benches/boundary_uuid_iter.rs
+++ b/benches/boundary_uuid_iter.rs
@@ -9,7 +9,7 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use delaunay::prelude::construction::{DelaunayTriangulation, vertex};
 use delaunay::prelude::generators::generate_random_points_in_range_seeded;
-use delaunay::prelude::geometry::CoordinateRange;
+use delaunay::prelude::geometry::{AdaptiveKernel, CoordinateRange};
 use delaunay::prelude::query::FacetIncidenceAnalysis;
 use delaunay::try_vertices_from_points;
 use uuid::Uuid;
@@ -30,7 +30,7 @@ fn benchmark_bounds() -> CoordinateRange<f64> {
 
 fn boundary_triangulation_3d(
     requested_vertices: usize,
-) -> DelaunayTriangulation<delaunay::prelude::geometry::AdaptiveKernel<f64>, (), (), 3> {
+) -> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 3> {
     let points = generate_random_points_in_range_seeded::<3>(
         requested_vertices,
         benchmark_bounds(),
@@ -93,8 +93,7 @@ fn bench_boundary_facets_micro(c: &mut Criterion) {
     group.finish();
 }
 
-fn uuid_iter_source()
--> DelaunayTriangulation<delaunay::prelude::geometry::AdaptiveKernel<f64>, (), (), 3> {
+fn uuid_iter_source() -> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 3> {
     let vertices = vec![
         vertex![0.0, 0.0, 0.0].or_abort(),
         vertex![1.0, 0.0, 0.0].or_abort(),

--- a/benches/circumsphere_containment.rs
+++ b/benches/circumsphere_containment.rs
@@ -15,7 +15,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use delaunay::prelude::generators::generate_random_points_in_range_seeded;
-use delaunay::prelude::geometry::CoordinateRange;
+use delaunay::prelude::geometry::{CoordinateRange, Point};
 use delaunay::prelude::query::*;
 use std::hint::black_box;
 
@@ -371,10 +371,7 @@ fn numerical_consistency_test() {
             println!("    Test point: {:?}", test.coords());
             println!(
                 "    Simplex: {:?}",
-                simplex
-                    .iter()
-                    .map(delaunay::geometry::Point::coords)
-                    .collect::<Vec<_>>()
+                simplex.iter().map(Point::coords).collect::<Vec<_>>()
             );
         }
     }

--- a/justfile
+++ b/justfile
@@ -895,7 +895,7 @@ rust-core-check: fmt-check clippy-all-targets doc-check semgrep semgrep-test
 
 # Repository-owned Semgrep rules for project-specific Rust diagnostics.
 semgrep: _ensure-uv
-    uv run semgrep --error --strict --timeout 30 --config semgrep.yaml .
+    uv run semgrep --error --strict --timeout 120 --config semgrep.yaml .
 
 semgrep-test: _ensure-uv
     #!/usr/bin/env bash

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1424,21 +1424,30 @@ rules:
     languages:
       - generic
     severity: WARNING
-    message: "Use vertex! for incidental vertex setup in workflow tests, examples, and benchmarks."
+    message: "Use vertex! for incidental vertex setup outside constructor-focused tests and docs."
     metadata:
       category: maintainability
       rationale: >-
-        Higher-level workflow samples should keep attention on the API under
-        test. Reserve Vertex::try_new and Vertex::try_new_with_data for
-        constructor-focused tests and docs.
+        Incidental fixtures should keep attention on the API under test and use
+        the short constructor macro. Reserve Vertex::try_new and
+        Vertex::try_new_with_data for constructor-focused tests and docs.
     paths:
       include:
-        - "/tests/pachner_roundtrip.rs"
+        - "/src/**/*.rs"
+        - "/tests/**/*.rs"
         - "/benches/pachner_stress.rs"
         - "/examples/**/*.rs"
         - "/tests/semgrep/src/project_rules/workflow_vertex_macro.rs"
-    pattern-regex: >-
-      ^\s*(?!//|///|\*)[^\n]*\b(?:delaunay::prelude::)?Vertex\s*(?:::<[^;\n]+>)?\s*::\s*try_new(?:_with_data)?\s*\(
+      exclude:
+        - "/src/bench_fixtures.rs"
+        - "/src/core/vertex.rs"
+        - "/src/lib.rs"
+        - "/tests/proptest_vertex.rs"
+        - "/tests/semgrep/src/project_rules/rust_style.rs"
+    patterns:
+      - pattern-regex: >-
+          ^\s*[^\n]*\b(?:delaunay::prelude::)?Vertex\s*(?:::<[^;\n]+>)?\s*::\s*try_new(?:_with_data)?\s*\(
+      - pattern-not-regex: '^[ \t]*(//|///|/\*|\*|")'
 
   - id: delaunay.rust.no-public-raw-bench-fixture-builders
     languages:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1422,7 +1422,7 @@ rules:
 
   - id: delaunay.rust.prefer-vertex-macro-for-workflow-fixtures
     languages:
-      - generic
+      - rust
     severity: WARNING
     message: "Use vertex! for incidental vertex setup outside constructor-focused tests and docs."
     metadata:
@@ -1445,9 +1445,12 @@ rules:
         - "/tests/proptest_vertex.rs"
         - "/tests/semgrep/src/project_rules/rust_style.rs"
     patterns:
-      - pattern-regex: >-
-          ^\s*[^\n]*\b(?:delaunay::prelude::)?Vertex\s*(?:::<[^;\n]+>)?\s*::\s*try_new(?:_with_data)?\s*\(
-      - pattern-not-regex: '^[ \t]*(//|///|/\*|\*|")'
+      - pattern-either:
+          - pattern: $VERTEX::try_new(...)
+          - pattern: $VERTEX::try_new_with_data(...)
+      - metavariable-regex:
+          metavariable: $VERTEX
+          regex: '^(?:delaunay::prelude::)?Vertex(?:::<.*>)?$'
 
   - id: delaunay.rust.no-public-raw-bench-fixture-builders
     languages:

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1450,7 +1450,7 @@ rules:
           - pattern: $VERTEX::try_new_with_data(...)
       - metavariable-regex:
           metavariable: $VERTEX
-          regex: '^(?:delaunay::prelude::)?Vertex(?:::<.*>)?$'
+          regex: "^(?:delaunay::prelude::)?Vertex(?:::<.*>)?$"
 
   - id: delaunay.rust.no-public-raw-bench-fixture-builders
     languages:

--- a/src/core/adjacency.rs
+++ b/src/core/adjacency.rs
@@ -354,7 +354,7 @@ impl SimplexNeighborIndex<'_> {
 mod tests {
     use super::*;
     use crate::DelaunayTriangulation;
-    use crate::core::vertex::Vertex;
+    use crate::vertex;
     use slotmap::SlotMap;
     use std::collections::HashSet;
 
@@ -395,12 +395,12 @@ mod tests {
         // Two tetrahedra sharing a triangular facet.
         let vertices: Vec<_> = vec![
             // Shared triangle
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 2.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 2.0, 0.0]).unwrap(),
             // Two apices
-            Vertex::<(), _>::try_new([1.0, 0.7, 1.5]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.7, -1.5]).unwrap(),
+            vertex!([1.0, 0.7, 1.5]).unwrap(),
+            vertex!([1.0, 0.7, -1.5]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -3221,7 +3221,7 @@ impl From<&HullExtensionReason> for FlipNeighborHullExtensionFailureKind {
             HullExtensionReason::BoundaryEdgeSplitFacetCount { .. } => {
                 Self::BoundaryEdgeSplitFacetCount
             }
-            HullExtensionReason::MultipleBoundaryEdgeSplitFacets => {
+            HullExtensionReason::MultipleBoundaryEdgeSplitFacets { .. } => {
                 Self::MultipleBoundaryEdgeSplitFacets
             }
             HullExtensionReason::DisconnectedVisiblePatch { .. } => Self::DisconnectedVisiblePatch,
@@ -15149,7 +15149,10 @@ mod tests {
         );
 
         assert_hull_extension_failure_kind(
-            &HullExtensionReason::MultipleBoundaryEdgeSplitFacets,
+            &HullExtensionReason::MultipleBoundaryEdgeSplitFacets {
+                first: FacetHandle::from_validated(SimplexKey::default(), 0),
+                second: FacetHandle::from_validated(SimplexKey::default(), 1),
+            },
             FlipNeighborHullExtensionFailureKind::MultipleBoundaryEdgeSplitFacets,
             "multiple boundary edge split facets",
         );

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -10442,6 +10442,7 @@ mod tests {
     use crate::geometry::traits::coordinate::CoordinateConversionValue;
     use crate::repair::DelaunayRepairOperation;
     use crate::topology::traits::topological_space::ToroidalConstructionMode;
+    use crate::vertex;
     use approx::assert_relative_eq;
     use proptest::prelude::*;
     use rand::{RngExt, SeedableRng, rngs::StdRng};
@@ -10506,17 +10507,13 @@ mod tests {
     ) -> Vec<VertexKey> {
         let mut vertices = Vec::with_capacity(D + 1);
         vertices.push(
-            tds.insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; D]).unwrap(),
-            )
-            .unwrap(),
+            tds.insert_vertex_with_mapping(vertex!([0.0; D]).unwrap())
+                .unwrap(),
         );
         for axis in 0..D {
             vertices.push(
-                tds.insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<D>(axis)).unwrap(),
-                )
-                .unwrap(),
+                tds.insert_vertex_with_mapping(vertex!(unit_vector::<D>(axis)).unwrap())
+                    .unwrap(),
             );
         }
         vertices
@@ -10753,29 +10750,19 @@ mod tests {
         fn new() -> Self {
             let mut tds: Tds<(), (), 3> = Tds::empty();
             let origin_vertex = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
                 .unwrap();
             let x_axis_vertex = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
                 .unwrap();
             let y_axis_vertex = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
                 .unwrap();
             let upper_apex_vertex = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
                 .unwrap();
             let lower_apex_vertex = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, -1.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([0.0, 0.0, -1.0]).unwrap())
                 .unwrap();
 
             let upper_tetrahedron = tds
@@ -11110,19 +11097,13 @@ mod tests {
     fn test_resolve_facet_handle_for_key_remaps_after_slot_swap() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -11161,24 +11142,16 @@ mod tests {
     fn test_resolve_ridge_handle_for_key_remaps_after_slot_swap() {
         let mut tds: Tds<(), (), 3> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -11225,29 +11198,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_left_bottom = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_right_bottom = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0]).unwrap())
             .unwrap();
         let v_left_top = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 2.0]).unwrap())
             .unwrap();
         let v_right_top = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
         let v_external = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-1.0, 1.0]).unwrap())
             .unwrap();
 
         // Flip cavity: two triangles sharing the bottom edge.
@@ -11341,29 +11304,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_left_bottom = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_right_bottom = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0]).unwrap())
             .unwrap();
         let v_left_top = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 2.0]).unwrap())
             .unwrap();
         let v_right_top = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
         let v_external = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-1.0, 1.0]).unwrap())
             .unwrap();
 
         let offset_left_bottom = [0_i8, 0_i8];
@@ -11672,9 +11625,9 @@ mod tests {
                 fn [<test_replacement_orientation_helpers_cover_error_paths_ $dim d>]() {
                     let mut tds: Tds<(), (), $dim> = Tds::empty();
                     let simplex_vertices = insert_standard_simplex_vertices(&mut tds);
-                    let v_square = tds.insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([1.0; $dim]).unwrap()).unwrap();
+                    let v_square = tds.insert_vertex_with_mapping(vertex!([1.0; $dim]).unwrap()).unwrap();
                     let v_collinear = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(scaled_unit_vector::<$dim>(0, 2.0)).unwrap())
+                        .insert_vertex_with_mapping(vertex!(scaled_unit_vector::<$dim>(0, 2.0)).unwrap())
                         .unwrap();
 
                     let source = vertex_key_buffer(&simplex_vertices);
@@ -11770,7 +11723,7 @@ mod tests {
                 fn [<test_orient_replacement_simplices_aligns_external_and_internal_facets_ $dim d>]() {
                     let mut tds: Tds<(), (), $dim> = Tds::empty();
                     let simplex_vertices = insert_standard_simplex_vertices(&mut tds);
-                    let v_square = tds.insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([1.0; $dim]).unwrap()).unwrap();
+                    let v_square = tds.insert_vertex_with_mapping(vertex!([1.0; $dim]).unwrap()).unwrap();
                     let external_simplex_key = tds
                         .insert_simplex_with_mapping(Simplex::try_new_with_data(simplex_vertices.clone(), None).unwrap())
                         .unwrap();
@@ -11827,7 +11780,7 @@ mod tests {
                     let mut tds: Tds<(), (), $dim> = Tds::empty();
                     let simplex_vertices = insert_standard_simplex_vertices(&mut tds);
                     let v_collinear = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(scaled_unit_vector::<$dim>(0, 2.0)).unwrap())
+                        .insert_vertex_with_mapping(vertex!(scaled_unit_vector::<$dim>(0, 2.0)).unwrap())
                         .unwrap();
 
                     let mut positive_vertices = simplex_vertices.clone();
@@ -11880,36 +11833,24 @@ mod tests {
         // NOTE: keep `v_edge_start` off the plane of (v_cycle_0, v_cycle_1, v_cycle_2)
         // so the post-flip inserted tetrahedra are non-degenerate.
         let v_edge_start = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_edge_end = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0, 0.0]).unwrap())
             .unwrap();
 
         let v_cycle_0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 2.0, 0.0]).unwrap())
             .unwrap();
         let v_cycle_1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 2.0]).unwrap())
             .unwrap();
         let v_cycle_2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 2.0, 2.0]).unwrap())
             .unwrap();
 
         let v_external = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-1.0, 1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-1.0, 1.0, 1.0]).unwrap())
             .unwrap();
 
         // Three tetrahedra around the ridge (edge) (v_edge_start, v_edge_end).
@@ -12257,20 +12198,16 @@ mod tests {
     ) -> (Vec<VertexKey>, SimplexKey) {
         let mut vertices = Vec::with_capacity(D + 1);
         vertices.push(
-            tds.insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([offset; D]).unwrap(),
-            )
-            .unwrap(),
+            tds.insert_vertex_with_mapping(vertex!([offset; D]).unwrap())
+                .unwrap(),
         );
 
         for axis in 0..D {
             let mut coords = [offset; D];
             coords[axis] += 1.0;
             vertices.push(
-                tds.insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap(),
-                )
-                .unwrap(),
+                tds.insert_vertex_with_mapping(vertex!(coords).unwrap())
+                    .unwrap(),
             );
         }
 
@@ -12290,9 +12227,7 @@ mod tests {
         tds.assign_incident_simplices().unwrap();
 
         let isolated_vertex = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([20.0; D]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([20.0; D]).unwrap())
             .unwrap();
         tds.vertex_mut(isolated_vertex)
             .unwrap()
@@ -12301,8 +12236,7 @@ mod tests {
         let before = snapshot_topology(&tds);
         let before_incidence = snapshot_incidence(&tds);
         let denominator = f64::from(u32::try_from(D + 2).unwrap());
-        let new_vertex =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0 / denominator; D]).unwrap();
+        let new_vertex = vertex!([1.0 / denominator; D]).unwrap();
 
         let result = apply_bistellar_flip_k1(&mut tds, first_simplex, new_vertex);
         match result {
@@ -12342,19 +12276,13 @@ mod tests {
     fn test_flip_trial_validation_rejects_unassigned_neighbor_slot() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(
@@ -12395,10 +12323,7 @@ mod tests {
         for i in 0..D {
             let vertex = tds
                 .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(
-                        translated_scaled_unit_vector::<D>(i, offset, scale),
-                    )
-                    .unwrap(),
+                    vertex!(translated_scaled_unit_vector::<D>(i, offset, scale)).unwrap(),
                 )
                 .map_err(|err| {
                     TestCaseError::fail(format!("shared vertex insertion failed: {err:?}"))
@@ -12407,14 +12332,10 @@ mod tests {
         }
 
         let opposite_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([offset; D]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([offset; D]).unwrap())
             .map_err(|err| TestCaseError::fail(format!("opposite A insertion failed: {err:?}")))?;
         let opposite_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([offset + scale; D]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([offset + scale; D]).unwrap())
             .map_err(|err| TestCaseError::fail(format!("opposite B insertion failed: {err:?}")))?;
 
         let mut vertices_with_first_opposite = shared_vertices.clone();
@@ -12527,10 +12448,7 @@ mod tests {
         for i in 0..ridge_vertex_count {
             let vertex = tds
                 .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(
-                        translated_scaled_unit_vector::<D>(i, offset, scale),
-                    )
-                    .unwrap(),
+                    vertex!(translated_scaled_unit_vector::<D>(i, offset, scale)).unwrap(),
                 )
                 .map_err(|err| {
                     TestCaseError::fail(format!("ridge vertex insertion failed: {err:?}"))
@@ -12539,13 +12457,11 @@ mod tests {
         }
 
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([offset; D]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([offset; D]).unwrap())
             .map_err(|err| TestCaseError::fail(format!("opposite A insertion failed: {err:?}")))?;
         let b = tds
             .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new(translated_scaled_unit_vector::<D>(
+                vertex!(translated_scaled_unit_vector::<D>(
                     ridge_vertex_count,
                     offset,
                     scale,
@@ -12555,10 +12471,7 @@ mod tests {
             .map_err(|err| TestCaseError::fail(format!("opposite B insertion failed: {err:?}")))?;
         let c = tds
             .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new(translated_scaled_skewed_point::<D>(
-                    offset, scale,
-                ))
-                .unwrap(),
+                vertex!(translated_scaled_skewed_point::<D>(offset, scale)).unwrap(),
             )
             .map_err(|err| TestCaseError::fail(format!("opposite C insertion failed: {err:?}")))?;
 
@@ -12748,12 +12661,12 @@ mod tests {
                     init_tracing();
                     let mut tds: Tds<(), (), $dim> = Tds::empty();
 
-                    let origin = tds.insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([0.0; $dim]).unwrap()).unwrap();
+                    let origin = tds.insert_vertex_with_mapping(vertex!([0.0; $dim]).unwrap()).unwrap();
                     let mut vertices = Vec::with_capacity($dim + 1);
                     vertices.push(origin);
                     for i in 0..$dim {
                         let v = tds
-                            .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<$dim>(i)).unwrap())
+                            .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(i)).unwrap())
                             .unwrap();
                         vertices.push(v);
                     }
@@ -12764,7 +12677,7 @@ mod tests {
 
                     let before = snapshot_topology(&tds);
 
-                    let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.1; $dim]).unwrap();
+                    let new_vertex = vertex!([0.1; $dim]).unwrap();
                     let new_uuid = new_vertex.uuid();
                     let _info = apply_bistellar_flip_k1(&mut tds, simplex_key, new_vertex)
                         .unwrap();
@@ -12785,16 +12698,16 @@ mod tests {
                     let mut shared_vertices = Vec::with_capacity($dim);
                     for i in 0..$dim {
                         let v = tds
-                            .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<$dim>(i)).unwrap())
+                            .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(i)).unwrap())
                             .unwrap();
                         shared_vertices.push(v);
                     }
 
                     let opposite_a = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([0.0; $dim]).unwrap())
+                        .insert_vertex_with_mapping(vertex!([0.0; $dim]).unwrap())
                         .unwrap();
                     let opposite_b = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([1.0; $dim]).unwrap())
+                        .insert_vertex_with_mapping(vertex!([1.0; $dim]).unwrap())
                         .unwrap();
 
                     let mut vertices_with_first_opposite = shared_vertices.clone();
@@ -12868,19 +12781,19 @@ mod tests {
                     let mut ridge_vertices = Vec::with_capacity($dim - 1);
                     for i in 0..($dim - 1) {
                         let v = tds
-                            .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<$dim>(i)).unwrap())
+                            .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(i)).unwrap())
                             .unwrap();
                         ridge_vertices.push(v);
                     }
 
                     let a = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([0.0; $dim]).unwrap())
+                        .insert_vertex_with_mapping(vertex!([0.0; $dim]).unwrap())
                         .unwrap();
                     let b = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<$dim>($dim - 1)).unwrap())
+                        .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>($dim - 1)).unwrap())
                         .unwrap();
                     let c = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(skewed_point::<$dim>()).unwrap())
+                        .insert_vertex_with_mapping(vertex!(skewed_point::<$dim>()).unwrap())
                         .unwrap();
 
                     let mut c1_vertices = ridge_vertices.clone();
@@ -13132,24 +13045,16 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.2]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.2]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13186,24 +13091,16 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.2]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.2]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13235,43 +13132,29 @@ mod tests {
 
         // Opposite vertices across the shared face.
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
 
         // Shared face vertices.
         let v_x = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let v_y = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let v_z = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 1.0]).unwrap())
             .unwrap();
 
         // Extra vertices for an existing tetrahedron containing the edge (v_a, v_b).
         let v_p = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_q = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 1.0, 0.0]).unwrap())
             .unwrap();
 
         // Two tetrahedra sharing face (v_x, v_y, v_z): a k=2 flip across that face would insert edge (v_a, v_b).
@@ -13312,29 +13195,19 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.2]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.2]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13370,29 +13243,19 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 3> = Tds::empty();
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.2, 0.2, 1.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.3, -0.1, -0.8]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.3, -0.1, -0.8]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13421,29 +13284,19 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 3> = Tds::empty();
         let r0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.2, 0.2, -1.0]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13479,34 +13332,22 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 4> = Tds::empty();
         let r0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.2, 0.2, 0.2, 0.2]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13542,39 +13383,25 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 5> = Tds::empty();
         let r0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13610,19 +13437,13 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex = tds
             .insert_simplex_with_mapping(Simplex::try_new_with_data(vec![a, b, c], None).unwrap())
@@ -13640,24 +13461,16 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 3> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let simplex = tds
             .insert_simplex_with_mapping(
@@ -13675,29 +13488,19 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 3> = Tds::empty();
         let ridge_start = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let ridge_end = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let first_opposite = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let second_opposite = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let dangling_opposite = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0, 1.0]).unwrap())
             .unwrap();
         let simplex = tds
             .insert_simplex_with_mapping(
@@ -13745,22 +13548,16 @@ mod tests {
         let mut shared_vertices = Vec::with_capacity(4);
         for i in 0..4 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<4>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<4>(i)).unwrap())
                 .unwrap();
             shared_vertices.push(v);
         }
 
         let opposite_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 4]).unwrap())
             .unwrap();
         let opposite_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0; 4]).unwrap())
             .unwrap();
 
         let mut vertices_with_first_opposite = shared_vertices.clone();
@@ -13789,17 +13586,13 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 5> = Tds::empty();
         let origin = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 5]).unwrap())
             .unwrap();
         let mut vertices = Vec::with_capacity(6);
         vertices.push(origin);
         for i in 0..5 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<5>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<5>(i)).unwrap())
                 .unwrap();
             vertices.push(v);
         }
@@ -13825,31 +13618,21 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(Simplex::try_new_with_data(vec![a, b, c], None).unwrap())
             .unwrap();
 
         let before = snapshot_topology(&tds);
-        let err = apply_bistellar_flip_k1(
-            &mut tds,
-            simplex_key,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.0]).unwrap(),
-        )
-        .unwrap_err();
+        let err = apply_bistellar_flip_k1(&mut tds, simplex_key, vertex!([0.5, 0.0]).unwrap())
+            .unwrap_err();
 
         assert_matches!(err, FlipError::DegenerateSimplex);
         assert_eq!(snapshot_topology(&tds), before);
@@ -13863,22 +13646,16 @@ mod tests {
         let mut shared_vertices = Vec::with_capacity(4);
         for i in 0..4 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<4>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<4>(i)).unwrap())
                 .unwrap();
             shared_vertices.push(v);
         }
 
         let opposite_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 4]).unwrap())
             .unwrap();
         let opposite_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0; 4]).unwrap())
             .unwrap();
 
         let mut vertices_with_first_opposite = shared_vertices.clone();
@@ -13915,39 +13692,25 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 5> = Tds::empty();
         let r0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -13995,30 +13758,19 @@ mod tests {
 
             let mut tds: Tds<(), (), 3> = Tds::empty();
             let v_a = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(jitter([0.0, 0.0, 0.0])).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(jitter([0.0, 0.0, 0.0])).unwrap())
                 .unwrap();
             let v_b = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(jitter([1.0, 0.0, 0.0])).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(jitter([1.0, 0.0, 0.0])).unwrap())
                 .unwrap();
             let v_c = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(jitter([0.0, 1.0, 0.0])).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(jitter([0.0, 1.0, 0.0])).unwrap())
                 .unwrap();
             let v_d = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(jitter([0.2, 0.2, 1.0])).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(jitter([0.2, 0.2, 1.0])).unwrap())
                 .unwrap();
             let v_e = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(jitter([0.3, -0.1, -0.8]))
-                        .unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(jitter([0.3, -0.1, -0.8])).unwrap())
                 .unwrap();
 
             let c1 = tds
@@ -14066,24 +13818,16 @@ mod tests {
         for d_coords in d_candidates {
             let mut candidate: Tds<(), (), 2> = Tds::empty();
             let a = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(a_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(a_coords).unwrap())
                 .unwrap();
             let b = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(b_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(b_coords).unwrap())
                 .unwrap();
             let c = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(c_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(c_coords).unwrap())
                 .unwrap();
             let d = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(d_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(d_coords).unwrap())
                 .unwrap();
 
             let _c1 = candidate
@@ -14133,24 +13877,16 @@ mod tests {
         for d_coords in d_candidates {
             let mut candidate: Tds<(), (), 2> = Tds::empty();
             let a = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
                 .unwrap();
             let b = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
                 .unwrap();
             let c = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
                 .unwrap();
             let d = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(d_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(d_coords).unwrap())
                 .unwrap();
 
             let _c1 = candidate
@@ -14217,29 +13953,19 @@ mod tests {
 
         let mut tds: Tds<(), (), 3> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.3, 0.3, 0.3]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.3, 0.3, 0.3]).unwrap())
             .unwrap();
 
         let _c1 = tds
@@ -14295,24 +14021,16 @@ mod tests {
         for d_coords in d_candidates {
             let mut candidate: Tds<(), (), 2> = Tds::empty();
             let a = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(a_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(a_coords).unwrap())
                 .unwrap();
             let b = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(b_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(b_coords).unwrap())
                 .unwrap();
             let c = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(c_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(c_coords).unwrap())
                 .unwrap();
             let d = candidate
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(d_coords).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(d_coords).unwrap())
                 .unwrap();
 
             let _c1 = candidate
@@ -14369,24 +14087,16 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1e-9]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1e-9]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -14413,24 +14123,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         // a, c, d are collinear on the x-axis → replacement simplex {a,c,d} is degenerate
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.0]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -14459,24 +14161,16 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -14504,22 +14198,16 @@ mod tests {
         let mut shared_vertices = Vec::with_capacity(4);
         for i in 0..4 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<4>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<4>(i)).unwrap())
                 .unwrap();
             shared_vertices.push(v);
         }
 
         let opposite_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 4]).unwrap())
             .unwrap();
         let opposite_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0; 4]).unwrap())
             .unwrap();
 
         let mut vertices_with_first_opposite = shared_vertices.clone();
@@ -14560,17 +14248,13 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 4> = Tds::empty();
         let origin = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 4]).unwrap())
             .unwrap();
         let mut vertices = Vec::with_capacity(5);
         vertices.push(origin);
         for i in 0..4 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<4>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<4>(i)).unwrap())
                 .unwrap();
             vertices.push(v);
         }
@@ -14579,7 +14263,7 @@ mod tests {
             .insert_simplex_with_mapping(Simplex::try_new_with_data(vertices, None).unwrap())
             .unwrap();
 
-        let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.1; 4]).unwrap();
+        let new_vertex = vertex!([0.1; 4]).unwrap();
         let new_uuid = new_vertex.uuid();
         let info = apply_bistellar_flip_k1(&mut tds, simplex_key, new_vertex).unwrap();
 
@@ -14601,39 +14285,25 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 5> = Tds::empty();
         let r0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -14684,22 +14354,16 @@ mod tests {
         let mut shared_vertices = Vec::with_capacity(5);
         for i in 0..5 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<5>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<5>(i)).unwrap())
                 .unwrap();
             shared_vertices.push(v);
         }
 
         let opposite_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 5]).unwrap())
             .unwrap();
         let opposite_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0; 5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0; 5]).unwrap())
             .unwrap();
 
         let mut vertices_with_first_opposite = shared_vertices.clone();
@@ -14740,17 +14404,13 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 5> = Tds::empty();
         let origin = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 5]).unwrap())
             .unwrap();
         let mut vertices = Vec::with_capacity(6);
         vertices.push(origin);
         for i in 0..5 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<5>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<5>(i)).unwrap())
                 .unwrap();
             vertices.push(v);
         }
@@ -14759,7 +14419,7 @@ mod tests {
             .insert_simplex_with_mapping(Simplex::try_new_with_data(vertices, None).unwrap())
             .unwrap();
 
-        let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.1; 5]).unwrap();
+        let new_vertex = vertex!([0.1; 5]).unwrap();
         let new_uuid = new_vertex.uuid();
         let info = apply_bistellar_flip_k1(&mut tds, simplex_key, new_vertex).unwrap();
 
@@ -14780,26 +14440,20 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex = tds
             .insert_simplex_with_mapping(Simplex::try_new_with_data(vec![a, b, c], None).unwrap())
             .unwrap();
 
-        let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2]).unwrap();
+        let new_vertex = vertex!([0.2, 0.2]).unwrap();
         let new_uuid = new_vertex.uuid();
         let info = apply_bistellar_flip_k1(&mut tds, simplex, new_vertex).unwrap();
 
@@ -14824,22 +14478,16 @@ mod tests {
         let mut shared_vertices = Vec::with_capacity(4);
         for i in 0..4 {
             let v = tds
-                .insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<4>(i)).unwrap(),
-                )
+                .insert_vertex_with_mapping(vertex!(unit_vector::<4>(i)).unwrap())
                 .unwrap();
             shared_vertices.push(v);
         }
 
         let opposite_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; 4]).unwrap())
             .unwrap();
         let opposite_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0; 4]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0; 4]).unwrap())
             .unwrap();
 
         let mut vertices_with_first_opposite = shared_vertices.clone();
@@ -14883,39 +14531,25 @@ mod tests {
         init_tracing();
         let mut tds: Tds<(), (), 5> = Tds::empty();
         let r0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let r3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.2, 0.2, 0.2, 0.2, 0.5]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -16075,7 +15709,7 @@ mod tests {
                     let mut extra_coords = [0.0_f64; $dim];
                     extra_coords[0] = 2.0;
                     let extra_vertex = tds
-                        .insert_vertex_with_mapping(Vertex::<(), _>::try_new(extra_coords).unwrap())
+                        .insert_vertex_with_mapping(vertex!(extra_coords).unwrap())
                         .unwrap();
                     let mut mismatched_vertices = vertices[1..].to_vec();
                     mismatched_vertices.push(extra_vertex);
@@ -16203,10 +15837,8 @@ mod tests {
                     f64::from(u32::try_from(index + 2).expect("test index fits in u32")),
                     coords[next_index],
                 );
-                tds.insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap(),
-                )
-                .unwrap()
+                tds.insert_vertex_with_mapping(vertex!(coords).unwrap())
+                    .unwrap()
             })
             .collect()
     }
@@ -16218,7 +15850,7 @@ mod tests {
                 fn [<test_periodic_lift_helpers_use_simplex_offsets_ $dim d>]() {
                     let mut tds: Tds<(), (), $dim> = Tds::empty();
                     let lifted_vertex = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<$dim>(0)).unwrap())
+                        .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(0)).unwrap())
                         .unwrap();
                     let mut simplex_vertices = Vec::with_capacity($dim + 1);
                     simplex_vertices.push(lifted_vertex);
@@ -16266,10 +15898,10 @@ mod tests {
                 fn [<test_periodic_lift_treats_missing_source_offsets_as_zero_frame_ $dim d>]() {
                     let mut tds: Tds<(), (), $dim> = Tds::empty();
                     let shared_vertex = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([0.0; $dim]).unwrap())
+                        .insert_vertex_with_mapping(vertex!([0.0; $dim]).unwrap())
                         .unwrap();
                     let lifted_vertex = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<$dim>(0)).unwrap())
+                        .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(0)).unwrap())
                         .unwrap();
 
                     let mut target_vertices = Vec::with_capacity($dim + 1);
@@ -16307,15 +15939,15 @@ mod tests {
                 fn [<test_periodic_lift_rejects_conflicting_shared_translations_ $dim d>]() {
                     let mut tds: Tds<(), (), $dim> = Tds::empty();
                     let shared_a = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new([0.0; $dim]).unwrap())
+                        .insert_vertex_with_mapping(vertex!([0.0; $dim]).unwrap())
                         .unwrap();
                     let mut shared_b_coords = [0.0; $dim];
                     shared_b_coords[0] = 0.2;
                     let shared_b = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(shared_b_coords).unwrap())
+                        .insert_vertex_with_mapping(vertex!(shared_b_coords).unwrap())
                         .unwrap();
                     let lifted_vertex = tds
-                        .insert_vertex_with_mapping(crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<$dim>(0)).unwrap())
+                        .insert_vertex_with_mapping(vertex!(unit_vector::<$dim>(0)).unwrap())
                         .unwrap();
 
                     let mut target_vertices = Vec::with_capacity($dim + 1);
@@ -16385,21 +16017,15 @@ mod tests {
         let mut face_vertices = Vec::with_capacity(D);
         for axis in 0..D {
             face_vertices.push(
-                tds.insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<D>(axis)).unwrap(),
-                )
-                .unwrap(),
+                tds.insert_vertex_with_mapping(vertex!(unit_vector::<D>(axis)).unwrap())
+                    .unwrap(),
             );
         }
         let opposite_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; D]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; D]).unwrap())
             .unwrap();
         let opposite_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.25; D]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.25; D]).unwrap())
             .unwrap();
 
         let lifted_vertex = face_vertices[0];
@@ -16439,26 +16065,18 @@ mod tests {
         let mut ridge_vertices = Vec::with_capacity(D - 1);
         for axis in 0..(D - 1) {
             ridge_vertices.push(
-                tds.insert_vertex_with_mapping(
-                    crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<D>(axis)).unwrap(),
-                )
-                .unwrap(),
+                tds.insert_vertex_with_mapping(vertex!(unit_vector::<D>(axis)).unwrap())
+                    .unwrap(),
             );
         }
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0; D]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0; D]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new(unit_vector::<D>(D - 1)).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!(unit_vector::<D>(D - 1)).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new(skewed_point::<D>()).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!(skewed_point::<D>()).unwrap())
             .unwrap();
         let triangle_vertices = vec![a, b, c];
 
@@ -16671,10 +16289,10 @@ mod tests {
     fn test_repair_run_full_reseed_preserves_mutation_frontier() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.2]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 0.2]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -16703,10 +16321,10 @@ mod tests {
     fn test_repair_k2_empty_seed_does_not_full_reseed() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.2]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 0.2]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -16734,10 +16352,10 @@ mod tests {
     fn test_repair_queue_k2_local_seed() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.2]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 0.2]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -4791,6 +4791,7 @@ mod tests {
     };
     use crate::topology::characteristics::euler::TopologyClassification;
     use crate::topology::traits::topological_space::TopologyKind;
+    use crate::vertex;
     use slotmap::KeyData;
     use std::assert_matches;
 
@@ -4950,50 +4951,50 @@ mod tests {
     test_fill_cavity!(
         2,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ],
-        crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+        vertex!([0.5, 0.5]).unwrap(),
         3 // D+1 facets for a 2-simplex
     );
 
     test_fill_cavity!(
         3,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ],
-        crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
+        vertex!([0.25, 0.25, 0.25]).unwrap(),
         4 // D+1 facets for a 3-simplex
     );
 
     test_fill_cavity!(
         4,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
-        crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
+        vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
         5 // D+1 facets for a 4-simplex
     );
 
     test_fill_cavity!(
         5,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
-        crate::core::vertex::Vertex::<(), _>::try_new([0.15, 0.15, 0.15, 0.15, 0.15]).unwrap(),
+        vertex!([0.15, 0.15, 0.15, 0.15, 0.15]).unwrap(),
         6 // D+1 facets for a 5-simplex
     );
 
@@ -5002,9 +5003,9 @@ mod tests {
     #[test]
     fn test_fill_cavity_with_invalid_vertex_key() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -5028,17 +5029,15 @@ mod tests {
     #[test]
     fn test_fill_cavity_with_invalid_facet_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
 
         let new_vkey = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5]).unwrap())
             .unwrap();
         let invalid_simplex_key = SimplexKey::from(KeyData::from_ffi(u64::MAX));
         let invalid_boundary_facets: Vec<FacetHandle> = (0..=2)
@@ -5058,17 +5057,15 @@ mod tests {
     #[test]
     fn test_fill_cavity_with_invalid_facet_index() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
 
         let new_vkey = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5]).unwrap())
             .unwrap();
         let simplex_key = tds.simplex_keys().next().unwrap();
         let original_simplex_count = tds.number_of_simplices();
@@ -5092,9 +5089,9 @@ mod tests {
     #[test]
     fn test_wire_cavity_neighbors_with_invalid_simplices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -5118,34 +5115,22 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, 2.0]).unwrap())
             .unwrap();
         let v5 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 3.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 3.0]).unwrap())
             .unwrap();
 
         let new_simplex = tds
@@ -5187,29 +5172,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0]).unwrap())
             .unwrap();
 
         let new_simplex_a = tds
@@ -5277,19 +5252,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(
@@ -5323,24 +5292,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -5388,17 +5349,15 @@ mod tests {
     #[test]
     fn test_fill_cavity_with_empty_boundary_facets() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
 
         let new_vkey = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5]).unwrap())
             .unwrap();
         let empty_facets: Vec<FacetHandle> = vec![];
         let result = fill_cavity(tds, new_vkey, &empty_facets);
@@ -5410,18 +5369,16 @@ mod tests {
     #[test]
     fn test_fill_cavity_errors_on_boundary_simplex_wrong_vertex_count() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
 
         // Insert a new vertex (apex)
         let new_vkey = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5]).unwrap())
             .unwrap();
 
         // Corrupt the single boundary simplex by adding one extra vertex key.
@@ -5448,29 +5405,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -5508,9 +5455,9 @@ mod tests {
     fn test_wire_cavity_neighbors_errors_on_wrong_simplex_arity() {
         // Force a 2D simplex away from triangle arity so wiring reports the invariant directly.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -6435,46 +6382,46 @@ mod tests {
     test_repair_neighbors!(
         2,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5]).unwrap(),
         ]
     );
 
     test_repair_neighbors!(
         3,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.25, 0.25, 0.25]).unwrap(),
         ]
     );
 
     test_repair_neighbors!(
         4,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
         ]
     );
 
     test_repair_neighbors!(
         5,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.15, 0.15, 0.15, 0.15, 0.15]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.15, 0.15, 0.15, 0.15, 0.15]).unwrap(),
         ]
     );
 
@@ -6482,10 +6429,10 @@ mod tests {
     fn test_repair_neighbor_pointers_reconstructs_missing_neighbors() {
         // Create a simple 2D triangulation with two triangles.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.1]).unwrap(), // break cocircular symmetry
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.1]).unwrap(), // break cocircular symmetry
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -6582,98 +6529,95 @@ mod tests {
     test_repair_neighbor_pointers_local_dimensions!(
         2,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.1]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.1]).unwrap(),
         ],
+        vec![vertex!([0.0, 0.0]).unwrap(), vertex!([1.0, 0.0]).unwrap()],
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap()
-        ],
-        vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([0.0, -1.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
         ]
     );
 
     test_repair_neighbor_pointers_local_dimensions!(
         3,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.25, 0.25, 0.25]).unwrap(),
         ],
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
         ],
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, -1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, -1.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0]).unwrap(),
         ]
     );
 
     test_repair_neighbor_pointers_local_dimensions!(
         4,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
         ],
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
         ],
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, -1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, -1.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0, 1.0]).unwrap(),
         ]
     );
 
     test_repair_neighbor_pointers_local_dimensions!(
         5,
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.15, 0.15, 0.15, 0.15, 0.15]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.15, 0.15, 0.15, 0.15, 0.15]).unwrap(),
         ],
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
         ],
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, -1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0, 1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, -1.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0, 1.0, 1.0]).unwrap(),
         ]
     );
 
     #[test]
     fn test_repair_neighbor_pointers_local_replaces_stale_neighbor_slot() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.1]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.1]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -6700,34 +6644,22 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0]).unwrap())
             .unwrap();
         let v_f = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 1.0]).unwrap())
             .unwrap();
 
         let c1 = tds
@@ -6769,11 +6701,11 @@ mod tests {
     #[test]
     fn test_repair_neighbor_pointers_local_does_not_scan_unseeded_simplices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.1]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.35]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.1]).unwrap(),
+            vertex!([0.5, 0.35]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -6796,9 +6728,9 @@ mod tests {
     #[test]
     fn test_extend_hull_adds_simplices_for_exterior_vertex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -6806,9 +6738,7 @@ mod tests {
         let kernel = FastKernel::<f64>::new();
         let p = Point::try_new([2.0, 2.0]).expect("finite point coordinates");
         let new_vkey = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
 
         let new_simplices = extend_hull(tds, &kernel, new_vkey, &p).unwrap();
@@ -6819,9 +6749,9 @@ mod tests {
     #[test]
     fn test_extend_hull_errors_when_no_visible_facets() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let tds = dt.tds_mut();
@@ -6829,9 +6759,7 @@ mod tests {
         let kernel = FastKernel::<f64>::new();
         let p = Point::try_new([0.25, 0.25]).expect("finite point coordinates"); // inside
         let new_vkey = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.25, 0.25]).unwrap())
             .unwrap();
 
         let err = extend_hull(tds, &kernel, new_vkey, &p).unwrap_err();
@@ -6892,9 +6820,9 @@ mod tests {
     #[test]
     fn test_find_boundary_edge_split_facet_on_segment_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let point = Point::try_new([0.5, 0.0]).expect("finite point coordinates"); // on boundary edge
@@ -6906,9 +6834,9 @@ mod tests {
     #[test]
     fn test_find_boundary_edge_split_facet_hull_vertex_is_retryable_typed_reason() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let point = Point::try_new([0.0, 0.0]).expect("finite point coordinates");
@@ -6930,9 +6858,9 @@ mod tests {
     #[test]
     fn test_find_boundary_edge_split_facet_off_segment_returns_none_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let point = Point::try_new([2.0, 0.0]).expect("finite point coordinates"); // collinear with an edge line, outside segment
@@ -6944,9 +6872,9 @@ mod tests {
     #[test]
     fn test_find_boundary_edge_split_facet_next_after_endpoint_returns_none_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let point = Point::try_new([f64::from_bits(1.0_f64.to_bits() + 1), 0.0])
@@ -6959,9 +6887,9 @@ mod tests {
     #[test]
     fn test_find_visible_boundary_facets_inside_returns_empty_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -6974,9 +6902,9 @@ mod tests {
     #[test]
     fn test_find_visible_boundary_facets_outside_returns_non_empty_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -7005,19 +6933,13 @@ mod tests {
     fn test_set_neighbor_errors_on_invalid_facet_index() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -54,9 +54,11 @@ use crate::geometry::kernel::Kernel;
 use crate::geometry::point::Point;
 use crate::geometry::predicates::Orientation;
 use crate::geometry::robust_predicates::robust_orientation;
+#[cfg(debug_assertions)]
+use crate::geometry::traits::coordinate::DEFAULT_TOLERANCE_F64;
 use crate::geometry::traits::coordinate::{
     CoordinateConversionError, CoordinateConversionValue, CoordinateValidationError,
-    CoordinateValues, DEFAULT_TOLERANCE_F64, InvalidCoordinateValue,
+    CoordinateValues, InvalidCoordinateValue,
 };
 use crate::validation::DelaunayTriangulationValidationError;
 use std::fmt;
@@ -89,8 +91,13 @@ pub enum HullExtensionReason {
         actual: usize,
     },
     /// Boundary-edge split matched more than one candidate facet.
-    #[error("2D boundary edge split matched multiple facets")]
-    MultipleBoundaryEdgeSplitFacets,
+    #[error("2D boundary edge split matched multiple facets: first={first:?}, second={second:?}")]
+    MultipleBoundaryEdgeSplitFacets {
+        /// First matching boundary facet.
+        first: FacetHandle,
+        /// Second matching boundary facet.
+        second: FacetHandle,
+    },
     /// Visible facets form a disconnected or non-manifold patch.
     #[error(
         "visible patch is disconnected or non-manifold: boundary_ridges={boundary_ridges}, ridge_fans={ridge_fans}, components={components}, boundary_components={boundary_components}, boundary_subface_nonmanifold={boundary_subface_nonmanifold}"
@@ -1882,7 +1889,7 @@ impl InsertionError {
                     reason,
                     HullExtensionReason::NoVisibleFacets
                         | HullExtensionReason::BoundaryEdgeSplitFacetCount { .. }
-                        | HullExtensionReason::MultipleBoundaryEdgeSplitFacets
+                        | HullExtensionReason::MultipleBoundaryEdgeSplitFacets { .. }
                         | HullExtensionReason::DisconnectedVisiblePatch { .. }
                 )
             }
@@ -2001,7 +2008,7 @@ impl InsertionError {
                 reason,
                 HullExtensionReason::NoVisibleFacets
                     | HullExtensionReason::BoundaryEdgeSplitFacetCount { .. }
-                    | HullExtensionReason::MultipleBoundaryEdgeSplitFacets
+                    | HullExtensionReason::MultipleBoundaryEdgeSplitFacets { .. }
                     | HullExtensionReason::DisconnectedVisiblePatch { .. }
             ),
             InitialSimplexUnexpectedInsertionStage::TopologyValidation { source, .. } => {
@@ -3768,46 +3775,7 @@ where
     U: DataType,
     V: DataType,
 {
-    // 2D special-case: if the point is collinear with a boundary edge and lies on
-    // that edge segment, split the edge instead of building new hull triangles.
-    if D == 2
-        && let Some(edge_facet) = find_boundary_edge_split_facet(tds, point)?
-    {
-        #[cfg(debug_assertions)]
-        if std::env::var_os("DELAUNAY_DEBUG_HULL").is_some() {
-            tracing::debug!(
-                point = ?point,
-                simplex_key = ?edge_facet.simplex_key(),
-                facet_index = usize::from(edge_facet.facet_index()),
-                "extend_hull: 2D boundary-edge split"
-            );
-        }
-
-        let mut conflict_simplices = SimplexKeyBuffer::new();
-        conflict_simplices.push(edge_facet.simplex_key());
-
-        let mut boundary_facets = extract_cavity_boundary(tds, &conflict_simplices)
-            .map_err(InsertionError::ConflictRegion)?;
-        boundary_facets.retain(|facet| {
-            facet.simplex_key() != edge_facet.simplex_key()
-                || facet.facet_index() != edge_facet.facet_index()
-        });
-
-        validate_boundary_edge_split_facet_count(boundary_facets.len())?;
-
-        let external_facets =
-            external_facets_for_boundary(tds, &conflict_simplices, &boundary_facets)?;
-
-        let new_simplices = fill_cavity_replacing_simplices(tds, new_vertex_key, &boundary_facets)?;
-        wire_cavity_neighbors(
-            tds,
-            &new_simplices,
-            external_facets.iter().copied(),
-            Some(&conflict_simplices),
-        )?;
-        tds.remove_simplices_by_keys(&conflict_simplices)
-            .map_err(|e| InsertionError::TopologyValidation(e.into_inner()))?;
-
+    if let Some(new_simplices) = split_2d_boundary_edge_if_needed(tds, new_vertex_key, point)? {
         return Ok(new_simplices);
     }
 
@@ -3857,6 +3825,104 @@ where
     // Wire neighbors using comprehensive facet matching
     // For hull extension, no conflict simplices (nothing is removed)
     wire_cavity_neighbors(tds, &new_simplices, visible_facets.iter().copied(), None)?;
+
+    Ok(new_simplices)
+}
+
+/// Split a 2D boundary edge when `point` lies exactly on it.
+///
+/// This handles the degenerate boundary insertion that geometric point-location
+/// may classify as either outside or inside depending on symbolic perturbation.
+pub(crate) fn split_2d_boundary_edge_if_needed<U, V, const D: usize>(
+    tds: &mut Tds<U, V, D>,
+    new_vertex_key: VertexKey,
+    point: &Point<D>,
+) -> Result<Option<SimplexKeyBuffer>, InsertionError>
+where
+    U: DataType,
+    V: DataType,
+{
+    let Some(edge_facet) = find_boundary_edge_split_facet(tds, point)? else {
+        return Ok(None);
+    };
+
+    split_2d_boundary_edge_at_facet(tds, new_vertex_key, point, edge_facet).map(Some)
+}
+
+/// Split a 2D boundary edge of `start_simplex` when `point` lies exactly on it.
+///
+/// The localized variant avoids walking every hull edge after point-location
+/// has already identified a simplex adjacent to the degenerate point.
+pub(crate) fn split_2d_boundary_edge_in_simplex_if_needed<U, V, const D: usize>(
+    tds: &mut Tds<U, V, D>,
+    new_vertex_key: VertexKey,
+    point: &Point<D>,
+    start_simplex: SimplexKey,
+) -> Result<Option<SimplexKeyBuffer>, InsertionError>
+where
+    U: DataType,
+    V: DataType,
+{
+    let Some(edge_facet) = find_boundary_edge_split_facet_in_simplex(tds, point, start_simplex)?
+    else {
+        return Ok(None);
+    };
+
+    split_2d_boundary_edge_at_facet(tds, new_vertex_key, point, edge_facet).map(Some)
+}
+
+/// Replaces one 2D boundary triangle with two triangles that include the new vertex.
+///
+/// This is the mutation behind exact layered-boundary support: the inserted
+/// point is already present in the TDS, and this helper preserves its original
+/// coordinates while splitting the containing boundary facet instead of asking
+/// hull extension or Delaunay repair to infer a perturbation-based outcome.
+fn split_2d_boundary_edge_at_facet<U, V, const D: usize>(
+    tds: &mut Tds<U, V, D>,
+    new_vertex_key: VertexKey,
+    point: &Point<D>,
+    edge_facet: FacetHandle,
+) -> Result<SimplexKeyBuffer, InsertionError>
+where
+    U: DataType,
+    V: DataType,
+{
+    #[cfg(not(debug_assertions))]
+    let _ = point;
+
+    #[cfg(debug_assertions)]
+    if std::env::var_os("DELAUNAY_DEBUG_HULL").is_some() {
+        tracing::debug!(
+            point = ?point,
+            simplex_key = ?edge_facet.simplex_key(),
+            facet_index = usize::from(edge_facet.facet_index()),
+            "2D boundary-edge split"
+        );
+    }
+
+    let mut conflict_simplices = SimplexKeyBuffer::new();
+    conflict_simplices.push(edge_facet.simplex_key());
+
+    let mut boundary_facets = extract_cavity_boundary(tds, &conflict_simplices)
+        .map_err(InsertionError::ConflictRegion)?;
+    boundary_facets.retain(|facet| {
+        facet.simplex_key() != edge_facet.simplex_key()
+            || facet.facet_index() != edge_facet.facet_index()
+    });
+
+    validate_boundary_edge_split_facet_count(boundary_facets.len())?;
+
+    let external_facets = external_facets_for_boundary(tds, &conflict_simplices, &boundary_facets)?;
+
+    let new_simplices = fill_cavity_replacing_simplices(tds, new_vertex_key, &boundary_facets)?;
+    wire_cavity_neighbors(
+        tds,
+        &new_simplices,
+        external_facets.iter().copied(),
+        Some(&conflict_simplices),
+    )?;
+    tds.remove_simplices_by_keys(&conflict_simplices)
+        .map_err(|e| InsertionError::TopologyValidation(e.into_inner()))?;
 
     Ok(new_simplices)
 }
@@ -3943,20 +4009,20 @@ const fn visible_patch_failure_reason(
     }
 }
 
+/// Searches all 2D hull edges for the unique boundary facet containing `point`.
+///
+/// The full scan is used from hull extension when point location has classified
+/// the point outside the current triangulation. Returning a typed multiple-match
+/// error protects callers from silently accepting ambiguous boundary geometry.
 fn find_boundary_edge_split_facet<U, V, const D: usize>(
     tds: &Tds<U, V, D>,
     point: &Point<D>,
-) -> Result<Option<FacetHandle>, InsertionError>
-where
-    U: DataType,
-    V: DataType,
-{
+) -> Result<Option<FacetHandle>, InsertionError> {
     if D != 2 {
         return Ok(None);
     }
 
     let mut match_facet: Option<FacetHandle> = None;
-    let tol = DEFAULT_TOLERANCE_F64;
 
     let boundary_facets = tds
         .one_sided_facets()
@@ -3968,96 +4034,163 @@ where
         let facet_view = facet_view.map_err(boundary_facet_iteration_error)?;
         let simplex_key = facet_view.simplex_key();
         let facet_index = facet_view.facet_index();
-        let simplex = tds.simplex(simplex_key).ok_or_else(|| {
-            missing_boundary_simplex(simplex_key, "2D boundary edge split facet lookup")
-        })?;
 
-        let mut edge_points = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
-        let mut opposite_point: Option<Point<D>> = None;
-
-        for (i, &vkey) in simplex.vertices().iter().enumerate() {
-            let vertex = tds.vertex(vkey).ok_or_else(|| {
-                missing_boundary_vertex(vkey, simplex_key, "2D boundary edge split facet")
-            })?;
-            if i == usize::from(facet_index) {
-                opposite_point = Some(*vertex.point());
-            } else {
-                edge_points.push(*vertex.point());
-            }
-        }
-
-        if edge_points.len() != 2 {
-            continue;
-        }
-
-        let opposite_point = opposite_point
-            .ok_or_else(|| invalid_boundary_facet_index(facet_index, simplex.vertices().len()))?;
-
-        let mut simplex_points = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
-        simplex_points.extend(edge_points.iter().copied());
-        simplex_points.push(opposite_point);
-
-        // Use exact orientation (not kernel SoS) to detect true degeneracy.
-        // SoS-based kernels never return 0, which would mask the geometric
-        // property we need here: is the opposite simplex truly degenerate?
-        let opposite_degenerate = matches!(
-            robust_orientation(&simplex_points).map_err(|e| InsertionError::HullExtension {
-                reason: HullExtensionReason::PredicateFailed(e),
-            })?,
-            Orientation::DEGENERATE
-        );
-
-        if opposite_degenerate {
-            continue;
-        }
-
-        let mut edge_line = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
-        edge_line.extend(edge_points.iter().copied());
-        edge_line.push(*point);
-
-        // Use exact orientation (not kernel SoS) to detect true collinearity.
-        // SoS-based kernels never return 0, which would mask the geometric
-        // property we need here: is the point truly on the line through the edge?
-        let is_collinear = matches!(
-            robust_orientation(&edge_line).map_err(|e| InsertionError::HullExtension {
-                reason: HullExtensionReason::PredicateFailed(e),
-            })?,
-            Orientation::DEGENERATE
-        );
-
-        if !is_collinear {
-            continue;
-        }
-
-        let p0 = edge_points[0].coords();
-        let p1 = edge_points[1].coords();
-        let p = point.coords();
-        let (min_x, max_x) = if p0[0] <= p1[0] {
-            (p0[0], p1[0])
-        } else {
-            (p1[0], p0[0])
-        };
-        let (min_y, max_y) = if p0[1] <= p1[1] {
-            (p0[1], p1[1])
-        } else {
-            (p1[1], p0[1])
-        };
-        let on_segment = p[0] >= min_x - tol
-            && p[0] <= max_x + tol
-            && p[1] >= min_y - tol
-            && p[1] <= max_y + tol;
-
-        if on_segment {
-            if match_facet.is_some() {
-                return Err(InsertionError::HullExtension {
-                    reason: HullExtensionReason::MultipleBoundaryEdgeSplitFacets,
-                });
-            }
-            match_facet = Some(FacetHandle::from_validated(simplex_key, facet_index));
+        if boundary_edge_split_facet_matches(tds, point, simplex_key, facet_index)? {
+            let current_facet = FacetHandle::from_validated(simplex_key, facet_index);
+            record_boundary_edge_split_match(&mut match_facet, current_facet)?;
         }
     }
 
     Ok(match_facet)
+}
+
+/// Searches boundary facets of a located simplex for an exact 2D edge split.
+///
+/// This localized path handles points that symbolic perturbation can classify as
+/// inside or on a facet even though their physical coordinates lie exactly on a
+/// hull edge. It preserves the public contract that distinct boundary vertices
+/// are kept without applying coordinate jitter.
+fn find_boundary_edge_split_facet_in_simplex<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    point: &Point<D>,
+    start_simplex: SimplexKey,
+) -> Result<Option<FacetHandle>, InsertionError> {
+    if D != 2 {
+        return Ok(None);
+    }
+
+    let simplex = tds
+        .simplex(start_simplex)
+        .ok_or_else(|| missing_boundary_simplex(start_simplex, "2D local boundary edge split"))?;
+    let facet_count = simplex.number_of_vertices();
+
+    let mut match_facet: Option<FacetHandle> = None;
+
+    for facet_idx in 0..facet_count {
+        if !matches!(simplex.neighbor_key(facet_idx), Some(None)) {
+            continue;
+        }
+        let facet_index = u8::try_from(facet_idx)
+            .map_err(|_| invalid_boundary_facet_index(u8::MAX, facet_count))?;
+        if boundary_edge_split_facet_matches(tds, point, start_simplex, facet_index)? {
+            let current_facet = FacetHandle::from_validated(start_simplex, facet_index);
+            record_boundary_edge_split_match(&mut match_facet, current_facet)?;
+        }
+    }
+
+    Ok(match_facet)
+}
+
+const fn record_boundary_edge_split_match(
+    match_facet: &mut Option<FacetHandle>,
+    current_facet: FacetHandle,
+) -> Result<(), InsertionError> {
+    if let Some(first) = *match_facet {
+        return Err(InsertionError::HullExtension {
+            reason: HullExtensionReason::MultipleBoundaryEdgeSplitFacets {
+                first,
+                second: current_facet,
+            },
+        });
+    }
+
+    *match_facet = Some(current_facet);
+    Ok(())
+}
+
+/// Tests whether a boundary facet should be split by `point`.
+///
+/// The test uses exact non-SoS orientation to distinguish true collinearity from
+/// symbolic tie-breaking, then applies exact segment bounds. Degenerate opposite
+/// simplices are ignored so the split only operates on a valid 2D boundary
+/// triangle.
+fn boundary_edge_split_facet_matches<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    point: &Point<D>,
+    simplex_key: SimplexKey,
+    facet_index: u8,
+) -> Result<bool, InsertionError> {
+    let simplex = tds.simplex(simplex_key).ok_or_else(|| {
+        missing_boundary_simplex(simplex_key, "2D boundary edge split facet lookup")
+    })?;
+
+    let mut edge_points = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
+    let mut opposite_point: Option<Point<D>> = None;
+
+    for (i, &vkey) in simplex.vertices().iter().enumerate() {
+        let vertex = tds.vertex(vkey).ok_or_else(|| {
+            missing_boundary_vertex(vkey, simplex_key, "2D boundary edge split facet")
+        })?;
+        if i == usize::from(facet_index) {
+            opposite_point = Some(*vertex.point());
+        } else {
+            edge_points.push(*vertex.point());
+        }
+    }
+
+    if edge_points.len() != 2 {
+        return Ok(false);
+    }
+
+    let opposite_point = opposite_point
+        .ok_or_else(|| invalid_boundary_facet_index(facet_index, simplex.vertices().len()))?;
+
+    let p0 = edge_points[0].coords();
+    let p1 = edge_points[1].coords();
+    let p = point.coords();
+    let (min_x, max_x) = if p0[0] <= p1[0] {
+        (p0[0], p1[0])
+    } else {
+        (p1[0], p0[0])
+    };
+    let (min_y, max_y) = if p0[1] <= p1[1] {
+        (p0[1], p1[1])
+    } else {
+        (p1[1], p0[1])
+    };
+
+    // Segment bounds are a cheap necessary condition before exact orientation.
+    if p[0] < min_x || p[0] > max_x || p[1] < min_y || p[1] > max_y {
+        return Ok(false);
+    }
+
+    let mut simplex_points = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
+    simplex_points.extend(edge_points.iter().copied());
+    simplex_points.push(opposite_point);
+
+    // Use exact orientation (not kernel SoS) to detect true degeneracy.
+    // SoS-based kernels never return 0, which would mask the geometric
+    // property we need here: is the opposite simplex truly degenerate?
+    let opposite_degenerate = matches!(
+        robust_orientation(&simplex_points).map_err(|e| InsertionError::HullExtension {
+            reason: HullExtensionReason::PredicateFailed(e),
+        })?,
+        Orientation::DEGENERATE
+    );
+
+    if opposite_degenerate {
+        return Ok(false);
+    }
+
+    let mut edge_line = SmallBuffer::<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE>::new();
+    edge_line.extend(edge_points.iter().copied());
+    edge_line.push(*point);
+
+    // Use exact orientation (not kernel SoS) to detect true collinearity.
+    // SoS-based kernels never return 0, which would mask the geometric
+    // property we need here: is the point truly on the line through the edge?
+    let is_collinear = matches!(
+        robust_orientation(&edge_line).map_err(|e| InsertionError::HullExtension {
+            reason: HullExtensionReason::PredicateFailed(e),
+        })?,
+        Orientation::DEGENERATE
+    );
+
+    if !is_collinear {
+        return Ok(false);
+    }
+
+    Ok(true)
 }
 
 /// Find all boundary facets visible from a point.
@@ -6786,8 +6919,11 @@ mod tests {
         assert_matches!(
             err,
             InsertionError::HullExtension {
-                reason: HullExtensionReason::MultipleBoundaryEdgeSplitFacets,
-            }
+                reason: HullExtensionReason::MultipleBoundaryEdgeSplitFacets {
+                    first,
+                    second,
+                },
+            } if first != second
         );
     }
 
@@ -6800,6 +6936,21 @@ mod tests {
         ];
         let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
         let point = Point::try_new([2.0, 0.0]).expect("finite point coordinates"); // collinear with an edge line, outside segment
+
+        let facet = find_boundary_edge_split_facet(dt.tds(), &point).unwrap();
+        assert!(facet.is_none());
+    }
+
+    #[test]
+    fn test_find_boundary_edge_split_facet_next_after_endpoint_returns_none_2d() {
+        let vertices = vec![
+            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
+            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
+            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        ];
+        let dt = DelaunayTriangulation::<_, (), (), 2>::try_new(&vertices).unwrap();
+        let point = Point::try_new([f64::from_bits(1.0_f64.to_bits() + 1), 0.0])
+            .expect("finite point coordinates");
 
         let facet = find_boundary_edge_split_facet(dt.tds(), &point).unwrap();
         assert!(facet.is_none());

--- a/src/core/algorithms/locate.rs
+++ b/src/core/algorithms/locate.rs
@@ -2127,6 +2127,7 @@ mod tests {
     use crate::core::simplex::Simplex;
     use crate::geometry::kernel::{FastKernel, RobustKernel};
     use crate::prelude::DelaunayTriangulation;
+    use crate::vertex;
     use slotmap::KeyData;
     use std::assert_matches;
 
@@ -2170,9 +2171,9 @@ mod tests {
     #[test]
     fn test_format_vertex_and_simplex_references_include_missing_markers() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let tds = dt.tds();
@@ -2235,82 +2236,50 @@ mod tests {
     }
 
     #[test]
-    #[expect(
-        clippy::too_many_lines,
-        reason = "regression test spells out the multi-fan cavity fixture"
-    )]
     fn test_extract_cavity_boundary_accumulates_multiple_ridge_fans_2d() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let center_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let a0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let a1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let a2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-1.0, 0.0]).unwrap())
             .unwrap();
         let a3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let a4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
         let a5 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-1.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-1.0, -1.0]).unwrap())
             .unwrap();
 
         let center_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, 0.0]).unwrap())
             .unwrap();
         let b0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([11.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([11.0, 0.0]).unwrap())
             .unwrap();
         let b1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, 1.0]).unwrap())
             .unwrap();
         let b2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([9.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([9.0, 0.0]).unwrap())
             .unwrap();
         let b3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, -1.0]).unwrap())
             .unwrap();
         let b4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([11.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([11.0, 1.0]).unwrap())
             .unwrap();
         let b5 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([9.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([9.0, -1.0]).unwrap())
             .unwrap();
 
         let origin_simplices = [
@@ -2375,9 +2344,9 @@ mod tests {
         // Triangle: (0,0), (1,0), (0,1)
         // Point inside: (0.3, 0.3)
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2453,9 +2422,9 @@ mod tests {
     #[test]
     fn test_locate_point_inside_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2475,10 +2444,10 @@ mod tests {
     #[test]
     fn test_locate_point_inside_3d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2498,9 +2467,9 @@ mod tests {
     #[test]
     fn test_locate_point_outside_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2515,10 +2484,10 @@ mod tests {
     #[test]
     fn test_locate_point_outside_3d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2533,10 +2502,10 @@ mod tests {
     #[test]
     fn test_locate_with_hint_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2552,9 +2521,9 @@ mod tests {
     #[test]
     fn test_locate_with_robust_kernel() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = RobustKernel::<f64>::default();
@@ -2571,9 +2540,9 @@ mod tests {
         // pointers to create a self-loop. This forces facet walking to revisit a simplex, exercising
         // the cycle-detection fallback path deterministically.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2609,10 +2578,10 @@ mod tests {
     #[test]
     fn test_is_point_outside_facet_inside() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2630,10 +2599,10 @@ mod tests {
     #[test]
     fn test_is_point_outside_facet_outside() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2661,9 +2630,9 @@ mod tests {
     #[test]
     fn test_locate_near_boundary() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = RobustKernel::<f64>::default();
@@ -2683,7 +2652,7 @@ mod tests {
     macro_rules! test_locate_dimension {
         ($dim:literal, $inside_point:expr, $($coords:expr),+ $(,)?) => {{
             let vertices: Vec<_> = vec![
-                $(crate::core::vertex::Vertex::<(), _>::try_new($coords).unwrap()),+
+                $(vertex!($coords).unwrap()),+
             ];
             let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
             let kernel = FastKernel::<f64>::new();
@@ -2747,7 +2716,7 @@ mod tests {
     macro_rules! test_find_conflict_region_dimension {
         ($dim:literal, $inside_point:expr, $($coords:expr),+ $(,)?) => {{
             let vertices: Vec<_> = vec![
-                $(crate::core::vertex::Vertex::<(), _>::try_new($coords).unwrap()),+
+                $(vertex!($coords).unwrap()),+
             ];
             let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
             let kernel = FastKernel::<f64>::new();
@@ -2814,10 +2783,10 @@ mod tests {
     fn test_find_conflict_region_outside_point() {
         // Point outside - should find zero simplices in conflict
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2839,9 +2808,9 @@ mod tests {
     #[test]
     fn test_find_conflict_region_invalid_start_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -2862,9 +2831,9 @@ mod tests {
     fn test_find_conflict_region_with_robust_kernel() {
         // Test with robust kernel
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = RobustKernel::<f64>::default();
@@ -2886,7 +2855,7 @@ mod tests {
     macro_rules! test_cavity_boundary_dimension {
         ($dim:literal, $expected_facets:expr, $($coords:expr),+ $(,)?) => {{
             let vertices: Vec<_> = vec![
-                $(crate::core::vertex::Vertex::<(), _>::try_new($coords).unwrap()),+
+                $(vertex!($coords).unwrap()),+
             ];
             let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -2958,9 +2927,9 @@ mod tests {
     fn test_extract_cavity_boundary_empty_conflict() {
         // Empty conflict region should produce empty boundary
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -2978,9 +2947,9 @@ mod tests {
     #[test]
     fn test_locate_with_stats_invalid_hint_uses_arbitrary_start_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -3000,9 +2969,9 @@ mod tests {
     #[test]
     fn test_locate_by_scan_inside_and_outside() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -3025,29 +2994,19 @@ mod tests {
     fn test_extract_cavity_boundary_rejects_nonmanifold_facet_2d() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let origin = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let x_axis = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let y_axis = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let upper_right = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
         let top_apex = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 1.5]).unwrap())
             .unwrap();
 
         let first_simplex = tds
@@ -3085,34 +3044,22 @@ mod tests {
     fn test_extract_cavity_boundary_detects_disconnected_boundary_2d() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let left_origin = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let left_x = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let left_y = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let right_origin = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, 0.0]).unwrap())
             .unwrap();
         let right_x = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([4.0, 0.0]).unwrap())
             .unwrap();
         let right_y = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, 1.0]).unwrap())
             .unwrap();
 
         let left = tds
@@ -3157,9 +3104,9 @@ mod tests {
     #[test]
     fn test_locate_with_stats_valid_hint_marks_used_hint() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -3189,9 +3136,9 @@ mod tests {
     #[test]
     fn test_extract_cavity_boundary_invalid_conflict_simplex_key() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -3211,19 +3158,13 @@ mod tests {
     fn test_is_point_outside_facet_underdimensioned_simplex_returns_invalid_arity() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3260,19 +3201,13 @@ mod tests {
     fn test_is_point_outside_facet_invalid_facet_index_returns_invalid_facet_index() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3305,19 +3240,13 @@ mod tests {
     fn test_is_point_outside_facet_unresolvable_opposite_vertex_returns_missing_vertex() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3361,19 +3290,13 @@ mod tests {
     fn test_is_point_outside_facet_degenerate_simplex_missing_vertex_returns_missing_vertex() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         // Build a valid simplex first, then mutate its vertex list to include a missing key.
@@ -3416,19 +3339,13 @@ mod tests {
     fn test_find_conflict_region_vanished_neighbor_returns_simplex_data_access_failed() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3466,19 +3383,13 @@ mod tests {
     fn test_find_conflict_region_underdimensioned_simplex_returns_invalid_simplex_arity() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3518,19 +3429,13 @@ mod tests {
     fn test_find_conflict_region_degenerate_simplex_returns_missing_simplex_vertex() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         // Build valid simplex then mutate one vertex to a missing key.
@@ -3571,9 +3476,9 @@ mod tests {
     #[test]
     fn test_locate_with_stats_none_hint_picks_arbitrary_start_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -3599,7 +3504,7 @@ mod tests {
     macro_rules! test_verify_conflict_region_complete_dimension {
         ($dim:literal, $inside_point:expr, $($coords:expr),+ $(,)?) => {{
             let vertices: Vec<_> = vec![
-                $(crate::core::vertex::Vertex::<(), _>::try_new($coords).unwrap()),+
+                $(vertex!($coords).unwrap()),+
             ];
             let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
             let kernel = FastKernel::<f64>::new();
@@ -3687,9 +3592,9 @@ mod tests {
     #[test]
     fn test_verify_conflict_region_completeness_empty_bfs_detects_missed() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -3710,10 +3615,10 @@ mod tests {
     #[test]
     fn test_verify_conflict_region_completeness_outside_point_zero_missed() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -3748,10 +3653,10 @@ mod tests {
         // All 4 points are co-circular, so a center-ish query point is strictly
         // inside both circumcircles → conflict region has 2 simplices.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([4.0, 3.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 3.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([4.0, 0.0]).unwrap(),
+            vertex!([4.0, 3.0]).unwrap(),
+            vertex!([0.0, 3.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let kernel = FastKernel::<f64>::new();
@@ -3781,39 +3686,25 @@ mod tests {
     fn test_extract_cavity_boundary_rejects_ridge_fan_2d() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let center = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let axis_x = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let axis_y = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let axis_neg_x = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-1.0, 0.0]).unwrap())
             .unwrap();
         let axis_neg_y = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let far_x = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0]).unwrap())
             .unwrap();
         let far_y = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 2.0]).unwrap())
             .unwrap();
 
         let first_simplex = tds

--- a/src/core/algorithms/pl_manifold_repair.rs
+++ b/src/core/algorithms/pl_manifold_repair.rs
@@ -512,6 +512,7 @@ where
 mod tests {
     use super::*;
     use crate::triangulation::DelaunayTriangulation;
+    use crate::vertex;
     use slotmap::KeyData;
 
     // =============================================================================
@@ -556,10 +557,10 @@ mod tests {
     fn test_already_pl_manifold_is_noop() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -581,10 +582,10 @@ mod tests {
     fn test_budget_exhaustion_zero_iterations() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -607,10 +608,10 @@ mod tests {
     fn test_2d_already_pl_manifold() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -631,9 +632,9 @@ mod tests {
     fn test_stats_populated_on_success() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -660,11 +661,11 @@ mod tests {
     fn make_overshared_tds() -> Tds<(), (), 3> {
         // 5 points
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -825,10 +826,10 @@ mod tests {
     fn test_simplex_quality_score_finite_and_deterministic() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -867,11 +868,11 @@ mod tests {
     fn test_deterministic_repeated_runs() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();

--- a/src/core/collections/triangulation_maps.rs
+++ b/src/core/collections/triangulation_maps.rs
@@ -194,8 +194,7 @@ mod tests {
         let mut vertex_slots: SlotMap<VertexKey, i32> = SlotMap::default();
 
         let simplex_key = simplex_slots.insert(1);
-        let mut vertex_buffer: crate::core::collections::SimplexVertexKeyBuffer =
-            crate::core::collections::SimplexVertexKeyBuffer::new();
+        let mut vertex_buffer: SimplexVertexKeyBuffer = SimplexVertexKeyBuffer::new();
         // Simulate D+1 vertices for a 2D simplex (3 vertices)
         for _ in 0..3 {
             vertex_buffer.push(vertex_slots.insert(1));

--- a/src/core/construction.rs
+++ b/src/core/construction.rs
@@ -747,6 +747,7 @@ mod tests {
     use crate::core::simplex::NeighborSlot;
     use crate::geometry::kernel::FastKernel;
     use crate::geometry::traits::coordinate::{CoordinateValidationError, InvalidCoordinateValue};
+    use crate::vertex;
     use std::assert_matches;
 
     #[test]
@@ -835,7 +836,7 @@ mod tests {
                 #[test]
                 fn [<build_initial_simplex_ $dim d>]() {
                     let vertices: Vec<Vertex<(), $dim>> = vec![
-                        $(crate::core::vertex::Vertex::<(), _>::try_new($simplex_coords).unwrap()),+
+                        $(vertex!($simplex_coords).unwrap()),+
                     ];
 
                     let expected_vertices = vertices.len();
@@ -901,8 +902,8 @@ mod tests {
     #[test]
     fn build_initial_simplex_insufficient_vertices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
         ];
 
         let result = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices);
@@ -916,10 +917,10 @@ mod tests {
     #[test]
     fn build_initial_simplex_too_many_vertices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5]).unwrap(),
         ];
 
         let result = Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices);
@@ -958,9 +959,9 @@ mod tests {
 
     #[test]
     fn build_initial_simplex_with_user_data() {
-        let v1 = Vertex::try_new_with_data([0.0, 0.0], 42_usize).unwrap();
-        let v2 = Vertex::try_new_with_data([1.0, 0.0], 43_usize).unwrap();
-        let v3 = Vertex::try_new_with_data([0.0, 1.0], 44_usize).unwrap();
+        let v1 = vertex!([0.0, 0.0]; data = 42_usize).unwrap();
+        let v2 = vertex!([1.0, 0.0]; data = 43_usize).unwrap();
+        let v3 = vertex!([0.0, 1.0]; data = 44_usize).unwrap();
 
         let vertices = vec![v1, v2, v3];
         let tds = Triangulation::<FastKernel<f64>, usize, (), 2>::build_initial_simplex(&vertices)
@@ -983,9 +984,9 @@ mod tests {
     #[test]
     fn build_initial_simplex_rejects_collinear_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
         ];
 
         let result = Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices);
@@ -999,10 +1000,10 @@ mod tests {
     #[test]
     fn build_initial_simplex_rejects_coplanar_3d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.0]).unwrap(),
         ];
 
         let result = Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices);

--- a/src/core/edge.rs
+++ b/src/core/edge.rs
@@ -636,7 +636,8 @@ impl<U, V, const D: usize> Eq for EdgeView<'_, U, V, D> {}
 mod tests {
     use super::*;
     use crate::core::simplex::Simplex;
-    use crate::prelude::{DelaunayTriangulationBuilder, Vertex};
+    use crate::prelude::DelaunayTriangulationBuilder;
+    use crate::vertex;
     use std::{
         collections::{BTreeSet, HashSet},
         ptr,
@@ -644,9 +645,9 @@ mod tests {
 
     fn with_triangle_tds(test: impl FnOnce(&Tds<(), (), 2>, [VertexKey; 3])) {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -718,10 +719,10 @@ mod tests {
     #[test]
     fn edge_key_rejects_live_vertices_without_edge() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -795,16 +796,16 @@ mod tests {
     fn edge_view_enumerates_incident_simplices_from_incidence_index() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let c0 = tds
@@ -833,16 +834,16 @@ mod tests {
     fn edge_key_rejects_partial_missing_reverse_vertex_incidence() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let retained_simplex = tds
@@ -869,16 +870,16 @@ mod tests {
     fn edge_view_rejects_stale_vertex_incidence() {
         let mut tds: Tds<(), (), 3> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let stale_simplex = tds
             .insert_simplex_with_mapping(Simplex::try_new(vec![v0, v1, v2, v3]).unwrap())
@@ -906,13 +907,13 @@ mod tests {
     fn edge_view_rejects_missing_reverse_vertex_incidence() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(Simplex::try_new(vec![v0, v1, v2]).unwrap())
@@ -942,13 +943,13 @@ mod tests {
     fn edge_view_rejects_missing_forward_vertex_incidence() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(Simplex::try_new(vec![v0, v1, v2]).unwrap())
@@ -978,10 +979,10 @@ mod tests {
     fn edge_view_rejects_live_endpoints_without_stored_edge() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
 
         let edge = EdgeKey::from_validated_endpoints(v0, v1);

--- a/src/core/facet.rs
+++ b/src/core/facet.rs
@@ -2240,6 +2240,7 @@ mod tests {
     use crate::core::vertex::Vertex;
     use crate::geometry::kernel::AdaptiveKernel;
     use crate::triangulation::DelaunayTriangulation;
+    use crate::vertex;
     use slotmap::{KeyData, SlotMap};
     use std::assert_matches;
     use std::{collections::HashSet, mem};
@@ -2294,10 +2295,7 @@ mod tests {
     #[test]
     fn test_facet_error_handling() {
         // Create a 1D triangulation (2 vertices forming an edge)
-        let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
 
@@ -2312,10 +2310,10 @@ mod tests {
     fn facet_new() {
         // Create a 3D triangulation with a tetrahedron
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -2329,10 +2327,10 @@ mod tests {
     #[test]
     fn facet_handle_view_roundtrip() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -2360,9 +2358,9 @@ mod tests {
     fn test_facet_new_success_coverage() {
         // Test 2D case: Create a triangle (2D simplex with 3 vertices)
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 1.0]).unwrap(),
         ];
         let dt_2d = DelaunayTriangulation::try_new(&vertices_2d).unwrap();
         let simplex_key_2d = dt_2d.simplices().next().unwrap().0;
@@ -2374,10 +2372,7 @@ mod tests {
         assert_eq!(facet_2d.vertices().count(), 2); // 2D facet should have 2 vertices
 
         // Test 1D case: Create an edge (1D simplex with 2 vertices)
-        let vertices_1d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices_1d = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let dt_1d = DelaunayTriangulation::try_new(&vertices_1d).unwrap();
         let simplex_key_1d = dt_1d.simplices().next().unwrap().0;
         let result_1d = FacetView::try_new(dt_1d.tds(), simplex_key_1d, 0);
@@ -2392,10 +2387,10 @@ mod tests {
     fn facet_new_with_incorrect_vertex() {
         // Create a 3D triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -2408,10 +2403,10 @@ mod tests {
     fn facet_vertices() {
         // Create a 3D triangulation with a tetrahedron
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -2429,10 +2424,10 @@ mod tests {
     fn facet_partial_eq() {
         // Create a 3D triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -2450,10 +2445,10 @@ mod tests {
     fn facet_clone() {
         // Create a 3D triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -2480,10 +2475,10 @@ mod tests {
     fn facet_debug() {
         // Create a 3D triangulation with a non-degenerate tetrahedron
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -2505,10 +2500,10 @@ mod tests {
     fn facet_with_typed_data() {
         // Create 3D triangulation with typed vertex data
         let vertices: Vec<Vertex<i32, 3>> = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 2).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 3).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 4).unwrap(),
+            vertex!([0.0, 0.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 2).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 3).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 4).unwrap(),
         ];
         let options = ConstructionOptions::default()
             .with_insertion_order(InsertionOrderStrategy::Input)
@@ -2638,30 +2633,30 @@ mod tests {
     // Generate tests for dimensions 2D through 5D
     test_facet_dimensions! {
         facet_2d_triangle => 2 => "triangle" => 2 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 1.0]).unwrap(),
         ],
         facet_3d_tetrahedron => 3 => "tetrahedron" => 3 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ],
         facet_4d_simplex => 4 => "4-simplex" => 4 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
         facet_5d_simplex => 5 => "5-simplex" => 5 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
     }
 
@@ -2669,10 +2664,7 @@ mod tests {
     #[test]
     fn facet_1d_edge() {
         // Create 1D triangulation (edge with 2 vertices)
-        let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let options = ConstructionOptions::default()
             .with_insertion_order(InsertionOrderStrategy::Input)
             .with_initial_simplex_strategy(InitialSimplexStrategy::First);
@@ -2724,7 +2716,7 @@ mod tests {
         for i in 0..=usize::from(u8::MAX) {
             let mut coords = [0.0; 255];
             coords[0] = f64::from(u32::try_from(i).unwrap());
-            let vertex = Vertex::<(), 255>::try_new(coords).unwrap();
+            let vertex = vertex!(coords).unwrap();
             vertex_keys.push(tds.insert_vertex_with_mapping(vertex).unwrap());
         }
         let simplex_key = tds
@@ -2745,9 +2737,9 @@ mod tests {
     /// vertices than can be represented by the `u8` facet-index storage.
     fn overwide_simplex_tds() -> Tds<(), (), 2> {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut tds =
             Triangulation::<AdaptiveKernel<f64>, (), (), 2>::build_initial_simplex(&vertices)
@@ -2767,10 +2759,10 @@ mod tests {
 
     fn tetrahedron_tds() -> Tds<(), (), 3> {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         Triangulation::<AdaptiveKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap()
     }
@@ -3039,10 +3031,10 @@ mod tests {
     fn test_facet_key_consistency() {
         // Create 3D triangulation with a tetrahedron
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -3070,10 +3062,7 @@ mod tests {
     #[test]
     fn facet_vertices_empty_simplex() {
         // Test edge case of minimal simplex (1D edge with 2 vertices)
-        let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
 
@@ -3090,10 +3079,10 @@ mod tests {
     fn facet_vertices_ordering() {
         // Test that vertices are filtered correctly
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -3110,10 +3099,10 @@ mod tests {
     fn facet_eq_different_vertices() {
         // Create a 3D triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -3137,10 +3126,10 @@ mod tests {
     fn facet_key_hash() {
         // Create a 3D triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.simplices().next().unwrap().0;
@@ -3209,10 +3198,10 @@ mod tests {
     #[test]
     fn test_facet_view_creation() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3231,10 +3220,10 @@ mod tests {
     #[test]
     fn test_facet_view_vertices_iteration() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3263,10 +3252,10 @@ mod tests {
     #[test]
     fn test_facet_view_opposite_vertex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3288,10 +3277,10 @@ mod tests {
     #[test]
     fn test_facet_view_key_computation() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3307,10 +3296,10 @@ mod tests {
     #[test]
     fn test_try_simplex_facets() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3336,10 +3325,10 @@ mod tests {
     #[test]
     fn test_facet_view_equality() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3359,10 +3348,10 @@ mod tests {
     #[test]
     fn test_facet_view_debug() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();

--- a/src/core/facet_incidence.rs
+++ b/src/core/facet_incidence.rs
@@ -6,6 +6,8 @@
 
 #![forbid(unsafe_code)]
 
+#[cfg(test)]
+use super::collections::FacetToSimplicesMap;
 use super::{
     facet::{FacetError, FacetToSimplicesIndex, FacetView, OneSidedFacetsIter},
     tds::{Tds, TdsError},
@@ -21,7 +23,7 @@ use std::ptr;
 /// being counted as boundary.
 #[cfg(test)]
 fn number_of_one_sided_facets_in_map(
-    facet_to_simplices: &super::collections::FacetToSimplicesMap,
+    facet_to_simplices: &FacetToSimplicesMap,
 ) -> Result<usize, TdsError> {
     let mut count = 0usize;
     for (&facet_key, simplices) in facet_to_simplices {
@@ -362,10 +364,10 @@ mod tests {
     use crate::core::query::QueryError;
     use crate::core::simplex::Simplex;
     use crate::core::tds::{SimplexKey, Tds, TdsError};
-    use crate::core::vertex::Vertex;
     use crate::geometry::point::Point;
     use crate::triangulation::DelaunayTriangulation;
     use crate::try_vertices_from_points;
+    use crate::vertex;
     use std::assert_matches;
 
     #[cfg(feature = "diagnostics")]
@@ -987,13 +989,13 @@ mod tests {
     fn periodic_self_identified_one_sided_facet_is_not_boundary() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let mut simplex = Simplex::try_new(vec![v0, v1, v2]).unwrap();

--- a/src/core/insertion.rs
+++ b/src/core/insertion.rs
@@ -2847,6 +2847,7 @@ mod tests {
         F64_MANTISSA_DIGITS,
     };
     use crate::triangulation::DelaunayTriangulation;
+    use crate::vertex;
     use std::assert_matches;
 
     use slotmap::KeyData;
@@ -3158,11 +3159,11 @@ mod tests {
 
     fn unit_simplex_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
         let mut vertices = Vec::with_capacity(D + 1);
-        vertices.push(crate::core::vertex::Vertex::<(), _>::try_new([0.0_f64; D]).unwrap());
+        vertices.push(vertex!([0.0_f64; D]).unwrap());
         for axis in 0..D {
             let mut coords = [0.0_f64; D];
             coords[axis] = 1.0;
-            vertices.push(crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap());
+            vertices.push(vertex!(coords).unwrap());
         }
         vertices
     }
@@ -3170,11 +3171,11 @@ mod tests {
     /// Build a simplex whose feature length is controlled by one shared axis scale.
     fn axis_scaled_simplex_vertices<const D: usize>(scale: f64) -> Vec<Vertex<(), D>> {
         let mut vertices = Vec::with_capacity(D + 1);
-        vertices.push(crate::core::vertex::Vertex::<(), _>::try_new([0.0_f64; D]).unwrap());
+        vertices.push(vertex!([0.0_f64; D]).unwrap());
         for axis in 0..D {
             let mut coords = [0.0_f64; D];
             coords[axis] = scale;
-            vertices.push(crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap());
+            vertices.push(vertex!(coords).unwrap());
         }
         vertices
     }
@@ -3189,9 +3190,9 @@ mod tests {
     #[test]
     fn test_select_locate_hint_from_hash_grid_returns_incident_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -3213,9 +3214,7 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
         let vkey = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         {
             let vertex = tri.tds.vertex_mut(vkey).unwrap();
@@ -3235,9 +3234,7 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
         let vkey = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
 
         let mut index: HashGridIndex<2> = HashGridIndex::try_new(1.0).unwrap();
@@ -3254,9 +3251,7 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
         let _ = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
 
         let mut index: HashGridIndex<2> = HashGridIndex::try_new(1.0).unwrap();
@@ -3271,10 +3266,7 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
         let _ = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new(coords_with_first::<D>(1.0e-6))
-                    .unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!(coords_with_first::<D>(1.0e-6)).unwrap())
             .unwrap();
 
         let candidate = coords_with_first::<D>(1.0e-6 + 1.0e-11);
@@ -3376,9 +3368,9 @@ mod tests {
     #[test]
     fn test_estimate_local_perturbation_scale_uses_hint_simplex_vertices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -3395,9 +3387,7 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
         let _ = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
 
         let scale = tri.estimate_local_perturbation_scale(&[0.0, 0.0], None);
@@ -3411,33 +3401,18 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
 
         // First insertion succeeds.
-        insert(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .expect("first insertion should succeed");
+        insert(&mut tri, vertex!([0.0, 0.0, 0.0]).unwrap(), None, None)
+            .expect("first insertion should succeed");
         assert_eq!(tri.number_of_vertices(), 1);
 
         // Second insertion at same coordinates: insert() returns Err; the internal
         // statistics helper reports Skipped so telemetry can classify the no-op.
-        let err = insert(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap_err();
+        let err = insert(&mut tri, vertex!([0.0, 0.0, 0.0]).unwrap(), None, None).unwrap_err();
         assert_matches!(err, InsertionError::DuplicateCoordinates { .. });
 
-        let (outcome, stats) = insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (outcome, stats) =
+            insert_with_statistics(&mut tri, vertex!([0.0, 0.0, 0.0]).unwrap(), None, None)
+                .unwrap();
         assert!(stats.skipped());
         assert_matches!(outcome, InsertionOutcome::Skipped { .. });
 
@@ -3451,13 +3426,8 @@ mod tests {
         let mut tri: Triangulation<FastKernel<f64>, (), (), 3> =
             Triangulation::new_empty(FastKernel::new());
 
-        insert(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .expect("first insertion should succeed");
+        insert(&mut tri, vertex!([0.0, 0.0, 0.0]).unwrap(), None, None)
+            .expect("first insertion should succeed");
         assert_eq!(tri.number_of_vertices(), 1);
 
         let existing_uuid = tri.tds.vertices().next().unwrap().1.uuid();
@@ -3488,13 +3458,9 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
 
         // Insert first vertex
-        let (outcome, stats) = insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .expect("insertion should succeed");
+        let (outcome, stats) =
+            insert_with_statistics(&mut tri, vertex!([0.0, 0.0]).unwrap(), None, None)
+                .expect("insertion should succeed");
 
         assert_matches!(outcome, InsertionOutcome::Inserted { hint: None, .. });
         assert_eq!(stats.attempts, 1);
@@ -3511,10 +3477,10 @@ mod tests {
 
         // Insert D+1 vertices to create initial simplex
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         for (i, v) in vertices.into_iter().enumerate() {
@@ -3547,19 +3513,13 @@ mod tests {
             [0.0, 1.0, 0.0],
             [0.0, 0.0, 1.0],
         ] {
-            insert_with_statistics(
-                &mut tri,
-                crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap(),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_with_statistics(&mut tri, vertex!(coords).unwrap(), None, None).unwrap();
         }
 
         let hint = tri.simplices().next().map(|(simplex_key, _)| simplex_key);
         let detail = tri
             .insert_with_statistics_seeded_indexed_detailed(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0, 2.0]).unwrap(),
+                vertex!([2.0, 2.0, 2.0]).unwrap(),
                 None,
                 hint,
                 0,
@@ -3602,20 +3562,14 @@ mod tests {
             [0.0, 1.0, 0.0],
             [0.0, 0.0, 1.0],
         ] {
-            insert_with_statistics(
-                &mut tri,
-                crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap(),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_with_statistics(&mut tri, vertex!(coords).unwrap(), None, None).unwrap();
         }
 
         let hint = tri.simplices().next().map(|(simplex_key, _)| simplex_key);
         let empty_conflicts = SimplexKeyBuffer::new();
         let detail = tri
             .insert_with_statistics_seeded_indexed_detailed(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0, 2.0]).unwrap(),
+                vertex!([2.0, 2.0, 2.0]).unwrap(),
                 Some(&empty_conflicts),
                 hint,
                 0,
@@ -3647,9 +3601,9 @@ mod tests {
     #[test]
     fn triangulation_caller_conflicts_do_not_force_delaunay_repair() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -3665,7 +3619,7 @@ mod tests {
         conflict_simplices.push(start_simplex);
         let detail = tri
             .insert_with_statistics_seeded_indexed_detailed(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25]).unwrap(),
+                vertex!([0.25, 0.25]).unwrap(),
                 Some(&conflict_simplices),
                 Some(start_simplex),
                 0,
@@ -3693,20 +3647,14 @@ mod tests {
             if i > 0 {
                 coords[i - 1] = 1.0;
             }
-            insert_with_statistics(
-                &mut tri,
-                crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap(),
-                None,
-                None,
-            )
-            .unwrap();
+            insert_with_statistics(&mut tri, vertex!(coords).unwrap(), None, None).unwrap();
         }
 
         // Insert with explicit hint
         let hint_simplex = tri.simplices().next().map(|(key, _)| key);
         let (outcome, stats) = insert_with_statistics(
             &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
+            vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
             None,
             hint_simplex,
         )
@@ -3723,21 +3671,11 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
 
         // Insert first vertex
-        insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
+        insert_with_statistics(&mut tri, vertex!([1.0, 2.0, 3.0]).unwrap(), None, None).unwrap();
 
         // Try duplicate - should be skipped
-        let result = insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap(),
-            None,
-            None,
-        );
+        let result =
+            insert_with_statistics(&mut tri, vertex!([1.0, 2.0, 3.0]).unwrap(), None, None);
 
         assert_matches!(
             result,
@@ -3756,11 +3694,11 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
 
         let points = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.3, 0.3]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.7, 0.3]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 1.0]).unwrap(),
+            vertex!([0.3, 0.3]).unwrap(),
+            vertex!([0.7, 0.3]).unwrap(),
         ];
 
         let mut all_succeeded = true;
@@ -3789,13 +3727,8 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
 
         // Test Inserted variant
-        let (outcome, _) = insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (outcome, _) =
+            insert_with_statistics(&mut tri, vertex!([0.0, 0.0]).unwrap(), None, None).unwrap();
 
         match outcome {
             InsertionOutcome::Inserted { vertex_key, hint } => {
@@ -3819,13 +3752,8 @@ mod tests {
                 coords[i - 1] = 1.0;
             }
 
-            let (outcome, stats) = insert_with_statistics(
-                &mut tri,
-                crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap(),
-                None,
-                None,
-            )
-            .unwrap();
+            let (outcome, stats) =
+                insert_with_statistics(&mut tri, vertex!(coords).unwrap(), None, None).unwrap();
 
             assert_matches!(outcome, InsertionOutcome::Inserted { .. });
             assert_eq!(stats.attempts, 1);
@@ -3842,38 +3770,15 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
 
         // Build simplex
-        insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
-        insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
-        insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
+        insert_with_statistics(&mut tri, vertex!([0.0, 0.0]).unwrap(), None, None).unwrap();
+        insert_with_statistics(&mut tri, vertex!([1.0, 0.0]).unwrap(), None, None).unwrap();
+        insert_with_statistics(&mut tri, vertex!([0.5, 1.0]).unwrap(), None, None).unwrap();
 
         let simplices_before = tri.number_of_simplices();
 
         // Insert interior point - might trigger repair
-        let (_outcome, stats) = insert_with_statistics(
-            &mut tri,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.3]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (_outcome, stats) =
+            insert_with_statistics(&mut tri, vertex!([0.5, 0.3]).unwrap(), None, None).unwrap();
 
         let simplices_after = tri.number_of_simplices();
 
@@ -3910,39 +3815,27 @@ mod tests {
         // Two triangles that share no vertices (→ DisconnectedBoundary on extraction).
         let v0 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 1.0]).unwrap())
             .unwrap();
         let v3 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([5.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([5.0, 0.0]).unwrap())
             .unwrap();
         let v4 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([6.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([6.0, 0.0]).unwrap())
             .unwrap();
         let v5 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([5.5, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([5.5, 1.0]).unwrap())
             .unwrap();
 
         let simplex_a = tri
@@ -3962,9 +3855,7 @@ mod tests {
         // the first iteration and the `else { break; }` arm fires immediately.
         let new_v = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.3]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.3]).unwrap())
             .unwrap();
         let point = Point::try_new([0.5_f64, 0.3_f64]).expect("finite point coordinates");
 
@@ -4001,40 +3892,28 @@ mod tests {
 
         let v0 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         // Three distinct fourth vertices that all pair with the {v0,v1,v2} face.
         let v3 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let v4 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, -1.0]).unwrap())
             .unwrap();
         let v5 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 2.0]).unwrap())
             .unwrap();
 
         let simplex1 = tri
@@ -4058,9 +3937,7 @@ mod tests {
 
         let new_v = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.1, 0.1]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.1, 0.1, 0.1]).unwrap())
             .unwrap();
         let point = Point::try_new([0.1_f64, 0.1_f64, 0.1_f64]).expect("finite point coordinates");
 
@@ -4093,10 +3970,6 @@ mod tests {
     ///
     /// Covers: `RidgeFan` SHRINK body (lines 3434-3442) and re-extraction (line 3514).
     #[test]
-    #[expect(
-        clippy::too_many_lines,
-        reason = "regression test keeps the ridge-fan shrink fixture explicit"
-    )]
     fn test_cavity_reduction_ridge_fan_shrink_fires_for_4_conflict_simplices_2d() {
         let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
             Triangulation::new_empty(FastKernel::new());
@@ -4104,57 +3977,39 @@ mod tests {
         // `center` appears in 8 boundary edges (2 per simplex × 4 simplices) → RidgeFan.
         let center = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let va = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-1.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-1.0, 2.0]).unwrap())
             .unwrap();
         let vb = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 2.0]).unwrap())
             .unwrap();
         let vc = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-3.0, -2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-3.0, -2.0]).unwrap())
             .unwrap();
         let vd = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-2.0, -3.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-2.0, -3.0]).unwrap())
             .unwrap();
         let ve = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, -2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, -2.0]).unwrap())
             .unwrap();
         let vf = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, -3.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, -3.0]).unwrap())
             .unwrap();
         let vg = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-4.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-4.0, 1.0]).unwrap())
             .unwrap();
         let vh = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([-4.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([-4.0, -1.0]).unwrap())
             .unwrap();
 
         let simplex1 = tri
@@ -4184,9 +4039,7 @@ mod tests {
 
         let new_v = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.3, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.3, 1.0]).unwrap())
             .unwrap();
         let point = Point::try_new([0.3_f64, 1.0_f64]).expect("finite point coordinates");
 
@@ -4238,10 +4091,6 @@ mod tests {
     /// Covers: EXPAND body (lines 3470-3480), SHRINK-fallback (lines 3481-3491),
     /// and re-extraction after each reshape (line 3514).
     #[test]
-    #[expect(
-        clippy::too_many_lines,
-        reason = "regression test keeps the disconnected cavity fixture explicit"
-    )]
     fn test_cavity_reduction_disconnected_expand_then_shrink_2d() {
         let mut tri: Triangulation<FastKernel<f64>, (), (), 2> =
             Triangulation::new_empty(FastKernel::new());
@@ -4249,52 +4098,36 @@ mod tests {
         // Group A: simplex_a = {v0,v1,v2} shares edge {v0,v1} with simplex_c = {v0,v1,v6}.
         let v0 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 1.0]).unwrap())
             .unwrap();
         let v6 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, -1.0]).unwrap())
             .unwrap();
         // Group B: simplex_b = {v3,v4,v5} shares edge {v3,v4} with simplex_d = {v3,v4,v7}.
         let v3 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([5.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([5.0, 0.0]).unwrap())
             .unwrap();
         let v4 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([6.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([6.0, 0.0]).unwrap())
             .unwrap();
         let v5 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([5.5, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([5.5, 1.0]).unwrap())
             .unwrap();
         let v7 = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([5.5, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([5.5, -1.0]).unwrap())
             .unwrap();
 
         let simplex_a = tri
@@ -4340,9 +4173,7 @@ mod tests {
 
         let new_v = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.3]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.3]).unwrap())
             .unwrap();
         let point = Point::try_new([0.5_f64, 0.3_f64]).expect("finite point coordinates");
 
@@ -4413,12 +4244,12 @@ mod tests {
     fn simplex_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
         let mut verts = Vec::with_capacity(D + 1);
         // Origin
-        verts.push(Vertex::try_new([0.0; D]).unwrap());
+        verts.push(vertex!([0.0; D]).unwrap());
         // Unit vectors along each axis
         for i in 0..D {
             let mut coords = [0.0; D];
             coords[i] = 1.0;
-            verts.push(Vertex::try_new(coords).unwrap());
+            verts.push(vertex!(coords).unwrap());
         }
         verts
     }
@@ -4477,7 +4308,7 @@ mod tests {
                     for c in interior.iter_mut() {
                         *c = 1.0 / (<f64 as std::convert::From<i32>>::from($dim + 1) * 2.0);
                     }
-                    let interior_vertex = Vertex::try_new(interior).unwrap();
+                    let interior_vertex = vertex!(interior).unwrap();
                     let (_, hint) = insert(&mut tri, interior_vertex, None, None).unwrap();
 
                     assert!(hint.is_some(), "{}D: hint returned after D+2 insertion", $dim);
@@ -4508,13 +4339,8 @@ mod tests {
 
         let points = [[0.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.25, 0.25]];
         for coords in &points {
-            let (outcome, stats) = insert_with_statistics(
-                &mut tri,
-                crate::core::vertex::Vertex::<(), _>::try_new(*coords).unwrap(),
-                None,
-                None,
-            )
-            .unwrap();
+            let (outcome, stats) =
+                insert_with_statistics(&mut tri, vertex!(*coords).unwrap(), None, None).unwrap();
             assert!(stats.success());
             assert_matches!(outcome, InsertionOutcome::Inserted { .. });
             assert_eq!(stats.attempts, 1);
@@ -4533,9 +4359,7 @@ mod tests {
             Triangulation::new_empty(FastKernel::new());
         let _ = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 4.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, 4.0]).unwrap())
             .unwrap();
 
         let tol = 1e-10_f64;
@@ -4586,14 +4410,7 @@ mod tests {
             ];
             let vertices: Vec<Vertex<(), 3>> = base_coords
                 .iter()
-                .map(|c| {
-                    crate::core::vertex::Vertex::<(), _>::try_new([
-                        c[0] * scale,
-                        c[1] * scale,
-                        c[2] * scale,
-                    ])
-                    .unwrap()
-                })
+                .map(|c| vertex!([c[0] * scale, c[1] * scale, c[2] * scale]).unwrap())
                 .collect();
             let dt: DelaunayTriangulation<_, (), (), 3> =
                 DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -4647,9 +4464,9 @@ mod tests {
         // This near-degenerate configuration exercises the full insert_transactional path
         // including epsilon_value computation.
         let initial_f64: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0_f64, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0_f64, 1.0]).unwrap(),
+            vertex!([0.0_f64, 0.0]).unwrap(),
+            vertex!([1.0_f64, 0.0]).unwrap(),
+            vertex!([0.0_f64, 1.0]).unwrap(),
         ];
         let tds_f64 =
             Triangulation::<AdaptiveKernel<f64>, (), (), 2>::build_initial_simplex(&initial_f64)
@@ -4659,13 +4476,9 @@ mod tests {
             tds_f64,
         );
 
-        let (outcome_f64, stats_f64) = insert_with_statistics(
-            &mut tri_f64,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5_f64, 0.0]).unwrap(),
-            None,
-            None,
-        )
-        .unwrap();
+        let (outcome_f64, stats_f64) =
+            insert_with_statistics(&mut tri_f64, vertex!([0.5_f64, 0.0]).unwrap(), None, None)
+                .unwrap();
         assert!(
             stats_f64.attempts >= 1,
             "f64 insertion must execute at least 1 attempt"
@@ -4850,11 +4663,11 @@ mod tests {
     #[test]
     fn test_perturbation_retry_and_exhaustion_4d() {
         let initial_vertices: Vec<Vertex<(), 4>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let tds = Triangulation::<AdaptiveKernel<f64>, (), (), 4>::build_initial_simplex(
             &initial_vertices,
@@ -4866,7 +4679,7 @@ mod tests {
         );
 
         let _guard = ForceNextRetryableInsertionFailureGuard::enable();
-        let retry_success_vertex = Vertex::try_new([0.2, 0.2, 0.2, 0.2]).unwrap();
+        let retry_success_vertex = vertex!([0.2, 0.2, 0.2, 0.2]).unwrap();
         let (_outcome, retry_success_stats) =
             insert_with_statistics(&mut retry_success_tri, retry_success_vertex, None, None)
                 .unwrap();

--- a/src/core/insertion.rs
+++ b/src/core/insertion.rs
@@ -8,7 +8,8 @@
 
 use crate::core::algorithms::incremental_insertion::{
     CavityFillingError, CavityRepairStage, HullExtensionReason, InsertionError, extend_hull,
-    external_facets_for_boundary, fill_cavity_replacing_simplices, wire_cavity_neighbors,
+    external_facets_for_boundary, fill_cavity_replacing_simplices,
+    split_2d_boundary_edge_in_simplex_if_needed, wire_cavity_neighbors,
 };
 #[cfg(debug_assertions)]
 use crate::core::algorithms::locate::locate;
@@ -670,6 +671,7 @@ where
                     delaunay_repair_required,
                     ..
                 }) => {
+                    let (vertex_key, hint) = inserted;
                     stats.simplices_removed_during_repair = simplices_removed;
                     stats.result = InsertionResult::Inserted;
                     #[cfg(debug_assertions)]
@@ -679,7 +681,6 @@ where
                         );
                     }
 
-                    let (vertex_key, hint) = inserted;
                     transaction.commit();
                     // Only the committed attempt updates the duplicate index. Earlier
                     // retries all rolled back to the pre-attempt triangulation state.
@@ -1147,6 +1148,93 @@ where
         }
 
         Ok(insert_ok)
+    }
+
+    /// Splits an exact 2D boundary edge from the located simplex before `SoS` turns it interior.
+    ///
+    /// This preserves the public construction contract for exact layered 2D
+    /// inputs: a vertex whose physical coordinates lie on a hull edge should be
+    /// inserted as a boundary split, even when symbolic perturbation gives point
+    /// location an interior tie-break result. The returned insertion outcome
+    /// seeds the usual local validation and repair bookkeeping.
+    fn try_split_2d_boundary_edge_in_located_simplex(
+        &mut self,
+        v_key: VertexKey,
+        point: &Point<D>,
+        start_simplex: SimplexKey,
+        telemetry: &mut InsertionTelemetry,
+        telemetry_mode: InsertionTelemetryMode,
+    ) -> Result<Option<TryInsertImplOk>, InsertionError> {
+        if D != 2 {
+            return Ok(None);
+        }
+
+        let split_started = Self::start_insertion_timing(telemetry_mode);
+        let split_result =
+            split_2d_boundary_edge_in_simplex_if_needed(&mut self.tds, v_key, point, start_simplex);
+
+        let new_simplices = match split_result {
+            Ok(Some(new_simplices)) => {
+                Self::record_hull_extension_telemetry(
+                    telemetry,
+                    split_started.map(|started| Self::duration_nanos_saturating(started.elapsed())),
+                );
+                new_simplices
+            }
+            Ok(None) => return Ok(None),
+            Err(err) => {
+                Self::record_hull_extension_telemetry(
+                    telemetry,
+                    split_started.map(|started| Self::duration_nanos_saturating(started.elapsed())),
+                );
+                return Err(err);
+            }
+        };
+
+        self.canonicalize_positive_orientation_for_simplices(&new_simplices)?;
+
+        let mut incident_repair_vertices =
+            SmallBuffer::<VertexKey, CLEANUP_OPERATION_BUFFER_SIZE>::new();
+        Self::push_incident_repair_vertex(&mut incident_repair_vertices, v_key);
+        self.extend_incident_repair_vertices_from_simplices(
+            &new_simplices,
+            &mut incident_repair_vertices,
+        );
+
+        let mut orientation_simplices = SimplexKeyBuffer::new();
+        append_live_unique_simplex_seeds(&self.tds, &new_simplices, &mut orientation_simplices);
+        self.validate_local_orientation_for_simplices(&orientation_simplices)?;
+
+        let hint = new_simplices.iter().copied().find(|&simplex_key| {
+            self.tds
+                .simplex(simplex_key)
+                .is_some_and(|simplex| simplex.contains_vertex(v_key))
+        });
+        if let Some(incident_simplex) = hint
+            && let Some(vertex) = self.tds.vertex_mut(v_key)
+        {
+            vertex.set_incident_simplex(Some(incident_simplex));
+        }
+
+        self.repair_stale_incident_simplices(&incident_repair_vertices)?;
+        self.validate_connectedness(&new_simplices)?;
+
+        let mut repair_seed_simplices = SimplexKeyBuffer::new();
+        append_live_unique_simplex_seeds(&self.tds, &new_simplices, &mut repair_seed_simplices);
+        let embedding_validation_simplices = new_simplices
+            .iter()
+            .copied()
+            .filter(|simplex_key| self.tds.contains_simplex(*simplex_key))
+            .collect();
+
+        Ok(Some(TryInsertImplOk {
+            inserted: (v_key, hint),
+            simplices_removed: 0,
+            suspicion: SuspicionFlags::default(),
+            repair_seed_simplices,
+            embedding_validation_simplices,
+            delaunay_repair_required: true,
+        }))
     }
 
     /// After a Level 3 topology validation failure, try to recover by performing a star-split
@@ -2122,6 +2210,24 @@ where
                 fallback = ?locate_stats.fallback,
                 "try_insert_impl: locate stats"
             );
+        }
+
+        let local_boundary_split_simplex = match location {
+            LocateResult::InsideSimplex(start_simplex)
+            | LocateResult::OnFacet(start_simplex, _)
+            | LocateResult::OnEdge(start_simplex) => Some(start_simplex),
+            LocateResult::Outside | LocateResult::OnVertex(_) => None,
+        };
+        if let Some(start_simplex) = local_boundary_split_simplex
+            && let Some(outcome) = self.try_split_2d_boundary_edge_in_located_simplex(
+                v_key,
+                &point,
+                start_simplex,
+                telemetry,
+                telemetry_mode,
+            )?
+        {
+            return Ok(outcome);
         }
 
         // 4. Determine the supported insertion site and any conflict simplices it needs.

--- a/src/core/operations.rs
+++ b/src/core/operations.rs
@@ -10,7 +10,7 @@
 #![forbid(unsafe_code)]
 
 use crate::core::algorithms::incremental_insertion::InsertionError;
-use crate::core::tds::SimplexKey;
+use crate::core::tds::{SimplexKey, VertexKey};
 use crate::core::validation::TopologyGuarantee;
 use crate::repair::{DelaunayCheckPolicy, DelaunayRepairPolicy};
 
@@ -382,9 +382,9 @@ pub enum InsertionOutcome {
     /// The vertex was inserted successfully.
     Inserted {
         /// Key of the inserted vertex.
-        vertex_key: crate::core::tds::VertexKey,
+        vertex_key: VertexKey,
         /// Optional simplex key that can be used as a hint for subsequent insertions.
-        hint: Option<crate::core::tds::SimplexKey>,
+        hint: Option<SimplexKey>,
     },
     /// The vertex was intentionally not inserted.
     ///

--- a/src/core/orientation.rs
+++ b/src/core/orientation.rs
@@ -518,6 +518,7 @@ mod tests {
     use crate::topology::traits::topological_space::{
         GlobalTopology, ToroidalConstructionMode, ToroidalDomainError,
     };
+    use crate::vertex;
     use std::assert_matches;
 
     /// Regression test: a negatively oriented but topologically valid simplex
@@ -525,9 +526,9 @@ mod tests {
     #[test]
     fn negative_oriented_simplex_topology_only() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -550,10 +551,10 @@ mod tests {
     #[test]
     fn local_geometric_orientation_validation_errors_on_missing_scope_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
@@ -574,9 +575,9 @@ mod tests {
     #[test]
     fn is_valid_rejects_negative_geometric_simplex_orientation() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -598,9 +599,9 @@ mod tests {
     #[test]
     fn validate_geometric_simplex_orientation_returns_enriched_error_on_negative() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -624,9 +625,9 @@ mod tests {
     #[test]
     fn simplices_require_positive_orientation_promotion_detects_negative_without_mutating() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -650,9 +651,9 @@ mod tests {
     #[test]
     fn simplices_require_positive_orientation_promotion_false_for_positive_without_mutating() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -673,9 +674,9 @@ mod tests {
     #[test]
     fn periodic_geometric_orientation_validation_uses_lifted_coordinates() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.8]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([0.8, 0.0]).unwrap(),
+            vertex!([0.0, 0.8]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -711,9 +712,9 @@ mod tests {
     #[test]
     fn periodic_geometric_orientation_validation_requires_toroidal_metadata() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.8]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([0.8, 0.0]).unwrap(),
+            vertex!([0.0, 0.8]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -736,9 +737,9 @@ mod tests {
     #[test]
     fn periodic_geometric_orientation_validation_rejects_offset_count_mismatch() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.8]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([0.8, 0.0]).unwrap(),
+            vertex!([0.0, 0.8]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();

--- a/src/core/query.rs
+++ b/src/core/query.rs
@@ -936,6 +936,7 @@ mod tests {
     use crate::core::tds::Tds;
     use crate::geometry::kernel::FastKernel;
     use crate::triangulation::DelaunayTriangulation;
+    use crate::vertex;
 
     use slotmap::KeyData;
     use std::assert_matches;
@@ -952,7 +953,7 @@ mod tests {
                 coords[point_idx - 1] = 1.0;
             }
             let vertex_key = tds
-                .insert_vertex_with_mapping(Vertex::<(), _>::try_new(coords).unwrap())
+                .insert_vertex_with_mapping(vertex!(coords).unwrap())
                 .unwrap();
             shared_vertex_keys.push(vertex_key);
         }
@@ -960,13 +961,13 @@ mod tests {
         let mut positive_apex = [0.2; D];
         positive_apex[D - 1] = 1.0;
         let positive_apex_key = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new(positive_apex).unwrap())
+            .insert_vertex_with_mapping(vertex!(positive_apex).unwrap())
             .unwrap();
 
         let mut negative_apex = [0.2; D];
         negative_apex[D - 1] = -1.0;
         let negative_apex_key = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new(negative_apex).unwrap())
+            .insert_vertex_with_mapping(vertex!(negative_apex).unwrap())
             .unwrap();
 
         let mut positive_simplex_vertices = shared_vertex_keys.clone();
@@ -1001,19 +1002,19 @@ mod tests {
     ) {
         let mut tds = Tds::empty();
         let left_endpoint = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let right_endpoint = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let upper_apex = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let lower_apex = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, -1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let extra_apex = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.5, 0.5]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5]).unwrap())
             .unwrap();
 
         for apex in [upper_apex, lower_apex, extra_apex] {
@@ -1114,7 +1115,7 @@ mod tests {
                     );
 
                     let vertices = vec![
-                        $(crate::core::vertex::Vertex::<(), _>::try_new($simplex_coords).unwrap()),+
+                        $(vertex!($simplex_coords).unwrap()),+
                     ];
                     let expected_vertex_count = vertices.len();
 
@@ -1184,9 +1185,9 @@ mod tests {
     #[test]
     fn test_boundary_facets_reports_corrupted_facet_map() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -1230,9 +1231,9 @@ mod tests {
     #[test]
     fn topology_edges_triangle_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -1338,11 +1339,11 @@ mod tests {
     #[test]
     fn topology_edges_and_incident_edges_double_tetrahedron_3d() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 2.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.7, 1.5]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.7, -1.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 2.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.7, 1.5]).unwrap(),
+            vertex!([1.0, 0.7, -1.5]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -1410,9 +1411,9 @@ mod tests {
     #[test]
     fn topology_queries_missing_keys_are_empty_or_none() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1455,9 +1456,9 @@ mod tests {
     #[test]
     fn topology_geometry_accessors_round_trip() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -1634,9 +1635,9 @@ mod tests {
     #[test]
     fn split_topology_indexes_include_isolated_vertex_entries() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -1645,9 +1646,7 @@ mod tests {
 
         let isolated_vertex = tri
             .tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 10.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, 10.0]).unwrap())
             .unwrap();
         let incidence = tri.incidence().unwrap();
         let edge_index = tri.build_edge_index().unwrap();
@@ -1674,9 +1673,9 @@ mod tests {
     #[test]
     fn incidence_errors_on_stale_vertex_incidence_index() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -1697,9 +1696,9 @@ mod tests {
     #[test]
     fn simplex_neighbor_index_errors_on_missing_neighbor_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -1734,9 +1733,9 @@ mod tests {
     #[test]
     fn simplex_neighbors_filters_missing_neighbor_simplex() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -1758,9 +1757,9 @@ mod tests {
     #[test]
     fn edge_index_errors_on_missing_vertex_key() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 2>::build_initial_simplex(&vertices).unwrap();
@@ -1798,11 +1797,11 @@ mod tests {
     #[test]
     fn topology_queries_on_two_tet_triangulation() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();

--- a/src/core/repair.rs
+++ b/src/core/repair.rs
@@ -21,6 +21,8 @@ use crate::core::tds::{InvariantError, SimplexKey, TdsError, VertexKey};
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
 use crate::core::validation::{TriangulationValidationError, insertion_error_to_invariant_error};
+#[cfg(test)]
+use crate::deletion::DeleteVertexError;
 use crate::geometry::kernel::Kernel;
 use crate::geometry::quality::{QualityError, QualitySimplexVerticesError, radius_ratio};
 use std::env;
@@ -2305,7 +2307,7 @@ mod tests {
         assert!(
             matches!(
                 error,
-                crate::DeleteVertexError::InvariantViolation {
+                DeleteVertexError::InvariantViolation {
                     ref source
                 } if matches!(
                     source.as_ref(),

--- a/src/core/rollback.rs
+++ b/src/core/rollback.rs
@@ -64,15 +64,15 @@ where
 mod tests {
     use super::*;
     use crate::core::tds::Tds;
-    use crate::core::vertex::Vertex;
     use crate::geometry::kernel::FastKernel;
+    use crate::vertex;
     use std::sync::Arc;
 
     fn insert_test_vertex<const D: usize>(
         triangulation: &mut Triangulation<FastKernel<f64>, (), (), D>,
         coordinate: f64,
     ) {
-        let vertex = Vertex::<(), D>::try_new([coordinate; D]).unwrap();
+        let vertex = vertex!([coordinate; D]).unwrap();
         triangulation
             .tds
             .insert_vertex_with_mapping(vertex)

--- a/src/core/simplex.rs
+++ b/src/core/simplex.rs
@@ -69,6 +69,8 @@ use super::{
     traits::{DataDeserialize, DataSerialize},
     util::{UuidValidationError, make_uuid, validate_uuid},
 };
+#[cfg(test)]
+use crate::core::collections::FastHashSet;
 use crate::core::collections::{
     FastHashMap, NeighborBuffer, PeriodicOffsetBuffer, SimplexVertexKeyBuffer,
     SimplexVertexUuidBuffer, fast_hash_map_with_capacity,
@@ -2037,12 +2039,14 @@ mod tests {
     use super::*;
     use crate::builder::DelaunayTriangulationBuilder;
     use crate::core::facet::FacetError;
+    use crate::core::vertex::Vertex;
     use crate::geometry::kernel::AdaptiveKernel;
     use crate::geometry::matrix::MAX_STACK_MATRIX_DIM;
     use crate::geometry::point::Point;
     use crate::geometry::predicates::insphere;
     use crate::geometry::util::{circumcenter, circumradius, circumradius_with_center};
     use crate::prelude::DelaunayTriangulation;
+    use crate::vertex;
     use approx::assert_relative_eq;
     use std::assert_matches;
     use std::{
@@ -2197,30 +2201,30 @@ mod tests {
     // Generate tests for dimensions 2D through 5D
     test_simplex_dimensions! {
         simplex_2d => 2 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ],
         simplex_3d => 3 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ],
         simplex_4d => 4 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
         simplex_5d => 5 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
     }
 
@@ -2242,18 +2246,18 @@ mod tests {
     // Helper functions for creating common test data
     fn create_test_vertices_3d() -> Vec<TestVertex3D> {
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]
     }
 
     fn create_test_vertices_2d() -> Vec<TestVertex2D> {
         vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ]
     }
 
@@ -2263,10 +2267,10 @@ mod tests {
     fn simplex_from_triangulation_without_data() {
         // Public callers obtain simplices from a triangulation, not a standalone macro.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(), // Need 4 vertices for 3D simplex
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(), // Need 4 vertices for 3D simplex
         ];
 
         // Create DT to get a simplex with TDS context.
@@ -2315,10 +2319,10 @@ mod tests {
     fn test_eq_by_vertices_same_coordinates_different_tds() {
         // Create two separate TDS instances with identical vertex coordinates
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt1 = DelaunayTriangulation::try_new(&vertices).unwrap();
         let dt2 = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2334,9 +2338,9 @@ mod tests {
     #[test]
     fn test_eq_by_vertices_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt1 = DelaunayTriangulation::try_new(&vertices).unwrap();
         let dt2 = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2351,10 +2355,10 @@ mod tests {
     fn simplex_from_triangulation_with_data() {
         // Exercise simplex data by creating a TDS-backed simplex and modifying a clone.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         // Build DT with integer simplex data type
@@ -2403,10 +2407,10 @@ mod tests {
     fn simplex_with_vertex_data() {
         // Test simplices with vertex data through TDS.
         let vertices = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 2).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 3).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 4).unwrap(), // Need 4 vertices for 3D simplex
+            vertex!([0.0, 0.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 2).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 3).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 4).unwrap(), // Need 4 vertices for 3D simplex
         ];
 
         // Create DT with vertex data - simple constructor works since simplex data is ()
@@ -2442,10 +2446,10 @@ mod tests {
     fn simplex_partial_eq() {
         // Test PartialEq using simplices from TDS.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex1) = dt.simplices().next().unwrap();
@@ -2465,11 +2469,11 @@ mod tests {
     fn simplex_partial_ord() {
         // Test PartialOrd using TDS with multiple simplices.
         let all_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&all_vertices).unwrap();
         let simplices: Vec<_> = dt.simplices().map(|(_, simplex)| simplex).collect();
@@ -2491,10 +2495,10 @@ mod tests {
     #[test]
     fn simplex_hash() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex1) = dt.simplices().next().unwrap();
@@ -2516,10 +2520,10 @@ mod tests {
     #[test]
     fn simplex_clone() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 1.0, 1.0], 2).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 1).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 1.0, 1.0]; data = 2).unwrap(),
         ];
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, i32, i32, 3> =
             DelaunayTriangulation::try_with_kernel(&AdaptiveKernel::new(), &vertices).unwrap();
@@ -2534,10 +2538,10 @@ mod tests {
     #[test]
     fn simplex_ordering_edge_cases() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex1) = dt.simplices().next().unwrap();
@@ -2576,10 +2580,10 @@ mod tests {
     fn simplex_mirror_facet_index_shared_facet_2d() {
         // Four points in convex position should yield two triangles that share an edge.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.1]).unwrap(), // break cocircular symmetry
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.1]).unwrap(), // break cocircular symmetry
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -2598,7 +2602,7 @@ mod tests {
                 let simplex_a = simplices[i];
                 let simplex_b = simplices[j];
 
-                let shared: crate::core::collections::FastHashSet<VertexKey> = simplex_a
+                let shared: FastHashSet<VertexKey> = simplex_a
                     .vertices()
                     .iter()
                     .copied()
@@ -2651,11 +2655,11 @@ mod tests {
     fn simplex_mirror_facet_index_returns_none_when_simplices_do_not_share_facet_2d() {
         // Add a point strictly inside the convex hull to yield multiple triangles.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -2695,9 +2699,9 @@ mod tests {
     #[test]
     fn simplex_mirror_facet_index_returns_none_for_mismatched_vertex_counts() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -2725,14 +2729,10 @@ mod tests {
 
     #[test]
     fn simplex_contains_vertex() {
-        let vertex1: Vertex<i32, 3> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 1).unwrap();
-        let vertex2 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap();
-        let vertex3 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap();
-        let vertex4 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 1.0, 1.0], 2).unwrap();
+        let vertex1: Vertex<i32, 3> = vertex!([0.0, 0.0, 1.0]; data = 1).unwrap();
+        let vertex2 = vertex!([0.0, 1.0, 0.0]; data = 1).unwrap();
+        let vertex3 = vertex!([1.0, 0.0, 0.0]; data = 1).unwrap();
+        let vertex4 = vertex!([1.0, 1.0, 1.0]; data = 2).unwrap();
 
         // Create DT to get VertexKeys - use generic constructor for vertex data
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
@@ -2755,10 +2755,10 @@ mod tests {
     fn simplex_has_vertex_in_common() {
         // Test has_vertex_in_common (replacement for deprecated contains_vertex_of)
         let vertices1 = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 1.0, 1.0], 2).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 1).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 1.0, 1.0]; data = 2).unwrap(),
         ];
         let tds1: DelaunayTriangulation<AdaptiveKernel<f64>, i32, i32, 3> =
             DelaunayTriangulation::try_with_kernel(&AdaptiveKernel::new(), &vertices1).unwrap();
@@ -2767,10 +2767,10 @@ mod tests {
         simplex.data = Some(42);
 
         let vertices2 = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 0).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 1).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 1).unwrap(),
+            vertex!([0.0, 0.0, 0.0]; data = 0).unwrap(),
         ];
         let tds2: DelaunayTriangulation<AdaptiveKernel<f64>, i32, i32, 3> =
             DelaunayTriangulation::try_with_kernel(&AdaptiveKernel::new(), &vertices2).unwrap();
@@ -2789,14 +2789,10 @@ mod tests {
     #[test]
     fn test_vertex_uuids_success() {
         // Test the vertex_uuids method returns correct vertex UUIDs vector
-        let vertex1 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 10).unwrap();
-        let vertex2 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 20).unwrap();
-        let vertex3 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 30).unwrap();
-        let vertex4 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 40).unwrap();
+        let vertex1 = vertex!([0.0, 0.0, 0.0]; data = 10).unwrap();
+        let vertex2 = vertex!([1.0, 0.0, 0.0]; data = 20).unwrap();
+        let vertex3 = vertex!([0.0, 1.0, 0.0]; data = 30).unwrap();
+        let vertex4 = vertex!([0.0, 0.0, 1.0]; data = 40).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, i32, (), 3> =
@@ -2831,8 +2827,7 @@ mod tests {
         // Test that TDS creation fails gracefully with insufficient vertices for dimension
         // Tested through TDS, which is the user-facing API.
 
-        let vertices =
-            vec![crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap()];
+        let vertices = vec![vertex!([0.0, 0.0, 0.0]).unwrap()];
         let result = DelaunayTriangulation::try_new(&vertices);
 
         assert!(result.is_err());
@@ -2843,12 +2838,9 @@ mod tests {
     #[test]
     fn test_vertex_uuids_2d_simplex() {
         // Test vertex_uuids with a 2D simplex (triangle)
-        let vertex1 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 1).unwrap();
-        let vertex2 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0], 2).unwrap();
-        let vertex3 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.5, 1.0], 3).unwrap();
+        let vertex1 = vertex!([0.0, 0.0]; data = 1).unwrap();
+        let vertex2 = vertex!([1.0, 0.0]; data = 2).unwrap();
+        let vertex3 = vertex!([0.5, 1.0]; data = 3).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3];
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, i32, (), 2> =
@@ -2881,16 +2873,11 @@ mod tests {
     fn test_vertex_uuids_4d_simplex() {
         // Test vertex_uuids with a 4D simplex (4-simplex) using integer data
         let vertices = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 1)
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0, 0.0], 2)
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0, 0.0], 3)
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0, 0.0], 4)
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 1.0], 5)
-                .unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]; data = 1).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]; data = 2).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]; data = 3).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]; data = 4).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]; data = 5).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, i32, (), 4> =
@@ -2945,10 +2932,7 @@ mod tests {
     // Keep 1D test separate as it's less common
     #[test]
     fn simplex_1d() {
-        let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex) = dt.simplices().next().unwrap();
         assert_simplex_properties(simplex, 2, 1);
@@ -2958,8 +2942,7 @@ mod tests {
     fn simplex_single_vertex() {
         // Test that creating a 3D triangulation with insufficient vertices fails validation
         // Tested through TDS, which is the user-facing API.
-        let vertices =
-            vec![crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap()];
+        let vertices = vec![vertex!([0.0, 0.0, 0.0]).unwrap()];
         let result = DelaunayTriangulation::try_new(&vertices);
 
         assert!(result.is_err());
@@ -2972,10 +2955,10 @@ mod tests {
     #[test]
     fn simplex_neighbors_none_by_default() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex) = dt.simplices().next().unwrap();
@@ -2987,10 +2970,10 @@ mod tests {
     #[test]
     fn simplex_data_none_by_default() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex) = dt.simplices().next().unwrap();
@@ -3001,10 +2984,10 @@ mod tests {
     #[test]
     fn simplex_data_can_be_set() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), i32, 3> =
             DelaunayTriangulation::try_with_kernel(&AdaptiveKernel::new(), &vertices).unwrap();
@@ -3026,11 +3009,11 @@ mod tests {
     #[test]
     fn simplex_into_hashmap_multiple() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -3061,9 +3044,9 @@ mod tests {
     #[test]
     fn simplex_try_into_hashmap_rejects_duplicate_uuid() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -3086,10 +3069,10 @@ mod tests {
         // Use a simple non-degenerate 3D tetrahedron so `DelaunayTriangulation::try_new` can construct
         // a valid simplex for debug-format testing.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), i32, 3> =
             DelaunayTriangulation::try_with_kernel(&AdaptiveKernel::new(), &vertices).unwrap();
@@ -3119,10 +3102,10 @@ mod tests {
         // Use a non-degenerate 3D tetrahedron so `DelaunayTriangulation::try_new` can construct a
         // valid initial simplex.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -3229,10 +3212,10 @@ mod tests {
 
         // Test 2: Serialization with Some(data) includes field
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), i32, 3> =
             DelaunayTriangulation::try_with_kernel(&AdaptiveKernel::new(), &vertices).unwrap();
@@ -3288,10 +3271,10 @@ mod tests {
 
         // Negative coordinates: fully in negative octant
         let negative_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([-1.0, -1.0, -1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([-2.0, -1.0, -1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([-1.0, -2.0, -1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([-1.0, -1.0, -2.0]).unwrap(),
+            vertex!([-1.0, -1.0, -1.0]).unwrap(),
+            vertex!([-2.0, -1.0, -1.0]).unwrap(),
+            vertex!([-1.0, -2.0, -1.0]).unwrap(),
+            vertex!([-1.0, -1.0, -2.0]).unwrap(),
         ];
         let dt_neg = DelaunayTriangulation::try_new(&negative_vertices).unwrap();
         let (_, simplex_neg) = dt_neg.tds().simplices().next().unwrap();
@@ -3300,10 +3283,10 @@ mod tests {
 
         // Large coordinates: large-magnitude coordinates
         let large_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1e6, 1e6, 1e6]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2e6, 1e6, 1e6]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e6, 2e6, 1e6]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e6, 1e6, 2e6]).unwrap(),
+            vertex!([1e6, 1e6, 1e6]).unwrap(),
+            vertex!([2e6, 1e6, 1e6]).unwrap(),
+            vertex!([1e6, 2e6, 1e6]).unwrap(),
+            vertex!([1e6, 1e6, 2e6]).unwrap(),
         ];
         let dt_large = DelaunayTriangulation::try_new(&large_vertices).unwrap();
         let (_, simplex_large) = dt_large.tds().simplices().next().unwrap();
@@ -3312,10 +3295,10 @@ mod tests {
 
         // Small coordinates: scaled-down tetrahedron without degeneracy
         let small_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-3, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e-3, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e-3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1e-3, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1e-3, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e-3]).unwrap(),
         ];
         let dt_small = DelaunayTriangulation::try_new(&small_vertices).unwrap();
         let (_, simplex_small) = dt_small.tds().simplices().next().unwrap();
@@ -3325,9 +3308,9 @@ mod tests {
 
     #[test]
     fn simplex_circumradius_2d() {
-        let vertex1 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap();
-        let vertex2 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap();
-        let vertex3 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap();
+        let vertex1 = vertex!([0.0, 0.0]).unwrap();
+        let vertex2 = vertex!([1.0, 0.0]).unwrap();
+        let vertex3 = vertex!([0.0, 1.0]).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3349,12 +3332,11 @@ mod tests {
 
     #[test]
     fn simplex_contains_vertex_false() {
-        let vertex1 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
-        let vertex2 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap();
-        let vertex3 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap();
-        let vertex4 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(); // 4th vertex to complete 3D simplex
-        let vertex_outside: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0, 2.0]).unwrap();
+        let vertex1 = vertex!([0.0, 0.0, 0.0]).unwrap();
+        let vertex2 = vertex!([1.0, 0.0, 0.0]).unwrap();
+        let vertex3 = vertex!([0.0, 1.0, 0.0]).unwrap();
+        let vertex4 = vertex!([0.0, 0.0, 1.0]).unwrap(); // 4th vertex to complete 3D simplex
+        let vertex_outside: Vertex<(), 3> = vertex!([2.0, 2.0, 2.0]).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3370,14 +3352,10 @@ mod tests {
     fn simplex_circumsphere_contains_vertex_determinant() {
         // Test the matrix determinant method for circumsphere containment
         // Use a simple, well-known case: unit tetrahedron
-        let vertex1 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1).unwrap();
-        let vertex2 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap();
-        let vertex3 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap();
-        let vertex4 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 2).unwrap();
+        let vertex1 = vertex!([0.0, 0.0, 0.0]; data = 1).unwrap();
+        let vertex2 = vertex!([1.0, 0.0, 0.0]; data = 1).unwrap();
+        let vertex3 = vertex!([0.0, 1.0, 0.0]; data = 1).unwrap();
+        let vertex4 = vertex!([0.0, 0.0, 1.0]; data = 2).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
         let dt: DelaunayTriangulation<AdaptiveKernel<f64>, i32, (), 3> =
@@ -3386,8 +3364,7 @@ mod tests {
         let simplex = &dt.tds().simplex(simplex_key).unwrap();
 
         // Test vertex clearly outside circumsphere
-        let vertex_far_outside: Vertex<i32, 3> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([10.0, 10.0, 10.0], 4).unwrap();
+        let vertex_far_outside: Vertex<i32, 3> = vertex!([10.0, 10.0, 10.0]; data = 4).unwrap();
         // Just check that the method runs without error for now
         let vertex_points: Vec<Point<3>> = simplex
             .vertices()
@@ -3398,8 +3375,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Test with origin (should be inside or on boundary)
-        let origin: Vertex<i32, 3> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 3).unwrap();
+        let origin: Vertex<i32, 3> = vertex!([0.0, 0.0, 0.0]; data = 3).unwrap();
         let vertex_points: Vec<Point<3>> = simplex
             .vertices()
             .iter()
@@ -3412,9 +3388,9 @@ mod tests {
     #[test]
     fn simplex_circumsphere_contains_vertex_2d() {
         // Test 2D case for circumsphere containment using determinant method
-        let vertex1 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap();
-        let vertex2 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap();
-        let vertex3 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap();
+        let vertex1 = vertex!([0.0, 0.0]).unwrap();
+        let vertex2 = vertex!([1.0, 0.0]).unwrap();
+        let vertex3 = vertex!([0.0, 1.0]).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3422,8 +3398,7 @@ mod tests {
         let simplex = &dt.tds().simplex(simplex_key).unwrap();
 
         // Test vertex far outside circumcircle
-        let vertex_far_outside: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([10.0, 10.0]).unwrap();
+        let vertex_far_outside: Vertex<(), 2> = vertex!([10.0, 10.0]).unwrap();
         let vertex_points: Vec<Point<2>> = simplex
             .vertices()
             .iter()
@@ -3433,8 +3408,7 @@ mod tests {
         assert!(result.is_ok());
 
         // Test with center of triangle (should be inside)
-        let center: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.33, 0.33]).unwrap();
+        let center: Vertex<(), 2> = vertex!([0.33, 0.33]).unwrap();
         let vertex_points: Vec<Point<2>> = simplex
             .vertices()
             .iter()
@@ -3447,10 +3421,10 @@ mod tests {
     #[test]
     fn simplex_circumradius_with_center() {
         // Test the circumradius_with_center method
-        let vertex1 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
-        let vertex2 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap();
-        let vertex3 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap();
-        let vertex4 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap();
+        let vertex1 = vertex!([0.0, 0.0, 0.0]).unwrap();
+        let vertex2 = vertex!([1.0, 0.0, 0.0]).unwrap();
+        let vertex3 = vertex!([0.0, 1.0, 0.0]).unwrap();
+        let vertex4 = vertex!([0.0, 0.0, 1.0]).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3475,10 +3449,10 @@ mod tests {
     #[test]
     fn simplex_facet_views_comprehensive() {
         // Test comprehensive facet view functionality
-        let vertex1 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
-        let vertex2 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap();
-        let vertex3 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap();
-        let vertex4 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap();
+        let vertex1 = vertex!([0.0, 0.0, 0.0]).unwrap();
+        let vertex2 = vertex!([1.0, 0.0, 0.0]).unwrap();
+        let vertex3 = vertex!([0.0, 1.0, 0.0]).unwrap();
+        let vertex4 = vertex!([0.0, 0.0, 1.0]).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3524,10 +3498,10 @@ mod tests {
     #[test]
     fn test_facet_vertex_uniqueness() {
         // Test that facet vertices are unique and don't include the opposite vertex
-        let vertex1 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap();
-        let vertex2 = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap();
-        let vertex3 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap();
-        let vertex4 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap();
+        let vertex1 = vertex!([0.0, 0.0, 1.0]).unwrap();
+        let vertex2 = vertex!([0.0, 1.0, 0.0]).unwrap();
+        let vertex3 = vertex!([1.0, 0.0, 0.0]).unwrap();
+        let vertex4 = vertex!([1.0, 1.0, 1.0]).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3573,18 +3547,12 @@ mod tests {
     #[test]
     fn simplex_high_dimensional() {
         // Test with higher dimensions (5D)
-        let vertex1 =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap();
-        let vertex2 =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap();
-        let vertex3 =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap();
-        let vertex4 =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap();
-        let vertex5 =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap();
-        let vertex6 =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap();
+        let vertex1 = vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap();
+        let vertex2 = vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap();
+        let vertex3 = vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap();
+        let vertex4 = vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap();
+        let vertex5 = vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap();
+        let vertex6 = vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap();
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4, vertex5, vertex6];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -3605,14 +3573,10 @@ mod tests {
     #[test]
     fn simplex_vertex_data_consistency() {
         // Test simplices with vertices that have different data types
-        let vertex1 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1).unwrap();
-        let vertex2 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 2).unwrap();
-        let vertex3 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 3).unwrap();
-        let vertex4 =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 4).unwrap(); // Need 4 vertices for 3D simplex
+        let vertex1 = vertex!([0.0, 0.0, 0.0]; data = 1).unwrap();
+        let vertex2 = vertex!([1.0, 0.0, 0.0]; data = 2).unwrap();
+        let vertex3 = vertex!([0.0, 1.0, 0.0]; data = 3).unwrap();
+        let vertex4 = vertex!([0.0, 0.0, 1.0]; data = 4).unwrap(); // Need 4 vertices for 3D simplex
 
         let vertices = vec![vertex1, vertex2, vertex3, vertex4];
         let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, i32, u32, 3> =
@@ -3674,10 +3638,10 @@ mod tests {
 
         // Valid 3D simplex with correct vertex count (D+1 = 4)
         let vertices_3d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices_3d).unwrap();
         let (_, simplex_3d) = dt.simplices().next().unwrap();
@@ -3688,9 +3652,9 @@ mod tests {
 
         // Valid 2D simplex with correct vertex count (D+1 = 3)
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices_2d).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -3723,10 +3687,10 @@ mod tests {
 
         // Invalid UUID (nil)
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -3742,8 +3706,8 @@ mod tests {
 
         // Insufficient vertices (TDS construction fails)
         let insufficient_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
         ];
         let result = DelaunayTriangulation::try_new(&insufficient_vertices);
         assert!(
@@ -3753,9 +3717,9 @@ mod tests {
 
         // Invalid neighbors length (too few)
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices_2d).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -3795,10 +3759,10 @@ mod tests {
     #[test]
     fn simplex_new_rejects_insufficient_and_duplicate_vertices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let vkeys: Vec<_> = dt.tds().vertices().map(|(k, _)| k).collect();
@@ -3825,10 +3789,10 @@ mod tests {
     #[test]
     fn simplex_is_valid_rejects_insufficient_and_duplicate_vertices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -3853,9 +3817,9 @@ mod tests {
     #[test]
     fn simplex_ensure_neighbors_buffer_mut_initializes_and_reuses() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (simplex_key, simplex_ref) = dt.simplices().next().unwrap();
@@ -3877,9 +3841,9 @@ mod tests {
     #[test]
     fn simplex_try_ensure_neighbors_buffer_mut_rejects_malformed_existing_buffer() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -3901,9 +3865,9 @@ mod tests {
     #[test]
     fn simplex_neighbor_views_distinguish_unassigned_boundary_and_neighbor_slots() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (simplex_key, simplex_ref) = dt.simplices().next().unwrap();
@@ -3935,9 +3899,9 @@ mod tests {
     #[test]
     fn simplex_validation_rejects_unassigned_slot_inside_assigned_neighbors() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -3955,9 +3919,9 @@ mod tests {
     #[test]
     fn simplex_swap_vertex_slots_swaps_vertices_neighbors_and_offsets() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (simplex_key, simplex_ref) = dt.simplices().next().unwrap();
@@ -3991,9 +3955,9 @@ mod tests {
     #[should_panic(expected = "neighbors index out of bounds")]
     fn simplex_swap_vertex_slots_panics_when_neighbors_shorter_than_vertices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let (_, simplex_ref) = dt.simplices().next().unwrap();
@@ -4008,10 +3972,10 @@ mod tests {
     #[test]
     fn simplex_facet_view_helpers_reject_excessive_vertex_count() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let simplex_key = dt.tds().simplex_keys().next().unwrap();
@@ -4109,9 +4073,9 @@ mod tests {
     fn test_simplex_partial_eq_different_dimensions() {
         // Test equality for simplices of different dimensions
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt1 = DelaunayTriangulation::try_new(&vertices_2d).unwrap();
         let (_, simplex_2d) = dt1.tds().simplices().next().unwrap();
@@ -4129,10 +4093,10 @@ mod tests {
     fn test_try_simplex_facets() {
         // Test the owner-bound simplex facet iterator.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -4196,9 +4160,9 @@ mod tests {
     #[test]
     fn test_simplex_data_accessor() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<i32>()

--- a/src/core/tds/equality.rs
+++ b/src/core/tds/equality.rs
@@ -203,10 +203,12 @@ impl<U, V, const D: usize> PartialEq for Tds<U, V, D> {
 
 #[cfg(test)]
 mod tests {
+    use super::compare_coords;
     use crate::DelaunayTriangulation;
     use crate::core::collections::PeriodicOffsetBuffer;
     use crate::core::tds::VertexKey;
     use crate::core::vertex::Vertex;
+    use crate::vertex;
     use slotmap::KeyData;
     use std::cmp::Ordering as CmpOrdering;
 
@@ -217,25 +219,25 @@ mod tests {
     #[test]
     fn compare_coords_uses_total_coordinate_ordering() {
         assert_eq!(
-            super::compare_coords(&[f64::NAN, 1.0], &[0.0, 1.0]),
+            compare_coords(&[f64::NAN, 1.0], &[0.0, 1.0]),
             CmpOrdering::Greater
         );
     }
 
     fn standard_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
         let mut vertices = Vec::with_capacity(D + 1);
-        vertices.push(Vertex::<(), _>::try_new([0.0; D]).unwrap());
+        vertices.push(vertex!([0.0; D]).unwrap());
         for axis in 0..D {
             let mut coords = [0.0; D];
             coords[axis] = 1.0;
-            vertices.push(Vertex::<(), _>::try_new(coords).unwrap());
+            vertices.push(vertex!(coords).unwrap());
         }
         vertices
     }
 
     fn standard_vertices_with_extra<const D: usize>() -> Vec<Vertex<(), D>> {
         let mut vertices = standard_vertices::<D>();
-        vertices.push(Vertex::<(), _>::try_new([0.1; D]).unwrap());
+        vertices.push(vertex!([0.1; D]).unwrap());
         vertices
     }
 
@@ -305,14 +307,14 @@ mod tests {
     #[test]
     fn test_tds_partial_eq_different_structures_not_equal() {
         let verts_a = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let verts_b = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 2.0]).unwrap(),
         ];
         let dt_a: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&verts_a).unwrap();

--- a/src/core/tds/incidence.rs
+++ b/src/core/tds/incidence.rs
@@ -23,7 +23,7 @@ pub(crate) struct VertexIncidenceIndex {
 /// buffer exactly. This record stores the removed simplex and the per-vertex
 /// positions needed to undo [`VertexIncidenceIndex::remove_simplex`].
 #[derive(Clone, Debug)]
-pub(in crate::core::tds) struct SimplexIncidenceRemoval {
+pub(super) struct SimplexIncidenceRemoval {
     simplex_key: SimplexKey,
     removed_vertices: SmallBuffer<RemovedVertexIncidence, MAX_PRACTICAL_DIMENSION_SIZE>,
 }
@@ -41,7 +41,7 @@ struct RemovedVertexIncidence {
 impl VertexIncidenceIndex {
     /// Creates an empty incidence index with capacity for `vertex_capacity` vertices.
     #[must_use]
-    pub(in crate::core::tds) fn with_vertex_capacity(vertex_capacity: usize) -> Self {
+    pub(super) fn with_vertex_capacity(vertex_capacity: usize) -> Self {
         Self {
             map: fast_hash_map_with_capacity(vertex_capacity),
         }
@@ -109,10 +109,7 @@ impl VertexIncidenceIndex {
     ///
     /// Returns [`TdsError::InconsistentDataStructure`] if the vertex already has
     /// an incidence entry.
-    pub(in crate::core::tds) fn insert_vertex(
-        &mut self,
-        vertex_key: VertexKey,
-    ) -> Result<(), TdsError> {
+    pub(super) fn insert_vertex(&mut self, vertex_key: VertexKey) -> Result<(), TdsError> {
         if self.map.contains_key(&vertex_key) {
             return Err(TdsError::InconsistentDataStructure {
                 message: format!(
@@ -135,10 +132,7 @@ impl VertexIncidenceIndex {
     /// Returns [`TdsError::VertexNotFound`] if the vertex has no index entry, or
     /// [`TdsError::InconsistentDataStructure`] if the vertex still has incident
     /// simplices.
-    pub(in crate::core::tds) fn remove_isolated_vertex(
-        &mut self,
-        vertex_key: VertexKey,
-    ) -> Result<(), TdsError> {
+    pub(super) fn remove_isolated_vertex(&mut self, vertex_key: VertexKey) -> Result<(), TdsError> {
         let Some(incident_simplices) = self.map.get(&vertex_key) else {
             return Err(TdsError::VertexNotFound {
                 vertex_key,
@@ -166,7 +160,7 @@ impl VertexIncidenceIndex {
     /// Returns a typed error if a vertex is missing from the index, if
     /// `vertices` contains duplicate vertex keys, or if this simplex is already
     /// recorded for any listed vertex.
-    pub(in crate::core::tds) fn insert_simplex(
+    pub(super) fn insert_simplex(
         &mut self,
         simplex_key: SimplexKey,
         vertices: &[VertexKey],
@@ -218,7 +212,7 @@ impl VertexIncidenceIndex {
     /// currently recorded for any listed vertex. If an error occurs after some
     /// vertex incidence entries have been removed, those entries are rolled back
     /// before the error is returned.
-    pub(in crate::core::tds) fn remove_simplex(
+    pub(super) fn remove_simplex(
         &mut self,
         simplex_key: SimplexKey,
         vertices: &[VertexKey],
@@ -310,10 +304,7 @@ impl VertexIncidenceIndex {
     /// restored to its state before the corresponding removal. `Tds` batch
     /// mutation uses this to keep failed removals from perturbing later
     /// adjacency queries or diagnostics.
-    pub(in crate::core::tds) fn rollback_removed_simplex(
-        &mut self,
-        removal: &SimplexIncidenceRemoval,
-    ) {
+    pub(super) fn rollback_removed_simplex(&mut self, removal: &SimplexIncidenceRemoval) {
         for removed_vertex in removal.removed_vertices.iter().rev() {
             if let Some(incident_simplices) = self.map.get_mut(&removed_vertex.vertex_key) {
                 if removed_vertex.position < incident_simplices.len() {
@@ -328,7 +319,7 @@ impl VertexIncidenceIndex {
     }
 
     #[cfg(test)]
-    pub(in crate::core::tds) fn clear_vertex_for_test(&mut self, vertex_key: VertexKey) {
+    pub(super) fn clear_vertex_for_test(&mut self, vertex_key: VertexKey) {
         if let Some(incident_simplices) = self.map.get_mut(&vertex_key) {
             incident_simplices.clear();
         }

--- a/src/core/tds/mutation.rs
+++ b/src/core/tds/mutation.rs
@@ -13,6 +13,8 @@ use crate::core::collections::{
 };
 use crate::core::simplex::{NeighborSlot, Simplex};
 use crate::core::vertex::Vertex;
+#[cfg(test)]
+use crate::deletion::DeleteVertexError;
 use std::collections::VecDeque;
 use std::sync::{
     Arc,
@@ -2186,6 +2188,7 @@ mod tests {
     use crate::core::simplex::Simplex;
     use crate::core::tds::errors::TriangulationConstructionState;
     use crate::geometry::point::Point;
+    use crate::vertex;
     use slotmap::KeyData;
     use std::assert_matches;
     use uuid::Uuid;
@@ -2204,10 +2207,10 @@ mod tests {
 
     fn initial_simplex_vertices_3d() -> [Vertex<(), 3>; 4] {
         [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]
     }
 
@@ -2220,8 +2223,8 @@ mod tests {
         let initial_vertices = initial_simplex_vertices_3d();
         let mut dt = DelaunayTriangulation::try_new(&initial_vertices).unwrap();
 
-        let vertex = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
-        let duplicate = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex = vertex!([1.0, 2.0, 3.0]).unwrap();
+        let duplicate = vertex!([1.0, 2.0, 3.0]).unwrap();
         dt.insert_vertex(vertex).unwrap();
 
         // Same coordinates again (distinct UUID, constructed via Vertex smart constructors)
@@ -2238,7 +2241,7 @@ mod tests {
         let initial_vertices = initial_simplex_vertices_3d();
         let mut dt = DelaunayTriangulation::try_new(&initial_vertices).unwrap();
 
-        let vertex1 = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex1 = vertex!([1.0, 2.0, 3.0]).unwrap();
         let uuid1 = vertex1.uuid();
         dt.insert_vertex(vertex1).unwrap();
 
@@ -2264,7 +2267,7 @@ mod tests {
         let mut dt = DelaunayTriangulation::try_new(&initial_vertices).unwrap();
         let initial_simplex_count = dt.number_of_simplices();
 
-        let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap();
+        let new_vertex = vertex!([0.5, 0.5, 0.5]).unwrap();
         dt.insert_vertex(new_vertex).unwrap();
 
         assert_eq!(dt.number_of_vertices(), 5);
@@ -2283,7 +2286,7 @@ mod tests {
         let initial_vertices = initial_simplex_vertices_3d();
         let mut dt = DelaunayTriangulation::try_new(&initial_vertices).unwrap();
 
-        let vertex = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex = vertex!([1.0, 2.0, 3.0]).unwrap();
         let uuid = vertex.uuid();
         dt.insert_vertex(vertex).unwrap();
         assert_eq!(dt.number_of_vertices(), 5);
@@ -2321,10 +2324,10 @@ mod tests {
         // Test that remove_vertex properly clears dangling neighbor references
         // Create a triangulation with multiple simplices
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.5, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 1.0]).unwrap(),
+            vertex!([1.5, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -2391,9 +2394,9 @@ mod tests {
     #[test]
     fn test_delete_vertex_rejects_nonexistent_vertex_key() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -2407,7 +2410,7 @@ mod tests {
 
         assert_matches!(
             err,
-            crate::DeleteVertexError::VertexNotFound { vertex_key }
+            DeleteVertexError::VertexNotFound { vertex_key }
                 if vertex_key == nonexistent_key
         );
         assert_eq!(
@@ -2425,10 +2428,10 @@ mod tests {
     #[test]
     fn test_delete_vertex_rejects_stale_vertex_key() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2444,7 +2447,7 @@ mod tests {
         let err = dt.delete_vertex(vertex_key).unwrap_err();
         assert_matches!(
             err,
-            crate::DeleteVertexError::VertexNotFound { vertex_key: stale_key }
+            DeleteVertexError::VertexNotFound { vertex_key: stale_key }
                 if stale_key == vertex_key
         );
         assert_eq!(dt.number_of_vertices(), vertices_after);
@@ -2458,10 +2461,10 @@ mod tests {
         // 2D test
         {
             let vertices_2d = [
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+                vertex!([0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0]).unwrap(),
+                vertex!([0.0, 1.0]).unwrap(),
+                vertex!([1.0, 1.0]).unwrap(),
             ];
             let mut dt_2d: DelaunayTriangulation<_, (), (), 2> =
                 DelaunayTriangulation::try_new(&vertices_2d).unwrap();
@@ -2474,11 +2477,11 @@ mod tests {
         // 3D test
         {
             let vertices_3d = [
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2]).unwrap(),
+                vertex!([0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 1.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 1.0]).unwrap(),
+                vertex!([0.2, 0.2, 0.2]).unwrap(),
             ];
             let mut dt_3d: DelaunayTriangulation<_, (), (), 3> =
                 DelaunayTriangulation::try_new(&vertices_3d).unwrap();
@@ -2501,12 +2504,12 @@ mod tests {
         // 4D test
         {
             let vertices_4d = [
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+                vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
             ];
             let mut dt_4d: DelaunayTriangulation<_, (), (), 4> =
                 DelaunayTriangulation::try_new(&vertices_4d).unwrap();
@@ -2535,12 +2538,12 @@ mod tests {
         // 3. All remaining incident_simplex pointers are valid
 
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
             // Interior vertex to remove; offset from circumcenter to avoid degenerate configuration
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2]).unwrap(),
+            vertex!([0.2, 0.2, 0.2]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2628,19 +2631,13 @@ mod tests {
     fn test_assign_neighbors_errors_on_missing_vertex_key() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -2662,29 +2659,19 @@ mod tests {
         // Three triangles sharing the same edge (v_a,v_b) is non-manifold in 2D.
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -2716,39 +2703,25 @@ mod tests {
     fn test_remove_simplices_by_keys_rolls_back_incidence_order_exactly_on_batch_failure() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let shared_vertex = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let kept_vertex_1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let kept_vertex_2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let first_removed_vertex_1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 0.0]).unwrap())
             .unwrap();
         let first_removed_vertex_2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 1.0]).unwrap())
             .unwrap();
         let corrupted_vertex = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, 0.0]).unwrap())
             .unwrap();
         let second_removed_vertex = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, 1.0]).unwrap())
             .unwrap();
 
         let kept = tds
@@ -2806,24 +2779,16 @@ mod tests {
         // Two triangles sharing an edge.
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1 = tds
@@ -2862,24 +2827,16 @@ mod tests {
     fn test_remove_simplices_by_keys_errors_before_mutation_on_stale_incidence() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let stale = tds
@@ -2915,24 +2872,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1 = tds
@@ -3005,9 +2954,7 @@ mod tests {
     fn test_remove_isolated_vertex_uses_canonical_incidence_not_stale_hint() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let vk = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
 
         // Manually set a stale incident-simplex hint. Canonical isolation is
@@ -3028,9 +2975,7 @@ mod tests {
     fn test_remove_isolated_vertex_removes_truly_isolated() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let vk = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 2.0]).unwrap())
             .unwrap();
         let uuid = tds.vertex(vk).unwrap().uuid();
 
@@ -3056,24 +3001,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let origin_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let east_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let north_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let diagonal_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1 = tds
@@ -3146,29 +3083,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
 
         let simplex1 = tds
@@ -3207,24 +3134,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1 = tds
@@ -3257,24 +3176,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1 = tds
@@ -3319,10 +3230,8 @@ mod tests {
                         }
                     }
                     vertex_keys.push(
-                        tds.insert_vertex_with_mapping(
-                            crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap(),
-                        )
-                        .unwrap(),
+                        tds.insert_vertex_with_mapping(vertex!(coords).unwrap())
+                            .unwrap(),
                     );
                 }
 
@@ -3373,9 +3282,7 @@ mod tests {
     fn test_assign_incident_simplices_clears_incident_simplex_when_no_simplices() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let vkey = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
 
         // Corrupt incident_simplex and ensure it gets cleared.
@@ -3396,24 +3303,16 @@ mod tests {
     fn test_normalize_coherent_orientation_produces_coherent_result() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         // Two triangles sharing edge v1-v2, with deliberately inconsistent vertex order
@@ -3447,19 +3346,13 @@ mod tests {
     fn test_remove_duplicate_simplices_removes_exact_duplicates() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         // Insert the same simplex twice
@@ -3498,29 +3391,19 @@ mod tests {
     fn test_remove_duplicate_simplices_rolls_back_when_rebuild_fails() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, -0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, -0.5]).unwrap())
             .unwrap();
 
         // Three distinct triangles share edge v0-v1, so global neighbor
@@ -3559,11 +3442,11 @@ mod tests {
     fn test_clear_all_neighbors_and_rebuild() {
         // Use 5 vertices so there are multiple simplices with actual neighbor pointers
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let mut tds = dt.tds().clone();
@@ -3593,19 +3476,13 @@ mod tests {
     fn test_insert_simplex_with_mapping_registers_uuid_mapping() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex = Simplex::try_new_with_data(vec![v0, v1, v2], None).unwrap();
@@ -3621,14 +3498,10 @@ mod tests {
     fn test_insert_simplex_with_mapping_rejects_missing_vertex() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         // Use a stale key that doesn't exist in the TDS.
         let stale = VertexKey::from(KeyData::from_ffi(0xDEAD));
@@ -3645,14 +3518,10 @@ mod tests {
     fn test_insert_simplex_with_mapping_trusted_vertices_rejects_missing_vertex() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let stale = VertexKey::from(KeyData::from_ffi(0xDEAD));
 
@@ -3670,19 +3539,13 @@ mod tests {
     fn test_insert_simplex_with_mapping_rejects_duplicate_uuid() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_a = Simplex::try_new_with_data(vec![v0, v1, v2], None).unwrap();
@@ -3699,19 +3562,13 @@ mod tests {
     fn test_insert_simplex_rejects_candidate_periodic_offset_count_mismatch() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let mut candidate = Simplex::try_new_with_data(vec![v0, v1, v2], None).unwrap();
@@ -3738,24 +3595,16 @@ mod tests {
     fn test_insert_simplex_propagates_existing_periodic_facet_key_error() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let existing = tds
@@ -3789,19 +3638,13 @@ mod tests {
     fn test_insert_simplex_with_mapping_rejects_duplicate_simplex_without_mutation() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -3827,29 +3670,19 @@ mod tests {
     fn test_insert_simplex_with_mapping_rejects_third_incident_facet_without_mutation() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -3893,29 +3726,19 @@ mod tests {
     fn test_removed_simplices_do_not_block_future_simplex_insertions() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, -1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let removed = tds
@@ -3949,11 +3772,11 @@ mod tests {
     #[test]
     fn test_remove_simplices_by_keys_batch_repairs_incidence_and_neighbors() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let mut tds = dt.tds().clone();
@@ -3992,19 +3815,13 @@ mod tests {
     fn test_assign_incident_simplices_errors_on_dangling_vertex_key() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let _ck = tds
@@ -4039,11 +3856,11 @@ mod tests {
     #[test]
     fn test_normalize_coherent_orientation_multi_simplex() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let mut tds = dt.tds().clone();
@@ -4068,19 +3885,13 @@ mod tests {
     fn test_remove_simplices_by_keys_deduplicates_request_keys() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex = tds
             .insert_simplex_with_mapping(
@@ -4101,24 +3912,16 @@ mod tests {
     fn test_remove_simplices_by_keys_repairs_local_topology() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let removed_key = tds
@@ -4185,9 +3988,9 @@ mod tests {
     #[test]
     fn test_set_vertex_data_replaces_existing() {
         let vertices: [Vertex<i32, 2>; 3] = [
-            Vertex::<_, _>::try_new_with_data([0.0, 0.0], 10i32).unwrap(),
-            Vertex::<_, _>::try_new_with_data([1.0, 0.0], 20).unwrap(),
-            Vertex::<_, _>::try_new_with_data([0.0, 1.0], 30).unwrap(),
+            vertex!([0.0, 0.0]; data = 10i32).unwrap(),
+            vertex!([1.0, 0.0]; data = 20).unwrap(),
+            vertex!([0.0, 1.0]; data = 30).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -4204,9 +4007,9 @@ mod tests {
     fn test_set_vertex_data_on_no_data_vertex() {
         // Vertices without data have U = (), so set_vertex_data sets ().
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let mut tds = dt.tds().clone();
@@ -4229,9 +4032,9 @@ mod tests {
     #[test]
     fn test_set_simplex_data_on_empty_simplex() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<i32>()
@@ -4247,9 +4050,9 @@ mod tests {
     #[test]
     fn test_set_simplex_data_replaces_existing() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<i32>()
@@ -4274,9 +4077,9 @@ mod tests {
     #[test]
     fn test_set_vertex_data_preserves_triangulation_validity() {
         let vertices: [Vertex<i32, 2>; 3] = [
-            Vertex::<_, _>::try_new_with_data([0.0, 0.0], 1i32).unwrap(),
-            Vertex::<_, _>::try_new_with_data([1.0, 0.0], 2).unwrap(),
-            Vertex::<_, _>::try_new_with_data([0.0, 1.0], 3).unwrap(),
+            vertex!([0.0, 0.0]; data = 1i32).unwrap(),
+            vertex!([1.0, 0.0]; data = 2).unwrap(),
+            vertex!([0.0, 1.0]; data = 3).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -4301,10 +4104,10 @@ mod tests {
     #[test]
     fn test_set_simplex_data_preserves_triangulation_validity() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 1.0]).unwrap(),
+            vertex!([1.5, 0.5]).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<i32>()
@@ -4330,9 +4133,9 @@ mod tests {
     #[test]
     fn test_set_vertex_data_via_delaunay_wrapper() {
         let vertices: [Vertex<i32, 2>; 3] = [
-            Vertex::<_, _>::try_new_with_data([0.0, 0.0], 10i32).unwrap(),
-            Vertex::<_, _>::try_new_with_data([1.0, 0.0], 20).unwrap(),
-            Vertex::<_, _>::try_new_with_data([0.0, 1.0], 30).unwrap(),
+            vertex!([0.0, 0.0]; data = 10i32).unwrap(),
+            vertex!([1.0, 0.0]; data = 20).unwrap(),
+            vertex!([0.0, 1.0]; data = 30).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -4353,9 +4156,9 @@ mod tests {
     #[test]
     fn test_set_vertex_data_via_delaunay_wrapper_invalid_key_returns_error() {
         let vertices: [Vertex<i32, 2>; 3] = [
-            Vertex::<_, _>::try_new_with_data([0.0, 0.0], 10i32).unwrap(),
-            Vertex::<_, _>::try_new_with_data([1.0, 0.0], 20).unwrap(),
-            Vertex::<_, _>::try_new_with_data([0.0, 1.0], 30).unwrap(),
+            vertex!([0.0, 0.0]; data = 10i32).unwrap(),
+            vertex!([1.0, 0.0]; data = 20).unwrap(),
+            vertex!([0.0, 1.0]; data = 30).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -4378,9 +4181,9 @@ mod tests {
     #[test]
     fn test_set_simplex_data_via_delaunay_wrapper() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<i32>()
@@ -4401,9 +4204,9 @@ mod tests {
     #[test]
     fn test_set_simplex_data_via_delaunay_wrapper_invalid_key_returns_error() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<i32>()
@@ -4426,16 +4229,16 @@ mod tests {
     #[test]
     fn test_set_data_via_dt_does_not_invalidate_locate_hint() {
         let vertices: [Vertex<i32, 2>; 3] = [
-            Vertex::<_, _>::try_new_with_data([0.0, 0.0], 0i32).unwrap(),
-            Vertex::<_, _>::try_new_with_data([1.0, 0.0], 0).unwrap(),
-            Vertex::<_, _>::try_new_with_data([0.0, 1.0], 0).unwrap(),
+            vertex!([0.0, 0.0]; data = 0i32).unwrap(),
+            vertex!([1.0, 0.0]; data = 0).unwrap(),
+            vertex!([0.0, 1.0]; data = 0).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
             .unwrap();
 
         // Insert a new vertex so the locate hint is populated.
-        let extra = Vertex::<_, _>::try_new_with_data([0.25, 0.25], 0i32).unwrap();
+        let extra = vertex!([0.25, 0.25]; data = 0i32).unwrap();
         dt.insert_vertex(extra).unwrap();
 
         // Data mutation should NOT clear the insertion hint.
@@ -4449,7 +4252,7 @@ mod tests {
         );
 
         // A subsequent insert should still succeed (hint not invalidated).
-        let another = Vertex::<_, _>::try_new_with_data([0.75, 0.1], 0i32).unwrap();
+        let another = vertex!([0.75, 0.1]; data = 0i32).unwrap();
         assert!(dt.insert_vertex(another).is_ok());
         assert!(dt.validate().is_ok());
     }

--- a/src/core/tds/snapshot.rs
+++ b/src/core/tds/snapshot.rs
@@ -1221,28 +1221,29 @@ mod tests {
     use crate::core::tds::TriangulationConstructionState;
     use crate::core::vertex::Vertex;
     use crate::geometry::point::Point;
+    use crate::vertex;
     use slotmap::KeyData;
     use std::assert_matches;
 
     fn initial_simplex_vertices_3d() -> [Vertex<(), 3>; 4] {
         [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]
     }
 
     fn periodic_offset_tds_2d() -> (Tds<(), (), 2>, Uuid, Vec<[i8; 2]>) {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let offsets = vec![[0_i8, 0_i8], [1_i8, 0_i8], [0_i8, 1_i8]];
         let mut simplex = Simplex::try_new_with_data(vec![v0, v1, v2], None).unwrap();
@@ -1363,11 +1364,11 @@ mod tests {
     #[test]
     fn test_tds_snapshot_serialization_includes_stable_uuid_relationships() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let original = dt.tds().clone();
@@ -1637,11 +1638,11 @@ mod tests {
     #[test]
     fn test_tds_snapshot_serde_round_trip_multi_simplex_triangulation() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let original = dt.tds().clone();
@@ -1659,10 +1660,10 @@ mod tests {
     #[test]
     fn test_tds_snapshot_serde_round_trip_2d() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1939,11 +1940,11 @@ mod tests {
     #[test]
     fn test_tds_snapshot_deserialize_rejects_duplicate_simplex_vertex_uuid_sets() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let original = dt.tds().clone();
@@ -1982,13 +1983,13 @@ mod tests {
     fn test_tds_snapshot_round_trips_vertex_and_simplex_payload_data() {
         let mut tds: Tds<i32, i32, 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<_, _>::try_new_with_data([0.0, 0.0], 10).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]; data = 10).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<_, _>::try_new_with_data([1.0, 0.0], 20).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]; data = 20).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<_, _>::try_new_with_data([0.0, 1.0], 30).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]; data = 30).unwrap())
             .unwrap();
         let simplex = Simplex::try_new_with_data(vec![v0, v1, v2], Some(99)).unwrap();
 
@@ -2021,34 +2022,25 @@ mod tests {
         let mut tds: Tds<NonCopyPayload, NonCopyPayload, 2> = Tds::empty();
         let v0 = tds
             .insert_vertex_with_mapping(
-                Vertex::<_, _>::try_new_with_data(
-                    [0.0, 0.0],
-                    NonCopyPayload {
-                        label: "v0".to_owned(),
-                    },
-                )
+                vertex!([0.0, 0.0]; data = NonCopyPayload {
+                    label: "v0".to_owned(),
+                })
                 .unwrap(),
             )
             .unwrap();
         let v1 = tds
             .insert_vertex_with_mapping(
-                Vertex::<_, _>::try_new_with_data(
-                    [1.0, 0.0],
-                    NonCopyPayload {
-                        label: "v1".to_owned(),
-                    },
-                )
+                vertex!([1.0, 0.0]; data = NonCopyPayload {
+                    label: "v1".to_owned(),
+                })
                 .unwrap(),
             )
             .unwrap();
         let v2 = tds
             .insert_vertex_with_mapping(
-                Vertex::<_, _>::try_new_with_data(
-                    [0.0, 1.0],
-                    NonCopyPayload {
-                        label: "v2".to_owned(),
-                    },
-                )
+                vertex!([0.0, 1.0]; data = NonCopyPayload {
+                    label: "v2".to_owned(),
+                })
                 .unwrap(),
             )
             .unwrap();
@@ -2279,11 +2271,11 @@ mod tests {
     #[test]
     fn test_tds_snapshot_error_preserves_dangling_neighbor_uuid_reference() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let mut snapshot = raw_snapshot_from_tds(dt.tds());
@@ -2371,11 +2363,11 @@ mod tests {
     #[test]
     fn test_tds_snapshot_error_preserves_inconsistent_neighbor_connectivity() {
         let vertices = [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let mut snapshot = raw_snapshot_from_tds(dt.tds());

--- a/src/core/tds/storage.rs
+++ b/src/core/tds/storage.rs
@@ -433,10 +433,10 @@ use uuid::Uuid;
 /// ```
 pub struct Tds<U, V, const D: usize> {
     /// Storage map for vertices, allowing stable keys and efficient access.
-    pub(in crate::core::tds) vertices: StorageMap<VertexKey, Vertex<U, D>>,
+    pub(super) vertices: StorageMap<VertexKey, Vertex<U, D>>,
 
     /// Storage map for simplices, providing stable keys and efficient access.
-    pub(in crate::core::tds) simplices: StorageMap<SimplexKey, Simplex<V, D>>,
+    pub(super) simplices: StorageMap<SimplexKey, Simplex<V, D>>,
 
     /// Fast mapping from Vertex UUIDs to their `VertexKeys` for efficient UUID → Key lookups.
     /// This optimizes the common operation of looking up vertex keys by UUID.
@@ -466,7 +466,7 @@ pub struct Tds<U, V, const D: usize> {
     /// entries.
     ///
     /// Note: Not serialized - reconstructed during deserialization from simplices.
-    pub(in crate::core::tds) vertex_to_simplices: VertexIncidenceIndex,
+    pub(super) vertex_to_simplices: VertexIncidenceIndex,
 
     /// The current construction state of the triangulation.
     /// This field tracks whether the triangulation has enough vertices to form a complete
@@ -482,7 +482,7 @@ pub struct Tds<U, V, const D: usize> {
     /// Uses `Arc<AtomicU64>` for thread-safe operations in concurrent contexts while allowing Clone.
     ///
     /// Note: Not serialized - generation is runtime-only.
-    pub(in crate::core::tds) generation: Arc<AtomicU64>,
+    pub(super) generation: Arc<AtomicU64>,
 
     /// Runtime identity for cache/handle provenance checks.
     ///
@@ -491,7 +491,7 @@ pub struct Tds<U, V, const D: usize> {
     /// storage by generation alone.
     ///
     /// Note: Not serialized - identity is runtime-only.
-    pub(in crate::core::tds) identity: Arc<Uuid>,
+    pub(super) identity: Arc<Uuid>,
 }
 
 impl<U, V, const D: usize> Clone for Tds<U, V, D>
@@ -571,7 +571,7 @@ where
 //
 impl<U, V, const D: usize> Tds<U, V, D> {
     #[inline]
-    pub(in crate::core::tds) fn allows_periodic_self_neighbor(simplex: &Simplex<V, D>) -> bool {
+    pub(super) fn allows_periodic_self_neighbor(simplex: &Simplex<V, D>) -> bool {
         let Some(offsets) = simplex.periodic_vertex_offsets() else {
             return false;
         };
@@ -626,7 +626,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         )
     }
 
-    pub(in crate::core::tds) fn build_periodic_vertex_uuid_offsets(
+    pub(super) fn build_periodic_vertex_uuid_offsets(
         &self,
         simplex_key: SimplexKey,
         vertices: &[VertexKey],
@@ -669,7 +669,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         Ok(vertex_uuid_offsets)
     }
 
-    pub(in crate::core::tds) fn lifted_vertex_identities(
+    pub(super) fn lifted_vertex_identities(
         simplex_key: SimplexKey,
         simplex: &Simplex<V, D>,
     ) -> Result<SmallBuffer<(VertexKey, [i8; D]), MAX_PRACTICAL_DIMENSION_SIZE>, TdsError> {
@@ -697,7 +697,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         Ok(lifted_vertices)
     }
 
-    pub(in crate::core::tds) fn matching_lifted_facet_index(
+    pub(super) fn matching_lifted_facet_index(
         simplex: &Simplex<V, D>,
         neighbor: &Simplex<V, D>,
     ) -> Result<Option<usize>, TdsError> {
@@ -726,7 +726,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     }
 
     /// Finds the neighbor facet that matches a source facet in lifted periodic coordinates.
-    pub(in crate::core::tds) fn matching_lifted_mirror_facet_index(
+    pub(super) fn matching_lifted_mirror_facet_index(
         simplex: &Simplex<V, D>,
         facet_idx: usize,
         neighbor: &Simplex<V, D>,
@@ -1335,7 +1335,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
 
     /// Refreshes the derived vertex count carried by an incomplete construction state.
     #[inline]
-    pub(in crate::core::tds) fn refresh_incomplete_construction_state(&mut self) {
+    pub(super) fn refresh_incomplete_construction_state(&mut self) {
         if matches!(
             self.construction_state,
             TriangulationConstructionState::Incomplete(_)
@@ -1524,7 +1524,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     ///
     /// This method is thread-safe due to the use of `Arc<AtomicU64>`.
     #[inline]
-    pub(in crate::core::tds) fn bump_generation(&self) {
+    pub(super) fn bump_generation(&self) {
         // Relaxed is fine for an invalidation counter
         self.generation.fetch_add(1, Ordering::Relaxed);
     }
@@ -2225,7 +2225,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
 
     /// Registers an isolated vertex in the maintained vertex-to-simplices index.
     #[inline]
-    pub(in crate::core::tds) fn insert_empty_vertex_incidence(
+    pub(super) fn insert_empty_vertex_incidence(
         &mut self,
         vertex_key: VertexKey,
     ) -> Result<(), TdsError> {
@@ -2234,7 +2234,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
 
     /// Removes a vertex from the maintained vertex-to-simplices index.
     #[inline]
-    pub(in crate::core::tds) fn remove_vertex_incidence(
+    pub(super) fn remove_vertex_incidence(
         &mut self,
         vertex_key: VertexKey,
     ) -> Result<(), TdsError> {
@@ -2242,7 +2242,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     }
 
     /// Registers a simplex under each of its vertices in the maintained incidence index.
-    pub(in crate::core::tds) fn add_simplex_to_vertex_incidence(
+    pub(super) fn add_simplex_to_vertex_incidence(
         &mut self,
         simplex_key: SimplexKey,
         vertices: &[VertexKey],
@@ -2256,9 +2256,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     /// # Errors
     ///
     /// Returns [`TdsError::VertexNotFound`] if a simplex references a missing vertex key.
-    pub(in crate::core::tds) fn rebuild_vertex_to_simplices_index(
-        &mut self,
-    ) -> Result<(), TdsError> {
+    pub(super) fn rebuild_vertex_to_simplices_index(&mut self) -> Result<(), TdsError> {
         let mut vertex_to_simplices =
             VertexIncidenceIndex::with_vertex_capacity(self.vertices.len());
         for vertex_key in self.vertices.keys() {
@@ -2421,7 +2419,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
 // TRAIT IMPLEMENTATIONS
 // =============================================================================
 
-pub(in crate::core::tds) type SimplexUuidSortKey<const D: usize> =
+pub(super) type SimplexUuidSortKey<const D: usize> =
     SmallBuffer<(Uuid, [i8; D]), MAX_PRACTICAL_DIMENSION_SIZE>;
 
 // =============================================================================
@@ -2432,11 +2430,12 @@ mod tests {
     use super::*;
     use crate::core::simplex::Simplex;
     use crate::core::tds::TdsRollbackTransaction;
+    use crate::vertex;
     use std::assert_matches;
     use std::sync::Arc;
 
     fn insert_test_vertex<const D: usize>(tds: &mut Tds<(), (), D>, coordinate: f64) -> VertexKey {
-        let vertex = Vertex::<(), _>::try_new([coordinate; D]).unwrap();
+        let vertex = vertex!([coordinate; D]).unwrap();
         tds.insert_vertex_with_mapping(vertex).unwrap()
     }
 
@@ -2463,7 +2462,7 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         assert_matches!(
             tds.construction_state(),
@@ -2471,7 +2470,7 @@ mod tests {
         );
 
         let _v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         assert_matches!(
             tds.construction_state(),
@@ -2489,13 +2488,13 @@ mod tests {
     fn test_vertex_to_simplices_index_tracks_simplex_insertion() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         for vertex_key in [v0, v1, v2] {
@@ -2530,19 +2529,19 @@ mod tests {
     fn test_vertex_to_simplices_index_returns_disconnected_vertex_star() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let shared = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([-1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([-1.0, 0.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, -1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0]).unwrap())
             .unwrap();
 
         let first = tds
@@ -2570,13 +2569,13 @@ mod tests {
     fn test_facet_key_for_simplex_facet_maps_periodic_derivation_errors() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v_a = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -2604,7 +2603,7 @@ mod tests {
         assert_eq!(tds.generation(), 0);
 
         let _v = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         assert!(tds.generation() > 0);
 
@@ -2621,13 +2620,13 @@ mod tests {
     fn test_simplex_vertices_errors_on_missing_vertex_key() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let ck = tds
@@ -2680,7 +2679,7 @@ mod tests {
                     fn [<test_clone_for_rollback_preserves_identity_with_independent_generation_ $dim d>]() {
                         let mut tds: Tds<(), (), $dim> = Tds::empty();
                         let _v = tds
-                            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0_f64; $dim]).unwrap())
+                            .insert_vertex_with_mapping(vertex!([0.0_f64; $dim]).unwrap())
                             .unwrap();
                         let snapshot = tds.clone_for_rollback();
                         let snapshot_generation = snapshot.generation();
@@ -2703,16 +2702,16 @@ mod tests {
                     fn [<test_clone_from_for_rollback_replaces_storage_and_preserves_identity_ $dim d>]() {
                         let mut source: Tds<(), (), $dim> = Tds::empty();
                         let source_vertex = source
-                            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0_f64; $dim]).unwrap())
+                            .insert_vertex_with_mapping(vertex!([0.0_f64; $dim]).unwrap())
                             .unwrap();
                         let source_generation = source.generation();
 
                         let mut target: Tds<(), (), $dim> = Tds::empty();
                         let _stale_vertex = target
-                            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0_f64; $dim]).unwrap())
+                            .insert_vertex_with_mapping(vertex!([1.0_f64; $dim]).unwrap())
                             .unwrap();
                         let _extra_stale_vertex = target
-                            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([2.0_f64; $dim]).unwrap())
+                            .insert_vertex_with_mapping(vertex!([2.0_f64; $dim]).unwrap())
                             .unwrap();
                         assert!(
                             !Arc::ptr_eq(source.identity(), target.identity()),

--- a/src/core/tds/validation.rs
+++ b/src/core/tds/validation.rs
@@ -701,7 +701,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     }
 
     /// Resolves the mirror facet for orientation validation without forcing periodic parity checks.
-    pub(in crate::core::tds) fn orientation_mirror_facet_index(
+    pub(super) fn orientation_mirror_facet_index(
         simplex: &Simplex<V, D>,
         facet_idx: usize,
         neighbor_simplex: &Simplex<V, D>,
@@ -726,7 +726,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         Ok((mirror_idx, uses_periodic_offsets))
     }
 
-    pub(in crate::core::tds) fn facet_vertices_in_simplex_order(
+    pub(super) fn facet_vertices_in_simplex_order(
         simplex: &Simplex<V, D>,
         omit_idx: usize,
     ) -> Result<SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>, TdsError> {
@@ -822,7 +822,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     /// Returns `(currently_coherent, observed_odd_permutation, expected_odd_permutation)`.
     /// The expected odd parity follows the coherent boundary-orientation convention:
     /// odd is expected exactly when `(facet_idx + mirror_idx)` is even.
-    pub(in crate::core::tds) fn facet_permutation_parity(
+    pub(super) fn facet_permutation_parity(
         simplex: &Simplex<V, D>,
         facet_idx: usize,
         neighbor_simplex: &Simplex<V, D>,
@@ -1404,7 +1404,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     /// # Errors
     ///
     /// Returns [`TdsError`] if topology validation fails.
-    pub(in crate::core::tds) fn validate_neighbor_topology(
+    pub(super) fn validate_neighbor_topology(
         &self,
         simplex_key: SimplexKey,
         neighbors: &[Option<SimplexKey>],
@@ -1966,16 +1966,17 @@ mod tests {
     use crate::core::simplex::Simplex;
     use crate::core::tds::errors::{InvariantError, NeighborValidationError, TdsError};
     use crate::core::vertex::Vertex;
+    use crate::vertex;
     use slotmap::KeyData;
     use std::assert_matches;
     use uuid::Uuid;
 
     fn initial_simplex_vertices_3d() -> [Vertex<(), 3>; 4] {
         [
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]
     }
 
@@ -1983,19 +1984,13 @@ mod tests {
     fn test_facet_vertex_identities_anchor_uses_lexicographic_key_offset() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -2037,24 +2032,16 @@ mod tests {
     fn test_facet_permutation_parity_derives_coherent_and_incoherent_cases() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         // Shared edge for facet_idx=2 is (v_a, v_b).
@@ -2098,34 +2085,22 @@ mod tests {
     fn test_facet_permutation_parity_smoke_4d() {
         let mut tds: Tds<(), (), 4> = Tds::empty();
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let v_f = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0, 1.0, 1.0]).unwrap())
             .unwrap();
 
         // Shared 3-face for facet_idx=4 is [v_a, v_b, v_c, v_d].
@@ -2170,24 +2145,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1 = tds
@@ -2216,19 +2183,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex = tds
@@ -2251,19 +2212,13 @@ mod tests {
     fn test_validate_neighbor_topology_rejects_wrong_length() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -2292,24 +2247,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2345,29 +2292,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2410,24 +2347,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2457,29 +2386,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
         let v_e = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2515,19 +2434,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2563,24 +2476,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2611,24 +2516,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2665,24 +2562,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2731,24 +2620,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let origin_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let east_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let north_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let diagonal_key = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2789,24 +2670,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2844,24 +2717,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2906,24 +2771,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -2961,24 +2818,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -3019,24 +2868,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -3088,19 +2929,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3143,19 +2978,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3186,24 +3015,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -3261,19 +3082,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(
@@ -3309,19 +3124,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(
@@ -3357,24 +3166,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v_a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -3427,24 +3228,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 3.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([3.0, 3.0]).unwrap())
             .unwrap();
 
         let simplex1_key = tds
@@ -3470,19 +3263,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3523,19 +3310,13 @@ mod tests {
     fn test_validate_vertex_and_simplex_mappings_detect_inconsistencies() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(Simplex::try_new_with_data(vec![a, b, c], None).unwrap())
@@ -3582,19 +3363,13 @@ mod tests {
     fn test_validate_simplex_vertex_keys_detects_missing_vertices() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let a = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let b = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let c = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3624,36 +3399,24 @@ mod tests {
 
         // Component A
         let a0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let a1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let a2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         // Component B (far away, no shared vertices)
         let b0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, 0.0]).unwrap())
             .unwrap();
         let b1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([11.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([11.0, 0.0]).unwrap())
             .unwrap();
         let b2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, 1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -3677,19 +3440,13 @@ mod tests {
     fn test_validate_vertex_incidence_detects_dangling_incident_simplex() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let ck = tds
@@ -3710,19 +3467,13 @@ mod tests {
     fn test_validate_vertex_to_simplices_index_detects_missing_reverse_entry() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3755,19 +3506,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         // Two distinct vertex keys with identical coordinates
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -3787,29 +3532,19 @@ mod tests {
     fn test_validate_facet_sharing_rejects_triple_shared_facet() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.3, 0.3]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.3, 0.3]).unwrap())
             .unwrap();
 
         // Three simplices sharing the v0-v1 edge (facet):
@@ -3867,19 +3602,13 @@ mod tests {
     fn test_validate_no_duplicate_simplices_detects_dupes() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -3921,19 +3650,13 @@ mod tests {
     fn test_validation_report_accumulates_violations() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         // Create a simplex, then corrupt the UUID mapping
@@ -3960,19 +3683,13 @@ mod tests {
     fn test_validate_vertex_incidence_detects_inconsistent_incident_simplex() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let _ck = tds
@@ -3984,9 +3701,7 @@ mod tests {
 
         // Create a second simplex that does NOT contain v0, then point v0 at it.
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([2.0, 2.0]).unwrap())
             .unwrap();
         let ck2 = tds
             .insert_simplex_with_mapping(
@@ -4003,19 +3718,13 @@ mod tests {
     fn test_validate_vertex_incidence_detects_dangling_simplex_key() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(

--- a/src/core/traits/facet_cache.rs
+++ b/src/core/traits/facet_cache.rs
@@ -310,10 +310,10 @@ mod tests {
     /// Create a simple test triangulation for testing
     fn create_test_triangulation() -> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 3> {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         DelaunayTriangulation::try_new(&vertices).expect("Failed to create test triangulation")
     }

--- a/src/core/util/canonical_points.rs
+++ b/src/core/util/canonical_points.rs
@@ -180,8 +180,8 @@ pub(crate) fn sorted_facet_points_with_extra<U, V, const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::vertex::Vertex;
     use crate::geometry::kernel::{AdaptiveKernel, Kernel};
+    use crate::vertex;
     use slotmap::KeyData;
     use std::assert_matches;
 
@@ -197,7 +197,7 @@ mod tests {
         let mut tds = Tds::<(), (), D>::empty();
         let mut keys = Vec::with_capacity(coords.len());
         for c in coords {
-            let v = Vertex::<(), D>::try_new(*c).expect("finite point coordinates");
+            let v = vertex!(*c).expect("finite point coordinates");
             let vk = tds
                 .insert_vertex_with_mapping(v)
                 .expect("insert should succeed");

--- a/src/core/util/deduplication.rs
+++ b/src/core/util/deduplication.rs
@@ -320,13 +320,14 @@ pub(crate) fn coords_within_epsilon<const D: usize>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
 
     use crate::geometry::point::Point;
     use crate::try_vertices_from_points;
     use approx::assert_relative_eq;
 
     fn vertex(coords: [f64; 2]) -> Vertex<(), 2> {
-        Vertex::try_new(coords).expect("finite vertex coordinates")
+        vertex!(coords).expect("finite vertex coordinates")
     }
 
     #[test]
@@ -560,9 +561,9 @@ mod tests {
     #[test]
     fn test_filter_vertices_excluding_empty_reference() {
         let vertices: Vec<Vertex<(), 1>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0]).unwrap(),
+            vertex!([0.0]).unwrap(),
+            vertex!([1.0]).unwrap(),
+            vertex!([2.0]).unwrap(),
         ];
         let reference: Vec<Vertex<(), 1>> = vec![];
         let filtered = filter_vertices_excluding(&vertices, &reference);

--- a/src/core/util/facet_keys.rs
+++ b/src/core/util/facet_keys.rs
@@ -362,6 +362,7 @@ pub fn usize_to_u8(idx: usize, facet_count: usize) -> Result<u8, FacetError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
     use std::assert_matches;
 
     use crate::core::simplex::Simplex;
@@ -468,10 +469,10 @@ mod tests {
 
         // Create a triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let tds = &dt.as_triangulation().tds;
@@ -608,10 +609,10 @@ mod tests {
     fn test_verify_facet_index_consistency_true_false_and_error_cases() {
         // True case: comparing a simplex to itself.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let tds = &dt.as_triangulation().tds;
@@ -631,34 +632,22 @@ mod tests {
         // False case: two disjoint triangles in the same TDS share no facet keys.
         let mut tds2: Tds<(), (), 2> = Tds::empty();
         let v_a = tds2
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v_b = tds2
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v_c = tds2
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v_d = tds2
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 10.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, 10.0]).unwrap())
             .unwrap();
         let v_e = tds2
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([11.0, 10.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([11.0, 10.0]).unwrap())
             .unwrap();
         let v_f = tds2
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 11.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([10.0, 11.0]).unwrap())
             .unwrap();
 
         let c1 = tds2

--- a/src/core/util/facet_utils.rs
+++ b/src/core/util/facet_utils.rs
@@ -198,6 +198,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
 
     use crate::core::collections::FastHashSet;
     use crate::triangulation::DelaunayTriangulation;
@@ -207,10 +208,10 @@ mod tests {
     fn test_generate_combinations_comprehensive() {
         // Test basic functionality with 4 vertices
         let vertices: Vec<Vertex<(), 1>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0]).unwrap(),
+            vertex!([0.0]).unwrap(),
+            vertex!([1.0]).unwrap(),
+            vertex!([2.0]).unwrap(),
+            vertex!([3.0]).unwrap(),
         ];
 
         // Combinations of 2 from 4 - should be C(4,2) = 6
@@ -270,20 +271,20 @@ mod tests {
 
         // Test with different size - 3 vertices, choose 2
         let small_vertices: Vec<Vertex<(), 1>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0]).unwrap(),
+            vertex!([1.0]).unwrap(),
+            vertex!([2.0]).unwrap(),
+            vertex!([3.0]).unwrap(),
         ];
         let combinations_small = generate_combinations(&small_vertices, 2);
         assert_eq!(combinations_small.len(), 3, "C(3,2) should equal 3");
 
         // Test larger case - 5 vertices, choose 3 to exercise inner loops
         let large_vertices: Vec<Vertex<(), 1>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([4.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([5.0]).unwrap(),
+            vertex!([1.0]).unwrap(),
+            vertex!([2.0]).unwrap(),
+            vertex!([3.0]).unwrap(),
+            vertex!([4.0]).unwrap(),
+            vertex!([5.0]).unwrap(),
         ];
         let combinations_large = generate_combinations(&large_vertices, 3);
         assert_eq!(combinations_large.len(), 10, "C(5,3) should equal 10");
@@ -333,13 +334,13 @@ mod tests {
 
         // Create two tetrahedra that share 3 vertices (forming a shared triangular face)
         let shared_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // v0
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // v0
+            vertex!([1.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([0.5, 1.0, 0.0]).unwrap(), // v2
         ];
 
-        let vertex_a = crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 1.0]).unwrap(); // Above the shared triangle
-        let vertex_b = crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, -1.0]).unwrap(); // Below the shared triangle
+        let vertex_a = vertex!([0.5, 0.5, 1.0]).unwrap(); // Above the shared triangle
+        let vertex_b = vertex!([0.5, 0.5, -1.0]).unwrap(); // Below the shared triangle
 
         // Tetrahedron 1: shared triangle + vertex_a
         let mut vertices1 = shared_vertices.clone();
@@ -425,12 +426,12 @@ mod tests {
 
         // Create two 2D triangles that share an edge (2 vertices)
         let shared_edge = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(), // v0
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(), // v1
+            vertex!([0.0, 0.0]).unwrap(), // v0
+            vertex!([1.0, 0.0]).unwrap(), // v1
         ];
 
-        let vertex_c = crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(); // Above the shared edge
-        let vertex_d = crate::core::vertex::Vertex::<(), _>::try_new([0.5, -1.0]).unwrap(); // Below the shared edge
+        let vertex_c = vertex!([0.5, 1.0]).unwrap(); // Above the shared edge
+        let vertex_d = vertex!([0.5, -1.0]).unwrap(); // Below the shared edge
 
         // Triangle 1: shared edge + vertex_c
         let mut vertices1 = shared_edge.clone();
@@ -480,9 +481,9 @@ mod tests {
         // In 1D, simplices are edges and facets are vertices (0D)
         // Two edges sharing a vertex have adjacent facets
 
-        let shared_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap();
-        let vertex_left = crate::core::vertex::Vertex::<(), _>::try_new([-1.0]).unwrap();
-        let vertex_right = crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap();
+        let shared_vertex = vertex!([0.0]).unwrap();
+        let vertex_left = vertex!([-1.0]).unwrap();
+        let vertex_right = vertex!([1.0]).unwrap();
 
         // Edge 1: shared_vertex to vertex_left
         let vertices1 = vec![shared_vertex, vertex_left];
@@ -535,10 +536,10 @@ mod tests {
 
         // Test with minimal triangulation (single tetrahedron)
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -575,10 +576,10 @@ mod tests {
 
         // Create a moderately complex case to test performance
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 2.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 2.0, 0.0]).unwrap(),
+            vertex!([1.0, 1.0, 2.0]).unwrap(),
         ];
 
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -614,17 +615,17 @@ mod tests {
 
         // Create vertices with different coordinates to ensure different UUIDs
         let vertices1 = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let vertices2 = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([10.0, 10.0, 10.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([11.0, 10.0, 10.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([10.0, 11.0, 10.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([10.0, 10.0, 11.0]).unwrap(),
+            vertex!([10.0, 10.0, 10.0]).unwrap(),
+            vertex!([11.0, 10.0, 10.0]).unwrap(),
+            vertex!([10.0, 11.0, 10.0]).unwrap(),
+            vertex!([10.0, 10.0, 11.0]).unwrap(),
         ];
 
         let dt1 = DelaunayTriangulation::try_new(&vertices1).unwrap();
@@ -653,10 +654,10 @@ mod tests {
 
         // Create identical geometry in separate TDS instances
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt1 = DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -706,16 +707,14 @@ mod tests {
 
         // Create two 4D simplices (5-vertices each) that share a 3D facet (4 vertices)
         let shared_tetrahedron = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(), // v0
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(), // v3
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(), // v0
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(), // v3
         ];
 
-        let vertex_e =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25, 1.0]).unwrap(); // Above in 4th dimension
-        let vertex_f =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25, -1.0]).unwrap(); // Below in 4th dimension
+        let vertex_e = vertex!([0.25, 0.25, 0.25, 1.0]).unwrap(); // Above in 4th dimension
+        let vertex_f = vertex!([0.25, 0.25, 0.25, -1.0]).unwrap(); // Below in 4th dimension
 
         // 4D Simplex 1: shared tetrahedron + vertex_e
         let mut vertices1 = shared_tetrahedron.clone();
@@ -768,17 +767,15 @@ mod tests {
 
         // Create two 5D simplices (6-vertices each) that share a 4D facet (5 vertices)
         let shared_4d_simplex = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(), // v0
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(), // v3
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(), // v4
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(), // v0
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(), // v3
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(), // v4
         ];
 
-        let vertex_g =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, 1.0]).unwrap(); // Above in 5th dimension
-        let vertex_h =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, -1.0]).unwrap(); // Below in 5th dimension
+        let vertex_g = vertex!([0.2, 0.2, 0.2, 0.2, 1.0]).unwrap(); // Above in 5th dimension
+        let vertex_h = vertex!([0.2, 0.2, 0.2, 0.2, -1.0]).unwrap(); // Below in 5th dimension
 
         // 5D Simplex 1: shared 4D simplex + vertex_g
         let mut vertices1 = shared_4d_simplex.clone();

--- a/src/core/util/jaccard.rs
+++ b/src/core/util/jaccard.rs
@@ -645,6 +645,7 @@ macro_rules! assert_jaccard_gte {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
     use std::assert_matches;
 
     use crate::core::tds::{Tds, VertexKey};
@@ -704,10 +705,10 @@ mod tests {
     fn test_set_extraction_utilities_comprehensive() {
         // Create a simple tetrahedron for all extraction tests
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let tds = &dt.as_triangulation().tds;
@@ -747,10 +748,10 @@ mod tests {
     #[test]
     fn test_extract_edge_set_errors_on_missing_vertex_key() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -772,10 +773,10 @@ mod tests {
     #[test]
     fn test_extract_facet_identifier_set_errors_on_boundary_facet_retrieval_failure() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -811,10 +812,10 @@ mod tests {
     #[test]
     fn test_extract_hull_facet_set_consistent_with_boundary_facets() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulation::try_new(&vertices).unwrap();
         let tri = dt.as_triangulation();

--- a/src/core/vertex.rs
+++ b/src/core/vertex.rs
@@ -862,6 +862,7 @@ mod tests {
     use crate::core::tds::SimplexKey;
     use crate::core::traits::DataType;
     use crate::core::util::{UuidValidationError, make_uuid, usize_to_u8};
+    use crate::core::vertex::Vertex;
     use crate::geometry::point::Point;
     use crate::geometry::traits::coordinate::{
         Coordinate, CoordinateValidationError, InvalidCoordinateValue,
@@ -980,12 +981,10 @@ mod tests {
 
     #[test]
     fn test_vertex_data_accessor() {
-        let v_with: Vertex<i32, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0], 42).unwrap();
+        let v_with: Vertex<i32, 2> = Vertex::<_, _>::try_new_with_data([1.0, 2.0], 42).unwrap();
         assert_eq!(v_with.data(), Some(&42));
 
-        let v_without: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let v_without: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
         assert_eq!(v_without.data(), None);
     }
 
@@ -995,8 +994,7 @@ mod tests {
 
     #[test]
     fn test_vertex_try_new_constructor_variants() {
-        let v1: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let v1: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         assert_relative_eq!(
             v1.point().coords().as_slice(),
             [1.0, 2.0, 3.0].as_slice(),
@@ -1006,8 +1004,7 @@ mod tests {
         assert!(!v1.uuid().is_nil());
         assert!(v1.data.is_none());
 
-        let v2: Vertex<i32, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0], 99).unwrap();
+        let v2: Vertex<i32, 2> = Vertex::<_, _>::try_new_with_data([0.0, 1.0], 99).unwrap();
         assert_relative_eq!(
             v2.point().coords().as_slice(),
             [0.0, 1.0].as_slice(),
@@ -1018,8 +1015,7 @@ mod tests {
         assert_eq!(v2.data.unwrap(), 99);
 
         let v3: Vertex<u32, 4> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 42u32)
-                .unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 42u32).unwrap();
         assert_relative_eq!(
             v3.point().coords().as_slice(),
             [1.0f64, 2.0f64, 3.0f64, 4.0f64].as_slice(),
@@ -1063,8 +1059,7 @@ mod tests {
     fn test_vertex_basic_operations() {
         // Test vertex copying
         let vertex: Vertex<u8, 4> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 4u8)
-                .unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 4u8).unwrap();
         let vertex_copy = vertex;
         assert_eq!(vertex, vertex_copy);
         assert_relative_eq!(
@@ -1111,8 +1106,8 @@ mod tests {
 
         assert_eq!(values.len(), 3);
 
-        values.sort_by_key(super::Vertex::uuid);
-        vertices.sort_by_key(super::Vertex::uuid);
+        values.sort_by_key(Vertex::uuid);
+        vertices.sort_by_key(Vertex::uuid);
 
         assert_eq!(values, vertices);
 
@@ -1121,8 +1116,7 @@ mod tests {
         assert!(empty_hashmap.is_empty());
 
         // Test Vertex::try_into_hashmap() with single vertex
-        let single_vertex: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let single_vertex: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         let uuid = single_vertex.uuid();
         let single_hashmap = Vertex::try_into_hashmap([single_vertex]).unwrap();
 
@@ -1192,8 +1186,7 @@ mod tests {
     #[test]
     fn test_vertex_serialization_roundtrip() {
         // Test basic serialization/deserialization roundtrip
-        let vertex: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         let serialized = serde_json::to_string(&vertex).unwrap();
 
         assert!(serialized.contains("point"));
@@ -1214,7 +1207,7 @@ mod tests {
 
         // Test serialization with data
         let vertex_with_data: Vertex<i32, 3> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0], 42).unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0], 42).unwrap();
         let serialized_with_data = serde_json::to_string(&vertex_with_data).unwrap();
         assert!(serialized_with_data.contains("\"data\":"));
         assert!(serialized_with_data.contains("42"));
@@ -1229,8 +1222,7 @@ mod tests {
         );
 
         // Test serialization with None data (should omit data field)
-        let vertex_no_data: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex_no_data: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         let serialized_no_data = serde_json::to_string(&vertex_no_data).unwrap();
         assert!(!serialized_no_data.contains("\"data\":"));
 
@@ -1255,8 +1247,7 @@ mod tests {
 
         // Test with different data types
         let vertex_char: Vertex<char, 4> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 'A')
-                .unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 'A').unwrap();
         let serialized_char = serde_json::to_string(&vertex_char).unwrap();
         let deserialized_char: Vertex<char, 4> = serde_json::from_str(&serialized_char).unwrap();
         assert_eq!(deserialized_char.data, Some('A'));
@@ -1280,12 +1271,9 @@ mod tests {
     #[test]
     fn test_vertex_equality_and_hashing() {
         // Test basic equality behavior
-        let v1: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
-        let v2: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
-        let v3: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 4.0]).unwrap();
+        let v1: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let v2: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let v3: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 4.0]).unwrap();
 
         // Same coordinates should be equal
         assert_eq!(v1, v2);
@@ -1303,10 +1291,8 @@ mod tests {
         assert!(v1.eq(&v1));
 
         // Test that equality ignores UUID, incident_simplex, and data
-        let v4: Vertex<i32, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0], 42).unwrap();
-        let v5: Vertex<i32, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0], 99).unwrap(); // Different data
+        let v4: Vertex<i32, 2> = Vertex::<_, _>::try_new_with_data([1.0, 2.0], 42).unwrap();
+        let v5: Vertex<i32, 2> = Vertex::<_, _>::try_new_with_data([1.0, 2.0], 99).unwrap(); // Different data
 
         // Different UUIDs and data but same coordinates
         assert_ne!(v4.uuid(), v5.uuid());
@@ -1316,8 +1302,8 @@ mod tests {
         assert_eq!(v4, v5);
 
         // Test with None data
-        let v6: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
-        let v7: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let v6: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let v7: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
         assert_eq!(v6, v7);
 
         // Test hash consistency for same vertex
@@ -1371,10 +1357,8 @@ mod tests {
         ];
 
         for (coords1, coords2) in test_cases {
-            let v_a: Vertex<(), 2> =
-                crate::core::vertex::Vertex::<(), _>::try_new(coords1).unwrap();
-            let v_b: Vertex<(), 2> =
-                crate::core::vertex::Vertex::<(), _>::try_new(coords2).unwrap();
+            let v_a: Vertex<(), 2> = Vertex::<(), _>::try_new(coords1).unwrap();
+            let v_b: Vertex<(), 2> = Vertex::<(), _>::try_new(coords2).unwrap();
 
             // Verify equality
             assert_eq!(v_a, v_b);
@@ -1392,10 +1376,8 @@ mod tests {
 
     #[test]
     fn test_vertex_signed_zero_eq_hash_and_order_are_consistent() {
-        let positive_zero: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, -0.0]).unwrap();
-        let negative_zero: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([-0.0, 0.0]).unwrap();
+        let positive_zero: Vertex<(), 2> = Vertex::<(), _>::try_new([0.0, -0.0]).unwrap();
+        let negative_zero: Vertex<(), 2> = Vertex::<(), _>::try_new([-0.0, 0.0]).unwrap();
 
         assert_eq!(positive_zero, negative_zero);
         assert_eq!(
@@ -1415,9 +1397,9 @@ mod tests {
         // Test vertices in collections to verify Hash/Eq contract in practice
         let mut set: FastHashSet<Vertex<(), 2>> = FastHashSet::default();
 
-        let v1: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
-        let v2: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([3.0, 4.0]).unwrap();
-        let v3: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(); // Same coordinates as v1
+        let v1: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let v2: Vertex<(), 2> = Vertex::<(), _>::try_new([3.0, 4.0]).unwrap();
+        let v3: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(); // Same coordinates as v1
 
         // Insert vertices
         assert!(set.insert(v1)); // First insert should succeed
@@ -1432,14 +1414,14 @@ mod tests {
         assert!(set.contains(&v3)); // v3 is "found" because it equals v1
 
         // Verify we can look up by coordinates
-        let v4: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let v4: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
         assert!(set.contains(&v4)); // Should find it even with different UUID
 
         // Test vertices as FastHashMap keys
         let mut map: FastHashMap<Vertex<(), 2>, i32> = FastHashMap::default();
 
-        let v5: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
-        let v6: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([3.0, 4.0]).unwrap();
+        let v5: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let v6: Vertex<(), 2> = Vertex::<(), _>::try_new([3.0, 4.0]).unwrap();
 
         map.insert(v5, 10);
         map.insert(v6, 20);
@@ -1450,7 +1432,7 @@ mod tests {
         assert_eq!(map.len(), 2);
 
         // Test lookup with equivalent vertex (same coordinates, different UUID)
-        let v7: Vertex<(), 2> = crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let v7: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
         assert_eq!(map.get(&v7), Some(&10)); // Should find v5's value
 
         // Test overwrite with equivalent vertex
@@ -1460,10 +1442,8 @@ mod tests {
         assert_eq!(map.get(&v5), Some(&30)); // v5 now maps to new value
 
         // Test that vertices with different data types but same coordinates work in collections
-        let v8: Vertex<u16, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0], 999u16).unwrap();
-        let v9: Vertex<i32, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([3.0, 4.0], -42i32).unwrap();
+        let v8: Vertex<u16, 2> = Vertex::<_, _>::try_new_with_data([1.0, 2.0], 999u16).unwrap();
+        let v9: Vertex<i32, 2> = Vertex::<_, _>::try_new_with_data([3.0, 4.0], -42i32).unwrap();
 
         let mut map1: FastHashMap<Vertex<u16, 2>, &str> = FastHashMap::default();
         map1.insert(v8, "first");
@@ -1502,7 +1482,7 @@ mod tests {
                 #[test]
                     fn $test_name() {
                         // Test basic vertex creation
-                        let vertex: Vertex<(), $dim> = crate::core::vertex::Vertex::<(), _>::try_new([$($coord),+]).unwrap();
+                        let vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new([$($coord),+]).unwrap();
                     assert_vertex_properties(&vertex, [$($coord),+]);
                         assert!(vertex.data.is_none());
                     }
@@ -1511,7 +1491,7 @@ mod tests {
                     #[test]
                     fn [<$test_name _with_data>]() {
                         // Test vertex with data
-                        let vertex: Vertex<i32, $dim> = crate::core::vertex::Vertex::<_, _>::try_new_with_data([$($coord),+], 42).unwrap();
+                        let vertex: Vertex<i32, $dim> = Vertex::<_, _>::try_new_with_data([$($coord),+], 42).unwrap();
                         assert_vertex_properties(&vertex, [$($coord),+]);
                         assert_eq!(vertex.data, Some(42));
                     }
@@ -1519,7 +1499,7 @@ mod tests {
                     #[test]
                     fn [<$test_name _serialization_roundtrip>]() {
                         // Test serialization with Some data
-                        let vertex_with_data: Vertex<i32, $dim> = crate::core::vertex::Vertex::<_, _>::try_new_with_data([$($coord),+], 99).unwrap();
+                        let vertex_with_data: Vertex<i32, $dim> = Vertex::<_, _>::try_new_with_data([$($coord),+], 99).unwrap();
                         let serialized = serde_json::to_string(&vertex_with_data).unwrap();
                         assert!(serialized.contains("\"data\":"));
                         let deserialized: Vertex<i32, $dim> = serde_json::from_str(&serialized).unwrap();
@@ -1527,7 +1507,7 @@ mod tests {
                         assert_vertex_properties(&deserialized, [$($coord),+]);
 
                         // Test serialization with None data
-                        let vertex_no_data: Vertex<(), $dim> = crate::core::vertex::Vertex::<(), _>::try_new([$($coord),+]).unwrap();
+                        let vertex_no_data: Vertex<(), $dim> = Vertex::<(), _>::try_new([$($coord),+]).unwrap();
                         let serialized = serde_json::to_string(&vertex_no_data).unwrap();
                         assert!(!serialized.contains("\"data\":"));
                         let deserialized: Vertex<(), $dim> = serde_json::from_str(&serialized).unwrap();
@@ -1537,8 +1517,8 @@ mod tests {
                     #[test]
                     fn [<$test_name _uuid_uniqueness>]() {
                         // Test UUID uniqueness for same coordinates
-                        let v1: Vertex<(), $dim> = crate::core::vertex::Vertex::<(), _>::try_new([$($coord),+]).unwrap();
-                        let v2: Vertex<(), $dim> = crate::core::vertex::Vertex::<(), _>::try_new([$($coord),+]).unwrap();
+                        let v1: Vertex<(), $dim> = Vertex::<(), _>::try_new([$($coord),+]).unwrap();
+                        let v2: Vertex<(), $dim> = Vertex::<(), _>::try_new([$($coord),+]).unwrap();
                         assert_ne!(v1.uuid(), v2.uuid());
                         assert!(!v1.uuid().is_nil());
                         assert!(!v2.uuid().is_nil());
@@ -1559,7 +1539,7 @@ mod tests {
     // Keep 1D test separate as it's less common
     #[test]
     fn vertex_1d() {
-        let vertex: Vertex<(), 1> = crate::core::vertex::Vertex::<(), _>::try_new([42.0]).unwrap();
+        let vertex: Vertex<(), 1> = Vertex::<(), _>::try_new([42.0]).unwrap();
         assert_vertex_properties(&vertex, [42.0]);
         assert!(vertex.data.is_none());
     }
@@ -1572,13 +1552,13 @@ mod tests {
     fn test_vertex_data_types_and_ordering() {
         // Test vertex with tuple data
         let vertex_tuple: Vertex<(i32, i32), 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0], (42, 84)).unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0], (42, 84)).unwrap();
         assert_vertex_properties(&vertex_tuple, [1.0, 2.0]);
         assert_eq!(vertex_tuple.data.unwrap(), (42, 84));
 
         // Test debug formatting
         let vertex_debug: Vertex<i32, 3> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0], 42).unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0], 42).unwrap();
         let debug_str = format!("{vertex_debug:?}");
 
         assert!(debug_str.contains("Vertex"));
@@ -1589,10 +1569,8 @@ mod tests {
         assert!(debug_str.contains("3.0"));
 
         // Test ordering edge cases
-        let vertex1: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
-        let vertex2: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let vertex1: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
+        let vertex2: Vertex<(), 2> = Vertex::<(), _>::try_new([1.0, 2.0]).unwrap();
 
         // Test that equal points result in equal ordering
         assert!(vertex1.partial_cmp(&vertex2) != Some(Ordering::Less));
@@ -1618,8 +1596,7 @@ mod tests {
     #[test]
     fn test_vertex_coordinate_values() {
         // Test negative coordinates
-        let vertex_neg: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([-1.0, -2.0, -3.0]).unwrap();
+        let vertex_neg: Vertex<(), 3> = Vertex::<(), _>::try_new([-1.0, -2.0, -3.0]).unwrap();
         assert_relative_eq!(
             vertex_neg.point().coords().as_slice(),
             [-1.0, -2.0, -3.0].as_slice(),
@@ -1628,15 +1605,12 @@ mod tests {
         assert_eq!(vertex_neg.dim(), 3);
 
         // Test zero coordinates
-        let vertex_zero: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
-        let origin_vertex: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
+        let vertex_zero: Vertex<(), 3> = Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
+        let origin_vertex: Vertex<(), 3> = Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
         assert_eq!(vertex_zero.point(), origin_vertex.point());
 
         // Test large coordinates
-        let vertex_large: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1e6, 2e6, 3e6]).unwrap();
+        let vertex_large: Vertex<(), 3> = Vertex::<(), _>::try_new([1e6, 2e6, 3e6]).unwrap();
         assert_relative_eq!(
             vertex_large.point().coords().as_slice(),
             [1_000_000.0, 2_000_000.0, 3_000_000.0].as_slice(),
@@ -1645,8 +1619,7 @@ mod tests {
         assert_eq!(vertex_large.dim(), 3);
 
         // Test small coordinates
-        let vertex_small: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-6, 2e-6, 3e-6]).unwrap();
+        let vertex_small: Vertex<(), 3> = Vertex::<(), _>::try_new([1e-6, 2e-6, 3e-6]).unwrap();
         assert_relative_eq!(
             vertex_small.point().coords().as_slice(),
             [0.000_001, 0.000_002, 0.000_003].as_slice(),
@@ -1655,8 +1628,7 @@ mod tests {
         assert_eq!(vertex_small.dim(), 3);
 
         // Test mixed positive/negative coordinates
-        let vertex_mixed: Vertex<(), 4> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, -2.0, 3.0, -4.0]).unwrap();
+        let vertex_mixed: Vertex<(), 4> = Vertex::<(), _>::try_new([1.0, -2.0, 3.0, -4.0]).unwrap();
         assert_relative_eq!(
             vertex_mixed.point().coords().as_slice(),
             [1.0, -2.0, 3.0, -4.0].as_slice(),
@@ -1668,10 +1640,8 @@ mod tests {
     #[test]
     fn test_vertex_properties() {
         // Test UUID uniqueness
-        let vertex1: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
-        let vertex2: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex1: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex2: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
 
         // Same points but different UUIDs
         assert_ne!(vertex1.uuid(), vertex2.uuid());
@@ -1682,8 +1652,7 @@ mod tests {
     #[test]
     fn test_vertex_type_conversions() {
         // Test implicit conversion from owned vertex to coordinates
-        let vertex_coords: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex_coords: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         let coords_owned: [f64; 3] = vertex_coords.into();
         assert_relative_eq!(
             coords_owned.as_slice(),
@@ -1692,8 +1661,7 @@ mod tests {
         );
 
         // Test implicit conversion from vertex reference to coordinates
-        let vertex_ref_coords: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([4.0, 5.0, 6.0]).unwrap();
+        let vertex_ref_coords: Vertex<(), 3> = Vertex::<(), _>::try_new([4.0, 5.0, 6.0]).unwrap();
         let coords_ref: [f64; 3] = (&vertex_ref_coords).into();
         assert_relative_eq!(
             coords_ref.as_slice(),
@@ -1709,8 +1677,7 @@ mod tests {
         );
 
         // Test implicit conversion from vertex reference to Point
-        let vertex_point: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex_point: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         let point_from_vertex: Point<3> = (&vertex_point).into();
         assert_relative_eq!(
             point_from_vertex.coords().as_slice(),
@@ -1729,8 +1696,7 @@ mod tests {
         );
 
         // Test with different dimensions
-        let vertex_2d: Vertex<(), 2> =
-            crate::core::vertex::Vertex::<(), _>::try_new([10.5, -5.3]).unwrap();
+        let vertex_2d: Vertex<(), 2> = Vertex::<(), _>::try_new([10.5, -5.3]).unwrap();
         let point_2d: Point<2> = (&vertex_2d).into();
         assert_relative_eq!(
             point_2d.coords().as_slice(),
@@ -1747,25 +1713,20 @@ mod tests {
     #[test]
     fn test_vertex_validation() {
         // Test valid vertices with f64 coordinates and various dimensions
-        let valid_f64: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let valid_f64: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         assert!(valid_f64.is_valid().is_ok());
 
-        let valid_negative: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([-1.0, -2.0, -3.0]).unwrap();
+        let valid_negative: Vertex<(), 3> = Vertex::<(), _>::try_new([-1.0, -2.0, -3.0]).unwrap();
         assert!(valid_negative.is_valid().is_ok());
 
-        let valid_zero: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
+        let valid_zero: Vertex<(), 3> = Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
         assert!(valid_zero.is_valid().is_ok());
 
         // Test different dimensions
-        let valid_1d: Vertex<(), 1> =
-            crate::core::vertex::Vertex::<(), _>::try_new([42.0]).unwrap();
+        let valid_1d: Vertex<(), 1> = Vertex::<(), _>::try_new([42.0]).unwrap();
         assert!(valid_1d.is_valid().is_ok());
 
-        let valid_5d: Vertex<(), 5> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
+        let valid_5d: Vertex<(), 5> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0, 4.0, 5.0]).unwrap();
         assert!(valid_5d.is_valid().is_ok());
 
         assert!(Point::<3>::try_new([1.0, f64::NAN, 3.0]).is_err());
@@ -1777,8 +1738,7 @@ mod tests {
         assert!(Point::<3>::try_new([f64::NAN, f64::INFINITY, 1.0]).is_err());
 
         // Test UUID validation
-        let valid_vertex: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let valid_vertex: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         assert!(valid_vertex.is_valid().is_ok());
         assert!(!valid_vertex.uuid().is_nil());
 
@@ -1820,10 +1780,10 @@ mod tests {
 
         // Use numeric IDs in vertices - this works perfectly and is efficient
         let vertices_with_ids: Vec<Vertex<u32, 2>> = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.5, 0.5], 0u32).unwrap(), // center
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 1.0], 1u32).unwrap(), // corner
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.5, 1.0], 2u32).unwrap(), // edge_midpoint
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.5], 3u32).unwrap(), // boundary_point
+            Vertex::<_, _>::try_new_with_data([0.5, 0.5], 0u32).unwrap(), // center
+            Vertex::<_, _>::try_new_with_data([1.0, 1.0], 1u32).unwrap(), // corner
+            Vertex::<_, _>::try_new_with_data([0.5, 1.0], 2u32).unwrap(), // edge_midpoint
+            Vertex::<_, _>::try_new_with_data([0.0, 0.5], 3u32).unwrap(), // boundary_point
         ];
 
         // Verify we can retrieve the labels
@@ -1854,9 +1814,9 @@ mod tests {
 
         // Alternative 1: Use character codes
         let vertices_with_chars: Vec<Vertex<char, 2>> = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 'A').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0], 'B').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0], 'C').unwrap(),
+            Vertex::<_, _>::try_new_with_data([0.0, 0.0], 'A').unwrap(),
+            Vertex::<_, _>::try_new_with_data([1.0, 0.0], 'B').unwrap(),
+            Vertex::<_, _>::try_new_with_data([0.0, 1.0], 'C').unwrap(),
         ];
 
         for (i, v) in vertices_with_chars.iter().enumerate() {
@@ -1868,12 +1828,9 @@ mod tests {
         // Alternative 2: Use small integer codes with enum mapping
 
         let vertices_with_enums: Vec<Vertex<PointType, 2>> = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0], PointType::Origin)
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0], PointType::Corner)
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.5, 0.5], PointType::Interior)
-                .unwrap(),
+            Vertex::<_, _>::try_new_with_data([0.0, 0.0], PointType::Origin).unwrap(),
+            Vertex::<_, _>::try_new_with_data([1.0, 0.0], PointType::Corner).unwrap(),
+            Vertex::<_, _>::try_new_with_data([0.5, 0.5], PointType::Interior).unwrap(),
         ];
 
         assert_eq!(vertices_with_enums[0].data.unwrap(), PointType::Origin);
@@ -1899,10 +1856,9 @@ mod tests {
     fn vertex_hash_with_copy_data() {
         // Test hashing with Copy data
         let vertex1: Vertex<u16, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0], 999u16).unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0], 999u16).unwrap();
 
-        let vertex2: Vertex<i32, 2> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([3.0, 4.0], 42).unwrap();
+        let vertex2: Vertex<i32, 2> = Vertex::<_, _>::try_new_with_data([3.0, 4.0], 42).unwrap();
 
         // Test that vertices with Copy data can be used as HashMap keys
         let mut map: FastHashMap<Vertex<u16, 2>, i32> = FastHashMap::default();
@@ -2118,8 +2074,7 @@ mod tests {
     fn test_serialization_deserialization_roundtrip() {
         // Test that serialization -> deserialization preserves all data
         let original_vertex: Vertex<char, 4> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 'A')
-                .unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0, 4.0], 'A').unwrap();
 
         // Serialize
         let serialized = serde_json::to_string(&original_vertex).unwrap();
@@ -2145,7 +2100,7 @@ mod tests {
     fn test_serialization_with_some_data_includes_field() {
         // Test that when data is Some, the JSON includes the data field
         let vertex: Vertex<i32, 3> =
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0], 42).unwrap();
+            Vertex::<_, _>::try_new_with_data([1.0, 2.0, 3.0], 42).unwrap();
         let serialized = serde_json::to_string(&vertex).unwrap();
 
         // Verify JSON contains "data" field
@@ -2168,8 +2123,7 @@ mod tests {
     #[test]
     fn test_serialization_with_none_data_omits_field() {
         // Test that when data is None, the JSON omits the data field entirely
-        let vertex: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
+        let vertex: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap();
         let serialized = serde_json::to_string(&vertex).unwrap();
 
         // Verify JSON does NOT contain "data" field (optimization)

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -420,16 +420,19 @@ pub enum ExplicitConstructionError {
     /// Toroidal topology is incompatible with explicit simplex construction.
     #[error("Toroidal topology cannot be combined with explicit simplex construction")]
     IncompatibleTopology,
-    /// Non-default [`ConstructionOptions`] were set on an explicit-simplex builder.
+    /// Unsupported [`ConstructionOptions`] were set on an explicit-simplex builder.
     ///
-    /// [`ConstructionOptions`] (insertion order, deduplication, retry policy) apply
-    /// only to the Delaunay point-insertion path and are not meaningful for
-    /// explicit simplex construction.
+    /// Most [`ConstructionOptions`] (insertion order, deduplication, retry
+    /// policy) apply only to the Delaunay point-insertion path and are not
+    /// meaningful for explicit simplex construction. The supported exception is
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`], which lets
+    /// callers import valid Levels 1-4 explicit connectivity without proving the
+    /// Level 5 Delaunay property.
     ///
     /// [`ConstructionOptions`]: crate::construction::ConstructionOptions
     #[error(
-        "ConstructionOptions are not applicable to explicit simplex construction \
-         and must be left at their default values"
+        "Only default ConstructionOptions or without_final_delaunay_enforcement() \
+         are supported for explicit simplex construction"
     )]
     UnsupportedConstructionOptions,
     /// Neighbor assignment failed while assembling explicit connectivity.
@@ -473,6 +476,13 @@ pub enum ExplicitConstructionError {
         /// Underlying TDS/geometric validation error.
         #[source]
         source: Box<TdsError>,
+    },
+    /// Level 4 embedding validation failed before returning the wrapper.
+    #[error("Embedding validation failed during explicit construction: {source}")]
+    EmbeddingValidation {
+        /// Underlying cumulative embedding validation error.
+        #[source]
+        source: Box<DelaunayTriangulationValidationError>,
     },
     /// Level 5 Delaunay validation failed before returning the wrapper.
     #[error("Delaunay validation failed during explicit construction: {source}")]
@@ -739,11 +749,13 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
     /// Simplex arity, bounds, and duplicate indices are validated before the
     /// builder stores the explicit connectivity. Euclidean explicit meshes are
     /// checked at Levels 1–4 during [`build`](Self::build) or
-    /// [`build_with_kernel`](Self::build_with_kernel), including the Delaunay
-    /// empty-circumsphere property. Non-Euclidean explicit connectivity is
-    /// rejected at build time because there is no successful Levels 1–3-only
-    /// path for the public `DelaunayTriangulation` wrapper; quotient meshes need
-    /// Level 4 handling before they can be accepted.
+    /// [`build_with_kernel`](Self::build_with_kernel). By default they must also
+    /// prove the Level 5 Delaunay empty-circumsphere property. Use
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`] when importing
+    /// exact degenerate or externally constrained connectivity that should be
+    /// valid as a triangulation but is not required to be strict Delaunay.
+    /// Non-Euclidean explicit connectivity is rejected at build time because
+    /// quotient meshes need Level 4 handling before they can be accepted.
     ///
     /// # Errors
     ///
@@ -1061,9 +1073,14 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
         self
     }
 
-    /// Sets the [`ConstructionOptions`] (insertion order, deduplication, retry policy).
+    /// Sets the [`ConstructionOptions`] for construction and final validation.
     ///
-    /// Defaults to [`ConstructionOptions::default`].
+    /// Defaults to [`ConstructionOptions::default`], which enforces final Level
+    /// 5 Delaunay validation. Explicit-simplex builders accept either the
+    /// default options or
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`] when callers
+    /// intentionally import valid Levels 1-4 connectivity without requiring a
+    /// strict Delaunay proof.
     ///
     /// # Examples
     ///
@@ -1256,6 +1273,10 @@ where
     /// - Toroidal canonicalization fails (non-finite coordinate in input).
     /// - The underlying triangulation construction fails (insufficient vertices,
     ///   geometric degeneracy, etc.).
+    /// - Explicit-simplex construction is requested with unsupported
+    ///   [`ConstructionOptions`], non-Euclidean topology, invalid topology or
+    ///   embedding, or a failed Level 5 Delaunay check when final enforcement is
+    ///   enabled.
     ///
     /// # Examples
     ///
@@ -1307,8 +1328,9 @@ where
     ///
     /// # Errors
     ///
-    /// Returns [`DelaunayTriangulationConstructionError`] if canonicalization or
-    /// construction fails (see [`build`](Self::build) for details).
+    /// Returns [`DelaunayTriangulationConstructionError`] if canonicalization,
+    /// point-insertion construction, or explicit-simplex construction fails (see
+    /// [`build`](Self::build) for the policy-level conditions).
     ///
     /// # Examples
     ///
@@ -1347,7 +1369,7 @@ where
             if !matches!(self.topology, BuilderTopology::Euclidean) {
                 return Err(ExplicitConstructionError::IncompatibleTopology.into());
             }
-            if self.construction_options != ConstructionOptions::default() {
+            if !Self::supports_explicit_construction_options(self.construction_options) {
                 return Err(ExplicitConstructionError::UnsupportedConstructionOptions.into());
             }
             return Self::build_explicit(
@@ -1356,6 +1378,7 @@ where
                 simplices.as_slice(),
                 self.topology_guarantee,
                 self.global_topology_or_default(),
+                self.construction_options.enforces_final_delaunay(),
             );
         }
 
@@ -1447,38 +1470,54 @@ where
         }
     }
 
+    /// Checks whether explicit-simplex construction can honor the requested options.
+    ///
+    /// Explicit connectivity bypasses insertion ordering, deduplication, and
+    /// retry policies, so accepting arbitrary [`ConstructionOptions`] would make
+    /// those knobs look meaningful when they are ignored. The one supported
+    /// non-default policy is
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`], which is the
+    /// public opt-in for importing valid Levels 1-4 constrained connectivity.
+    fn supports_explicit_construction_options(options: ConstructionOptions) -> bool {
+        options == ConstructionOptions::default()
+            || options == ConstructionOptions::default().without_final_delaunay_enforcement()
+    }
+
     /// Builds a triangulation from explicit vertex and simplex specifications.
     ///
     /// This is a purely combinatorial construction that assembles a valid TDS from
     /// the given connectivity without Delaunay point insertion. Euclidean explicit
-    /// meshes are validated at Levels 1–5 (elements, structure, topology,
-    /// embedding, and the Delaunay property). Non-Euclidean explicit
-    /// connectivity is rejected because it requires quotient embedding
-    /// validation before the public
+    /// meshes are validated at Levels 1–4 and, by default, Level 5. When
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`] is used, the
+    /// explicit connectivity is returned after Levels 1–4 validation without
+    /// Delaunay repair or proof. Non-Euclidean explicit connectivity is rejected
+    /// because it requires quotient embedding validation before the public
     /// `DelaunayTriangulation` wrapper can accept it.
     ///
     /// # Algorithm
     ///
     /// 1. Validate input: each simplex has D+1 in-bounds, unique vertex indices.
-    /// 2. Build a `Tds`: insert all vertices, then insert simplices from the specifications.
-    /// 3. Compute adjacency via `assign_neighbors()`.
-    /// 4. Assign incident simplices via `assign_incident_simplices()`.
-    /// 5. Wrap in a validation candidate.
-    /// 6. Normalize coherent orientation and promote to positive canonical sign
-    ///    via `normalize_and_promote_positive_orientation()`.
-    /// 7. Reject non-Euclidean explicit connectivity until quotient embedding
+    /// 2. Reject non-Euclidean explicit connectivity until quotient embedding
     ///    validation exists.
+    /// 3. Build a `Tds`: insert all vertices, then insert simplices from the specifications.
+    /// 4. Compute adjacency via `assign_neighbors()`.
+    /// 5. Assign incident simplices via `assign_incident_simplices()`.
+    /// 6. Wrap in a validation candidate.
+    /// 7. Normalize coherent orientation and promote to positive canonical sign
+    ///    via `normalize_and_promote_positive_orientation()`.
     /// 8. Validate Levels 1–2 (TDS structural: `tds.validate()`).
     /// 9. Validate Level 3 topology (excluding geometric orientation).
     /// 10. Validate PL-manifold completion (vertex links, if required).
     /// 11. Validate geometric nondegeneracy (reject zero-volume simplices).
-    /// 12. Validate the Euclidean Level 5 Delaunay property.
+    /// 12. Validate the Euclidean Level 5 Delaunay property unless final
+    ///     enforcement was disabled in [`ConstructionOptions`].
     fn build_explicit<K, V>(
         kernel: &K,
         vertices: &[Vertex<U, D>],
         simplices: &[Vec<usize>],
         topology_guarantee: TopologyGuarantee,
         global_topology: GlobalTopology<D>,
+        enforce_final_delaunay: bool,
     ) -> Result<DelaunayTriangulation<K, U, V, D>, DelaunayTriangulationConstructionError>
     where
         K: Kernel<D, Scalar = f64>,
@@ -1611,8 +1650,16 @@ where
             .into());
         }
 
-        let proof = Self::enforce_explicit_delaunay_property(&candidate)?;
+        if !enforce_final_delaunay {
+            let proof = candidate.validate_embedding_only().map_err(|source| {
+                ExplicitConstructionError::EmbeddingValidation {
+                    source: Box::new(source),
+                }
+            })?;
+            return Ok(candidate.into_embedding_validated_delaunay(proof));
+        }
 
+        let proof = Self::enforce_explicit_delaunay_property(&candidate)?;
         Ok(candidate.into_validated_delaunay(proof))
     }
 

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -512,11 +512,7 @@ impl<'v> ValidatedExplicitSimplices<'v> {
         specs: &'v [Vec<usize>],
     ) -> Result<Self, ExplicitConstructionError> {
         validate_explicit_simplex_specs::<D>(vertex_count, specs)?;
-        Ok(Self::from_validated_specs(specs))
-    }
-
-    const fn from_validated_specs(specs: &'v [Vec<usize>]) -> Self {
-        Self { specs }
+        Ok(Self { specs })
     }
 
     const fn as_slice(self) -> &'v [Vec<usize>] {
@@ -635,10 +631,10 @@ enum BuilderTopology<const D: usize> {
 //
 // U is inferred from the vertex slice.
 //
-//   let vertices = vec![crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0])?, ...];
+//   let vertices = vec![Vertex::<(), _>::try_new([0.0, 0.0])?, ...];
 //   let dt = DelaunayTriangulationBuilder::new(&vertices).build::<()>();
 //
-//   let typed: [Vertex<i32, 2>; 3] = [crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 1)?, ...];
+//   let typed: [Vertex<i32, 2>; 3] = [Vertex::<_, _>::try_new_with_data([0.0, 0.0], 1)?, ...];
 //   let dt = DelaunayTriangulationBuilder::new(&typed).build::<()>();
 //
 // =============================================================================
@@ -1375,7 +1371,7 @@ where
             return Self::build_explicit(
                 kernel,
                 self.vertices,
-                simplices.as_slice(),
+                simplices,
                 self.topology_guarantee,
                 self.global_topology_or_default(),
                 self.construction_options.enforces_final_delaunay(),
@@ -1496,7 +1492,8 @@ where
     ///
     /// # Algorithm
     ///
-    /// 1. Validate input: each simplex has D+1 in-bounds, unique vertex indices.
+    /// 1. Receive prevalidated simplex specs: each simplex has D+1 in-bounds,
+    ///    unique vertex indices.
     /// 2. Reject non-Euclidean explicit connectivity until quotient embedding
     ///    validation exists.
     /// 3. Build a `Tds`: insert all vertices, then insert simplices from the specifications.
@@ -1514,7 +1511,7 @@ where
     fn build_explicit<K, V>(
         kernel: &K,
         vertices: &[Vertex<U, D>],
-        simplices: &[Vec<usize>],
+        simplices: ValidatedExplicitSimplices<'_>,
         topology_guarantee: TopologyGuarantee,
         global_topology: GlobalTopology<D>,
         enforce_final_delaunay: bool,
@@ -1523,10 +1520,10 @@ where
         K: Kernel<D, Scalar = f64>,
         V: DataType,
     {
-        validate_explicit_simplex_specs::<D>(vertices.len(), simplices)?;
         Self::reject_explicit_non_euclidean_topology(global_topology)?;
 
         let vertex_count = vertices.len();
+        let simplices = simplices.as_slice();
 
         // --- Build TDS ---
         let mut tds: Tds<U, V, D> = Tds::empty();
@@ -2798,6 +2795,7 @@ mod tests {
     use crate::topology::traits::topological_space::{
         GlobalTopology, TopologyKind, ToroidalConstructionMode, ToroidalDomainError,
     };
+    use crate::vertex;
     use approx::assert_relative_eq;
     use slotmap::Key;
     use std::assert_matches;
@@ -2823,13 +2821,13 @@ mod tests {
 
     fn periodic_fixture_vertices_2d() -> Vec<Vertex<(), 2>> {
         vec![
-            Vertex::<(), _>::try_new([0.1_f64, 0.2]).unwrap(),
-            Vertex::<(), _>::try_new([0.4, 0.7]).unwrap(),
-            Vertex::<(), _>::try_new([0.7, 0.3]).unwrap(),
-            Vertex::<(), _>::try_new([0.2, 0.9]).unwrap(),
-            Vertex::<(), _>::try_new([0.8, 0.6]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 0.1]).unwrap(),
-            Vertex::<(), _>::try_new([0.3, 0.5]).unwrap(),
+            vertex!([0.1_f64, 0.2]).unwrap(),
+            vertex!([0.4, 0.7]).unwrap(),
+            vertex!([0.7, 0.3]).unwrap(),
+            vertex!([0.2, 0.9]).unwrap(),
+            vertex!([0.8, 0.6]).unwrap(),
+            vertex!([0.5, 0.1]).unwrap(),
+            vertex!([0.3, 0.5]).unwrap(),
         ]
     }
 
@@ -2981,9 +2979,9 @@ mod tests {
     #[test]
     fn test_builder_euclidean_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -2996,10 +2994,10 @@ mod tests {
     #[test]
     fn test_builder_euclidean_3d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -3011,9 +3009,9 @@ mod tests {
     #[test]
     fn test_builder_euclidean_rejects_non_euclidean_global_topology() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let result = DelaunayTriangulationBuilder::new(&vertices)
             .global_topology(GlobalTopology::Spherical)
@@ -3032,9 +3030,9 @@ mod tests {
     #[test]
     fn test_builder_topology_guarantee_propagated() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .topology_guarantee(TopologyGuarantee::Pseudomanifold)
@@ -3046,9 +3044,9 @@ mod tests {
     #[test]
     fn test_builder_custom_options_propagated() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let opts =
             ConstructionOptions::default().with_insertion_order(InsertionOrderStrategy::Input);
@@ -3068,10 +3066,10 @@ mod tests {
     #[test]
     fn test_builder_canonicalized_toroidal_canonicalizes_out_of_domain_vertices() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.3]).unwrap(), // in domain
-            crate::core::vertex::Vertex::<(), _>::try_new([1.8, 0.1]).unwrap(), // x → 0.8
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(), // in domain
-            crate::core::vertex::Vertex::<(), _>::try_new([-0.4, 0.9]).unwrap(), // x → 0.6
+            vertex!([0.2, 0.3]).unwrap(),  // in domain
+            vertex!([1.8, 0.1]).unwrap(),  // x → 0.8
+            vertex!([0.5, 0.7]).unwrap(),  // in domain
+            vertex!([-0.4, 0.9]).unwrap(), // x → 0.6
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .try_canonicalized_toroidal([1.0, 1.0])
@@ -3092,9 +3090,9 @@ mod tests {
     #[test]
     fn test_builder_canonicalized_toroidal_in_domain_vertices_unchanged() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.2]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.3]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.4, 0.9]).unwrap(),
+            vertex!([0.1, 0.2]).unwrap(),
+            vertex!([0.8, 0.3]).unwrap(),
+            vertex!([0.4, 0.9]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .try_canonicalized_toroidal([1.0, 1.0])
@@ -3112,10 +3110,10 @@ mod tests {
     #[test]
     fn test_builder_canonicalized_toroidal_build_succeeds_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.3]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.1]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.9]).unwrap(),
+            vertex!([0.2, 0.3]).unwrap(),
+            vertex!([0.8, 0.1]).unwrap(),
+            vertex!([0.5, 0.7]).unwrap(),
+            vertex!([0.1, 0.9]).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .try_canonicalized_toroidal([1.0, 1.0])
@@ -3131,10 +3129,10 @@ mod tests {
     #[test]
     fn test_builder_canonicalized_toroidal_build_out_of_domain_input_2d() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([2.2, 3.3]).unwrap(), // → (0.2, 0.3)
-            crate::core::vertex::Vertex::<(), _>::try_new([-0.2, 1.1]).unwrap(), // → (0.8, 0.1)
-            crate::core::vertex::Vertex::<(), _>::try_new([1.5, 0.7]).unwrap(), // → (0.5, 0.7)
-            crate::core::vertex::Vertex::<(), _>::try_new([-0.9, 2.9]).unwrap(), // → (0.1, 0.9)
+            vertex!([2.2, 3.3]).unwrap(),  // → (0.2, 0.3)
+            vertex!([-0.2, 1.1]).unwrap(), // → (0.8, 0.1)
+            vertex!([1.5, 0.7]).unwrap(),  // → (0.5, 0.7)
+            vertex!([-0.9, 2.9]).unwrap(), // → (0.1, 0.9)
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .try_canonicalized_toroidal([1.0, 1.0])
@@ -3150,10 +3148,10 @@ mod tests {
     #[test]
     fn test_builder_canonicalized_toroidal_rejects_non_euclidean_global_topology() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.2, 0.3]).unwrap(),
-            Vertex::<(), _>::try_new([0.8, 0.1]).unwrap(),
-            Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
-            Vertex::<(), _>::try_new([0.1, 0.9]).unwrap(),
+            vertex!([0.2, 0.3]).unwrap(),
+            vertex!([0.8, 0.1]).unwrap(),
+            vertex!([0.5, 0.7]).unwrap(),
+            vertex!([0.1, 0.9]).unwrap(),
         ];
         let topology =
             GlobalTopology::try_toroidal([1.0, 1.0], ToroidalConstructionMode::Canonicalized)
@@ -3182,9 +3180,9 @@ mod tests {
     #[test]
     fn test_builder_canonicalized_toroidal_invalid_domain_is_error() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.3]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.1]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
+            vertex!([0.2, 0.3]).unwrap(),
+            vertex!([0.8, 0.1]).unwrap(),
+            vertex!([0.5, 0.7]).unwrap(),
         ];
         let Err(err) =
             DelaunayTriangulationBuilder::new(&vertices).try_canonicalized_toroidal([0.0, 1.0])
@@ -3197,13 +3195,13 @@ mod tests {
     #[test]
     fn test_builder_toroidal_invalid_domain_is_error() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.2]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.4, 0.7]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.7, 0.3]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.9]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.6]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.1]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.3, 0.5]).unwrap(),
+            vertex!([0.1, 0.2]).unwrap(),
+            vertex!([0.4, 0.7]).unwrap(),
+            vertex!([0.7, 0.3]).unwrap(),
+            vertex!([0.2, 0.9]).unwrap(),
+            vertex!([0.8, 0.6]).unwrap(),
+            vertex!([0.5, 0.1]).unwrap(),
+            vertex!([0.3, 0.5]).unwrap(),
         ];
         let Err(err) = DelaunayTriangulationBuilder::new(&vertices).try_toroidal([1.0, 0.0]) else {
             panic!("zero period should be rejected");
@@ -3234,7 +3232,7 @@ mod tests {
 
     #[test]
     fn test_builder_toroidal_rejects_dimension_above_validated_range() {
-        let vertices = vec![Vertex::<(), _>::try_new([0.1_f64, 0.2, 0.3, 0.4]).unwrap()];
+        let vertices = vec![vertex!([0.1_f64, 0.2, 0.3, 0.4]).unwrap()];
         let result = DelaunayTriangulationBuilder::new(&vertices)
             .try_toroidal([1.0, 1.0, 1.0, 1.0])
             .unwrap()
@@ -3372,9 +3370,9 @@ mod tests {
     #[test]
     fn test_builder_canonicalized_toroidal_idempotent_on_canonical_input() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.2]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.8, 0.3]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.4, 0.9]).unwrap(),
+            vertex!([0.1, 0.2]).unwrap(),
+            vertex!([0.8, 0.3]).unwrap(),
+            vertex!([0.4, 0.9]).unwrap(),
         ];
         let dt_euclidean = DelaunayTriangulationBuilder::new(&vertices)
             .build::<()>()
@@ -3403,9 +3401,9 @@ mod tests {
     #[test]
     fn test_builder_new_preserves_vertex_data() {
         let vertices: Vec<Vertex<i32, 2>> = vec![
-            Vertex::try_new_with_data([0.2_f64, 0.3], 1_i32).unwrap(),
-            Vertex::try_new_with_data([1.8_f64, 0.1], 2_i32).unwrap(), // x → 0.8
-            Vertex::try_new_with_data([0.5_f64, 0.7], 3_i32).unwrap(),
+            vertex!([0.2_f64, 0.3]; data = 1_i32).unwrap(),
+            vertex!([1.8_f64, 0.1]; data = 2_i32).unwrap(), // x → 0.8
+            vertex!([0.5_f64, 0.7]; data = 3_i32).unwrap(),
         ];
         let dt = DelaunayTriangulationBuilder::new(&vertices)
             .try_canonicalized_toroidal([1.0, 1.0])
@@ -3431,10 +3429,10 @@ mod tests {
     #[test]
     fn test_builder_with_robust_kernel() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let kernel = RobustKernel::<f64>::new();
         let dt = DelaunayTriangulationBuilder::new(&vertices)
@@ -3551,9 +3549,9 @@ mod tests {
     #[test]
     fn test_canonicalize_vertices_preserves_uuids() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([2.5, 3.7]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.8, -0.5]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
+            vertex!([2.5, 3.7]).unwrap(),
+            vertex!([1.8, -0.5]).unwrap(),
+            vertex!([0.5, 0.7]).unwrap(),
         ];
         let original_uuids: Vec<_> = vertices.iter().map(Vertex::uuid).collect();
         let model = toroidal_model::<2>([2.0, 3.0], ToroidalConstructionMode::Canonicalized);
@@ -3569,9 +3567,9 @@ mod tests {
     #[test]
     fn test_canonicalize_vertices_preserves_data() {
         let vertices: Vec<Vertex<i32, 2>> = vec![
-            Vertex::try_new_with_data([2.5_f64, 3.7], 10_i32).unwrap(),
-            Vertex::try_new_with_data([1.8_f64, -0.5], 20_i32).unwrap(),
-            Vertex::try_new_with_data([0.5_f64, 0.7], 30_i32).unwrap(),
+            vertex!([2.5_f64, 3.7]; data = 10_i32).unwrap(),
+            vertex!([1.8_f64, -0.5]; data = 20_i32).unwrap(),
+            vertex!([0.5_f64, 0.7]; data = 30_i32).unwrap(),
         ];
         let model = toroidal_model::<2>([2.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let canonical =
@@ -3587,9 +3585,9 @@ mod tests {
     #[test]
     fn test_canonicalize_vertices_transforms_coordinates() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([2.5, 3.7]).unwrap(), // → (0.5, 0.7)
-            crate::core::vertex::Vertex::<(), _>::try_new([1.8, -0.5]).unwrap(), // → (1.8, 2.5)
-            crate::core::vertex::Vertex::<(), _>::try_new([0.3, 0.2]).unwrap(), // → (0.3, 0.2)
+            vertex!([2.5, 3.7]).unwrap(),  // → (0.5, 0.7)
+            vertex!([1.8, -0.5]).unwrap(), // → (1.8, 2.5)
+            vertex!([0.3, 0.2]).unwrap(),  // → (0.3, 0.2)
         ];
         let model = toroidal_model::<2>([2.0, 3.0], ToroidalConstructionMode::Canonicalized);
         let canonical =
@@ -3608,8 +3606,8 @@ mod tests {
     #[test]
     fn test_canonicalize_vertices_includes_vertex_context_on_error() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25_f64, 0.75_f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.9_f64, 0.1_f64]).unwrap(),
+            vertex!([0.25_f64, 0.75_f64]).unwrap(),
+            vertex!([0.9_f64, 0.1_f64]).unwrap(),
         ];
         let result = DelaunayTriangulationBuilder::<(), 2>::canonicalize_vertices(
             &vertices,
@@ -3634,11 +3632,11 @@ mod tests {
     fn test_build_periodic_requires_periodic_domain() {
         let kernel = AdaptiveKernel::new();
         let canonical_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1_f64, 0.1_f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.9_f64, 0.2_f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2_f64, 0.8_f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.7_f64, 0.9_f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5_f64, 0.4_f64]).unwrap(),
+            vertex!([0.1_f64, 0.1_f64]).unwrap(),
+            vertex!([0.9_f64, 0.2_f64]).unwrap(),
+            vertex!([0.2_f64, 0.8_f64]).unwrap(),
+            vertex!([0.7_f64, 0.9_f64]).unwrap(),
+            vertex!([0.5_f64, 0.4_f64]).unwrap(),
         ];
         let result = DelaunayTriangulationBuilder::<(), 2>::build_periodic::<_, (), _>(
             &kernel,
@@ -3661,9 +3659,9 @@ mod tests {
     #[test]
     fn test_canonicalize_vertices_euclidean_identity() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.5, 2.5]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([3.7, 4.2]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([-1.0, -2.0]).unwrap(),
+            vertex!([1.5, 2.5]).unwrap(),
+            vertex!([3.7, 4.2]).unwrap(),
+            vertex!([-1.0, -2.0]).unwrap(),
         ];
         let model = EuclideanModel;
         let canonical =

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -1511,6 +1511,13 @@ const fn default_batch_repair_policy() -> DelaunayRepairPolicy {
 }
 
 /// Options controlling batch construction behavior.
+///
+/// Defaults prioritize strict [`DelaunayTriangulation`] construction: insertion
+/// includes local repair and the completed triangulation must pass final Level 5
+/// Delaunay validation. Exact degenerate workloads that need to preserve a
+/// valid triangulation without proving strict empty-circumsphere validity can
+/// opt out with
+/// [`without_final_delaunay_enforcement`](Self::without_final_delaunay_enforcement).
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[non_exhaustive]
 pub struct ConstructionOptions {
@@ -1519,6 +1526,7 @@ pub struct ConstructionOptions {
     pub(crate) initial_simplex: InitialSimplexStrategy,
     pub(crate) retry_policy: RetryPolicy,
     pub(crate) batch_repair_policy: DelaunayRepairPolicy,
+    pub(crate) enforce_final_delaunay: bool,
     /// Whether final bulk repair can fall back to a global repair pass.
     pub(crate) use_global_repair_fallback: bool,
 }
@@ -1531,6 +1539,7 @@ impl Default for ConstructionOptions {
             initial_simplex: InitialSimplexStrategy::default(),
             retry_policy: RetryPolicy::default(),
             batch_repair_policy: default_batch_repair_policy(),
+            enforce_final_delaunay: true,
             use_global_repair_fallback: true,
         }
     }
@@ -1561,10 +1570,37 @@ impl ConstructionOptions {
         self.retry_policy
     }
 
-    /// Returns the automatic local Delaunay repair policy used during batch construction.
+    /// Returns the effective automatic local Delaunay repair policy used during batch construction.
+    ///
+    /// When final Level 5 Delaunay enforcement is disabled, construction does not
+    /// run automatic Delaunay repair and this returns [`DelaunayRepairPolicy::Never`].
     #[must_use]
     pub const fn batch_repair_policy(&self) -> DelaunayRepairPolicy {
-        self.batch_repair_policy
+        self.effective_batch_repair_policy()
+    }
+
+    /// Returns whether construction enforces final Level 5 Delaunay validity.
+    ///
+    /// When this is `true`, public constructors repair and validate the strict
+    /// Delaunay property before returning. When this is `false`, constructors
+    /// may return after Levels 1-4 validation so callers can preserve exact
+    /// degenerate connectivity and handle Level 5 policy externally.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::ConstructionOptions;
+    ///
+    /// assert!(ConstructionOptions::default().enforces_final_delaunay());
+    /// assert!(
+    ///     !ConstructionOptions::default()
+    ///         .without_final_delaunay_enforcement()
+    ///         .enforces_final_delaunay()
+    /// );
+    /// ```
+    #[must_use]
+    pub const fn enforces_final_delaunay(&self) -> bool {
+        self.enforce_final_delaunay
     }
 
     /// Sets the input ordering strategy used for batch construction.
@@ -1599,12 +1635,50 @@ impl ConstructionOptions {
     }
 
     /// Sets the automatic local Delaunay repair policy used during batch construction.
+    ///
+    /// This setting is effective only while
+    /// [`enforces_final_delaunay`](Self::enforces_final_delaunay) is `true`.
+    /// Non-enforcing construction always reports and uses
+    /// [`DelaunayRepairPolicy::Never`], so this setter is a no-op after
+    /// [`without_final_delaunay_enforcement`](Self::without_final_delaunay_enforcement).
     #[must_use]
     pub const fn with_batch_repair_policy(
         mut self,
         batch_repair_policy: DelaunayRepairPolicy,
     ) -> Self {
-        self.batch_repair_policy = batch_repair_policy;
+        if self.enforce_final_delaunay {
+            self.batch_repair_policy = batch_repair_policy;
+        }
+        self
+    }
+
+    /// Disables final Level 5 Delaunay enforcement during batch construction.
+    ///
+    /// The default constructor repairs and validates the strict Delaunay property
+    /// before returning. Exact degenerate inputs can have multiple valid
+    /// triangulations under symbolic perturbation, and flip-based strict repair
+    /// may cycle among equivalent choices. Use this mode when callers need a
+    /// valid Levels 1-4 triangulation that preserves exact coordinates and will
+    /// validate or repair the Level 5 Delaunay property separately.
+    ///
+    /// This also disables automatic batch Delaunay repair by setting
+    /// [`batch_repair_policy`](Self::batch_repair_policy) to
+    /// [`DelaunayRepairPolicy::Never`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{ConstructionOptions, DelaunayRepairPolicy};
+    ///
+    /// let options = ConstructionOptions::default().without_final_delaunay_enforcement();
+    ///
+    /// assert!(!options.enforces_final_delaunay());
+    /// assert_eq!(options.batch_repair_policy(), DelaunayRepairPolicy::Never);
+    /// ```
+    #[must_use]
+    pub const fn without_final_delaunay_enforcement(mut self) -> Self {
+        self.batch_repair_policy = DelaunayRepairPolicy::Never;
+        self.enforce_final_delaunay = false;
         self
     }
 
@@ -1613,6 +1687,15 @@ impl ConstructionOptions {
     pub(crate) const fn without_global_repair_fallback(mut self) -> Self {
         self.use_global_repair_fallback = false;
         self
+    }
+
+    /// Returns the batch repair policy that construction will actually apply.
+    pub(crate) const fn effective_batch_repair_policy(&self) -> DelaunayRepairPolicy {
+        if self.enforce_final_delaunay {
+            self.batch_repair_policy
+        } else {
+            DelaunayRepairPolicy::Never
+        }
     }
 }
 
@@ -3173,6 +3256,7 @@ where
         base_seed: Option<u64>,
         grid_cell_size: Option<f64>,
         batch_repair_policy: DelaunayRepairPolicy,
+        enforce_final_delaunay: bool,
         use_global_repair_fallback: bool,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
         let base_seed = base_seed.unwrap_or_else(|| Self::construction_shuffle_seed(vertices));
@@ -3197,33 +3281,39 @@ where
             vertices,
             topology_guarantee,
             0_u64,
-            true,
+            enforce_final_delaunay,
             grid_cell_size,
             batch_repair_policy,
             use_global_repair_fallback,
         ) {
-            Ok(candidate) => match candidate.is_delaunay_via_flips() {
-                Ok(()) => {
+            Ok(candidate) => {
+                if !enforce_final_delaunay {
                     log_construction_retry_result(0, None, 0_u64, "succeeded", None, None);
                     return Ok(candidate);
                 }
-                Err(source) if is_non_retryable_repair_error(&source) => {
-                    let err = Self::map_final_delaunay_repair_error(source);
-                    let err_string = err.to_string();
-                    log_construction_retry_result(
-                        0,
-                        None,
-                        0_u64,
-                        "failed",
-                        Some(&err_string),
-                        None,
-                    );
-                    return Err(err);
+                match candidate.is_delaunay_via_flips() {
+                    Ok(()) => {
+                        log_construction_retry_result(0, None, 0_u64, "succeeded", None, None);
+                        return Ok(candidate);
+                    }
+                    Err(source) if is_non_retryable_repair_error(&source) => {
+                        let err = Self::map_final_delaunay_repair_error(source);
+                        let err_string = err.to_string();
+                        log_construction_retry_result(
+                            0,
+                            None,
+                            0_u64,
+                            "failed",
+                            Some(&err_string),
+                            None,
+                        );
+                        return Err(err);
+                    }
+                    Err(source) => DelaunayConstructionRetryFailure::DelaunayValidation {
+                        source: Box::new(source),
+                    },
                 }
-                Err(source) => DelaunayConstructionRetryFailure::DelaunayValidation {
-                    source: Box::new(source),
-                },
-            },
+            }
             Err(err) => {
                 let err_string = err.to_string();
                 if Self::is_non_retryable_construction_error(&err) {
@@ -3286,13 +3376,13 @@ where
                 &shuffled,
                 topology_guarantee,
                 perturbation_seed,
-                true,
+                enforce_final_delaunay,
                 grid_cell_size,
                 batch_repair_policy,
                 use_global_repair_fallback,
             ) {
-                Ok(candidate) => match candidate.is_delaunay_via_flips() {
-                    Ok(()) => {
+                Ok(candidate) => {
+                    if !enforce_final_delaunay {
                         log_construction_retry_result(
                             attempt,
                             Some(attempt_seed),
@@ -3303,26 +3393,39 @@ where
                         );
                         return Ok(candidate);
                     }
-                    Err(source) => {
-                        if is_non_retryable_repair_error(&source) {
-                            let err = Self::map_final_delaunay_repair_error(source);
-                            let err_string = err.to_string();
+                    match candidate.is_delaunay_via_flips() {
+                        Ok(()) => {
                             log_construction_retry_result(
                                 attempt,
                                 Some(attempt_seed),
                                 perturbation_seed,
-                                "failed",
-                                Some(&err_string),
+                                "succeeded",
+                                None,
                                 None,
                             );
-                            return Err(err);
+                            return Ok(candidate);
                         }
-                        last_failure = DelaunayConstructionRetryFailure::DelaunayValidation {
-                            source: Box::new(source),
-                        };
-                        last_error = last_failure.to_string();
+                        Err(source) => {
+                            if is_non_retryable_repair_error(&source) {
+                                let err = Self::map_final_delaunay_repair_error(source);
+                                let err_string = err.to_string();
+                                log_construction_retry_result(
+                                    attempt,
+                                    Some(attempt_seed),
+                                    perturbation_seed,
+                                    "failed",
+                                    Some(&err_string),
+                                    None,
+                                );
+                                return Err(err);
+                            }
+                            last_failure = DelaunayConstructionRetryFailure::DelaunayValidation {
+                                source: Box::new(source),
+                            };
+                            last_error = last_failure.to_string();
+                        }
                     }
-                },
+                }
                 Err(err) => {
                     let err_string = err.to_string();
                     if Self::is_non_retryable_construction_error(&err) {
@@ -3395,6 +3498,7 @@ where
         base_seed: Option<u64>,
         grid_cell_size: Option<f64>,
         batch_repair_policy: DelaunayRepairPolicy,
+        enforce_final_delaunay: bool,
         use_global_repair_fallback: bool,
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
@@ -3424,12 +3528,24 @@ where
                 vertices,
                 topology_guarantee,
                 0_u64,
-                true,
+                enforce_final_delaunay,
                 grid_cell_size,
                 batch_repair_policy,
                 use_global_repair_fallback,
             ) {
                 Ok((candidate, mut stats)) => {
+                    if !enforce_final_delaunay {
+                        aggregate_stats.merge_from(&stats);
+                        log_construction_retry_result(
+                            0,
+                            None,
+                            0_u64,
+                            "succeeded",
+                            None,
+                            Some(&stats),
+                        );
+                        return Ok((candidate, aggregate_stats));
+                    }
                     let delaunay_started = Instant::now();
                     let delaunay_result = candidate.is_delaunay_via_flips();
                     stats
@@ -3551,12 +3667,24 @@ where
                 &shuffled,
                 topology_guarantee,
                 perturbation_seed,
-                true,
+                enforce_final_delaunay,
                 grid_cell_size,
                 batch_repair_policy,
                 use_global_repair_fallback,
             ) {
                 Ok((candidate, mut stats)) => {
+                    if !enforce_final_delaunay {
+                        aggregate_stats.merge_from(&stats);
+                        log_construction_retry_result(
+                            attempt,
+                            Some(attempt_seed),
+                            perturbation_seed,
+                            "succeeded",
+                            None,
+                            Some(&stats),
+                        );
+                        return Ok((candidate, aggregate_stats));
+                    }
                     let delaunay_started = Instant::now();
                     let delaunay_result = candidate.is_delaunay_via_flips();
                     stats
@@ -3671,6 +3799,7 @@ where
         topology_guarantee: TopologyGuarantee,
         grid_cell_size: Option<f64>,
         batch_repair_policy: DelaunayRepairPolicy,
+        enforce_final_delaunay: bool,
         use_global_repair_fallback: bool,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
         let dt = Self::build_with_kernel_inner_seeded(
@@ -3678,7 +3807,7 @@ where
             vertices,
             topology_guarantee,
             0,
-            true,
+            enforce_final_delaunay,
             grid_cell_size,
             batch_repair_policy,
             use_global_repair_fallback,
@@ -3686,22 +3815,24 @@ where
 
         // `DelaunayCheckPolicy::EndOnly`: always run a final global Delaunay validation pass after
         // batch construction.
-        tracing::debug!("post-construction: starting Delaunay validation (build)");
-        let delaunay_started = Instant::now();
-        let delaunay_result = dt.is_valid_delaunay();
-        tracing::debug!(
-            elapsed = ?delaunay_started.elapsed(),
-            success = delaunay_result.is_ok(),
-            "post-construction: Delaunay validation (build) completed"
-        );
-        delaunay_result.map_err(|source| {
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::FinalDelaunayValidation {
-                    context: FinalDelaunayValidationContext::ConstructionFinalize,
-                    source,
-                },
-            )
-        })?;
+        if enforce_final_delaunay {
+            tracing::debug!("post-construction: starting Delaunay validation (build)");
+            let delaunay_started = Instant::now();
+            let delaunay_result = dt.is_valid_delaunay();
+            tracing::debug!(
+                elapsed = ?delaunay_started.elapsed(),
+                success = delaunay_result.is_ok(),
+                "post-construction: Delaunay validation (build) completed"
+            );
+            delaunay_result.map_err(|source| {
+                DelaunayTriangulationConstructionError::Triangulation(
+                    DelaunayConstructionFailure::FinalDelaunayValidation {
+                        context: FinalDelaunayValidationContext::ConstructionFinalize,
+                        source,
+                    },
+                )
+            })?;
+        }
 
         Ok(dt)
     }
@@ -3718,6 +3849,7 @@ where
         topology_guarantee: TopologyGuarantee,
         grid_cell_size: Option<f64>,
         batch_repair_policy: DelaunayRepairPolicy,
+        enforce_final_delaunay: bool,
         use_global_repair_fallback: bool,
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
@@ -3726,7 +3858,7 @@ where
             vertices,
             topology_guarantee,
             0,
-            true,
+            enforce_final_delaunay,
             grid_cell_size,
             batch_repair_policy,
             use_global_repair_fallback,
@@ -3734,30 +3866,32 @@ where
 
         // `DelaunayCheckPolicy::EndOnly`: always run a final global Delaunay validation pass after
         // batch construction.
-        tracing::debug!("post-construction: starting Delaunay validation (build stats)");
-        let delaunay_started = Instant::now();
-        let delaunay_result = dt.is_valid_delaunay();
-        let delaunay_elapsed = delaunay_started.elapsed();
-        stats
-            .telemetry
-            .record_construction_final_delaunay_validation_timing(duration_nanos_saturating(
-                delaunay_elapsed,
-            ));
-        tracing::debug!(
-            elapsed = ?delaunay_elapsed,
-            success = delaunay_result.is_ok(),
-            "post-construction: Delaunay validation (build stats) completed"
-        );
-        if let Err(err) = delaunay_result {
-            return Err(DelaunayTriangulationConstructionErrorWithStatistics {
-                error: DelaunayTriangulationConstructionError::Triangulation(
-                    DelaunayConstructionFailure::FinalDelaunayValidation {
-                        context: FinalDelaunayValidationContext::ConstructionFinalize,
-                        source: err,
-                    },
-                ),
-                statistics: stats,
-            });
+        if enforce_final_delaunay {
+            tracing::debug!("post-construction: starting Delaunay validation (build stats)");
+            let delaunay_started = Instant::now();
+            let delaunay_result = dt.is_valid_delaunay();
+            let delaunay_elapsed = delaunay_started.elapsed();
+            stats
+                .telemetry
+                .record_construction_final_delaunay_validation_timing(duration_nanos_saturating(
+                    delaunay_elapsed,
+                ));
+            tracing::debug!(
+                elapsed = ?delaunay_elapsed,
+                success = delaunay_result.is_ok(),
+                "post-construction: Delaunay validation (build stats) completed"
+            );
+            if let Err(err) = delaunay_result {
+                return Err(DelaunayTriangulationConstructionErrorWithStatistics {
+                    error: DelaunayTriangulationConstructionError::Triangulation(
+                        DelaunayConstructionFailure::FinalDelaunayValidation {
+                            context: FinalDelaunayValidationContext::ConstructionFinalize,
+                            source: err,
+                        },
+                    ),
+                    statistics: stats,
+                });
+            }
         }
 
         Ok((dt, stats))
@@ -5002,13 +5136,15 @@ where
         topology_guarantee: TopologyGuarantee,
         options: ConstructionOptions,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
+        let batch_repair_policy = options.effective_batch_repair_policy();
         let ConstructionOptions {
             insertion_order,
             dedup_policy,
             initial_simplex,
             retry_policy,
-            batch_repair_policy,
+            enforce_final_delaunay,
             use_global_repair_fallback,
+            ..
         } = options;
 
         let preprocessed = Self::preprocess_vertices_for_construction(
@@ -5037,6 +5173,7 @@ where
                             base_seed,
                             grid_cell_size,
                             batch_repair_policy,
+                            enforce_final_delaunay,
                             use_global_repair_fallback,
                         );
                     }
@@ -5056,6 +5193,7 @@ where
                             base_seed,
                             grid_cell_size,
                             batch_repair_policy,
+                            enforce_final_delaunay,
                             use_global_repair_fallback,
                         );
                     }
@@ -5068,6 +5206,7 @@ where
                 topology_guarantee,
                 grid_cell_size,
                 batch_repair_policy,
+                enforce_final_delaunay,
                 use_global_repair_fallback,
             )
         };
@@ -5144,13 +5283,15 @@ where
         options: ConstructionOptions,
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
+        let batch_repair_policy = options.effective_batch_repair_policy();
         let ConstructionOptions {
             insertion_order,
             dedup_policy,
             initial_simplex,
             retry_policy,
-            batch_repair_policy,
+            enforce_final_delaunay,
             use_global_repair_fallback,
+            ..
         } = options;
 
         let preprocessing_started = Instant::now();
@@ -5195,6 +5336,7 @@ where
                             base_seed,
                             grid_cell_size,
                             batch_repair_policy,
+                            enforce_final_delaunay,
                             use_global_repair_fallback,
                         );
                     }
@@ -5214,6 +5356,7 @@ where
                             base_seed,
                             grid_cell_size,
                             batch_repair_policy,
+                            enforce_final_delaunay,
                             use_global_repair_fallback,
                         );
                     }
@@ -5226,6 +5369,7 @@ where
                 topology_guarantee,
                 grid_cell_size,
                 batch_repair_policy,
+                enforce_final_delaunay,
                 use_global_repair_fallback,
             )
         };
@@ -6316,6 +6460,7 @@ mod tests {
             ConstructionOptions::default().batch_repair_policy(),
             DelaunayRepairPolicy::EveryInsertion
         );
+        assert!(ConstructionOptions::default().enforces_final_delaunay());
         assert_eq!(
             DelaunayRepairPolicy::default(),
             DelaunayRepairPolicy::EveryInsertion
@@ -6337,6 +6482,23 @@ mod tests {
             DelaunayRepairPolicy::EveryN(NonZeroUsize::new(4).unwrap())
         );
         assert_eq!(opts.retry_policy(), RetryPolicy::Disabled);
+        assert!(opts.enforces_final_delaunay());
+
+        let non_enforcing = opts.without_final_delaunay_enforcement();
+        assert!(!non_enforcing.enforces_final_delaunay());
+        assert_eq!(
+            non_enforcing.batch_repair_policy(),
+            DelaunayRepairPolicy::Never
+        );
+
+        let late_repair_policy = non_enforcing
+            .with_batch_repair_policy(DelaunayRepairPolicy::EveryN(NonZeroUsize::new(8).unwrap()));
+        assert!(!late_repair_policy.enforces_final_delaunay());
+        assert_eq!(
+            late_repair_policy.batch_repair_policy(),
+            DelaunayRepairPolicy::Never
+        );
+        assert_eq!(late_repair_policy, non_enforcing);
     }
 
     #[test]

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -42,7 +42,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::builder::DelaunayTriangulationBuilder;
+use crate::builder::{DelaunayTriangulationBuilder, ExplicitConstructionError};
 use crate::core::algorithms::flips::{
     DelaunayRepairError, DelaunayRepairStats, FlipError, LocalRepairPhaseTiming,
     repair_delaunay_local_single_pass, repair_delaunay_local_single_pass_timed,
@@ -443,7 +443,7 @@ pub enum DelaunayTriangulationConstructionError {
 
     /// Input validation error from explicit combinatorial construction.
     #[error(transparent)]
-    ExplicitConstruction(#[from] crate::builder::ExplicitConstructionError),
+    ExplicitConstruction(#[from] ExplicitConstructionError),
 }
 
 impl From<TriangulationConstructionError> for DelaunayTriangulationConstructionError {
@@ -1510,6 +1510,79 @@ const fn default_batch_repair_policy() -> DelaunayRepairPolicy {
     DelaunayRepairPolicy::EveryInsertion
 }
 
+/// Final Level 5 policy for batch construction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FinalDelaunayEnforcement {
+    /// Run strict Delaunay repair/validation with the configured batch policy.
+    Strict {
+        /// Automatic local Delaunay repair cadence used during batch construction.
+        batch_repair_policy: DelaunayRepairPolicy,
+        /// Whether final bulk repair can fall back to a global repair pass.
+        use_global_repair_fallback: bool,
+    },
+    /// Return after Levels 1-4 validation without attempting Level 5 repair.
+    Disabled,
+}
+
+impl FinalDelaunayEnforcement {
+    const fn strict_default() -> Self {
+        Self::Strict {
+            batch_repair_policy: default_batch_repair_policy(),
+            use_global_repair_fallback: true,
+        }
+    }
+
+    const fn enforces_final_delaunay(self) -> bool {
+        matches!(self, Self::Strict { .. })
+    }
+
+    const fn batch_repair_policy(self) -> DelaunayRepairPolicy {
+        match self {
+            Self::Strict {
+                batch_repair_policy,
+                ..
+            } => batch_repair_policy,
+            Self::Disabled => DelaunayRepairPolicy::Never,
+        }
+    }
+
+    const fn use_global_repair_fallback(self) -> bool {
+        match self {
+            Self::Strict {
+                use_global_repair_fallback,
+                ..
+            } => use_global_repair_fallback,
+            Self::Disabled => false,
+        }
+    }
+
+    const fn with_batch_repair_policy(self, batch_repair_policy: DelaunayRepairPolicy) -> Self {
+        match self {
+            Self::Strict {
+                use_global_repair_fallback,
+                ..
+            } => Self::Strict {
+                batch_repair_policy,
+                use_global_repair_fallback,
+            },
+            Self::Disabled => Self::Disabled,
+        }
+    }
+
+    const fn without_global_repair_fallback(self) -> Self {
+        match self {
+            Self::Strict {
+                batch_repair_policy,
+                ..
+            } => Self::Strict {
+                batch_repair_policy,
+                use_global_repair_fallback: false,
+            },
+            Self::Disabled => Self::Disabled,
+        }
+    }
+}
+
 /// Options controlling batch construction behavior.
 ///
 /// Defaults prioritize strict [`DelaunayTriangulation`] construction: insertion
@@ -1525,10 +1598,7 @@ pub struct ConstructionOptions {
     pub(crate) dedup_policy: DedupPolicy,
     pub(crate) initial_simplex: InitialSimplexStrategy,
     pub(crate) retry_policy: RetryPolicy,
-    pub(crate) batch_repair_policy: DelaunayRepairPolicy,
-    pub(crate) enforce_final_delaunay: bool,
-    /// Whether final bulk repair can fall back to a global repair pass.
-    pub(crate) use_global_repair_fallback: bool,
+    pub(crate) final_delaunay: FinalDelaunayEnforcement,
 }
 
 impl Default for ConstructionOptions {
@@ -1538,9 +1608,7 @@ impl Default for ConstructionOptions {
             dedup_policy: DedupPolicy::default(),
             initial_simplex: InitialSimplexStrategy::default(),
             retry_policy: RetryPolicy::default(),
-            batch_repair_policy: default_batch_repair_policy(),
-            enforce_final_delaunay: true,
-            use_global_repair_fallback: true,
+            final_delaunay: FinalDelaunayEnforcement::strict_default(),
         }
     }
 }
@@ -1574,9 +1642,19 @@ impl ConstructionOptions {
     ///
     /// When final Level 5 Delaunay enforcement is disabled, construction does not
     /// run automatic Delaunay repair and this returns [`DelaunayRepairPolicy::Never`].
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{ConstructionOptions, DelaunayRepairPolicy};
+    ///
+    /// let options = ConstructionOptions::default().without_final_delaunay_enforcement();
+    ///
+    /// assert_eq!(options.batch_repair_policy(), DelaunayRepairPolicy::Never);
+    /// ```
     #[must_use]
     pub const fn batch_repair_policy(&self) -> DelaunayRepairPolicy {
-        self.effective_batch_repair_policy()
+        self.final_delaunay.batch_repair_policy()
     }
 
     /// Returns whether construction enforces final Level 5 Delaunay validity.
@@ -1600,7 +1678,7 @@ impl ConstructionOptions {
     /// ```
     #[must_use]
     pub const fn enforces_final_delaunay(&self) -> bool {
-        self.enforce_final_delaunay
+        self.final_delaunay.enforces_final_delaunay()
     }
 
     /// Sets the input ordering strategy used for batch construction.
@@ -1641,14 +1719,30 @@ impl ConstructionOptions {
     /// Non-enforcing construction always reports and uses
     /// [`DelaunayRepairPolicy::Never`], so this setter is a no-op after
     /// [`without_final_delaunay_enforcement`](Self::without_final_delaunay_enforcement).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{ConstructionOptions, DelaunayRepairPolicy};
+    /// use std::num::NonZeroUsize;
+    ///
+    /// let every = NonZeroUsize::MIN;
+    /// let options = ConstructionOptions::default()
+    ///     .with_batch_repair_policy(DelaunayRepairPolicy::EveryN(every));
+    ///
+    /// assert_eq!(options.batch_repair_policy(), DelaunayRepairPolicy::EveryN(every));
+    ///
+    /// let non_enforcing = options.without_final_delaunay_enforcement();
+    /// assert_eq!(non_enforcing.batch_repair_policy(), DelaunayRepairPolicy::Never);
+    /// ```
     #[must_use]
     pub const fn with_batch_repair_policy(
         mut self,
         batch_repair_policy: DelaunayRepairPolicy,
     ) -> Self {
-        if self.enforce_final_delaunay {
-            self.batch_repair_policy = batch_repair_policy;
-        }
+        self.final_delaunay = self
+            .final_delaunay
+            .with_batch_repair_policy(batch_repair_policy);
         self
     }
 
@@ -1677,25 +1771,15 @@ impl ConstructionOptions {
     /// ```
     #[must_use]
     pub const fn without_final_delaunay_enforcement(mut self) -> Self {
-        self.batch_repair_policy = DelaunayRepairPolicy::Never;
-        self.enforce_final_delaunay = false;
+        self.final_delaunay = FinalDelaunayEnforcement::Disabled;
         self
     }
 
     /// Disables the D<4 global repair fallback.
     #[must_use]
     pub(crate) const fn without_global_repair_fallback(mut self) -> Self {
-        self.use_global_repair_fallback = false;
+        self.final_delaunay = self.final_delaunay.without_global_repair_fallback();
         self
-    }
-
-    /// Returns the batch repair policy that construction will actually apply.
-    pub(crate) const fn effective_batch_repair_policy(&self) -> DelaunayRepairPolicy {
-        if self.enforce_final_delaunay {
-            self.batch_repair_policy
-        } else {
-            DelaunayRepairPolicy::Never
-        }
     }
 }
 
@@ -2961,7 +3045,10 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Errors
     /// Returns [`DelaunayTriangulationConstructionErrorWithStatistics`] if
     /// construction fails. The error includes partial statistics collected
-    /// before failure.
+    /// before failure. If
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`] is selected,
+    /// construction still fails when Levels 1–4 validation fails; only final
+    /// Level 5 Delaunay repair and validation are skipped.
     ///
     /// # Examples
     ///
@@ -3019,7 +3106,10 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// # Errors
     /// Returns [`DelaunayTriangulationConstructionErrorWithStatistics`] if
     /// construction fails. The error includes partial statistics collected
-    /// before failure.
+    /// before failure. If
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`] is selected,
+    /// construction still fails when Levels 1–4 validation fails; only final
+    /// Level 5 Delaunay repair and validation are skipped.
     ///
     /// # Examples
     ///
@@ -3087,7 +3177,10 @@ impl<const D: usize> DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D> {
     /// when skipped-input observability is required.
     ///
     /// # Errors
-    /// Returns an error if construction fails, or if the selected options are invalid.
+    /// Returns an error if construction fails, or if the selected options are
+    /// invalid. If [`ConstructionOptions::without_final_delaunay_enforcement`]
+    /// is selected, construction still fails when Levels 1–4 validation fails;
+    /// only final Level 5 Delaunay repair and validation are skipped.
     ///
     /// # Examples
     ///
@@ -3244,10 +3337,6 @@ where
         clippy::too_many_lines,
         reason = "construction retry flow keeps seed selection, validation, and diagnostics together"
     )]
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "private construction retry helper threads orthogonal batch knobs explicitly"
-    )]
     pub(crate) fn build_with_shuffled_retries(
         kernel: &K,
         vertices: &[Vertex<U, D>],
@@ -3255,11 +3344,10 @@ where
         attempts: NonZeroUsize,
         base_seed: Option<u64>,
         grid_cell_size: Option<f64>,
-        batch_repair_policy: DelaunayRepairPolicy,
-        enforce_final_delaunay: bool,
-        use_global_repair_fallback: bool,
+        final_delaunay: FinalDelaunayEnforcement,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
         let base_seed = base_seed.unwrap_or_else(|| Self::construction_shuffle_seed(vertices));
+        let enforce_final_delaunay = final_delaunay.enforces_final_delaunay();
 
         #[cfg(debug_assertions)]
         let log_shuffle = env::var_os("DELAUNAY_DEBUG_SHUFFLE").is_some();
@@ -3281,10 +3369,8 @@ where
             vertices,
             topology_guarantee,
             0_u64,
-            enforce_final_delaunay,
             grid_cell_size,
-            batch_repair_policy,
-            use_global_repair_fallback,
+            final_delaunay,
         ) {
             Ok(candidate) => {
                 if !enforce_final_delaunay {
@@ -3376,10 +3462,8 @@ where
                 &shuffled,
                 topology_guarantee,
                 perturbation_seed,
-                enforce_final_delaunay,
                 grid_cell_size,
-                batch_repair_policy,
-                use_global_repair_fallback,
+                final_delaunay,
             ) {
                 Ok(candidate) => {
                     if !enforce_final_delaunay {
@@ -3486,10 +3570,6 @@ where
         clippy::result_large_err,
         reason = "Internal helper propagates public by-value construction-statistics error type"
     )]
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "statistics retry helper mirrors the non-statistics construction path"
-    )]
     pub(crate) fn build_with_shuffled_retries_with_construction_statistics(
         kernel: &K,
         vertices: &[Vertex<U, D>],
@@ -3497,12 +3577,11 @@ where
         attempts: NonZeroUsize,
         base_seed: Option<u64>,
         grid_cell_size: Option<f64>,
-        batch_repair_policy: DelaunayRepairPolicy,
-        enforce_final_delaunay: bool,
-        use_global_repair_fallback: bool,
+        final_delaunay: FinalDelaunayEnforcement,
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
         let base_seed = base_seed.unwrap_or_else(|| Self::construction_shuffle_seed(vertices));
+        let enforce_final_delaunay = final_delaunay.enforces_final_delaunay();
 
         #[cfg(debug_assertions)]
         let log_shuffle = env::var_os("DELAUNAY_DEBUG_SHUFFLE").is_some();
@@ -3528,10 +3607,8 @@ where
                 vertices,
                 topology_guarantee,
                 0_u64,
-                enforce_final_delaunay,
                 grid_cell_size,
-                batch_repair_policy,
-                use_global_repair_fallback,
+                final_delaunay,
             ) {
                 Ok((candidate, mut stats)) => {
                     if !enforce_final_delaunay {
@@ -3667,10 +3744,8 @@ where
                 &shuffled,
                 topology_guarantee,
                 perturbation_seed,
-                enforce_final_delaunay,
                 grid_cell_size,
-                batch_repair_policy,
-                use_global_repair_fallback,
+                final_delaunay,
             ) {
                 Ok((candidate, mut stats)) => {
                     if !enforce_final_delaunay {
@@ -3798,20 +3873,17 @@ where
         vertices: &[Vertex<U, D>],
         topology_guarantee: TopologyGuarantee,
         grid_cell_size: Option<f64>,
-        batch_repair_policy: DelaunayRepairPolicy,
-        enforce_final_delaunay: bool,
-        use_global_repair_fallback: bool,
+        final_delaunay: FinalDelaunayEnforcement,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
         let dt = Self::build_with_kernel_inner_seeded(
             kernel,
             vertices,
             topology_guarantee,
             0,
-            enforce_final_delaunay,
             grid_cell_size,
-            batch_repair_policy,
-            use_global_repair_fallback,
+            final_delaunay,
         )?;
+        let enforce_final_delaunay = final_delaunay.enforces_final_delaunay();
 
         // `DelaunayCheckPolicy::EndOnly`: always run a final global Delaunay validation pass after
         // batch construction.
@@ -3848,9 +3920,7 @@ where
         vertices: &[Vertex<U, D>],
         topology_guarantee: TopologyGuarantee,
         grid_cell_size: Option<f64>,
-        batch_repair_policy: DelaunayRepairPolicy,
-        enforce_final_delaunay: bool,
-        use_global_repair_fallback: bool,
+        final_delaunay: FinalDelaunayEnforcement,
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
         let (dt, mut stats) = Self::build_with_kernel_inner_seeded_with_construction_statistics(
@@ -3858,11 +3928,10 @@ where
             vertices,
             topology_guarantee,
             0,
-            enforce_final_delaunay,
             grid_cell_size,
-            batch_repair_policy,
-            use_global_repair_fallback,
+            final_delaunay,
         )?;
+        let enforce_final_delaunay = final_delaunay.enforces_final_delaunay();
 
         // `DelaunayCheckPolicy::EndOnly`: always run a final global Delaunay validation pass after
         // batch construction.
@@ -3903,21 +3972,19 @@ where
         clippy::result_large_err,
         reason = "Internal helper propagates public by-value construction-statistics error type"
     )]
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "seeded construction helper carries retry, repair, and validation knobs"
-    )]
     fn build_with_kernel_inner_seeded_with_construction_statistics(
         kernel: K,
         vertices: &[Vertex<U, D>],
         topology_guarantee: TopologyGuarantee,
         perturbation_seed: u64,
-        run_final_repair: bool,
         grid_cell_size: Option<f64>,
-        batch_repair_policy: DelaunayRepairPolicy,
-        use_global_repair_fallback: bool,
+        final_delaunay: FinalDelaunayEnforcement,
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
+        let batch_repair_policy = final_delaunay.batch_repair_policy();
+        let run_final_repair = final_delaunay.enforces_final_delaunay();
+        let use_global_repair_fallback = final_delaunay.use_global_repair_fallback();
+
         if vertices.len() < D + 1 {
             return Err(DelaunayTriangulationConstructionErrorWithStatistics {
                 error: TriangulationConstructionError::InsufficientVertices {
@@ -4044,20 +4111,18 @@ where
 
     /// Implements the non-statistics seeded construction core for callers that
     /// only need the triangulation.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "seeded construction helper carries retry, repair, and validation knobs"
-    )]
     fn build_with_kernel_inner_seeded(
         kernel: K,
         vertices: &[Vertex<U, D>],
         topology_guarantee: TopologyGuarantee,
         perturbation_seed: u64,
-        run_final_repair: bool,
         grid_cell_size: Option<f64>,
-        batch_repair_policy: DelaunayRepairPolicy,
-        use_global_repair_fallback: bool,
+        final_delaunay: FinalDelaunayEnforcement,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
+        let batch_repair_policy = final_delaunay.batch_repair_policy();
+        let run_final_repair = final_delaunay.enforces_final_delaunay();
+        let use_global_repair_fallback = final_delaunay.use_global_repair_fallback();
+
         if vertices.len() < D + 1 {
             return Err(TriangulationConstructionError::InsufficientVertices {
                 dimension: D,
@@ -5101,7 +5166,10 @@ where
     ///
     /// # Errors
     /// Returns an error if construction fails, if validation fails, or if the
-    /// selected preprocessing options are invalid.
+    /// selected preprocessing options are invalid. If
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`] is selected,
+    /// construction still fails when Levels 1–4 validation fails; only final
+    /// Level 5 Delaunay repair and validation are skipped.
     ///
     /// # Examples
     ///
@@ -5136,15 +5204,12 @@ where
         topology_guarantee: TopologyGuarantee,
         options: ConstructionOptions,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
-        let batch_repair_policy = options.effective_batch_repair_policy();
         let ConstructionOptions {
             insertion_order,
             dedup_policy,
             initial_simplex,
             retry_policy,
-            enforce_final_delaunay,
-            use_global_repair_fallback,
-            ..
+            final_delaunay,
         } = options;
 
         let preprocessed = Self::preprocess_vertices_for_construction(
@@ -5172,9 +5237,7 @@ where
                             attempts,
                             base_seed,
                             grid_cell_size,
-                            batch_repair_policy,
-                            enforce_final_delaunay,
-                            use_global_repair_fallback,
+                            final_delaunay,
                         );
                     }
                 }
@@ -5192,9 +5255,7 @@ where
                             attempts,
                             base_seed,
                             grid_cell_size,
-                            batch_repair_policy,
-                            enforce_final_delaunay,
-                            use_global_repair_fallback,
+                            final_delaunay,
                         );
                     }
                 }
@@ -5205,9 +5266,7 @@ where
                 vertices,
                 topology_guarantee,
                 grid_cell_size,
-                batch_repair_policy,
-                enforce_final_delaunay,
-                use_global_repair_fallback,
+                final_delaunay,
             )
         };
 
@@ -5232,7 +5291,10 @@ where
     /// # Errors
     /// Returns [`DelaunayTriangulationConstructionErrorWithStatistics`] if
     /// construction fails. The error includes the partial statistics collected
-    /// before failure.
+    /// before failure. If
+    /// [`ConstructionOptions::without_final_delaunay_enforcement`] is selected,
+    /// construction still fails when Levels 1–4 validation fails; only final
+    /// Level 5 Delaunay repair and validation are skipped.
     ///
     /// # Examples
     ///
@@ -5283,15 +5345,12 @@ where
         options: ConstructionOptions,
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
-        let batch_repair_policy = options.effective_batch_repair_policy();
         let ConstructionOptions {
             insertion_order,
             dedup_policy,
             initial_simplex,
             retry_policy,
-            enforce_final_delaunay,
-            use_global_repair_fallback,
-            ..
+            final_delaunay,
         } = options;
 
         let preprocessing_started = Instant::now();
@@ -5335,9 +5394,7 @@ where
                             attempts,
                             base_seed,
                             grid_cell_size,
-                            batch_repair_policy,
-                            enforce_final_delaunay,
-                            use_global_repair_fallback,
+                            final_delaunay,
                         );
                     }
                 }
@@ -5355,9 +5412,7 @@ where
                             attempts,
                             base_seed,
                             grid_cell_size,
-                            batch_repair_policy,
-                            enforce_final_delaunay,
-                            use_global_repair_fallback,
+                            final_delaunay,
                         );
                     }
                 }
@@ -5368,9 +5423,7 @@ where
                 vertices,
                 topology_guarantee,
                 grid_cell_size,
-                batch_repair_policy,
-                enforce_final_delaunay,
-                use_global_repair_fallback,
+                final_delaunay,
             )
         };
 
@@ -6064,10 +6117,10 @@ mod tests {
     fn test_finalize_bulk_construction_validates_pseudomanifold_topology() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 2.0]).unwrap(),
+            vertex!([2.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulation::try_new_with_topology_guarantee(
             &vertices,
@@ -6229,9 +6282,9 @@ mod tests {
     fn test_with_kernel_fast_kernel() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<FastKernel<f64>, (), (), 2> =
@@ -6245,9 +6298,9 @@ mod tests {
     fn test_with_kernel_robust_kernel() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<RobustKernel<f64>, (), (), 2> =
@@ -6260,10 +6313,7 @@ mod tests {
     #[test]
     fn test_with_kernel_insufficient_vertices_2d() {
         init_tracing();
-        let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        ];
+        let vertices = vec![vertex!([0.0, 0.0]).unwrap(), vertex!([1.0, 0.0]).unwrap()];
 
         let result: Result<DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2>, _> =
             DelaunayTriangulation::try_with_kernel(&AdaptiveKernel::new(), &vertices);
@@ -6280,9 +6330,9 @@ mod tests {
     fn test_with_kernel_insufficient_vertices_3d() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
         ];
 
         let result: Result<DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 3>, _> =
@@ -6300,9 +6350,9 @@ mod tests {
     fn test_with_kernel_aborts_on_duplicate_uuid_in_insertion_loop() {
         init_tracing();
         let mut vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 2.0]).unwrap(),
         ];
 
         let dup_uuid = vertices[0].uuid();
@@ -6332,11 +6382,11 @@ mod tests {
     fn test_batch_3d_construction_with_extra_vertex_triggers_incremental_repair() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.3, 0.3, 0.3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.3, 0.3, 0.3]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -6348,11 +6398,11 @@ mod tests {
     fn test_batch_3d_construction_statistics_with_extra_vertex_triggers_incremental_repair() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.3, 0.3, 0.3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.3, 0.3, 0.3]).unwrap(),
         ];
         let (dt, stats) =
             DelaunayTriangulation::<_, (), (), 3>::try_new_with_construction_statistics(&vertices)
@@ -6366,13 +6416,13 @@ mod tests {
     fn test_batch_4d_forced_nonconvergent_local_repair_canonicalizes_without_stats() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.35, 0.25, 0.15, 0.3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
+            vertex!([0.35, 0.25, 0.15, 0.3]).unwrap(),
         ];
 
         let _guard = ForceRepairNonconvergentGuard::enable();
@@ -6390,13 +6440,13 @@ mod tests {
     fn test_batch_4d_forced_nonconvergent_local_repair_canonicalizes_with_stats() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.35, 0.25, 0.15, 0.3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
+            vertex!([0.35, 0.25, 0.15, 0.3]).unwrap(),
         ];
 
         let _guard = ForceRepairNonconvergentGuard::enable();
@@ -6421,13 +6471,13 @@ mod tests {
     fn test_batch_4d_every_n_repair_cadence_runs_with_pending_seeds() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.35, 0.25, 0.15, 0.3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
+            vertex!([0.35, 0.25, 0.15, 0.3]).unwrap(),
         ];
 
         test_hooks::reset_batch_local_repair_calls();
@@ -6504,16 +6554,16 @@ mod tests {
     #[test]
     fn construction_options_global_repair_fallback_toggle() {
         let default_opts = ConstructionOptions::default();
-        assert!(default_opts.use_global_repair_fallback);
+        assert!(default_opts.final_delaunay.use_global_repair_fallback());
 
         let disabled_opts = default_opts.without_global_repair_fallback();
-        assert!(!disabled_opts.use_global_repair_fallback);
+        assert!(!disabled_opts.final_delaunay.use_global_repair_fallback());
 
         let chained_opts = ConstructionOptions::default()
             .with_insertion_order(InsertionOrderStrategy::Input)
             .without_global_repair_fallback()
             .with_retry_policy(RetryPolicy::Disabled);
-        assert!(!chained_opts.use_global_repair_fallback);
+        assert!(!chained_opts.final_delaunay.use_global_repair_fallback());
         assert_eq!(
             chained_opts.insertion_order(),
             InsertionOrderStrategy::Input
@@ -6709,8 +6759,7 @@ mod tests {
     #[test]
     fn test_vertex_coords_f64_converts_f64_vertex_coords() {
         init_tracing();
-        let vertex: Vertex<(), 3> =
-            crate::core::vertex::Vertex::<(), _>::try_new([1.25, -2.5, 3.75]).unwrap();
+        let vertex: Vertex<(), 3> = vertex!([1.25, -2.5, 3.75]).unwrap();
 
         assert_eq!(vertex_coords_f64(&vertex), Some(vec![1.25, -2.5, 3.75]));
     }
@@ -6730,9 +6779,9 @@ mod tests {
     fn order_vertices_input_preserves_order() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
         ];
         let expected = coord_sequence_2d(&vertices);
 
@@ -6745,10 +6794,10 @@ mod tests {
     fn preprocess_hilbert_with_dedup_off_preserves_duplicate_vertices() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
         ];
 
         let preprocess = TestDelaunay::<2>::preprocess_vertices_for_construction(
@@ -6766,10 +6815,10 @@ mod tests {
     fn dedup_exact_sorted_without_grid() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let unique = dedup_vertices_exact_sorted(vertices);
@@ -6784,9 +6833,9 @@ mod tests {
     fn dedup_exact_grid_fallback() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
         ];
         let mut grid = HashGridIndex::<2, usize>::try_new(1.0e-10).unwrap();
 
@@ -6795,8 +6844,8 @@ mod tests {
         assert_eq!(coord_sequence_2d(&unique), vec![[0.0, 0.0], [1.0, 0.0]]);
 
         let vertices_6d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
         ];
         let mut unusable_grid = HashGridIndex::<6, usize>::try_new(1.0e-10).unwrap();
 
@@ -6809,27 +6858,25 @@ mod tests {
     fn epsilon_dedup_quantized_paths() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.09, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([0.09, 0.0]).unwrap(),
+            vertex!([0.25, 0.0]).unwrap(),
         ];
 
         let unique = dedup_vertices_epsilon_quantized(vertices, 0.1);
 
         assert_eq!(coord_sequence_2d(&unique), vec![[0.0, 0.0], [0.25, 0.0]]);
 
-        let zero_epsilon_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        ];
+        let zero_epsilon_vertices =
+            vec![vertex!([0.0, 0.0]).unwrap(), vertex!([0.0, 0.0]).unwrap()];
         let zero_epsilon_unique = dedup_vertices_epsilon_quantized(zero_epsilon_vertices, 0.0);
         assert_eq!(zero_epsilon_unique.len(), 2);
 
         assert!(Point::<2>::try_new([f64::NAN, 0.0]).is_err());
 
         let vertices_6d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.01, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.01, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
         ];
         let fallback_unique = dedup_vertices_epsilon_quantized(vertices_6d, 0.1);
         assert_eq!(fallback_unique.len(), 1);
@@ -6839,9 +6886,9 @@ mod tests {
     fn dedup_epsilon_grid_fallback() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.05, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([0.05, 0.0]).unwrap(),
+            vertex!([0.25, 0.0]).unwrap(),
         ];
         let mut grid = HashGridIndex::<2, usize>::try_new(0.1).unwrap();
 
@@ -6849,10 +6896,7 @@ mod tests {
 
         assert_eq!(coord_sequence_2d(&unique), vec![[0.0, 0.0], [0.25, 0.0]]);
 
-        let fallback_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.05, 0.0]).unwrap(),
-        ];
+        let fallback_vertices = vec![vertex!([0.0, 0.0]).unwrap(), vertex!([0.05, 0.0]).unwrap()];
         let mut unusable_grid = HashGridIndex::<2, usize>::try_new(0.1).unwrap();
         unusable_grid.remove_vertex(&0, &[f64::NAN, 0.0]);
 
@@ -6866,9 +6910,9 @@ mod tests {
     fn preprocess_falls_back_when_grid_unusable() {
         init_tracing();
         let exact_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
         ];
 
         let exact = TestDelaunay::<6>::preprocess_vertices_for_construction(
@@ -6883,9 +6927,9 @@ mod tests {
         assert!(exact.grid_cell_size().is_none());
 
         let epsilon_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.01, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.01, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
         ];
 
         let epsilon = TestDelaunay::<6>::preprocess_vertices_for_construction(
@@ -6904,9 +6948,9 @@ mod tests {
     fn preprocess_zero_epsilon_keeps_base() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
         ];
 
         let preprocess = TestDelaunay::<3>::preprocess_vertices_for_construction(
@@ -6965,10 +7009,7 @@ mod tests {
     #[test]
     fn hilbert_fallback_for_unsupported_dim() {
         init_tracing();
-        let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0; 17]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0; 17]).unwrap(),
-        ];
+        let vertices = vec![vertex!([1.0; 17]).unwrap(), vertex!([0.0; 17]).unwrap()];
 
         let ordered = order_vertices_hilbert(vertices, true);
 
@@ -6980,9 +7021,9 @@ mod tests {
     fn test_select_balanced_simplex_indices_insufficient_vertices() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
         ];
 
         let result = select_balanced_simplex_indices(&vertices);
@@ -7000,7 +7041,7 @@ mod tests {
             #[test]
             fn $test_name() {
                 init_tracing();
-                let vertices: Vec<Vertex<(), $dimension>> = vec![$(crate::core::vertex::Vertex::<(), _>::try_new($coords).unwrap()),+];
+                let vertices: Vec<Vertex<(), $dimension>> = vec![$(vertex!($coords).unwrap()),+];
 
                 let result = select_max_volume_simplex_indices(&vertices)
                     .expect("max-volume simplex selection failed");
@@ -7086,10 +7127,10 @@ mod tests {
     fn test_select_max_volume_simplex_indices_rejects_degenerate_pool() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0, 0.0]).unwrap(),
+            vertex!([3.0, 0.0, 0.0]).unwrap(),
         ];
 
         let result = select_max_volume_simplex_indices(&vertices);
@@ -7100,11 +7141,11 @@ mod tests {
     fn test_reorder_vertices_for_simplex_valid_and_invalid() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0, 2.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([2.0, 2.0, 2.0]).unwrap(),
         ];
 
         let indices = [2_usize, 0, 3, 1];
@@ -7134,11 +7175,11 @@ mod tests {
     fn test_preprocess_vertices_for_construction_balanced_sets_fallback() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0, 2.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([2.0, 2.0, 2.0]).unwrap(),
         ];
 
         let preprocess = DelaunayTriangulation::<AdaptiveKernel<f64>, (), (), 3>::preprocess_vertices_for_construction(
@@ -7159,13 +7200,13 @@ mod tests {
     fn test_preprocess_vertices_for_construction_max_volume_sets_largest_simplex_first() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([10.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 10.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 10.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([10.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 10.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 10.0]).unwrap(),
         ];
 
         let preprocess = DelaunayTriangulation::<
@@ -7245,7 +7286,7 @@ mod tests {
     ) -> Vec<Vertex<(), 3>> {
         permutation
             .iter()
-            .map(|&i| crate::core::vertex::Vertex::<(), _>::try_new(coords[i]).unwrap())
+            .map(|&i| vertex!(coords[i]).unwrap())
             .collect()
     }
 
@@ -7254,13 +7295,13 @@ mod tests {
         init_tracing();
         // Test that epsilon-based deduplication removes near-duplicates
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.25, 0.25, 0.25]).unwrap(),
             // Near-duplicate within tolerance 1e-10
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25 + 5e-11, 0.25, 0.25]).unwrap(),
+            vertex!([0.25 + 5e-11, 0.25, 0.25]).unwrap(),
         ];
 
         let opts = ConstructionOptions::default()
@@ -7325,11 +7366,11 @@ mod tests {
     /// Build D+1 standard simplex vertices: origin + D unit vectors.
     fn simplex_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
         let mut verts = Vec::with_capacity(D + 1);
-        verts.push(crate::core::vertex::Vertex::<(), _>::try_new([0.0; D]).unwrap());
+        verts.push(vertex!([0.0; D]).unwrap());
         for i in 0..D {
             let mut coords = [0.0; D];
             coords[i] = 1.0;
-            verts.push(crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap());
+            verts.push(vertex!(coords).unwrap());
         }
         verts
     }
@@ -7339,10 +7380,10 @@ mod tests {
         let mut verts = simplex_vertices::<D>();
         let distinct = verts.len();
         // Duplicate the origin and first unit vector
-        verts.push(crate::core::vertex::Vertex::<(), _>::try_new([0.0; D]).unwrap());
+        verts.push(vertex!([0.0; D]).unwrap());
         let mut unit = [0.0; D];
         unit[0] = 1.0;
-        verts.push(crate::core::vertex::Vertex::<(), _>::try_new(unit).unwrap());
+        verts.push(vertex!(unit).unwrap());
         (verts, distinct)
     }
 
@@ -7351,7 +7392,7 @@ mod tests {
         let mut verts = simplex_vertices::<D>();
         let dimension = safe_usize_to_scalar(D).expect("test dimensions fit in f64");
         let interior = [0.1_f64 / dimension; D];
-        verts.push(crate::core::vertex::Vertex::<(), _>::try_new(interior).unwrap());
+        verts.push(vertex!(interior).unwrap());
         verts
     }
 
@@ -7399,9 +7440,9 @@ mod tests {
                 fn [<test_hilbert_sort_dedup_all_identical_ $dim d>]() {
                     init_tracing();
                     let vertices: Vec<Vertex<(), $dim>> = vec![
-                        crate::core::vertex::Vertex::<(), _>::try_new([0.5; $dim]).unwrap(),
-                        crate::core::vertex::Vertex::<(), _>::try_new([0.5; $dim]).unwrap(),
-                        crate::core::vertex::Vertex::<(), _>::try_new([0.5; $dim]).unwrap(),
+                        vertex!([0.5; $dim]).unwrap(),
+                        vertex!([0.5; $dim]).unwrap(),
+                        vertex!([0.5; $dim]).unwrap(),
                     ];
                     let result = order_vertices_hilbert(vertices, true);
                     assert_eq!(
@@ -7433,8 +7474,7 @@ mod tests {
 
     #[test]
     fn test_hilbert_dedup_single_vertex() {
-        let vertices: Vec<Vertex<(), 3>> =
-            vec![crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0, 3.0]).unwrap()];
+        let vertices: Vec<Vertex<(), 3>> = vec![vertex!([1.0, 2.0, 3.0]).unwrap()];
         let result = order_vertices_hilbert(vertices, true);
         assert_eq!(result.len(), 1, "single vertex must be preserved");
     }
@@ -7443,10 +7483,10 @@ mod tests {
     fn test_hilbert_dedup_already_unique() {
         // Distinct vertices — dedup should be a no-op.
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let n = vertices.len();
         let result = order_vertices_hilbert(vertices, true);
@@ -7457,11 +7497,11 @@ mod tests {
     fn test_try_new_with_options_hilbert_smoke_3d() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.25, 0.25, 0.25]).unwrap(),
         ];
 
         let opts = ConstructionOptions::default()
@@ -7479,11 +7519,11 @@ mod tests {
     fn test_try_new_with_options_shuffled_retry_policy_smoke_3d() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.25, 0.25, 0.25]).unwrap(),
         ];
 
         let opts = ConstructionOptions::default()
@@ -7504,10 +7544,10 @@ mod tests {
     fn test_try_new_with_options_smoke_3d() {
         init_tracing();
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let opts = ConstructionOptions::default().with_retry_policy(RetryPolicy::Disabled);
@@ -7580,7 +7620,7 @@ mod tests {
     fn assert_duplicate_skip_statistics<const D: usize>() {
         init_tracing();
         let mut vertices = simplex_vertices::<D>();
-        vertices.push(Vertex::<(), _>::try_new([0.0; D]).unwrap());
+        vertices.push(vertex!([0.0; D]).unwrap());
         let duplicate_index = vertices.len() - 1;
         let duplicate_uuid = vertices[duplicate_index].uuid();
 
@@ -7650,9 +7690,9 @@ mod tests {
     fn test_new_with_topology_guarantee_sets_pl() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 2> =

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -3982,7 +3982,6 @@ where
     ) -> Result<(Self, ConstructionStatistics), DelaunayTriangulationConstructionErrorWithStatistics>
     {
         let batch_repair_policy = final_delaunay.batch_repair_policy();
-        let run_final_repair = final_delaunay.enforces_final_delaunay();
         let use_global_repair_fallback = final_delaunay.use_global_repair_fallback();
 
         if vertices.len() < D + 1 {
@@ -4088,8 +4087,7 @@ where
         let finalize_result = dt.finalize_bulk_construction(
             original_validation_policy,
             original_repair_policy,
-            run_final_repair,
-            batch_repair_policy,
+            final_delaunay,
             &pending_repair_seeds,
             &soft_fail_seeds,
             Some(&mut stats.telemetry),
@@ -4120,7 +4118,6 @@ where
         final_delaunay: FinalDelaunayEnforcement,
     ) -> Result<Self, DelaunayTriangulationConstructionError> {
         let batch_repair_policy = final_delaunay.batch_repair_policy();
-        let run_final_repair = final_delaunay.enforces_final_delaunay();
         let use_global_repair_fallback = final_delaunay.use_global_repair_fallback();
 
         if vertices.len() < D + 1 {
@@ -4184,8 +4181,7 @@ where
         dt.finalize_bulk_construction(
             original_validation_policy,
             original_repair_policy,
-            run_final_repair,
-            batch_repair_policy,
+            final_delaunay,
             &pending_repair_seeds,
             &soft_fail_seeds,
             None,
@@ -4847,23 +4843,30 @@ where
 
     /// Restores runtime policies and performs the final repair/orientation
     /// checks that were deferred during batch insertion.
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "bulk finalization restores policies, repair state, and optional statistics telemetry"
-    )]
+    ///
+    /// Batch construction temporarily disables per-insertion repair and may
+    /// override the global-repair fallback while it accumulates local repair
+    /// seeds. Finalization restores both caller-visible insertion policies so
+    /// options such as [`ConstructionOptions::without_final_delaunay_enforcement`]
+    /// and the crate-internal global-fallback toggle do not leak into later
+    /// incremental edits on the returned triangulation.
     pub(crate) fn finalize_bulk_construction(
         &mut self,
         original_validation_policy: ValidationPolicy,
         original_repair_policy: DelaunayRepairPolicy,
-        run_final_repair: bool,
-        batch_repair_policy: DelaunayRepairPolicy,
+        final_delaunay: FinalDelaunayEnforcement,
         pending_repair_seeds: &[SimplexKey],
         soft_fail_seeds: &[SimplexKey],
         mut construction_telemetry: Option<&mut ConstructionTelemetry>,
     ) -> Result<(), DelaunayTriangulationConstructionError> {
+        let run_final_repair = final_delaunay.enforces_final_delaunay();
+        let batch_repair_policy = final_delaunay.batch_repair_policy();
+        let restored_use_global_repair_fallback = final_delaunay.use_global_repair_fallback();
+
         // Restore policies after batch construction.
         self.tri.validation_policy = original_validation_policy;
         self.insertion_state.delaunay_repair_policy = original_repair_policy;
+        self.insertion_state.use_global_repair_fallback = restored_use_global_repair_fallback;
 
         let has_simplices = self.tri.tds.number_of_simplices() > 0;
         let mut completion_seed_simplices = SimplexKeyBuffer::new();
@@ -6138,8 +6141,10 @@ mod tests {
             .finalize_bulk_construction(
                 ValidationPolicy::OnSuspicion,
                 DelaunayRepairPolicy::Never,
-                false,
-                DelaunayRepairPolicy::Never,
+                FinalDelaunayEnforcement::Strict {
+                    batch_repair_policy: DelaunayRepairPolicy::Never,
+                    use_global_repair_fallback: true,
+                },
                 &[],
                 &[],
                 None,
@@ -6151,6 +6156,85 @@ mod tests {
             DelaunayTriangulationConstructionError::Triangulation(
                 DelaunayConstructionFailure::FinalTopologyValidation { .. }
             )
+        );
+    }
+
+    #[test]
+    fn test_finalize_bulk_construction_restores_global_repair_fallback_policy() {
+        init_tracing();
+        let vertices: Vec<Vertex<(), 2>> = vec![
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 2.0]).unwrap(),
+        ];
+        let mut dt = DelaunayTriangulation::try_new_with_topology_guarantee(
+            &vertices,
+            TopologyGuarantee::Pseudomanifold,
+        )
+        .unwrap();
+
+        dt.insertion_state.delaunay_repair_policy = DelaunayRepairPolicy::Never;
+        dt.insertion_state.use_global_repair_fallback = true;
+        dt.finalize_bulk_construction(
+            dt.tri.validation_policy,
+            DelaunayRepairPolicy::EveryInsertion,
+            FinalDelaunayEnforcement::Strict {
+                batch_repair_policy: DelaunayRepairPolicy::Never,
+                use_global_repair_fallback: false,
+            },
+            &[],
+            &[],
+            None,
+        )
+        .expect("valid triangulation should finalize");
+
+        assert_eq!(
+            dt.insertion_state.delaunay_repair_policy,
+            DelaunayRepairPolicy::EveryInsertion,
+            "bulk finalization should restore the caller's repair policy"
+        );
+        assert!(
+            !dt.insertion_state.use_global_repair_fallback,
+            "bulk finalization should restore the caller's fallback policy"
+        );
+    }
+
+    #[test]
+    fn test_seeded_construction_preserves_disabled_global_repair_fallback_policy() {
+        init_tracing();
+        let vertices: Vec<Vertex<(), 2>> = vec![
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
+            vertex!([0.0, 2.0]).unwrap(),
+        ];
+        let kernel = RobustKernel::<f64>::new();
+        let options = ConstructionOptions::default().without_global_repair_fallback();
+
+        let stats_dt =
+            DelaunayTriangulation::<RobustKernel<f64>, (), (), 2>::try_with_options_and_statistics(
+                &kernel,
+                &vertices,
+                TopologyGuarantee::Pseudomanifold,
+                options,
+            )
+            .expect("stats construction should succeed")
+            .0;
+        assert!(
+            !stats_dt.insertion_state.use_global_repair_fallback,
+            "stats construction should preserve the disabled fallback policy"
+        );
+
+        let no_stats_dt = DelaunayTriangulation::<RobustKernel<f64>, (), (), 2>::
+            try_with_topology_guarantee_and_options(
+                &kernel,
+                &vertices,
+                TopologyGuarantee::Pseudomanifold,
+                options,
+            )
+            .expect("non-stats construction should succeed");
+        assert!(
+            !no_stats_dt.insertion_state.use_global_repair_fallback,
+            "non-stats construction should preserve the disabled fallback policy"
         );
     }
 

--- a/src/delaunay/delaunayize.rs
+++ b/src/delaunay/delaunayize.rs
@@ -822,6 +822,7 @@ mod tests {
     use crate::geometry::point::Point;
     use crate::tds::{TdsError, VertexKey};
     use crate::try_vertices_from_points;
+    use crate::vertex;
     use crate::{DelaunayTriangulationBuilder, TriangulationConstructionError};
     use slotmap::KeyData;
     use std::assert_matches;
@@ -988,10 +989,10 @@ mod tests {
     fn test_already_delaunay_3d() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1006,10 +1007,10 @@ mod tests {
     fn test_already_delaunay_2d() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1027,11 +1028,11 @@ mod tests {
     fn test_outcome_populated_on_success() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1050,9 +1051,9 @@ mod tests {
     fn test_simplex_vertex_uuids_missing_vertex() {
         let mut tds: Tds<(), i32, 2> = Tds::empty();
         let vertex_keys: Vec<_> = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ]
         .iter()
         .map(|vertex| tds.insert_vertex_with_mapping(*vertex).unwrap())
@@ -1306,10 +1307,10 @@ mod tests {
     fn test_fallback_enabled_on_valid_triangulation() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1326,10 +1327,7 @@ mod tests {
     #[test]
     fn delaunay_repair_fallback_rebuilds_after_unsupported_dimension() {
         init_tracing();
-        let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices = [vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let mut dt: DelaunayTriangulation<_, (), (), 1> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -1356,10 +1354,10 @@ mod tests {
     fn delaunay_repair_fallback_rebuilds_supported_2d_after_repair_failure() {
         init_tracing();
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1404,9 +1402,9 @@ mod tests {
     fn test_rebuild_restores_simplex_data() {
         init_tracing();
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt = DelaunayTriangulationBuilder::new(&vertices)
             .build::<i32>()
@@ -1434,9 +1432,9 @@ mod tests {
     fn test_rebuild_drops_ambiguous_data() {
         init_tracing();
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut tds: Tds<(), i32, 2> = Tds::empty();
         let vertex_keys: Vec<_> = vertices
@@ -1475,11 +1473,11 @@ mod tests {
     fn test_deterministic_repeated_runs() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5, 0.5]).unwrap(),
         ];
 
         let config = DelaunayizeConfig::default();

--- a/src/delaunay/flips.rs
+++ b/src/delaunay/flips.rs
@@ -29,6 +29,8 @@ use crate::core::algorithms::flips::{
     apply_bistellar_flip_k2, apply_bistellar_flip_k3, build_k2_flip_context,
     build_k2_flip_context_from_edge, build_k3_flip_context, build_k3_flip_context_from_triangle,
 };
+#[cfg(test)]
+use crate::core::facet::FacetError;
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
 use crate::core::vertex::Vertex;
@@ -396,6 +398,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
     use std::assert_matches;
 
     use crate::TopologyGuarantee;
@@ -406,10 +409,10 @@ mod tests {
     #[test]
     fn triangulation_flip_k1_insert_and_remove_roundtrip() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -421,10 +424,7 @@ mod tests {
         let simplex_key = tri.simplices().next().unwrap().0;
 
         let inserted = tri
-            .flip_k1_insert(
-                simplex_key,
-                crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
-            )
+            .flip_k1_insert(simplex_key, vertex!([0.25, 0.25, 0.25]).unwrap())
             .unwrap();
         let inserted_vertex = inserted.inserted_face_vertices[0];
         assert!(!inserted.new_simplices.is_empty());
@@ -438,10 +438,10 @@ mod tests {
     #[test]
     fn flip_k1_insert_invalidates_caches() {
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -454,11 +454,8 @@ mod tests {
         }
         dt.spatial_index = Some(spatial_index);
 
-        dt.flip_k1_insert(
-            simplex_key,
-            crate::core::vertex::Vertex::<(), _>::try_new([0.2, 0.2, 0.2]).unwrap(),
-        )
-        .unwrap();
+        dt.flip_k1_insert(simplex_key, vertex!([0.2, 0.2, 0.2]).unwrap())
+            .unwrap();
 
         assert!(dt.insertion_state.last_inserted_simplex.is_none());
         assert!(dt.spatial_index.is_none());
@@ -468,10 +465,10 @@ mod tests {
     #[test]
     fn triangulation_flip_k2_rejects_invalid_facet_index() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -486,7 +483,7 @@ mod tests {
 
         assert_matches!(
             err,
-            crate::prelude::tds::FacetError::InvalidFacetIndex {
+            FacetError::InvalidFacetIndex {
                 index: u8::MAX,
                 facet_count: 4,
             }

--- a/src/delaunay/locality.rs
+++ b/src/delaunay/locality.rs
@@ -163,14 +163,15 @@ mod tests {
     use crate::geometry::kernel::FastKernel;
     use crate::geometry::point::Point;
     use crate::triangulation::DelaunayTriangulation;
+    use crate::vertex;
     use slotmap::KeyData;
 
     fn simplex_triangulation_3d() -> Triangulation<FastKernel<f64>, (), (), 3> {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
@@ -180,11 +181,11 @@ mod tests {
     #[test]
     fn accumulate_live_simplex_seeds_dedupes_and_ignores_stale() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -235,11 +236,11 @@ mod tests {
     #[test]
     fn append_live_unique_simplex_seeds_dedupes_and_ignores_stale() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -274,11 +275,11 @@ mod tests {
     #[test]
     fn retain_live_simplex_seeds_filters_stale_and_dedupes() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
+            vertex!([0.5, 0.5]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();

--- a/src/delaunay/query.rs
+++ b/src/delaunay/query.rs
@@ -1459,9 +1459,9 @@ mod tests {
     fn test_delaunay_constructors_default_to_pl_manifold_mode() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let dt_new: DelaunayTriangulation<_, (), (), 2> =
@@ -1504,9 +1504,9 @@ mod tests {
     fn test_try_global_topology_setter_rejects_closed_metadata_for_euclidean_boundary() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1545,9 +1545,9 @@ mod tests {
     fn test_boundary_facets_propagates_core_query_error() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1595,9 +1595,9 @@ mod tests {
         assert_eq!(dt_empty.validation_policy(), ValidationPolicy::ExplicitOnly);
 
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         // new() -> with_kernel() -> explicit validation_policy initialization
@@ -1629,9 +1629,9 @@ mod tests {
     fn test_validation_policy_setter_and_getter_roundtrip() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
@@ -1680,10 +1680,10 @@ mod tests {
     fn test_number_of_vertices_minimal_simplex() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -1696,10 +1696,10 @@ mod tests {
     fn test_number_of_simplices_minimal_simplex() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -1713,9 +1713,9 @@ mod tests {
     fn test_number_of_simplices_after_insertion() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
@@ -1732,30 +1732,30 @@ mod tests {
     fn test_dim_returns_correct_dimension() {
         init_tracing();
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt_2d: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_2d).unwrap();
         assert_eq!(dt_2d.dim(), 2);
 
         let vertices_3d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_3d: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices_3d).unwrap();
         assert_eq!(dt_3d.dim(), 3);
 
         let vertices_4d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_4d: DelaunayTriangulation<_, (), (), 4> =
             DelaunayTriangulation::try_new(&vertices_4d).unwrap();
@@ -1767,9 +1767,9 @@ mod tests {
         init_tracing();
         // 2D: exactly 3 vertices (minimum for 2D simplex)
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt_2d: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_2d).unwrap();
@@ -1778,10 +1778,10 @@ mod tests {
 
         // 3D: exactly 4 vertices (minimum for 3D simplex)
         let vertices_3d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_3d: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices_3d).unwrap();
@@ -1793,9 +1793,9 @@ mod tests {
     fn test_tds_accessor_provides_readonly_access() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1814,10 +1814,10 @@ mod tests {
     fn test_internal_tds_access() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1838,9 +1838,9 @@ mod tests {
     fn test_tds_accessor_reflects_insertions() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1860,11 +1860,11 @@ mod tests {
     fn test_tds_accessors_maintain_validation_invariants() {
         init_tracing();
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 4> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1886,10 +1886,10 @@ mod tests {
         init_tracing();
         // Single tetrahedron: 4 vertices, 1 simplex, 6 unique edges.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =

--- a/src/delaunay/repair.rs
+++ b/src/delaunay/repair.rs
@@ -935,6 +935,7 @@ mod tests {
     use crate::geometry::kernel::{AdaptiveKernel, RobustKernel};
     use crate::topology::traits::topological_space::GlobalTopology;
     use crate::triangulation::DelaunayTriangulation;
+    use crate::vertex;
     use std::{assert_matches, num::NonZeroUsize, sync::Once};
 
     fn init_tracing() {
@@ -986,24 +987,16 @@ mod tests {
     fn non_delaunay_quad_tds() -> Tds<(), (), 2> {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([4.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([4.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([4.0, 2.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 2.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -1027,10 +1020,7 @@ mod tests {
     #[test]
     fn test_should_run_delaunay_repair_for_skips_for_dimension_lt_2() {
         init_tracing();
-        let vertices: Vec<Vertex<(), 1>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices: Vec<Vertex<(), 1>> = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let dt: DelaunayTriangulation<_, (), (), 1> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -1059,9 +1049,9 @@ mod tests {
     fn test_should_run_delaunay_repair_for_skips_when_policy_never() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1075,9 +1065,9 @@ mod tests {
     fn test_should_run_delaunay_repair_for_respects_every_n_schedule() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1094,9 +1084,9 @@ mod tests {
     fn test_non_insertion_mutation_repair_gate_ignores_insertion_cadence() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1113,16 +1103,16 @@ mod tests {
     fn test_vertex_key_valid_after_explicit_heuristic_rebuild() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
 
         // Insert a vertex normally (no heuristic rebuild during insert).
-        let inserted = crate::core::vertex::Vertex::<(), _>::try_new([0.25, 0.25]).unwrap();
+        let inserted = vertex!([0.25, 0.25]).unwrap();
         let inserted_uuid = inserted.uuid();
 
         let (outcome, _stats) = dt.insert_with_statistics(inserted).unwrap();
@@ -1160,10 +1150,10 @@ mod tests {
     fn test_heuristic_rebuild_preserves_default_global_topology() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1187,10 +1177,10 @@ mod tests {
     fn test_heuristic_rebuild_threads_non_default_global_topology() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1212,10 +1202,10 @@ mod tests {
     fn test_repair_delaunay_with_flips_allows_pl_manifold() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
 
         let mut dt: DelaunayTriangulation<_, (), (), 2> =
@@ -1237,10 +1227,10 @@ mod tests {
     fn test_repair_delaunay_with_flips_advanced_robust_fallback_succeeds() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1268,10 +1258,10 @@ mod tests {
     fn test_repair_advanced_max_flips_zero_on_valid_triangulation_succeeds() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1296,10 +1286,10 @@ mod tests {
     fn test_repair_advanced_max_flips_zero_forced_nonconvergent_hits_robust_fallback() {
         init_tracing();
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+            vertex!([1.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1396,10 +1386,7 @@ mod tests {
     #[test]
     fn test_repair_delaunay_with_flips_returns_flip_error_for_1d() {
         init_tracing();
-        let vertices: Vec<Vertex<(), 1>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices: Vec<Vertex<(), 1>> = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 1> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
 
@@ -1424,10 +1411,7 @@ mod tests {
     #[test]
     fn test_repair_delaunay_with_flips_advanced_passes_through_non_retryable_error() {
         init_tracing();
-        let vertices: Vec<Vertex<(), 1>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices: Vec<Vertex<(), 1>> = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let mut dt: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 1> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
 

--- a/src/delaunay/rollback.rs
+++ b/src/delaunay/rollback.rs
@@ -116,14 +116,15 @@ mod tests {
     use crate::core::tds::VertexKey;
     use crate::core::vertex::Vertex;
     use crate::geometry::kernel::AdaptiveKernel;
+    use crate::vertex;
 
     fn simplex_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
         let mut vertices = Vec::with_capacity(D + 1);
-        vertices.push(Vertex::<(), D>::try_new([0.0; D]).unwrap());
+        vertices.push(vertex!([0.0; D]).unwrap());
         for axis in 0..D {
             let mut coords = [0.0; D];
             coords[axis] = 1.0;
-            vertices.push(Vertex::<(), D>::try_new(coords).unwrap());
+            vertices.push(vertex!(coords).unwrap());
         }
         vertices
     }
@@ -151,7 +152,7 @@ mod tests {
     fn insert_uncommitted_vertex<const D: usize>(
         transaction: &mut DelaunayRollbackTransaction<'_, AdaptiveKernel<f64>, (), (), D>,
     ) -> VertexKey {
-        let vertex = Vertex::<(), D>::try_new([0.25; D]).unwrap();
+        let vertex = vertex!([0.25; D]).unwrap();
         transaction
             .delaunay_mut()
             .tri

--- a/src/delaunay/serialization.rs
+++ b/src/delaunay/serialization.rs
@@ -91,6 +91,7 @@ mod tests {
     use crate::core::simplex::Simplex;
     use crate::core::tds::TriangulationConstructionState;
     use crate::geometry::kernel::AdaptiveKernel;
+    use crate::vertex;
     use std::sync::Once;
 
     fn init_tracing() {
@@ -108,24 +109,16 @@ mod tests {
     fn non_delaunay_quad_tds() -> Tds<(), (), 2> {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([4.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([4.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([4.0, 2.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 2.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -162,10 +155,10 @@ mod tests {
     fn serde_roundtrip_uses_custom_deserialize_impl() {
         init_tracing();
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =

--- a/src/delaunay/validation.rs
+++ b/src/delaunay/validation.rs
@@ -39,6 +39,10 @@ pub(crate) struct TdsStructureValidationProof(());
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct DelaunayTriangulationValidationProof(());
 
+/// Proof that a candidate passed Levels 1-4 through embedded-geometry validation.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct TriangulationEmbeddingValidationProof(());
+
 /// Internal assembly stage for a triangulation that has not crossed its validation boundary yet.
 ///
 /// This keeps raw or freshly assembled [`Tds`] values out of the final
@@ -102,6 +106,14 @@ impl<K, U, V, const D: usize> DelaunayTriangulationCandidate<K, U, V, D> {
     pub(crate) fn into_structurally_valid_delaunay(
         self,
         _proof: TdsStructureValidationProof,
+    ) -> DelaunayTriangulation<K, U, V, D> {
+        self.candidate
+    }
+
+    /// Converts a candidate after the caller has proved Levels 1-4 validity.
+    pub(crate) fn into_embedding_validated_delaunay(
+        self,
+        _proof: TriangulationEmbeddingValidationProof,
     ) -> DelaunayTriangulation<K, U, V, D> {
         self.candidate
     }
@@ -171,6 +183,14 @@ where
         }
 
         Ok(DelaunayTriangulationValidationProof(()))
+    }
+
+    /// Validates Levels 1-4 without enforcing the Level 5 Delaunay property.
+    pub(crate) fn validate_embedding_only(
+        &self,
+    ) -> Result<TriangulationEmbeddingValidationProof, DelaunayTriangulationValidationError> {
+        self.candidate.tri.validate_embedding()?;
+        Ok(TriangulationEmbeddingValidationProof(()))
     }
 }
 

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -2324,43 +2324,43 @@ mod tests {
     // Generate tests for dimensions 1D through 6D
     test_hull_dimensions! {
         hull_1d_segment => 1 => "line segment" => 2 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
+            vertex!([0.0]).unwrap(),
+            vertex!([1.0]).unwrap(),
         ],
         hull_2d_triangle => 2 => "triangle" => 3 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ],
         hull_3d_tetrahedron => 3 => "tetrahedron" => 4 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.5, 1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.5, 1.0]).unwrap(),
         ],
         hull_4d_simplex => 4 => "4-simplex" => 5 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
         hull_5d_simplex => 5 => "5-simplex" => 6 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
         hull_6d_simplex => 6 => "6-simplex" => 7 => vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ],
     }
 
@@ -2368,10 +2368,10 @@ mod tests {
     fn test_empty_hull_comprehensive() {
         // Create a triangulation for validation purposes
         let vertices_3d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_3d = create_triangulation(&vertices_3d);
 
@@ -2443,9 +2443,9 @@ mod tests {
         // ========================================================================
         test_debug!("  Testing 2D visibility algorithms...");
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt_2d = create_triangulation(&vertices_2d);
         let hull_2d: ConvexHull2D<(), ()> =
@@ -2490,10 +2490,10 @@ mod tests {
         // ========================================================================
         test_debug!("  Testing 3D visibility algorithms...");
         let vertices_3d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_3d = create_triangulation(&vertices_3d);
         let hull_3d: ConvexHull3D<(), ()> =
@@ -2653,11 +2653,11 @@ mod tests {
         // ========================================================================
         test_debug!("  Testing 4D visibility algorithms...");
         let vertices_4d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_4d = create_triangulation(&vertices_4d);
         let hull_4d: ConvexHull4D<(), ()> =
@@ -2686,12 +2686,12 @@ mod tests {
         // ========================================================================
         test_debug!("  Testing 5D visibility algorithms...");
         let vertices_5d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_5d = create_triangulation(&vertices_5d);
         let hull_5d: ConvexHull<(), (), 5> =
@@ -2735,10 +2735,10 @@ mod tests {
         // Test distance-based heuristic with 3D tetrahedron
         test_debug!("  Testing distance-based heuristic...");
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -2874,9 +2874,9 @@ mod tests {
 
         // Test 2D fallback
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt_2d = create_triangulation(&vertices_2d);
         let hull_2d: ConvexHull<(), (), 2> =
@@ -2893,11 +2893,11 @@ mod tests {
 
         // Test 4D fallback
         let vertices_4d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_4d = create_triangulation(&vertices_4d);
         let hull_4d: ConvexHull<(), (), 4> =
@@ -2929,9 +2929,9 @@ mod tests {
 
         // Create a minimal valid triangulation first to ensure the path works
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation());
@@ -2944,10 +2944,10 @@ mod tests {
     #[test]
     fn test_is_facet_visible_from_point_error_cases() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -2975,10 +2975,10 @@ mod tests {
         let empty_hull: ConvexHull<(), (), 3> = ConvexHull::default();
         // Create a dummy triangulation for validation
         let dummy_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dummy_dt = create_triangulation(&dummy_vertices);
         assert!(
@@ -2988,10 +2988,10 @@ mod tests {
 
         // Test valid hull validation (should pass)
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3024,10 +3024,7 @@ mod tests {
         test_debug!("  Testing valid hull validation in different dimensions...");
 
         // Test 1D hull (empty hull validation)
-        let dummy_vertices_1d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let dummy_vertices_1d = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
         let dummy_dt_1d = create_triangulation(&dummy_vertices_1d);
         let hull_1d: ConvexHull<(), (), 1> = ConvexHull::default();
         assert!(
@@ -3038,9 +3035,9 @@ mod tests {
 
         // Test 2D hull
         let vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt_2d = create_triangulation(&vertices_2d);
         let hull_2d: ConvexHull<(), (), 2> =
@@ -3074,10 +3071,10 @@ mod tests {
 
         // Test 3D hull
         let vertices_3d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_3d = create_triangulation(&vertices_3d);
         let hull_3d: ConvexHull<(), (), 3> =
@@ -3111,11 +3108,11 @@ mod tests {
 
         // Test 4D hull
         let vertices_4d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_4d = create_triangulation(&vertices_4d);
         let hull_4d: ConvexHull<(), (), 4> =
@@ -3149,12 +3146,12 @@ mod tests {
 
         // Test 5D hull (minimum required coverage)
         let vertices_5d: Vec<_> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_5d = create_triangulation(&vertices_5d);
         let hull_5d: ConvexHull<(), (), 5> =
@@ -3196,10 +3193,10 @@ mod tests {
 
         // Test with integer vertex data
         let vertices_int = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1i32).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 2i32).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 3i32).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 4i32).unwrap(),
+            vertex!([0.0, 0.0, 0.0]; data = 1i32).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 2i32).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 3i32).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 4i32).unwrap(),
         ];
         let dt_int = DelaunayTriangulation::<AdaptiveKernel<f64>, i32, (), 3>::try_with_kernel(
             &AdaptiveKernel::new(),
@@ -3214,10 +3211,10 @@ mod tests {
 
         // Test with character vertex data
         let vertices_char = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 'A').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 'B').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 'C').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 'D').unwrap(),
+            vertex!([0.0, 0.0, 0.0]; data = 'A').unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 'B').unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 'C').unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 'D').unwrap(),
         ];
         let dt_char = DelaunayTriangulation::<AdaptiveKernel<f64>, char, (), 3>::try_with_kernel(
             &AdaptiveKernel::new(),
@@ -3240,33 +3237,30 @@ mod tests {
             // Large coordinates
             (
                 vec![
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([1e15, 0.0, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e15, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e15]).unwrap(),
+                    vertex!([0.0, 0.0, 0.0]).unwrap(),
+                    vertex!([1e15, 0.0, 0.0]).unwrap(),
+                    vertex!([0.0, 1e15, 0.0]).unwrap(),
+                    vertex!([0.0, 0.0, 1e15]).unwrap(),
                 ],
                 "large",
             ),
             // Small coordinates
             (
                 vec![
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([1e-15, 0.0, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e-15, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e-15]).unwrap(),
+                    vertex!([0.0, 0.0, 0.0]).unwrap(),
+                    vertex!([1e-15, 0.0, 0.0]).unwrap(),
+                    vertex!([0.0, 1e-15, 0.0]).unwrap(),
+                    vertex!([0.0, 0.0, 1e-15]).unwrap(),
                 ],
                 "small",
             ),
             // Mixed extreme coordinates
             (
                 vec![
-                    crate::core::vertex::Vertex::<(), _>::try_new([f64::MIN_POSITIVE, 0.0, 0.0])
-                        .unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([f64::MAX / 1e10, 0.0, 0.0])
-                        .unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, f64::EPSILON, 0.0])
-                        .unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+                    vertex!([f64::MIN_POSITIVE, 0.0, 0.0]).unwrap(),
+                    vertex!([f64::MAX / 1e10, 0.0, 0.0]).unwrap(),
+                    vertex!([0.0, f64::EPSILON, 0.0]).unwrap(),
+                    vertex!([0.0, 0.0, 1.0]).unwrap(),
                 ],
                 "mixed",
             ),
@@ -3388,10 +3382,10 @@ mod tests {
 
         // Performance test - validate 100 times
         let perf_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let perf_dt = create_triangulation(&perf_vertices);
         let perf_hull: ConvexHull<(), (), 3> =
@@ -3424,10 +3418,10 @@ mod tests {
     #[test]
     fn test_find_nearest_visible_facet_comprehensive() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3474,10 +3468,10 @@ mod tests {
     #[test]
     fn test_facet_access_edge_cases() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3517,10 +3511,10 @@ mod tests {
     fn test_generic_types_comprehensive() {
         // Test coordinate type validation with f64
         let vertices_f64 = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0f64, 0.0f64, 0.0f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0f64, 0.0f64, 0.0f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0f64, 1.0f64, 0.0f64]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0f64, 0.0f64, 1.0f64]).unwrap(),
+            vertex!([0.0f64, 0.0f64, 0.0f64]).unwrap(),
+            vertex!([1.0f64, 0.0f64, 0.0f64]).unwrap(),
+            vertex!([0.0f64, 1.0f64, 0.0f64]).unwrap(),
+            vertex!([0.0f64, 0.0f64, 1.0f64]).unwrap(),
         ];
         let dt_f64 = create_triangulation(&vertices_f64);
         let hull_f64 = ConvexHull::try_from_triangulation(dt_f64.as_triangulation()).unwrap();
@@ -3536,14 +3530,10 @@ mod tests {
 
         // Test with high precision f64 coordinates
         let vertices_high_precision = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.000_000_000_000_001, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.000_000_000_000_001, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.000_000_000_000_001, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.000_000_000_000_001])
-                .unwrap(),
+            vertex!([0.000_000_000_000_001, 0.0, 0.0]).unwrap(),
+            vertex!([1.000_000_000_000_001, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.000_000_000_000_001, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.000_000_000_000_001]).unwrap(),
         ];
         let dt_hp = create_triangulation(&vertices_high_precision);
         let hull_hp = ConvexHull::try_from_triangulation(dt_hp.as_triangulation()).unwrap();
@@ -3555,10 +3545,10 @@ mod tests {
 
         // Test with integer vertex data
         let vertices_int = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1i32).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 2i32).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 3i32).unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 4i32).unwrap(),
+            vertex!([0.0, 0.0, 0.0]; data = 1i32).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 2i32).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 3i32).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 4i32).unwrap(),
         ];
         let dt_int = DelaunayTriangulation::<AdaptiveKernel<f64>, i32, (), 3>::try_with_kernel(
             &AdaptiveKernel::new(),
@@ -3573,10 +3563,10 @@ mod tests {
 
         // Test with character vertex data
         let vertices_char = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 'A').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 'B').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 'C').unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 'D').unwrap(),
+            vertex!([0.0, 0.0, 0.0]; data = 'A').unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = 'B').unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = 'C').unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = 'D').unwrap(),
         ];
         let dt_char = DelaunayTriangulation::<AdaptiveKernel<f64>, char, (), 3>::try_with_kernel(
             &AdaptiveKernel::new(),
@@ -3591,14 +3581,10 @@ mod tests {
 
         // Test with Option<i32> vertex data
         let vertices_with_data = vec![
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], Some(1))
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], Some(2))
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], Some(3))
-                .unwrap(),
-            crate::core::vertex::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], Some(4))
-                .unwrap(),
+            vertex!([0.0, 0.0, 0.0]; data = Some(1)).unwrap(),
+            vertex!([1.0, 0.0, 0.0]; data = Some(2)).unwrap(),
+            vertex!([0.0, 1.0, 0.0]; data = Some(3)).unwrap(),
+            vertex!([0.0, 0.0, 1.0]; data = Some(4)).unwrap(),
         ];
         let dt_with_data =
             DelaunayTriangulation::<AdaptiveKernel<f64>, Option<i32>, (), 3>::try_with_kernel(
@@ -3621,10 +3607,10 @@ mod tests {
     fn test_extreme_coordinate_values() {
         // Test with very large coordinates
         let vertices_large = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e6, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e6, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e6]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1e6, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1e6, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e6]).unwrap(),
         ];
         let dt_large = create_triangulation(&vertices_large);
         let hull_large = ConvexHull::try_from_triangulation(dt_large.as_triangulation()).unwrap();
@@ -3651,10 +3637,10 @@ mod tests {
         // Test with very small coordinates (but still large enough to avoid being
         // treated as numerically degenerate by the initial simplex search)
         let vertices_small = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-3, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e-3, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e-3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1e-3, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1e-3, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e-3]).unwrap(),
         ];
         let dt_small = create_triangulation(&vertices_small);
         let hull_small = ConvexHull::try_from_triangulation(dt_small.as_triangulation()).unwrap();
@@ -3666,10 +3652,10 @@ mod tests {
     #[test]
     fn test_trait_implementations_comprehensive() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3691,9 +3677,9 @@ mod tests {
 
         // Test Default trait for various dimensions
         let dummy_vertices_2d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dummy_dt_2d = create_triangulation(&dummy_vertices_2d);
         let hull_2d: ConvexHull<(), (), 2> = ConvexHull::default();
@@ -3709,11 +3695,11 @@ mod tests {
         assert!(hull_3d_default.validate(dt.as_triangulation()).is_ok());
 
         let dummy_vertices_4d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dummy_dt_4d = create_triangulation(&dummy_vertices_4d);
         let hull_4d: ConvexHull<(), (), 4> = ConvexHull::default();
@@ -3727,30 +3713,30 @@ mod tests {
     fn test_type_aliases() {
         // Test that type aliases compile and work correctly
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let _hull_2d: ConvexHull2D<(), ()> =
             ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
 
         let vertices_3d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_3d = create_triangulation(&vertices_3d);
         let _hull_3d: ConvexHull3D<(), ()> =
             ConvexHull::try_from_triangulation(dt_3d.as_triangulation()).unwrap();
 
         let vertices_4d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_4d = create_triangulation(&vertices_4d);
         let _hull_4d: ConvexHull4D<(), ()> =
@@ -3788,7 +3774,7 @@ mod tests {
         // Create a manually constructed TDS with vertices but no simplices
         // Note: We need to use the underlying TDS directly for this edge case test
         let mut tds = Tds::<(), (), 3>::empty();
-        let vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
+        let vertex = vertex!([0.0, 0.0, 0.0]).unwrap();
         tds.insert_vertex_with_mapping(vertex).unwrap();
 
         // Use the test-only constructor to avoid brittle struct literals.
@@ -3810,10 +3796,10 @@ mod tests {
         // by creating a TDS that would fail boundary facet extraction
         // For now, just test that the error mapping works with a valid TDS
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let result = ConvexHull::try_from_triangulation(dt.as_triangulation());
@@ -3826,10 +3812,10 @@ mod tests {
     fn test_visibility_check_insufficient_vertices_error() {
         // Create a hull and manually create a degenerate facet to test error path
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3851,10 +3837,10 @@ mod tests {
     fn test_fallback_visibility_test_degenerate_facet() {
         // Test the fallback visibility algorithm with degenerate geometry
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3890,10 +3876,10 @@ mod tests {
         // Consolidated test for inside point detection (no visible facets)
         // Tests both find_nearest_visible_facet and is_point_outside
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3915,10 +3901,10 @@ mod tests {
     #[test]
     fn test_find_nearest_visible_facet_equidistant_cases() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3933,10 +3919,10 @@ mod tests {
     #[test]
     fn test_hull_operations_extended() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3960,10 +3946,10 @@ mod tests {
     #[test]
     fn test_invalidate_cache() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -3980,10 +3966,10 @@ mod tests {
     #[test]
     fn test_facet_cache_provider_implementation() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4040,10 +4026,10 @@ mod tests {
     #[test]
     fn test_comprehensive_facet_iteration() {
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4115,10 +4101,10 @@ mod tests {
 
         // Test with populated hull
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4136,10 +4122,10 @@ mod tests {
         test_debug!("Testing error handling paths in convex hull methods");
 
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4177,10 +4163,10 @@ mod tests {
         // Create a triangulation that might produce degenerate orientations
         // while still allowing the initial simplex search to succeed.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-3, 0.0, 0.0]).unwrap(), // Small but not numerically wiped out
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e-3, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e-3]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1e-3, 0.0, 0.0]).unwrap(), // Small but not numerically wiped out
+            vertex!([0.0, 1e-3, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e-3]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4216,10 +4202,10 @@ mod tests {
 
         // Test with coordinates at the limits of f64 precision
         let vertices_extreme = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([f64::MIN_POSITIVE, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, f64::MIN_POSITIVE, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, f64::MIN_POSITIVE]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([f64::MIN_POSITIVE, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, f64::MIN_POSITIVE, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, f64::MIN_POSITIVE]).unwrap(),
         ];
 
         let dt_extreme_result = DelaunayTriangulation::try_new(&vertices_extreme);
@@ -4272,10 +4258,10 @@ mod tests {
 
         // Test with maximum finite values
         let vertices_max = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt_max = create_triangulation(&vertices_max);
         let hull_max = ConvexHull::try_from_triangulation(dt_max.as_triangulation()).unwrap();
@@ -4296,10 +4282,10 @@ mod tests {
         test_debug!("Testing numeric cast error handling in find_nearest_visible_facet");
 
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4353,10 +4339,10 @@ mod tests {
 
         // Create initial triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4420,7 +4406,7 @@ mod tests {
         let stale_hull_gen = hull.cached_generation().load(Ordering::Acquire);
 
         // Add a new vertex - this will bump the generation
-        let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(); // Interior point
+        let new_vertex = vertex!([0.5, 0.5, 0.5]).unwrap(); // Interior point
         dt.insert_vertex(new_vertex)
             .expect("Failed to insert vertex into DelaunayTriangulation");
 
@@ -4593,10 +4579,10 @@ mod tests {
 
         // Create a triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4652,7 +4638,7 @@ mod tests {
         let old_generation = dt.as_triangulation().tds.generation();
 
         // Add a new vertex to trigger generation bump
-        let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(); // Interior point
+        let new_vertex = vertex!([0.5, 0.5, 0.5]).unwrap(); // Interior point
         dt.insert_vertex(new_vertex)
             .expect("Failed to insert vertex");
 
@@ -4694,10 +4680,10 @@ mod tests {
 
         // Create a triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4786,10 +4772,10 @@ mod tests {
         // connected and that the method signature returns the right error type.
 
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4840,10 +4826,10 @@ mod tests {
 
         // Create a symmetric triangulation where multiple facets might be equidistant
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // Origin
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(), // X axis
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(), // Y axis
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(), // Z axis
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // Origin
+            vertex!([1.0, 0.0, 0.0]).unwrap(), // X axis
+            vertex!([0.0, 1.0, 0.0]).unwrap(), // Y axis
+            vertex!([0.0, 0.0, 1.0]).unwrap(), // Z axis
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -4941,10 +4927,10 @@ mod tests {
 
         // Create a triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -5046,10 +5032,10 @@ mod tests {
 
         // Create a triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -5143,10 +5129,10 @@ mod tests {
 
         // Create a valid setup
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -5211,10 +5197,10 @@ mod tests {
 
         // Create a simple triangulation to test with
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -5633,10 +5619,10 @@ mod tests {
 
         // Test with very large coordinates (may cause numeric issues)
         let large_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1e10, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e10, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e10]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e10, 1e10, 1e10]).unwrap(),
+            vertex!([1e10, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1e10, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e10]).unwrap(),
+            vertex!([1e10, 1e10, 1e10]).unwrap(),
         ];
 
         match DelaunayTriangulation::try_new(&large_vertices) {
@@ -5681,10 +5667,10 @@ mod tests {
 
         // Test with very small coordinates (may cause precision issues)
         let small_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-15, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e-15, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e-15]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-15, 1e-15, 1e-15]).unwrap(),
+            vertex!([1e-15, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1e-15, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e-15]).unwrap(),
+            vertex!([1e-15, 1e-15, 1e-15]).unwrap(),
         ];
 
         match DelaunayTriangulation::try_new(&small_vertices) {
@@ -5704,10 +5690,10 @@ mod tests {
 
         // Test fallback visibility with extreme coordinates
         let normal_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let normal_dt = create_triangulation(&normal_vertices);
         let normal_hull = ConvexHull::try_from_triangulation(normal_dt.as_triangulation()).unwrap();
@@ -5754,10 +5740,10 @@ mod tests {
 
         // Create basic triangulation to get valid facet structure
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -5863,10 +5849,10 @@ mod tests {
 
         // Create a triangulation with near-collinear points
         let near_collinear_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 1e-10, 0.0]).unwrap(), // Nearly collinear with first two
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.5, 1.0]).unwrap(), // Out of plane
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([2.0, 1e-10, 0.0]).unwrap(), // Nearly collinear with first two
+            vertex!([0.5, 0.5, 1.0]).unwrap(),   // Out of plane
         ];
 
         match DelaunayTriangulation::try_new(&near_collinear_vertices) {
@@ -5914,10 +5900,10 @@ mod tests {
 
         // Create a triangulation where facets might have very small areas
         let tiny_area_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-6, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1e-6, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e-6]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1e-6, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1e-6, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e-6]).unwrap(),
         ];
 
         match DelaunayTriangulation::try_new(&tiny_area_vertices) {
@@ -5974,10 +5960,10 @@ mod tests {
 
         // Create a well-defined triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -6058,19 +6044,19 @@ mod tests {
             (
                 "equilateral-like triangle",
                 vec![
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.333, 0.289, 1.0]).unwrap(),
+                    vertex!([0.0, 0.0, 0.0]).unwrap(),
+                    vertex!([1.0, 0.0, 0.0]).unwrap(),
+                    vertex!([0.5, 0.866, 0.0]).unwrap(),
+                    vertex!([0.333, 0.289, 1.0]).unwrap(),
                 ],
             ),
             (
                 "elongated triangle",
                 vec![
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                    crate::core::vertex::Vertex::<(), _>::try_new([10.0, 0.0, 0.0]).unwrap(), // Very long edge
-                    crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.1, 0.0]).unwrap(), // Short edge
-                    crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+                    vertex!([0.0, 0.0, 0.0]).unwrap(),
+                    vertex!([10.0, 0.0, 0.0]).unwrap(), // Very long edge
+                    vertex!([0.1, 0.1, 0.0]).unwrap(),  // Short edge
+                    vertex!([1.0, 1.0, 1.0]).unwrap(),
                 ],
             ),
         ];
@@ -6136,9 +6122,9 @@ mod tests {
         test_debug!("  Testing perfectly collinear points in 2D...");
 
         let collinear_2d_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(), // Collinear with first two
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(), // Collinear with first two
         ];
 
         match DelaunayTriangulation::try_new(&collinear_2d_vertices) {
@@ -6196,9 +6182,9 @@ mod tests {
         test_debug!("  Testing nearly collinear points with small perturbations...");
 
         let nearly_collinear_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1e-12]).unwrap(), // Nearly on the line y=0
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, -1e-12]).unwrap(), // Nearly on the line y=0
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 1e-12]).unwrap(),  // Nearly on the line y=0
+            vertex!([2.0, -1e-12]).unwrap(), // Nearly on the line y=0
         ];
 
         match DelaunayTriangulation::try_new(&nearly_collinear_vertices) {
@@ -6237,10 +6223,10 @@ mod tests {
         test_debug!("  Testing collinear points in 3D (degenerate configuration)...");
 
         let collinear_3d_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 2.0, 2.0]).unwrap(), // Collinear with first two
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0, 3.0, 3.0]).unwrap(), // Also collinear
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0]).unwrap(),
+            vertex!([2.0, 2.0, 2.0]).unwrap(), // Collinear with first two
+            vertex!([3.0, 3.0, 3.0]).unwrap(), // Also collinear
         ];
 
         match DelaunayTriangulation::try_new(&collinear_3d_vertices) {
@@ -6271,10 +6257,10 @@ mod tests {
 
         // Four points in the same plane (z=0)
         let coplanar_3d_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 0.0]).unwrap(), // All in z=0 plane
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([1.0, 1.0, 0.0]).unwrap(), // All in z=0 plane
         ];
 
         match DelaunayTriangulation::try_new(&coplanar_3d_vertices) {
@@ -6293,10 +6279,10 @@ mod tests {
         test_debug!("  Testing nearly coplanar points with small z-perturbations...");
 
         let nearly_coplanar_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 1e-10]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, -1e-10]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1e-10]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 1e-10]).unwrap(),
+            vertex!([0.0, 1.0, -1e-10]).unwrap(),
+            vertex!([1.0, 1.0, 1e-10]).unwrap(),
         ];
 
         match DelaunayTriangulation::try_new(&nearly_coplanar_vertices) {
@@ -6375,11 +6361,11 @@ mod tests {
 
         // Five points in the same 3D hyperplane (w=0)
         let coplanar_4d_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0, 0.0]).unwrap(), // All in w=0 hyperplane
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([1.0, 1.0, 1.0, 0.0]).unwrap(), // All in w=0 hyperplane
         ];
 
         match DelaunayTriangulation::try_new(&coplanar_4d_vertices) {
@@ -6405,11 +6391,11 @@ mod tests {
         test_debug!("  Testing exact duplicate vertices...");
 
         let duplicate_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // Exact duplicate of first vertex
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // Exact duplicate of first vertex
         ];
 
         match DelaunayTriangulation::try_new(&duplicate_vertices) {
@@ -6453,11 +6439,11 @@ mod tests {
         test_debug!("  Testing nearly coincident vertices (within floating-point precision)...");
 
         let nearly_coincident_vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-15, 1e-15, 1e-15]).unwrap(), // Nearly coincident with first
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([1e-15, 1e-15, 1e-15]).unwrap(), // Nearly coincident with first
         ];
 
         match DelaunayTriangulation::try_new(&nearly_coincident_vertices) {
@@ -6519,13 +6505,13 @@ mod tests {
 
         // Create a 6D simplex (7 vertices)
         let vertices_6d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]).unwrap(), // Interior point to make it non-degenerate
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.1, 0.1, 0.1, 0.1, 0.1, 0.1]).unwrap(), // Interior point to make it non-degenerate
         ];
 
         match DelaunayTriangulation::try_new(&vertices_6d) {
@@ -6576,22 +6562,14 @@ mod tests {
         test_debug!("  Testing 7D convex hull...");
 
         let vertices_7d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
-                .unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]).unwrap(),
         ];
 
         match DelaunayTriangulation::try_new(&vertices_7d) {
@@ -6614,24 +6592,15 @@ mod tests {
         test_debug!("  Testing 8D convex hull (stress test)...");
 
         let vertices_8d = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
-                .unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
-                .unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1, 0.1]).unwrap(),
         ];
 
         match DelaunayTriangulation::try_new(&vertices_8d) {
@@ -6685,7 +6654,7 @@ mod tests {
             let x = radius * angle1.cos() * angle2.sin();
             let y = radius * angle1.sin() * angle2.sin();
             let z = radius * angle2.cos();
-            large_vertices.push(crate::core::vertex::Vertex::<(), _>::try_new([x, y, z]).unwrap());
+            large_vertices.push(vertex!([x, y, z]).unwrap());
         }
 
         test_debug!("    Generated {num_vertices} vertices");
@@ -6771,7 +6740,7 @@ mod tests {
             let radius = <f64 as From<_>>::from(i).mul_add(0.01, 1.0);
             let x = radius * angle.cos();
             let y = radius * angle.sin();
-            large_2d_vertices.push(crate::core::vertex::Vertex::<(), _>::try_new([x, y]).unwrap());
+            large_2d_vertices.push(vertex!([x, y]).unwrap());
         }
 
         let start_2d = std::time::Instant::now();
@@ -6824,10 +6793,10 @@ mod tests {
 
         // Create a basic triangulation for testing
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -6843,12 +6812,8 @@ mod tests {
 
         // Rapidly modify the TDS to increment generation many times
         for i in 0..20 {
-            let new_vertex = crate::core::vertex::Vertex::<(), _>::try_new([
-                <f64 as From<_>>::from(i).mul_add(0.01, 0.1),
-                0.1,
-                0.1,
-            ])
-            .unwrap();
+            let new_vertex =
+                vertex!([<f64 as From<_>>::from(i).mul_add(0.01, 0.1), 0.1, 0.1]).unwrap();
             if dt.insert_vertex(new_vertex).is_ok() {
                 let current_gen = dt.as_triangulation().tds.generation();
                 test_debug!("    After modification {i}: TDS generation = {current_gen}");
@@ -6925,10 +6890,10 @@ mod tests {
         test_debug!("Testing cache consistency under rapid operations");
 
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -7063,10 +7028,10 @@ mod tests {
         test_debug!("  Testing cache memory cleanup...");
 
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt = create_triangulation(&vertices);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -7167,10 +7132,10 @@ mod tests {
 
         // Step 1: Create hull from initial DelaunayTriangulation
         let mut dt = DelaunayTriangulation::try_new(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ])
         .unwrap();
         let initial_gen = dt.as_triangulation().tds.generation();
@@ -7264,10 +7229,10 @@ mod tests {
     #[test]
     fn test_hull_rejects_different_tds_with_same_generation() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt1: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -7305,10 +7270,10 @@ mod tests {
     #[test]
     fn test_hull_rejects_cloned_tds_with_same_generation() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt1: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -7345,10 +7310,10 @@ mod tests {
     #[test]
     fn test_hull_cache_key_survives_failed_insert_rollback() {
         let vertices = [
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -7435,10 +7400,10 @@ mod tests {
         test_debug!("Testing that all hull operations fail on stale hull");
 
         let mut dt = DelaunayTriangulation::try_new(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ])
         .unwrap();
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -7513,10 +7478,10 @@ mod tests {
 
         // Create hull with nearly coplanar points (z << x,y) but still valid simplex
         let dt = DelaunayTriangulation::try_new(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 1e-6]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 1e-6]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 1e-6]).unwrap(),
+            vertex!([0.0, 1.0, 1e-6]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ])
         .unwrap();
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -7539,10 +7504,10 @@ mod tests {
 
         // Create a very flat triangulation (extreme aspect ratio)
         let dt = DelaunayTriangulation::try_new(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1000.0, 0.0, 0.0]).unwrap(), // Very long in x
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.001, 0.0]).unwrap(), // Very short in y
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.001]).unwrap(), // Very short in z
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1000.0, 0.0, 0.0]).unwrap(), // Very long in x
+            vertex!([0.0, 0.001, 0.0]).unwrap(),  // Very short in y
+            vertex!([0.0, 0.0, 0.001]).unwrap(),  // Very short in z
         ])
         .unwrap();
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
@@ -7568,10 +7533,10 @@ mod tests {
         test_debug!("Testing points exactly on hull surface");
 
         let dt = create_triangulation(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
 
@@ -7603,10 +7568,10 @@ mod tests {
         test_debug!("Testing points very close to hull surface (epsilon distance)");
 
         let dt = create_triangulation(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
 
@@ -7636,8 +7601,7 @@ mod tests {
                 // Origin - use nested macro to get correct type
                 macro_rules! make_vertex {
                     ($coords:expr) => {{
-                        let v: Vertex<(), $dim> =
-                            crate::core::vertex::Vertex::<(), _>::try_new($coords).unwrap();
+                        let v: Vertex<(), $dim> = vertex!($coords).unwrap();
                         v
                     }};
                 }
@@ -7752,10 +7716,10 @@ mod tests {
         test_debug!("Testing cache lifecycle through multiple operations");
 
         let dt = create_triangulation(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]);
         let hull = ConvexHull::try_from_triangulation(dt.as_triangulation()).unwrap();
 
@@ -7830,10 +7794,10 @@ mod tests {
         test_debug!("Testing cache independence between multiple hull instances");
 
         let dt = create_triangulation(&[
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ]);
 
         test_debug!("  Creating first hull and building cache...");

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -580,6 +580,7 @@ mod tests {
     use crate::core::triangulation::Triangulation;
     use crate::geometry::kernel::FastKernel;
     use crate::triangulation::DelaunayTriangulation;
+    use crate::vertex;
     use approx::assert_relative_eq;
     use std::assert_matches;
 
@@ -638,7 +639,7 @@ let key_base = dt_base.simplices().next().unwrap().0;
 	                        // Scale by 10x
 	                        let vertices_scaled: Vec<_> = vertices_base.iter().map(|v| {
 	                            let coords: [f64; $dim] = std::array::from_fn(|idx| v.point().coords()[idx] * 10.0);
-	                            crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap()
+	                            vertex!(coords).unwrap()
 	                        }).collect();
                         let dt_scaled: DelaunayTriangulation<_, (), (), $dim> = DelaunayTriangulation::try_new(&vertices_scaled).unwrap();
 let key_scaled = dt_scaled.simplices().next().unwrap().0;
@@ -662,7 +663,7 @@ let key_base = dt_base.simplices().next().unwrap().0;
 	                        // Translate by [5.0, 5.0, ...]
 	                        let vertices_translated: Vec<_> = vertices_base.iter().map(|v| {
 	                            let coords: [f64; $dim] = std::array::from_fn(|idx| v.point().coords()[idx] + 5.0);
-	                            crate::core::vertex::Vertex::<(), _>::try_new(coords).unwrap()
+	                            vertex!(coords).unwrap()
 	                        }).collect();
                         let dt_translated: DelaunayTriangulation<_, (), (), $dim> = DelaunayTriangulation::try_new(&vertices_translated).unwrap();
 let key_translated = dt_translated.simplices().next().unwrap().0;
@@ -684,74 +685,74 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
     test_quality_dimensions! {
         quality_2d_unit => 2 => "unit simplex" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+                vertex!([0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0]).unwrap(),
+                vertex!([0.0, 1.0]).unwrap(),
             ],
             2.0, 3.0,
 
         quality_2d_equilateral => 2 => "equilateral triangle" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025]).unwrap(),
+                vertex!([0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.866_025]).unwrap(),
             ],
             1.9, 2.1,
 
         quality_2d_right => 2 => "right triangle" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([3.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 4.0]).unwrap(),
+                vertex!([0.0, 0.0]).unwrap(),
+                vertex!([3.0, 0.0]).unwrap(),
+                vertex!([0.0, 4.0]).unwrap(),
             ],
             2.0, 5.0,
 
         quality_3d_unit => 3 => "unit simplex" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 1.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 1.0]).unwrap(),
             ],
             3.0, 5.0,
 
         quality_3d_regular => 3 => "regular tetrahedron" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.288_675, 0.816_497]).unwrap(),
+                vertex!([0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.866_025, 0.0]).unwrap(),
+                vertex!([0.5, 0.288_675, 0.816_497]).unwrap(),
             ],
             2.8, 3.2,
 
         quality_4d_unit => 4 => "unit simplex" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
             ],
             4.0, 7.0,
 
         quality_4d_regular => 4 => "regular simplex" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.288_675, 0.816_497, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.288_675, 0.204_124, 0.790_569]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.866_025, 0.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.288_675, 0.816_497, 0.0]).unwrap(),
+                vertex!([0.5, 0.288_675, 0.204_124, 0.790_569]).unwrap(),
             ],
             3.8, 4.2,
 
         quality_5d_unit => 5 => "unit simplex" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
             ],
             5.0, 15.0,
     }
@@ -764,9 +765,9 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
     fn test_degenerate_nearly_collinear() {
         // Nearly collinear points - tests both metrics
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.001]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.001]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -921,9 +922,9 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
         // Both metrics should agree on relative quality
         // Good quality triangle (equilateral)
         let vertices_good = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.866_025]).unwrap(),
         ];
         let dt_good: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_good).unwrap();
@@ -931,9 +932,9 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
 
         // Poor quality triangle (very flat)
         let vertices_poor = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.01]).unwrap(), // Nearly flat
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.01]).unwrap(), // Nearly flat
         ];
         let dt_poor: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_poor).unwrap();
@@ -962,9 +963,9 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
         // Currently, collinear points are accepted during construction but produce
         // degenerate simplices with very poor quality metrics.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(), // Collinear
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(), // Collinear
         ];
         let dt_result: Result<
             DelaunayTriangulation<_, (), (), 2>,
@@ -991,9 +992,9 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
     fn test_quality_near_duplicate_vertices() {
         // Two vertices very close together
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.000_000_1, 0.000_000_1]).unwrap(), // Nearly duplicate
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([1.000_000_1, 0.000_000_1]).unwrap(), // Nearly duplicate
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1009,9 +1010,9 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
     fn test_quality_mixed_scale_coordinates() {
         // Mix of large and small coordinates
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e10, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1e-10, 1e10]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1e10, 0.0]).unwrap(),
+            vertex!([1e-10, 1e10]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1034,13 +1035,13 @@ let key_translated = dt_translated.simplices().next().unwrap().0;
     fn test_quality_6d_simplex() {
         // 6D simplex at unit hypercube corners
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 6> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1079,54 +1080,54 @@ let simplex_key = dt.simplices().next().unwrap().0;
     test_poor_quality! {
         poor_quality_2d_flat => 2 => "very flat triangle" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([100.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([50.0, 0.1]).unwrap(),
+                vertex!([0.0, 0.0]).unwrap(),
+                vertex!([100.0, 0.0]).unwrap(),
+                vertex!([50.0, 0.1]).unwrap(),
             ],
             50.0,
 
         poor_quality_3d_nearly_coplanar => 3 => "nearly coplanar tetrahedron" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([10.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([5.0, 8.66, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([5.0, 2.89, 0.01]).unwrap(),
+                vertex!([0.0, 0.0, 0.0]).unwrap(),
+                vertex!([10.0, 0.0, 0.0]).unwrap(),
+                vertex!([5.0, 8.66, 0.0]).unwrap(),
+                vertex!([5.0, 2.89, 0.01]).unwrap(),
             ],
             30.0,
 
         poor_quality_4d_degenerate => 4 => "nearly 3D subspace" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.289, 0.816, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.289, 0.204, 0.001]).unwrap(),
+                vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.866, 0.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.289, 0.816, 0.0]).unwrap(),
+                vertex!([0.5, 0.289, 0.204, 0.001]).unwrap(),
             ],
             10.0,
 
         poor_quality_3d_sliver => 3 => "sliver tetrahedron" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.288_675, 0.001]).unwrap(),
+                vertex!([0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.866_025, 0.0]).unwrap(),
+                vertex!([0.5, 0.288_675, 0.001]).unwrap(),
             ],
             100.0,
 
         poor_quality_2d_needle => 2 => "needle triangle" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([100.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.1]).unwrap(),
+                vertex!([0.0, 0.0]).unwrap(),
+                vertex!([100.0, 0.0]).unwrap(),
+                vertex!([0.0, 0.1]).unwrap(),
             ],
             50.0,
 
         poor_quality_3d_cap => 3 => "cap tetrahedron" =>
             vec![
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025, 0.0]).unwrap(),
-                crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.288_675, 10.0]).unwrap(),
+                vertex!([0.0, 0.0, 0.0]).unwrap(),
+                vertex!([1.0, 0.0, 0.0]).unwrap(),
+                vertex!([0.5, 0.866_025, 0.0]).unwrap(),
+                vertex!([0.5, 0.288_675, 10.0]).unwrap(),
             ],
             10.0,
     }
@@ -1139,9 +1140,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_quality_invalid_simplex_key() {
         // Create triangulation
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.866_025]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1196,9 +1197,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
         // Test both ranking consistency and threshold validation in one test
         // Best: equilateral (good quality threshold)
         let vertices_best = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.866_025]).unwrap(),
         ];
         let dt_best: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_best).unwrap();
@@ -1206,9 +1207,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
 
         // Medium: right triangle (acceptable quality)
         let vertices_medium = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 4.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([3.0, 0.0]).unwrap(),
+            vertex!([0.0, 4.0]).unwrap(),
         ];
         let dt_medium: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_medium).unwrap();
@@ -1216,9 +1217,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
 
         // Worst: very flat (poor quality)
         let vertices_worst = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([10.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([5.0, 0.1]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([10.0, 0.0]).unwrap(),
+            vertex!([5.0, 0.1]).unwrap(),
         ];
         let dt_worst: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_worst).unwrap();
@@ -1252,9 +1253,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_special_triangles() {
         // Test right triangle
         let vertices_right = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
         let dt_right: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_right).unwrap();
@@ -1264,9 +1265,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
 
         // Test isosceles triangle
         let vertices_iso = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0]).unwrap(),
+            vertex!([1.0, 2.0]).unwrap(),
         ];
         let dt_iso: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices_iso).unwrap();
@@ -1287,9 +1288,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_simplex_points_valid() {
         // Test simplex_points helper with valid simplex
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.866_025]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1303,9 +1304,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_simplex_points_invalid_key() {
         // Test simplex_points with invalid simplex key
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.866_025]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1382,9 +1383,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_radius_ratio_wrong_vertex_count() {
         // Create a triangulation to test vertex count validation in radius_ratio
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 0.866_025]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 0.866_025]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1399,10 +1400,10 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_normalized_volume_wrong_vertex_count() {
         // Test normalized_volume with proper vertex count
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -1417,9 +1418,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_radius_ratio_numerical_edge_cases() {
         // Test with coordinates near numerical limits
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.5, 1e-15]).unwrap(), // Very small but non-zero height
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.5, 1e-15]).unwrap(), // Very small but non-zero height
         ];
         let dt_result: Result<
             DelaunayTriangulation<_, (), (), 2>,
@@ -1455,10 +1456,10 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_normalized_volume_numerical_edge_cases() {
         // Test normalized_volume with numerical edge cases
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1e-14]).unwrap(), // Very small but non-zero
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1e-14]).unwrap(), // Very small but non-zero
         ];
         let dt_result: Result<
             DelaunayTriangulation<_, (), (), 3>,
@@ -1497,19 +1498,13 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn normalized_volume_uses_dimensionally_consistent_volume_threshold() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0e-30]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0e-30]).unwrap())
             .unwrap();
         let simplex_key = tds
             .insert_simplex_with_mapping(
@@ -1555,9 +1550,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
     fn test_degenerate_simplex_error_details() {
         // Test that degenerate errors include helpful details when they occur.
         let vertices = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 1e-20]).unwrap(), // Nearly collinear
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([2.0, 1e-20]).unwrap(), // Nearly collinear
         ];
         let dt_result: Result<
             DelaunayTriangulation<_, (), (), 2>,

--- a/src/geometry/robust_predicates.rs
+++ b/src/geometry/robust_predicates.rs
@@ -8,8 +8,8 @@
 #![forbid(unsafe_code)]
 
 use super::predicates::{
-    InSphere, Orientation, relative_insphere_classification, relative_insphere_determinant_sign,
-    relative_insphere_signs,
+    InSphere, Orientation, insphere_distance, relative_insphere_classification,
+    relative_insphere_determinant_sign, relative_insphere_signs, try_orientation_from_matrix,
 };
 use crate::core::collections::{MAX_PRACTICAL_DIMENSION_SIZE, SmallBuffer};
 use crate::geometry::matrix::{MAX_STACK_MATRIX_DIM, matrix_set};
@@ -262,7 +262,7 @@ pub fn robust_insphere<const D: usize>(
     // non-degenerate cases correctly.  Only if the result is BOUNDARY
     // (truly degenerate) do we apply SoS tie-breaking.
     cold_path();
-    if let Ok(geometric_result) = super::predicates::insphere_distance(simplex_points, *test_point)
+    if let Ok(geometric_result) = insphere_distance(simplex_points, *test_point)
         && geometric_result != InSphere::BOUNDARY
     {
         return Ok(geometric_result);
@@ -439,7 +439,7 @@ pub fn robust_orientation<const D: usize>(
 
         // Route through the exact-sign orientation helper for provably correct
         // orientation classification on finite inputs.
-        Ok(super::predicates::try_orientation_from_matrix(&matrix, k)?)
+        Ok(try_orientation_from_matrix(&matrix, k)?)
     })
 }
 
@@ -481,7 +481,7 @@ fn verify_insphere_consistency<const D: usize>(
     determinant_result: InSphere,
 ) -> ConsistencyResult {
     // Use the existing distance-based insphere test for verification
-    super::predicates::insphere_distance(simplex_points, *test_point).map_or(
+    insphere_distance(simplex_points, *test_point).map_or(
         ConsistencyResult::Unverifiable,
         |distance_result| match (determinant_result, distance_result) {
             // Exact matches are always consistent

--- a/src/geometry/util/conversions.rs
+++ b/src/geometry/util/conversions.rs
@@ -86,7 +86,7 @@ pub enum ValueConversionError {
 ///
 /// Returns `CoordinateConversionError::NonFiniteValue` if the value is NaN or infinite
 /// Returns `CoordinateConversionError::ConversionFailed` if the conversion fails
-pub(in crate::geometry::util) fn safe_cast_to_f64(
+pub(super) fn safe_cast_to_f64(
     value: f64,
     coordinate_index: usize,
 ) -> Result<f64, CoordinateConversionError> {
@@ -120,7 +120,7 @@ pub(in crate::geometry::util) fn safe_cast_to_f64(
 ///
 /// Returns `CoordinateConversionError::NonFiniteValue` if the value is NaN or infinite
 /// Returns `CoordinateConversionError::ConversionFailed` if the conversion fails
-pub(in crate::geometry::util) fn safe_cast_from_f64(
+pub(super) fn safe_cast_from_f64(
     value: f64,
     coordinate_index: usize,
 ) -> Result<f64, CoordinateConversionError> {

--- a/src/geometry/util/measures.rs
+++ b/src/geometry/util/measures.rs
@@ -838,6 +838,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
     use std::assert_matches;
 
     use crate::core::traits::facet_incidence_analysis::FacetIncidenceAnalysis;
@@ -1599,10 +1600,10 @@ mod tests {
 
         // Create a right triangle tetrahedron
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0, 0.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 4.0, 0.0]).unwrap(), // v3
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(), // v4
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([3.0, 0.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 4.0, 0.0]).unwrap(), // v3
+            vertex!([0.0, 0.0, 1.0]).unwrap(), // v4
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -1647,11 +1648,11 @@ mod tests {
         // Create a triangulation with 5 vertices and 2 tetrahedra to get both boundary and internal facets
 
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(), // v3
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(), // v4
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(), // v5
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([1.0, 0.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 1.0, 0.0]).unwrap(), // v3
+            vertex!([0.0, 0.0, 1.0]).unwrap(), // v4
+            vertex!([1.0, 1.0, 1.0]).unwrap(), // v5
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -1972,18 +1973,18 @@ mod tests {
 
         // Create first triangulation with small right triangle (area = 0.5)
         let vertices1: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(), // v3
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(), // v4
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([1.0, 0.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 1.0, 0.0]).unwrap(), // v3
+            vertex!([0.0, 0.0, 1.0]).unwrap(), // v4
         ];
 
         // Create second triangulation with large right triangle (area = 24.0)
         let vertices2: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // v5
-            crate::core::vertex::Vertex::<(), _>::try_new([6.0, 0.0, 0.0]).unwrap(), // v6
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 8.0, 0.0]).unwrap(), // v7
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(), // v8
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // v5
+            vertex!([6.0, 0.0, 0.0]).unwrap(), // v6
+            vertex!([0.0, 8.0, 0.0]).unwrap(), // v7
+            vertex!([0.0, 0.0, 1.0]).unwrap(), // v8
         ];
         let dt1: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices1).unwrap();
@@ -2062,9 +2063,9 @@ mod tests {
 
         // Create 2D triangle (3-4-5 right triangle)
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([3.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 4.0]).unwrap(), // v3
+            vertex!([0.0, 0.0]).unwrap(), // v1
+            vertex!([3.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 4.0]).unwrap(), // v3
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -2089,11 +2090,11 @@ mod tests {
 
         // Create 4D simplex (5 vertices)
         let vertices: Vec<Vertex<(), 4>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(), // v3
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(), // v4
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(), // v5
+            vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(), // v3
+            vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(), // v4
+            vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(), // v5
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 4> =
@@ -2126,10 +2127,10 @@ mod tests {
 
         // Create a valid triangulation
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(), // v1
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(), // v2
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(), // v3
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(), // v4
+            vertex!([0.0, 0.0, 0.0]).unwrap(), // v1
+            vertex!([1.0, 0.0, 0.0]).unwrap(), // v2
+            vertex!([0.0, 1.0, 0.0]).unwrap(), // v3
+            vertex!([0.0, 0.0, 1.0]).unwrap(), // v4
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -2200,10 +2201,10 @@ mod tests {
         // Test with many facets from a simple tetrahedral triangulation
         // Use a simple tetrahedron to avoid degenerate boundary facets
         let vertices: Vec<Vertex<(), 3>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 2.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0, 2.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([2.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 2.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 2.0]).unwrap(),
         ];
 
         let dt: DelaunayTriangulation<_, (), (), 3> =

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -1131,6 +1131,7 @@ mod tests {
     use crate::geometry::coordinate_range::{
         CoordinateRangeBound, CoordinateRangeOrdering, InvalidCoordinateValue,
     };
+    use crate::vertex;
     use approx::assert_relative_eq;
     use std::assert_matches;
 
@@ -1400,9 +1401,9 @@ mod tests {
     fn test_random_triangulation_try_with_vertices_exercises_fallbacks() {
         // Use a valid 2D simplex, but require more vertices than provided to force retries.
         let vertices: Vec<Vertex<(), 2>> = vec![
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
         ];
 
         let result = random_triangulation_try_with_vertices::<(), (), 2>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -245,7 +245,10 @@
 //!   Level 5 (Delaunay property) validation is performed by
 //!   [`DelaunayTriangulation::is_valid_delaunay`](crate::DelaunayTriangulation::is_valid_delaunay) (Level 5 only) and
 //!   [`DelaunayTriangulation::validate`](crate::DelaunayTriangulation::validate) (Levels 1–5).
-//!   Batch construction runs final Delaunay validation before returning.
+//!   Batch construction normally runs final Delaunay validation before returning;
+//!   [`ConstructionOptions::without_final_delaunay_enforcement`](crate::construction::ConstructionOptions::without_final_delaunay_enforcement)
+//!   opts into returning after Levels 1–4 validation for exact degenerate or
+//!   externally constrained connectivity.
 //!   Incremental insertion can run global Level 5 checks according to
 //!   [`DelaunayCheckPolicy`](crate::repair::DelaunayCheckPolicy). If robust
 //!   fallback and repair cannot certify a checked result, the operation returns a
@@ -2058,6 +2061,7 @@ mod tests {
             verify_delaunay_for_triangulation, verify_delaunay_via_flip_predicates,
         },
         prelude::*,
+        vertex,
     };
     use std::assert_matches;
 
@@ -2165,9 +2169,9 @@ mod tests {
     #[test]
     fn prelude_repair_exports() {
         let vertices = vec![
-            crate::vertex![0.0, 0.0].unwrap(),
-            crate::vertex![1.0, 0.0].unwrap(),
-            crate::vertex![0.0, 1.0].unwrap(),
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
         ];
         let dt: RepairDelaunayTriangulation<_, (), (), 2> =
             RepairDelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2208,9 +2212,9 @@ mod tests {
     fn prelude_quality_exports() {
         // Test that quality functions are accessible from prelude
         let vertices = vec![
-            crate::vertex![0.0, 0.0].unwrap(),
-            crate::vertex![1.0, 0.0].unwrap(),
-            crate::vertex![0.0, 1.0].unwrap(),
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2279,16 +2283,16 @@ mod tests {
         assert_ne!(p1, p2);
 
         // Vertex construction via the fallible smart constructor.
-        let v1: Vertex<(), 3> = Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap();
-        let v2: Vertex<(), 3> = Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap();
+        let v1: Vertex<(), 3> = vertex!([0.0, 0.0, 0.0]).unwrap();
+        let v2: Vertex<(), 3> = vertex!([1.0, 0.0, 0.0]).unwrap();
         assert_ne!(v1.point(), v2.point());
 
         // DelaunayTriangulation construction
         let vertices = vec![
-            crate::vertex![0.0, 0.0, 0.0].unwrap(),
-            crate::vertex![1.0, 0.0, 0.0].unwrap(),
-            crate::vertex![0.0, 1.0, 0.0].unwrap(),
-            crate::vertex![0.0, 0.0, 1.0].unwrap(),
+            vertex![0.0, 0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0, 0.0].unwrap(),
+            vertex![0.0, 1.0, 0.0].unwrap(),
+            vertex![0.0, 0.0, 1.0].unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2312,9 +2316,9 @@ mod tests {
     fn test_prelude_point_location() {
         // Test that point location algorithms are accessible
         let vertices = vec![
-            crate::vertex![0.0, 0.0].unwrap(),
-            crate::vertex![1.0, 0.0].unwrap(),
-            crate::vertex![0.0, 1.0].unwrap(),
+            vertex![0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0].unwrap(),
+            vertex![0.0, 1.0].unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 2> =
             DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -2369,10 +2373,10 @@ mod tests {
     fn test_prelude_convex_hull() {
         // Test that convex hull operations are accessible
         let vertices = vec![
-            crate::vertex![0.0, 0.0, 0.0].unwrap(),
-            crate::vertex![1.0, 0.0, 0.0].unwrap(),
-            crate::vertex![0.0, 1.0, 0.0].unwrap(),
-            crate::vertex![0.0, 0.0, 1.0].unwrap(),
+            vertex![0.0, 0.0, 0.0].unwrap(),
+            vertex![1.0, 0.0, 0.0].unwrap(),
+            vertex![0.0, 1.0, 0.0].unwrap(),
+            vertex![0.0, 0.0, 1.0].unwrap(),
         ];
         let dt: DelaunayTriangulation<_, (), (), 3> =
             DelaunayTriangulation::try_new(&vertices).unwrap();

--- a/src/topology/characteristics/euler.rs
+++ b/src/topology/characteristics/euler.rs
@@ -856,6 +856,7 @@ pub fn expected_chi_for(classification: &TopologyClassification) -> Option<isize
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
 
     use crate::core::simplex::Simplex;
     use slotmap::{KeyData, SlotMap};
@@ -1101,24 +1102,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(
-                crate::core::vertex::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-            )
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let _ = tds

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -2144,12 +2144,12 @@ fn validate_ridge_link_graph(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::vertex;
     use std::{assert_matches, iter};
 
     use crate::core::facet::{FacetError, FacetHandle, FacetView};
     use crate::core::simplex::Simplex;
     use crate::core::triangulation::Triangulation;
-    use crate::core::vertex::Vertex;
     use crate::geometry::kernel::FastKernel;
     use crate::topology::traits::topological_space::ToroidalConstructionMode;
 
@@ -2174,13 +2174,13 @@ mod tests {
     fn build_single_triangle_tds(periodic_self_neighbor: bool) -> (Tds<(), (), 2>, SimplexKey) {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let mut simplex = Simplex::try_new(vec![v0, v1, v2]).unwrap();
@@ -2214,16 +2214,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         for tri in [[v0, v1, v2], [v0, v1, v3], [v0, v2, v3], [v1, v2, v3]] {
@@ -2242,23 +2242,23 @@ mod tests {
         let mut tds: Tds<(), (), 3> = Tds::empty();
 
         let shared_edge_v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let shared_edge_v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
 
         let tet1_v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let tet1_v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let tet2_v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, -1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, -1.0, 0.0]).unwrap())
             .unwrap();
         let tet2_v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, -1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, -1.0]).unwrap())
             .unwrap();
 
         let touched_simplex = tds
@@ -2287,10 +2287,10 @@ mod tests {
     #[test]
     fn test_validate_facet_degree_ok_for_single_tetrahedron() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let tds =
@@ -2307,21 +2307,21 @@ mod tests {
 
         // Shared triangle.
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
 
         // Apex points on opposite sides.
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, -1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, -1.0]).unwrap())
             .unwrap();
 
         let _ = tds
@@ -2345,23 +2345,23 @@ mod tests {
         let mut tds: Tds<(), (), 3> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
 
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
         let v4 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 2.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 2.0]).unwrap())
             .unwrap();
         let v5 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 3.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 3.0]).unwrap())
             .unwrap();
 
         let _ = tds
@@ -2398,10 +2398,10 @@ mod tests {
     #[test]
     fn test_validate_closed_boundary_ok_for_single_tetrahedron() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let tds =
@@ -2422,10 +2422,10 @@ mod tests {
     #[test]
     fn test_validate_closed_boundary_errors_on_out_of_bounds_facet_index() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let tds =
@@ -2628,13 +2628,13 @@ mod tests {
         let mut tds: Tds<(), (), 1> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([2.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([2.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(Simplex::try_new_with_data(vec![v0, v1], None).unwrap())
@@ -2652,10 +2652,10 @@ mod tests {
         let mut tds: Tds<(), (), 1> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(Simplex::try_new_with_data(vec![v0, v1], None).unwrap())
@@ -2672,13 +2672,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         tds.insert_simplex_with_mapping(
@@ -2713,19 +2713,19 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let va = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let vb = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let vc = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
         let vd = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let center = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.5, 0.5]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5]).unwrap())
             .unwrap();
 
         for tri in [
@@ -2809,10 +2809,7 @@ mod tests {
 
     #[test]
     fn test_validate_closed_boundary_noop_for_d_lt_2() {
-        let vertices = vec![
-            Vertex::<(), _>::try_new([0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0]).unwrap(),
-        ];
+        let vertices = vec![vertex!([0.0]).unwrap(), vertex!([1.0]).unwrap()];
 
         let tds =
             Triangulation::<FastKernel<f64>, (), (), 1>::build_initial_simplex(&vertices).unwrap();
@@ -2891,16 +2888,16 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([10.0, 10.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([10.0, 10.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -2944,13 +2941,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3030,10 +3027,10 @@ mod tests {
     #[test]
     fn test_validate_local_pseudomanifold_for_simplices_errors_on_missing_scope_simplex() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
         let mut tds =
             Triangulation::<FastKernel<f64>, (), (), 3>::build_initial_simplex(&vertices).unwrap();
@@ -3056,10 +3053,10 @@ mod tests {
     #[test]
     fn test_validate_ridge_links_ok_for_single_tetrahedron() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let tds =
@@ -3116,18 +3113,18 @@ mod tests {
 
         // Shared vertex.
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
 
         // First tetrahedron boundary (4 triangles on 4 vertices).
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 1.0]).unwrap())
             .unwrap();
 
         let c012 = tds
@@ -3153,13 +3150,13 @@ mod tests {
 
         // Second tetrahedron boundary (shares only v0).
         let v4 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([10.0, 10.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([10.0, 10.0]).unwrap())
             .unwrap();
         let v5 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([11.0, 10.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([11.0, 10.0]).unwrap())
             .unwrap();
         let v6 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([10.0, 11.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([10.0, 11.0]).unwrap())
             .unwrap();
 
         let _c045 = tds
@@ -3189,10 +3186,10 @@ mod tests {
     #[test]
     fn test_validate_ridge_links_for_simplices_ok_for_single_tetrahedron_in_3d() {
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let tds =
@@ -3219,10 +3216,10 @@ mod tests {
         let mut tds: Tds<(), (), 1> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0]).unwrap())
             .unwrap();
 
         let c01 = tds
@@ -3286,14 +3283,14 @@ mod tests {
                 let i_f = f64::from(u32::try_from(i).unwrap());
                 let j_f = f64::from(u32::try_from(j).unwrap());
                 *slot = tds
-                    .insert_vertex_with_mapping(Vertex::<(), _>::try_new([i_f, j_f, 0.0]).unwrap())
+                    .insert_vertex_with_mapping(vertex!([i_f, j_f, 0.0]).unwrap())
                     .unwrap();
             }
         }
 
         // Apex of the cone (interior vertex; not on any boundary facet).
         let apex = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.5, 0.5, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.5, 0.5, 1.0]).unwrap())
             .unwrap();
 
         // Triangulate each periodic square into two triangles, then cone to the apex.
@@ -3367,16 +3364,16 @@ mod tests {
         let mut tds: Tds<(), (), 3> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
 
         let simplex_key = tds
@@ -3546,21 +3543,21 @@ mod tests {
 
         // Base tetrahedron vertices (triangulated S^2 boundary)
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0, 0.0]).unwrap())
             .unwrap();
         let v3 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0, 1.0]).unwrap())
             .unwrap();
 
         // Apex of the cone
         let apex = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.3, 0.3, 0.3]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.3, 0.3, 0.3]).unwrap())
             .unwrap();
 
         // Each boundary triangle of the tetrahedron, coned to apex
@@ -3606,13 +3603,13 @@ mod tests {
         let mut tds: Tds<(), (), 2> = Tds::empty();
 
         let v0 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
             .unwrap();
         let v1 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
             .unwrap();
         let v2 = tds
-            .insert_vertex_with_mapping(Vertex::<(), _>::try_new([0.5, 1.0]).unwrap())
+            .insert_vertex_with_mapping(vertex!([0.5, 1.0]).unwrap())
             .unwrap();
 
         let mut simplex1 = Simplex::try_new_with_data(vec![v0, v1, v2], None).unwrap();
@@ -3639,10 +3636,10 @@ mod tests {
         // Each boundary vertex has a link homeomorphic to a 2-ball.
 
         let vertices = vec![
-            Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-            Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.0, 0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0, 0.0]).unwrap(),
+            vertex!([0.0, 0.0, 1.0]).unwrap(),
         ];
 
         let tds =

--- a/src/topology/ridge.rs
+++ b/src/topology/ridge.rs
@@ -1612,6 +1612,7 @@ mod tests {
         facet::facet_key_from_vertices,
         simplex::Simplex,
     };
+    use crate::vertex;
     use slotmap::{Key, KeyData};
     use std::iter;
 
@@ -1619,7 +1620,7 @@ mod tests {
         (Tds<(), (), 3>, SimplexKey, VertexKey, VertexKey, VertexKey);
 
     fn test_vertex<const D: usize>(coords: [f64; D]) -> Vertex<(), D> {
-        Vertex::try_new(coords).unwrap()
+        vertex!(coords).unwrap()
     }
 
     fn simplex(vertices: &[VertexKey]) -> LiftedVertexBuffer {

--- a/src/topology/traits/global_topology_model.rs
+++ b/src/topology/traits/global_topology_model.rs
@@ -580,8 +580,7 @@ mod tests {
 
         let toroidal = GlobalTopology::<2>::Toroidal {
             domain: ToroidalDomain::try_new([2.0, 3.0]).unwrap(),
-            mode:
-                crate::topology::traits::topological_space::ToroidalConstructionMode::Canonicalized,
+            mode: ToroidalConstructionMode::Canonicalized,
         }
         .model();
         assert_eq!(toroidal.kind(), TopologyKind::Toroidal);

--- a/tests/circumsphere_debug_tools.rs
+++ b/tests/circumsphere_debug_tools.rs
@@ -17,6 +17,7 @@ use delaunay::geometry::matrix::{Matrix, determinant};
 use delaunay::geometry::util::hypot;
 use delaunay::prelude::construction::Vertex;
 use delaunay::prelude::geometry::*;
+use delaunay::vertex;
 use serde::{Deserialize, Serialize};
 
 // Macro for standard test output formatting
@@ -173,9 +174,9 @@ fn test_everything_debug() {
 /// Test 2D circumsphere methods with a triangle
 fn test_2d_circumsphere() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0], 2).unwrap(),
+        vertex!([0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0]; data = 2).unwrap(),
     ];
 
     let test_points = test_points!(
@@ -252,8 +253,7 @@ fn test_point_generic<const D: usize>(
 ) where
     [f64; D]: Copy + Sized + Serialize + for<'de> Deserialize<'de>,
 {
-    let test_vertex: Vertex<i32, D> =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data(coords, 99).unwrap();
+    let test_vertex: Vertex<i32, D> = vertex!(coords; data = 99).unwrap();
 
     let vertex_points: Vec<Point<D>> = vertices.iter().map(Point::from).collect();
     let result_insphere = insphere(&vertex_points, Point::from(&test_vertex));
@@ -290,10 +290,10 @@ fn test_point_generic<const D: usize>(
 fn test_3d_circumsphere() {
     // Create a unit tetrahedron: (0,0,0), (1,0,0), (0,1,0), (0,0,1)
     let vertices = vec![
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 2).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 3).unwrap(),
+        vertex!([0.0, 0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0, 0.0]; data = 2).unwrap(),
+        vertex!([0.0, 0.0, 1.0]; data = 3).unwrap(),
     ];
 
     let test_points = test_points!(
@@ -324,11 +324,11 @@ fn test_3d_point(
 fn test_4d_circumsphere() {
     // Create a unit 4-simplex: vertices at origin and unit vectors along each axis
     let vertices = vec![
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0, 0.0], 2).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0, 0.0], 3).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 1.0], 4).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]; data = 2).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]; data = 3).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]; data = 4).unwrap(),
     ];
 
     let test_points = test_points!(
@@ -373,11 +373,11 @@ fn test_4d_circumsphere_methods() {
 
     // Create a unit 4-simplex: vertices at origin and unit vectors along each axis
     let vertices: Vec<Vertex<i32, 4>> = vec![
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 1.0], 2).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]; data = 2).unwrap(),
     ];
 
     // Calculate circumcenter and circumradius for reference
@@ -434,11 +434,11 @@ fn test_circumsphere_containment() {
     // along each coordinate axis. The circumcenter is at [0.5, 0.5, 0.5, 0.5] and
     // the circumradius is √4/2 = 1.0.
     let vertices: [Vertex<i32, 4>; 5] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 0).unwrap(), // Origin
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0, 0.0], 1).unwrap(), // Unit vector along x-axis
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0, 0.0], 2).unwrap(), // Unit vector along y-axis
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0, 0.0], 3).unwrap(), // Unit vector along z-axis
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 1.0], 4).unwrap(), // Unit vector along w-axis
+        vertex!([0.0, 0.0, 0.0, 0.0]; data = 0).unwrap(), // Origin
+        vertex!([1.0, 0.0, 0.0, 0.0]; data = 1).unwrap(), // Unit vector along x-axis
+        vertex!([0.0, 1.0, 0.0, 0.0]; data = 2).unwrap(), // Unit vector along y-axis
+        vertex!([0.0, 0.0, 1.0, 0.0]; data = 3).unwrap(), // Unit vector along z-axis
+        vertex!([0.0, 0.0, 0.0, 1.0]; data = 4).unwrap(), // Unit vector along w-axis
     ];
 
     println!("4D simplex vertices:");
@@ -455,11 +455,11 @@ fn test_circumsphere_containment() {
     // These are points with small coordinates that should be well within
     // the circumsphere radius of √4/2 = 1.0
     let test_points_inside: [Vertex<i32, 4>; 5] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.25, 0.25, 0.25, 0.25], 10).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.1, 0.1, 0.1, 0.1], 11).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.2, 0.2, 0.2, 0.2], 12).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.3, 0.2, 0.1, 0.0], 13).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 14).unwrap(), // Origin should be inside
+        vertex!([0.25, 0.25, 0.25, 0.25]; data = 10).unwrap(),
+        vertex!([0.1, 0.1, 0.1, 0.1]; data = 11).unwrap(),
+        vertex!([0.2, 0.2, 0.2, 0.2]; data = 12).unwrap(),
+        vertex!([0.3, 0.2, 0.1, 0.0]; data = 13).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]; data = 14).unwrap(), // Origin should be inside
     ];
 
     // Calculate circumcenter and circumradius for testing
@@ -481,12 +481,12 @@ fn test_circumsphere_containment() {
     // These include points with large coordinates and points along the axes
     // that extend beyond the simplex vertices
     let test_points_outside: [Vertex<i32, 4>; 6] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([2.0, 2.0, 2.0, 2.0], 20).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 1.0, 1.0, 1.0], 21).unwrap(), // boundary
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.8, 0.8, 0.8, 0.8], 22).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.5, 0.0, 0.0, 0.0], 23).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.5, 0.0, 0.0], 24).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.5, 0.0], 25).unwrap(),
+        vertex!([2.0, 2.0, 2.0, 2.0]; data = 20).unwrap(),
+        vertex!([1.0, 1.0, 1.0, 1.0]; data = 21).unwrap(), // boundary
+        vertex!([0.8, 0.8, 0.8, 0.8]; data = 22).unwrap(),
+        vertex!([1.5, 0.0, 0.0, 0.0]; data = 23).unwrap(),
+        vertex!([0.0, 1.5, 0.0, 0.0]; data = 24).unwrap(),
+        vertex!([0.0, 0.0, 1.5, 0.0]; data = 25).unwrap(),
     ];
 
     println!("Testing points that should be OUTSIDE (or on boundary) the circumsphere:");
@@ -546,11 +546,11 @@ fn test_circumsphere_containment() {
     // These points lie on the boundary of the 4D simplex and test
     // numerical stability near the boundary
     let boundary_points: [Vertex<i32, 4>; 5] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.5, 0.5, 0.0, 0.0], 30).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.5, 0.0, 0.5, 0.0], 31).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.5, 0.5, 0.0], 32).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.33, 0.33, 0.33, 0.01], 33).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.25, 0.25, 0.25, 0.25], 34).unwrap(),
+        vertex!([0.5, 0.5, 0.0, 0.0]; data = 30).unwrap(),
+        vertex!([0.5, 0.0, 0.5, 0.0]; data = 31).unwrap(),
+        vertex!([0.0, 0.5, 0.5, 0.0]; data = 32).unwrap(),
+        vertex!([0.33, 0.33, 0.33, 0.01]; data = 33).unwrap(),
+        vertex!([0.25, 0.25, 0.25, 0.25]; data = 34).unwrap(),
     ];
 
     println!("Testing boundary/edge points:");
@@ -613,10 +613,10 @@ fn test_simplex_orientation() {
 
     // Test 3D orientation (tetrahedron) for comparison
     let tetrahedron_vertices: [Vertex<i32, 3>; 4] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 0).unwrap(), // Origin
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap(), // Unit vector along x-axis
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 2).unwrap(), // Unit vector along y-axis
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 3).unwrap(), // Unit vector along z-axis
+        vertex!([0.0, 0.0, 0.0]; data = 0).unwrap(), // Origin
+        vertex!([1.0, 0.0, 0.0]; data = 1).unwrap(), // Unit vector along x-axis
+        vertex!([0.0, 1.0, 0.0]; data = 2).unwrap(), // Unit vector along y-axis
+        vertex!([0.0, 0.0, 1.0]; data = 3).unwrap(), // Unit vector along z-axis
     ];
 
     let tetrahedron_points: Vec<Point<3>> = tetrahedron_vertices.iter().map(Point::from).collect();
@@ -633,9 +633,9 @@ fn test_simplex_orientation() {
 
     // Test 2D orientation (triangle)
     let triangle_vertices: [Vertex<i32, 2>; 3] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0], 2).unwrap(),
+        vertex!([0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0]; data = 2).unwrap(),
     ];
 
     let triangle_points: Vec<Point<2>> = triangle_vertices.iter().map(Point::from).collect();
@@ -652,9 +652,9 @@ fn test_simplex_orientation() {
 
     // Test 2D orientation with reversed vertex order
     let triangle_vertices_reversed: [Vertex<i32, 2>; 3] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0], 2).unwrap(), // Swapped order
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0], 1).unwrap(), // Swapped order
+        vertex!([0.0, 0.0]; data = 0).unwrap(),
+        vertex!([0.0, 1.0]; data = 2).unwrap(), // Swapped order
+        vertex!([1.0, 0.0]; data = 1).unwrap(), // Swapped order
     ];
 
     let triangle_points_reversed: Vec<Point<2>> =
@@ -672,9 +672,9 @@ fn test_simplex_orientation() {
 
     // Test degenerate case (collinear points in 2D)
     let collinear_vertices: [Vertex<i32, 2>; 3] = [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([2.0, 0.0], 2).unwrap(), // Collinear point
+        vertex!([0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0]; data = 1).unwrap(),
+        vertex!([2.0, 0.0]; data = 2).unwrap(), // Collinear point
     ];
 
     let collinear_points: Vec<Point<2>> = collinear_vertices.iter().map(Point::from).collect();
@@ -692,21 +692,21 @@ fn test_simplex_orientation() {
 
 fn create_unit_4d_simplex() -> [Vertex<i32, 4>; 5] {
     [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0, 0.0], 2).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0, 0.0], 3).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 1.0], 4).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]; data = 2).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]; data = 3).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]; data = 4).unwrap(),
     ]
 }
 
 fn create_negative_4d_simplex() -> [Vertex<i32, 4>; 5] {
     [
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0, 0.0], 2).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0, 0.0], 3).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 1.0], 4).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]; data = 0).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]; data = 2).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]; data = 3).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]; data = 4).unwrap(),
     ]
 }
 
@@ -717,9 +717,7 @@ fn demonstrate_orientation_impact_on_circumsphere() {
     let vertices = create_unit_4d_simplex();
     let vertices_negative = create_negative_4d_simplex();
 
-    let test_point: Vertex<i32, 4> =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.25, 0.25, 0.25, 0.25], 100)
-            .unwrap();
+    let test_point: Vertex<i32, 4> = vertex!([0.25, 0.25, 0.25, 0.25]; data = 100).unwrap();
 
     let vertex_points: Vec<Point<4>> = vertices.iter().map(Point::from).collect();
     let vertex_points_negative: Vec<Point<4>> = vertices_negative.iter().map(Point::from).collect();
@@ -777,14 +775,10 @@ fn test_3d_simplex_analysis() {
 }
 
 fn create_3d_test_simplex() -> Vec<Vertex<i32, 3>> {
-    let vertex1_3d: Vertex<i32, 3> =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1).unwrap();
-    let vertex2_3d =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap();
-    let vertex3_3d =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap();
-    let vertex4_3d =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 2).unwrap();
+    let vertex1_3d: Vertex<i32, 3> = vertex!([0.0, 0.0, 0.0]; data = 1).unwrap();
+    let vertex2_3d = vertex!([1.0, 0.0, 0.0]; data = 1).unwrap();
+    let vertex3_3d = vertex!([0.0, 1.0, 0.0]; data = 1).unwrap();
+    let vertex4_3d = vertex!([0.0, 0.0, 1.0]; data = 2).unwrap();
     vec![vertex1_3d, vertex2_3d, vertex3_3d, vertex4_3d]
 }
 
@@ -806,8 +800,7 @@ fn test_point_against_3d_simplex(
     circumradius_3d: f64,
 ) {
     // Test the point [0.9, 0.9, 0.9]
-    let test_vertex_3d =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.9, 0.9, 0.9], 3).unwrap();
+    let test_vertex_3d = vertex!([0.9, 0.9, 0.9]; data = 3).unwrap();
 
     // Calculate distance from circumcenter to test point
     let distance_to_test_3d = distance(&circumcenter_3d.to_array(), &[0.9, 0.9, 0.9]);
@@ -871,11 +864,10 @@ fn setup_3d_matrix_test() -> Setup3DResult {
     println!("=============================================");
 
     // Create the 3D simplex: vertices at (0,0,0), (1,0,0), (0,1,0), (0,0,1)
-    let vertex1: Vertex<i32, 3> =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1).unwrap();
-    let vertex2 = delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap();
-    let vertex3 = delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap();
-    let vertex4 = delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 2).unwrap();
+    let vertex1: Vertex<i32, 3> = vertex!([0.0, 0.0, 0.0]; data = 1).unwrap();
+    let vertex2 = vertex!([1.0, 0.0, 0.0]; data = 1).unwrap();
+    let vertex3 = vertex!([0.0, 1.0, 0.0]; data = 1).unwrap();
+    let vertex4 = vertex!([0.0, 0.0, 1.0]; data = 2).unwrap();
     let simplex_vertices = vec![vertex1, vertex2, vertex3, vertex4];
 
     println!("3D Simplex vertices:");
@@ -887,7 +879,7 @@ fn setup_3d_matrix_test() -> Setup3DResult {
 
     // Test point
     let test_point = [0.9, 0.9, 0.9];
-    let test_vertex = delaunay::prelude::Vertex::<_, _>::try_new_with_data(test_point, 3).unwrap();
+    let test_vertex = vertex!(test_point; data = 3).unwrap();
 
     // Get reference vertex (first vertex)
     let ref_coords = [0.0, 0.0, 0.0];
@@ -1135,11 +1127,10 @@ fn debug_3d_circumsphere_properties() {
     println!("=== 3D Unit Tetrahedron Analysis ===");
 
     // Unit tetrahedron: vertices at (0,0,0), (1,0,0), (0,1,0), (0,0,1)
-    let vertex1: Vertex<i32, 3> =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 1).unwrap();
-    let vertex2 = delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap();
-    let vertex3 = delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 1).unwrap();
-    let vertex4 = delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 2).unwrap();
+    let vertex1: Vertex<i32, 3> = vertex!([0.0, 0.0, 0.0]; data = 1).unwrap();
+    let vertex2 = vertex!([1.0, 0.0, 0.0]; data = 1).unwrap();
+    let vertex3 = vertex!([0.0, 1.0, 0.0]; data = 1).unwrap();
+    let vertex4 = vertex!([0.0, 0.0, 1.0]; data = 2).unwrap();
     let simplex_vertices = [vertex1, vertex2, vertex3, vertex4];
 
     let simplex_points: Vec<Point<3>> = simplex_vertices.iter().map(Point::from).collect();
@@ -1157,8 +1148,7 @@ fn debug_3d_circumsphere_properties() {
         distance_to_center < radius
     );
 
-    let test_vertex: Vertex<i32, 3> =
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.9, 0.9, 0.9], 4).unwrap();
+    let test_vertex: Vertex<i32, 3> = vertex!([0.9, 0.9, 0.9]; data = 4).unwrap();
 
     let standard_result = insphere_distance(&simplex_points, Point::from(&test_vertex)).unwrap();
     let matrix_result = insphere_lifted(&simplex_points, Point::from(&test_vertex)).unwrap();
@@ -1172,12 +1162,11 @@ fn debug_4d_circumsphere_properties() {
     println!("\n=== 4D Symmetric Simplex Analysis ===");
 
     // Regular 4D simplex with vertices forming a specific pattern
-    let vertex1: Vertex<(), 4> =
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0, 1.0, 1.0]).unwrap();
-    let vertex2 = delaunay::prelude::Vertex::<(), _>::try_new([1.0, -1.0, -1.0, -1.0]).unwrap();
-    let vertex3 = delaunay::prelude::Vertex::<(), _>::try_new([-1.0, 1.0, -1.0, -1.0]).unwrap();
-    let vertex4 = delaunay::prelude::Vertex::<(), _>::try_new([-1.0, -1.0, 1.0, -1.0]).unwrap();
-    let vertex5 = delaunay::prelude::Vertex::<(), _>::try_new([-1.0, -1.0, -1.0, 1.0]).unwrap();
+    let vertex1: Vertex<(), 4> = vertex!([1.0, 1.0, 1.0, 1.0]).unwrap();
+    let vertex2 = vertex!([1.0, -1.0, -1.0, -1.0]).unwrap();
+    let vertex3 = vertex!([-1.0, 1.0, -1.0, -1.0]).unwrap();
+    let vertex4 = vertex!([-1.0, -1.0, 1.0, -1.0]).unwrap();
+    let vertex5 = vertex!([-1.0, -1.0, -1.0, 1.0]).unwrap();
     let simplex_vertices_4d = [vertex1, vertex2, vertex3, vertex4, vertex5];
 
     let simplex_points_4d: Vec<Point<4>> = simplex_vertices_4d.iter().map(Point::from).collect();
@@ -1195,8 +1184,7 @@ fn debug_4d_circumsphere_properties() {
         distance_to_center_4d < radius_4d
     );
 
-    let origin_vertex: Vertex<(), 4> =
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap();
+    let origin_vertex: Vertex<(), 4> = vertex!([0.0, 0.0, 0.0, 0.0]).unwrap();
 
     let standard_result_4d =
         insphere_distance(&simplex_points_4d, Point::from(&origin_vertex)).unwrap();
@@ -1212,9 +1200,9 @@ fn compare_circumsphere_methods() {
     println!("\n=== Comparing Circumsphere Methods ===");
 
     // Compare results between standard and matrix methods
-    let vertex1: Vertex<(), 2> = delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap();
-    let vertex2 = delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap();
-    let vertex3 = delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap();
+    let vertex1: Vertex<(), 2> = vertex!([0.0, 0.0]).unwrap();
+    let vertex2 = vertex!([1.0, 0.0]).unwrap();
+    let vertex3 = vertex!([0.0, 1.0]).unwrap();
     let simplex_vertices = [vertex1, vertex2, vertex3];
 
     // Test various points
@@ -1227,8 +1215,7 @@ fn compare_circumsphere_methods() {
     ];
 
     for (i, point) in test_points.iter().enumerate() {
-        let test_vertex: Vertex<(), 2> =
-            delaunay::prelude::Vertex::<(), _>::try_new(point.to_array()).unwrap();
+        let test_vertex: Vertex<(), 2> = vertex!(point.to_array()).unwrap();
         let simplex_points: Vec<Point<2>> = simplex_vertices.iter().map(Point::from).collect();
 
         let standard_result =
@@ -1306,9 +1293,9 @@ fn test_single_2d_point() {
 
     // Create a unit triangle: (0,0), (1,0), (0,1)
     let vertices = vec![
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0], 2).unwrap(),
+        vertex!([0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0]; data = 2).unwrap(),
     ];
 
     // Calculate circumcenter and circumradius
@@ -1348,10 +1335,10 @@ fn test_single_3d_point() {
 
     // Create a unit tetrahedron: (0,0,0), (1,0,0), (0,1,0), (0,0,1)
     let vertices = vec![
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0], 2).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0], 3).unwrap(),
+        vertex!([0.0, 0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0, 0.0]; data = 2).unwrap(),
+        vertex!([0.0, 0.0, 1.0]; data = 3).unwrap(),
     ];
 
     // Calculate circumcenter and circumradius
@@ -1391,11 +1378,11 @@ fn test_single_4d_point() {
 
     // Create a unit 4-simplex: vertices at origin and unit vectors along each axis
     let vertices = vec![
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 0.0], 0).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([1.0, 0.0, 0.0, 0.0], 1).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 1.0, 0.0, 0.0], 2).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 1.0, 0.0], 3).unwrap(),
-        delaunay::prelude::Vertex::<_, _>::try_new_with_data([0.0, 0.0, 0.0, 1.0], 4).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]; data = 0).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]; data = 1).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]; data = 2).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]; data = 3).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]; data = 4).unwrap(),
     ];
 
     // Calculate circumcenter and circumradius

--- a/tests/dedup_batch_construction.rs
+++ b/tests/dedup_batch_construction.rs
@@ -14,6 +14,7 @@ use delaunay::prelude::construction::{
     ConstructionOptions, DedupPolicy, DelaunayConstructionFailure, DelaunayTriangulation,
     DelaunayTriangulationConstructionError, InsertionOrderStrategy, Vertex,
 };
+use delaunay::vertex;
 
 // =============================================================================
 // HELPERS
@@ -60,11 +61,11 @@ fn is_geometric_degeneracy_or_retry_exhausted(
 /// Build D+1 standard simplex vertices: origin + D unit vectors.
 fn simplex_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
     let mut verts = Vec::with_capacity(D + 1);
-    verts.push(delaunay::prelude::Vertex::<(), _>::try_new([0.0; D]).unwrap());
+    verts.push(vertex!([0.0; D]).unwrap());
     for i in 0..D {
         let mut coords = [0.0; D];
         coords[i] = 1.0;
-        verts.push(delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap());
+        verts.push(vertex!(coords).unwrap());
     }
     verts
 }
@@ -79,20 +80,18 @@ fn simplex_with_interior_and_duplicates<const D: usize>() -> (Vec<Vertex<(), D>>
     let mut verts = simplex_vertices::<D>();
     // Interior point
     let interior = [0.25 / (D as f64); D];
-    verts.push(delaunay::prelude::Vertex::<(), _>::try_new(interior).unwrap());
+    verts.push(vertex!(interior).unwrap());
     let distinct = verts.len(); // D+2
 
     // Duplicates: origin + interior again
-    verts.push(delaunay::prelude::Vertex::<(), _>::try_new([0.0; D]).unwrap());
-    verts.push(delaunay::prelude::Vertex::<(), _>::try_new(interior).unwrap());
+    verts.push(vertex!([0.0; D]).unwrap());
+    verts.push(vertex!(interior).unwrap());
     (verts, distinct)
 }
 
 /// Build `count` copies of the same all-identical vertex.
 fn all_identical_vertices<const D: usize>(count: usize) -> Vec<Vertex<(), D>> {
-    (0..count)
-        .map(|_| delaunay::prelude::Vertex::<(), _>::try_new([1.0; D]).unwrap())
-        .collect()
+    (0..count).map(|_| vertex!([1.0; D]).unwrap()).collect()
 }
 
 /// Select exact preprocessing dedup so tests opt into duplicate collapse explicitly.
@@ -110,10 +109,10 @@ fn simplex_with_one_duplicate<const D: usize>() -> (Vec<Vertex<(), D>>, usize) {
     let mut verts = simplex_vertices::<D>();
     // Extra non-vertex interior point to make the triangulation interesting
     let interior = [0.5 / (D as f64); D];
-    verts.push(delaunay::prelude::Vertex::<(), _>::try_new(interior).unwrap());
+    verts.push(vertex!(interior).unwrap());
     let distinct = verts.len();
     // One duplicate of the origin
-    verts.push(delaunay::prelude::Vertex::<(), _>::try_new([0.0; D]).unwrap());
+    verts.push(vertex!([0.0; D]).unwrap());
     (verts, distinct)
 }
 
@@ -278,8 +277,8 @@ gen_dedup_batch_tests!(5);
 fn test_hilbert_dedup_quantized_collision_2d() {
     init_tracing();
     let mut vertices = simplex_vertices::<2>();
-    vertices.push(delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap());
-    vertices.push(delaunay::prelude::Vertex::<(), _>::try_new([0.5 + 1e-10, 0.5]).unwrap()); // quantizes to same simplex
+    vertices.push(vertex!([0.5, 0.5]).unwrap());
+    vertices.push(vertex!([0.5 + 1e-10, 0.5]).unwrap()); // quantizes to same simplex
     let total = vertices.len();
 
     let dt: DelaunayTriangulation<_, (), (), 2> =

--- a/tests/delaunay_edge_cases.rs
+++ b/tests/delaunay_edge_cases.rs
@@ -23,6 +23,7 @@ use delaunay::prelude::geometry::RobustKernel;
 use delaunay::prelude::validation::{
     DelaunayTriangulationValidationError, TriangulationEmbeddingValidationError,
 };
+use delaunay::vertex;
 use rand::SeedableRng;
 use rand::seq::SliceRandom;
 use std::num::NonZeroUsize;
@@ -177,11 +178,11 @@ test_regression_config!(
     regression_2d_canonical,
     2,
     vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.8, 0.7]).unwrap(), // interior
-        delaunay::prelude::Vertex::<(), _>::try_new([-0.5, -0.4]).unwrap(), // exterior
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0]).unwrap(),
+        vertex!([0.0, 2.0]).unwrap(),
+        vertex!([0.8, 0.7]).unwrap(),   // interior
+        vertex!([-0.5, -0.4]).unwrap(), // exterior
     ]
 );
 
@@ -201,7 +202,7 @@ test_regression_config!(
 fn debug_issue_120_empty_circumsphere_5d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             18.781125710207355,
             85.19556603270544,
             -35.577425948458725,
@@ -209,7 +210,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
             25.721771703577573,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -21.95447633622051,
             83.05734190480365,
             96.97214006048821,
@@ -217,7 +218,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
             -21.250997394474208,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             50.96615929339812,
             -12.888014856181814,
             64.35842847516192,
@@ -225,7 +226,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
             -67.85330902948604,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -74.19363960080797,
             -87.39864134220277,
             -31.002590635557322,
@@ -233,7 +234,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
             38.224369898650814,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -15.305719099426401,
             37.44773385928881,
             -31.57846617007415,
@@ -241,7 +242,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
             32.32927241254111,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -58.19271902837987,
             -50.763430349360824,
             72.37200252994022,
@@ -249,7 +250,7 @@ fn debug_issue_120_empty_circumsphere_5d() {
             53.51398806010464,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             96.64514856949884,
             69.99880120063219,
             29.117126126375382,
@@ -347,11 +348,11 @@ test_regression_config!(
     regression_3d_canonical,
     3,
     vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.4, 0.4, 0.3]).unwrap(), // interior
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 2.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 2.0]).unwrap(),
+        vertex!([0.4, 0.4, 0.3]).unwrap(), // interior
     ]
 );
 
@@ -360,12 +361,12 @@ test_regression_config!(
     regression_4d_canonical,
     4,
     vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 2.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.4, 0.3, 0.3, 0.3]).unwrap(), // interior
+        vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 2.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 2.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 2.0]).unwrap(),
+        vertex!([0.4, 0.3, 0.3, 0.3]).unwrap(), // interior
     ]
 );
 
@@ -382,63 +383,63 @@ test_regression_config!(
 #[test]
 fn test_regression_proptest_insertion_order_4d_euler_mismatch() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -65.070_532_013_377_94,
             72.223_880_592_145_24,
             -97.837_333_303_337_39,
             35.700_988_360_396_63,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             27.011_682_298_030_294,
             52.054_594_213_988_53,
             -4.067_357_689_604_181,
             59.253_713_038_817_09,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             64.848_601_083_080_47,
             84.907_367_805_317_42,
             -98.659_828_418_664_1,
             70.056_498_821_543_85,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -23.543_852_823_069_876,
             96.741_963_200_207_22,
             -50.539_503_136_092_634,
             -49.616_262_314_856_67,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             24.886_830_567_772_98,
             -81.708_725_314_824,
             50.775_700_870_880_27,
             20.281_603_779_436_033,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             78.030_479_318_165_25,
             -82.763_788_627_520_88,
             94.075_337_487_756_27,
             44.637_774_779_142_73,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -5.175_491_150_708_228,
             97.527_582_084_288_54,
             95.344_552_027_220_42,
             84.908_292_808_161_85,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             71.994_788_686_588_11,
             4.833_973_465_666_131,
             -80.802_685_728_835_39,
             64.010_634_775_159_37,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             23.390_079_186_814_17,
             -2.157_395_632_040_824_7,
             -6.601_766_119_999_574,
@@ -474,7 +475,7 @@ test_regression_config!(
     regression_5d_known_config,
     5,
     vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             61.994_906_139_357_86,
             66.880_064_158_234_8,
             62.542_871_273_730_91,
@@ -482,7 +483,7 @@ test_regression_config!(
             -78.369_282_526_711_23,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -31.430_765_957_270_268,
             50.418_208_939_604_746,
             88.657_219_404_750_96,
@@ -490,7 +491,7 @@ test_regression_config!(
             -81.163_199_600_681_14,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -89.902_834_998_758_96,
             93.719_989_121_636_87,
             64.524_277_928_893_98,
@@ -498,7 +499,7 @@ test_regression_config!(
             14.196_053_554_411_321,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             2.625_958_385_925_883,
             48.251_155_688_054_36,
             3.491_542_746_106_750_5,
@@ -506,7 +507,7 @@ test_regression_config!(
             -27.107_939_334_194_757,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             62.628_856_831_188_11,
             -18.181_728_263_486_345,
             -32.153_141_689_537_584,
@@ -514,7 +515,7 @@ test_regression_config!(
             26.369_541_091_117_114,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -41.886_149_523_644_406,
             -54.537_563_736_672_65,
             -54.555_379_092_740_964,
@@ -522,7 +523,7 @@ test_regression_config!(
             16.127_546_041_675_355,
         ])
         .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
+        vertex!([
             -77.161_459_173_963_2,
             -59.065_517_574_769_37,
             -19.652_689_679_369_03,
@@ -661,9 +662,9 @@ fn test_regression_non_manifold_nearby_seeds() {
 fn test_exact_minimum_vertices_2d() {
     // Exactly D+1 = 3 vertices for 2D
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -681,10 +682,10 @@ fn test_exact_minimum_vertices_2d() {
 fn test_exact_minimum_vertices_3d() {
     // Exactly D+1 = 4 vertices for 3D
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -702,11 +703,11 @@ fn test_exact_minimum_vertices_3d() {
 fn test_exact_minimum_vertices_4d() {
     // Exactly D+1 = 5 vertices for 4D
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 4> =
@@ -727,12 +728,12 @@ fn test_exact_minimum_vertices_4d() {
 #[test]
 fn test_multiple_interior_points_2d() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 4.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.5, 1.5]).unwrap(), // interior
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 1.5]).unwrap(), // interior
-        delaunay::prelude::Vertex::<(), _>::try_new([2.5, 1.5]).unwrap(), // interior
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([4.0, 0.0]).unwrap(),
+        vertex!([2.0, 4.0]).unwrap(),
+        vertex!([1.5, 1.5]).unwrap(), // interior
+        vertex!([2.0, 1.5]).unwrap(), // interior
+        vertex!([2.5, 1.5]).unwrap(), // interior
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -749,13 +750,13 @@ fn test_multiple_interior_points_2d() {
 #[test]
 fn test_multiple_interior_points_3d() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(), // interior
-        delaunay::prelude::Vertex::<(), _>::try_new([0.6, 0.5, 0.5]).unwrap(), // interior
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.6, 0.5]).unwrap(), // interior
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 2.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 2.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(), // interior
+        vertex!([0.6, 0.5, 0.5]).unwrap(), // interior
+        vertex!([0.5, 0.6, 0.5]).unwrap(), // interior
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -778,11 +779,11 @@ fn test_square_with_center_2d() {
     init_tracing();
     // Square vertices with center point
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(), // center
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0]).unwrap(),
+        vertex!([2.0, 2.0]).unwrap(),
+        vertex!([0.0, 2.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(), // center
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -800,14 +801,14 @@ fn test_square_with_center_2d() {
 fn test_cube_vertices_3d() {
     // 8 corners of a unit cube
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([1.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([1.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 1.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0, 1.0]).unwrap(),
     ];
 
     let err = DelaunayTriangulation::<_, (), (), 3>::try_new_with_topology_guarantee(
@@ -829,10 +830,10 @@ fn test_cube_vertices_3d() {
 #[test]
 fn test_large_coordinates_2d() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([1000.0, 1000.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2000.0, 1000.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1500.0, 2000.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1500.0, 1500.0]).unwrap(),
+        vertex!([1000.0, 1000.0]).unwrap(),
+        vertex!([2000.0, 1000.0]).unwrap(),
+        vertex!([1500.0, 2000.0]).unwrap(),
+        vertex!([1500.0, 1500.0]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -849,11 +850,11 @@ fn test_large_coordinates_2d() {
 #[test]
 fn test_small_coordinates_3d() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.001, 0.001, 0.001]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.002, 0.001, 0.001]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.001, 0.002, 0.001]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.001, 0.001, 0.002]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0015, 0.0015, 0.0015]).unwrap(),
+        vertex!([0.001, 0.001, 0.001]).unwrap(),
+        vertex!([0.002, 0.001, 0.001]).unwrap(),
+        vertex!([0.001, 0.002, 0.001]).unwrap(),
+        vertex!([0.001, 0.001, 0.002]).unwrap(),
+        vertex!([0.0015, 0.0015, 0.0015]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -870,10 +871,10 @@ fn test_small_coordinates_3d() {
 #[test]
 fn test_negative_coordinates_2d() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([-1.0, -1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, -1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
+        vertex!([-1.0, -1.0]).unwrap(),
+        vertex!([1.0, -1.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -895,10 +896,10 @@ fn test_negative_coordinates_2d() {
 fn test_robust_kernel_with_edge_case() {
     // Configuration that might benefit from robust predicates
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.866_025_403_784_438_7]).unwrap(), // ~sqrt(3)/2 - near-equilateral
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.5, 0.866_025_403_784_438_7]).unwrap(), // ~sqrt(3)/2 - near-equilateral
+        vertex!([0.5, 0.5]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<RobustKernel<f64>, (), (), 2> =
@@ -923,10 +924,10 @@ fn test_collinear_points_2d() {
     // AdaptiveKernel uses exact orientation (no SoS), so collinear points
     // are correctly detected as degenerate.
     let collinear = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([3.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0]).unwrap(),
+        vertex!([3.0, 0.0]).unwrap(),
     ];
 
     let result: Result<DelaunayTriangulation<_, (), (), 2>, _> =
@@ -968,7 +969,7 @@ fn regression_issue_228_exact_predicate_paths_3d_fast() {
         .expect("point generation should succeed");
     let vertices: Vec<Vertex<(), 3>> = points
         .into_iter()
-        .map(|p| delaunay::prelude::Vertex::<(), _>::try_new(p.into()).unwrap())
+        .map(|p| vertex!(p.into()).unwrap())
         .collect();
 
     let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -993,13 +994,13 @@ fn regression_issue_228_exact_predicate_paths_3d_fast() {
 #[test]
 fn test_5d_simplex_plus_interior() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, 0.2]).unwrap(), // interior
+        vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.2, 0.2, 0.2, 0.2, 0.2]).unwrap(), // interior
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 5> =

--- a/tests/delaunay_repair_fallback.rs
+++ b/tests/delaunay_repair_fallback.rs
@@ -10,6 +10,7 @@ use delaunay::prelude::construction::{
     DelaunayRepairPolicy, DelaunayTriangulation, TopologyGuarantee,
 };
 use delaunay::prelude::repair::DelaunayRepairHeuristicConfig;
+use delaunay::vertex;
 
 #[cfg(feature = "diagnostics")]
 fn init_tracing() {
@@ -46,10 +47,10 @@ macro_rules! test_debug_info {
 fn repair_fallback_produces_valid_triangulation() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([4.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([4.0, 0.0]).unwrap(),
+        vertex!([4.0, 2.0]).unwrap(),
+        vertex!([1.0, 2.0]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 2> =
         DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -117,13 +118,13 @@ fn incremental_insertion_with_repair_fallback() {
 
     // Insert vertices that might trigger repair challenges
     let test_vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.5, 1.5]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.5, 0.5]).unwrap(), // Interior point
-        delaunay::prelude::Vertex::<(), _>::try_new([0.8, 0.8, 0.8]).unwrap(), // Another interior point
-        delaunay::prelude::Vertex::<(), _>::try_new([1.2, 0.6, 0.7]).unwrap(), // Close to existing
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 2.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.5, 1.5]).unwrap(),
+        vertex!([1.0, 0.5, 0.5]).unwrap(), // Interior point
+        vertex!([0.8, 0.8, 0.8]).unwrap(), // Another interior point
+        vertex!([1.2, 0.6, 0.7]).unwrap(), // Close to existing
     ];
 
     for (i, vertex) in test_vertices.into_iter().enumerate() {
@@ -161,14 +162,14 @@ fn incremental_insertion_with_repair_fallback() {
 fn repair_fallback_2d() {
     // Use non-collinear points to avoid degeneracy
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 3.5]).unwrap(), // Non-collinear with first two
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([3.5, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.5, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.5, 2.5]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 3.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([4.0, 0.0]).unwrap(),
+        vertex!([2.0, 3.5]).unwrap(), // Non-collinear with first two
+        vertex!([0.5, 2.0]).unwrap(),
+        vertex!([3.5, 2.0]).unwrap(),
+        vertex!([1.5, 1.0]).unwrap(),
+        vertex!([2.5, 2.5]).unwrap(),
+        vertex!([1.0, 3.0]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -191,11 +192,11 @@ fn explicit_repair_call_validates_result() {
     init_tracing();
     // Build a triangulation
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
 
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
@@ -228,10 +229,10 @@ fn explicit_repair_call_validates_result() {
 #[test]
 fn repair_policy_configuration_with_fallback() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
 
     // Test with different repair policies

--- a/tests/delaunayize_workflow.rs
+++ b/tests/delaunayize_workflow.rs
@@ -12,6 +12,7 @@ use delaunay::flips::BistellarFlips;
 use delaunay::flips::FacetHandle;
 use delaunay::prelude::construction::TriangulationConstructionError;
 use delaunay::prelude::delaunayize::*;
+use delaunay::vertex;
 use std::{error::Error, mem::size_of};
 
 // =============================================================================
@@ -45,11 +46,11 @@ fn test_delaunayize_config_default_values() {
 fn test_non_delaunay_pl_manifold_repaired_2d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 4.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([4.0, 4.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 2.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([4.0, 0.0]).unwrap(),
+        vertex!([0.0, 4.0]).unwrap(),
+        vertex!([4.0, 4.0]).unwrap(),
+        vertex!([2.0, 2.0]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 2> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -66,12 +67,12 @@ fn test_non_delaunay_pl_manifold_repaired_2d() {
 fn test_non_delaunay_pl_manifold_repaired_3d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -90,10 +91,10 @@ fn test_non_delaunay_pl_manifold_repaired_3d() {
 fn test_fallback_off_does_not_rebuild() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -110,10 +111,10 @@ fn test_fallback_off_does_not_rebuild() {
 fn test_fallback_on_does_not_trigger_on_valid() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -136,11 +137,11 @@ fn test_fallback_on_does_not_trigger_on_valid() {
 fn test_outcome_stats_populated_3d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -163,11 +164,11 @@ fn test_outcome_stats_populated_3d() {
 fn test_repeat_run_determinism_2d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5]).unwrap(),
     ];
 
     let config = DelaunayizeConfig::default();
@@ -203,12 +204,12 @@ fn test_repeat_run_determinism_2d() {
 fn test_repeat_run_determinism_3d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
 
     let config = DelaunayizeConfig::default();
@@ -239,11 +240,11 @@ fn test_repeat_run_determinism_3d() {
 fn test_vertex_count_preserved_after_delaunayize() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0, 1.0]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -267,11 +268,11 @@ fn test_flip_breaks_delaunay_then_delaunayize_restores() {
     init_tracing();
     // 5 points in 3D — produces multiple simplices with interior facets.
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -475,11 +476,11 @@ fn test_prelude_exports_error_payloads() {
 fn test_delaunayize_with_explicit_flip_budget_3d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -500,11 +501,11 @@ fn test_delaunayize_with_explicit_flip_budget_3d() {
 fn test_delaunayize_with_flip_budget_and_fallback_2d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 2> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -527,11 +528,11 @@ fn test_delaunayize_with_flip_budget_and_fallback_2d() {
 fn test_flip_breaks_then_delaunayize_with_budget_restores_3d() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 3> =
         DelaunayTriangulation::try_new(&vertices).unwrap();
@@ -581,12 +582,12 @@ fn test_flip_breaks_then_delaunayize_with_budget_restores_3d() {
 fn test_full_validation_passes_after_delaunayize() {
     init_tracing();
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.25, 0.75]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5]).unwrap(),
+        vertex!([0.25, 0.75]).unwrap(),
     ];
     let mut dt: DelaunayTriangulation<_, (), (), 2> =
         DelaunayTriangulation::try_new(&vertices).unwrap();

--- a/tests/euler_characteristic.rs
+++ b/tests/euler_characteristic.rs
@@ -14,6 +14,7 @@
 //!
 //! For property-based tests with random triangulations, see `proptest_euler_characteristic.rs`.
 
+use delaunay::vertex;
 use std::assert_matches;
 
 use delaunay::builder::DelaunayTriangulationBuilder;
@@ -57,9 +58,9 @@ fn test_empty_triangulation_euler() {
 fn test_2d_single_triangle() {
     // Single triangle: V=3, E=3, F=1 → χ = 3-3+1 = 1
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.5, 1.0]).unwrap(),
     ];
 
     let dt = DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -83,9 +84,9 @@ fn test_2d_single_triangle() {
 #[test]
 fn test_euler_rejects_open_single_simplex_in_closed_topology() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.5, 1.0]).unwrap(),
     ];
 
     let dt = DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -127,10 +128,10 @@ fn test_euler_rejects_open_single_simplex_in_closed_topology() {
 fn test_2d_multiple_triangles() {
     // Four points forming multiple triangles
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.3]).unwrap(), // Interior point
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.5, 1.0]).unwrap(),
+        vertex!([0.5, 0.3]).unwrap(), // Interior point
     ];
 
     let dt = DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -156,10 +157,10 @@ fn test_2d_multiple_triangles() {
 fn test_3d_single_tetrahedron() {
     // Single tetrahedron: V=4, E=6, F=4, C=1 → χ = 4-6+4-1 = 1
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
 
     let dt = DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -185,11 +186,11 @@ fn test_3d_single_tetrahedron() {
 fn test_3d_with_interior_vertex() {
     // Tetrahedron with one interior vertex
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(), // Interior point
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.25, 0.25, 0.25]).unwrap(), // Interior point
     ];
 
     let dt = DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -216,11 +217,11 @@ fn test_4d_single_simplex() {
     // Single 4-simplex: V=5, E=10, F=10, T=5, C=1
     // χ = 5 - 10 + 10 - 5 + 1 = 1
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
     ];
 
     let dt = DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -247,12 +248,12 @@ fn test_4d_single_simplex() {
 fn test_5d_single_simplex() {
     // Single 5-simplex: χ = 1
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
     ];
 
     let dt = DelaunayTriangulation::try_new_with_topology_guarantee(
@@ -298,7 +299,7 @@ fn test_2d_toroidal_explicit_construction_rejected() {
     ];
     let vertices: Vec<_> = coords
         .iter()
-        .map(|c| delaunay::prelude::Vertex::<(), _>::try_new([c[0], c[1]]).unwrap())
+        .map(|c| vertex!([c[0], c[1]]).unwrap())
         .collect();
     let v = |i: usize, j: usize| -> usize { (i % N) * N + (j % N) };
     let mut simplices = Vec::with_capacity(2 * N * N);
@@ -354,7 +355,7 @@ fn test_3d_toroidal_explicit_construction_rejected() {
     for &x in &grid {
         for &y in &grid {
             for &z in &grid {
-                vertices.push(delaunay::prelude::Vertex::<(), _>::try_new([x, y, z]).unwrap());
+                vertices.push(vertex!([x, y, z]).unwrap());
             }
         }
     }
@@ -489,10 +490,10 @@ test_complex_with_interior!(
     test_2d_complex_with_interior,
     2,
     &[
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.5]).unwrap(), // Interior point
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0]).unwrap(),
+        vertex!([1.0, 2.0]).unwrap(),
+        vertex!([1.0, 0.5]).unwrap(), // Interior point
     ],
     0 // S¹ has χ = 0
 );
@@ -502,11 +503,11 @@ test_complex_with_interior!(
     test_3d_complex_with_interior,
     3,
     &[
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.5, 2.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.5, 0.5]).unwrap(), // Interior point
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 2.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.5, 2.0]).unwrap(),
+        vertex!([1.0, 0.5, 0.5]).unwrap(), // Interior point
     ],
     2 // S² has χ = 2
 );
@@ -516,12 +517,12 @@ test_complex_with_interior!(
     test_4d_complex_with_interior,
     4,
     &[
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.21, 0.17, 0.13, 0.11]).unwrap(), // Interior point
+        vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.21, 0.17, 0.13, 0.11]).unwrap(), // Interior point
     ],
     0 // S³ has χ = 0
 );
@@ -531,13 +532,13 @@ test_complex_with_interior!(
     test_5d_complex_with_interior,
     5,
     &[
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2, 0.2]).unwrap(), // Interior point
+        vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.2, 0.2, 0.2, 0.2, 0.2]).unwrap(), // Interior point
     ],
     2 // S⁴ has χ = 2
 );

--- a/tests/example_workflows.rs
+++ b/tests/example_workflows.rs
@@ -6,17 +6,22 @@ use delaunay::prelude::construction::{
     DelaunayTriangulation, DelaunayTriangulationConstructionError,
 };
 use delaunay::prelude::geometry::{CoordinateConversionError, CoordinateValidationError};
-use delaunay::prelude::query::{ConvexHull, Point, QueryError};
+use delaunay::prelude::query::{
+    ConvexHull, ConvexHullConstructionError, ConvexHullValidationError, Point, QueryError,
+    TopologyIndexBuildError,
+};
+use delaunay::prelude::validation::DelaunayTriangulationValidationError;
+use delaunay::vertex;
 
 #[test]
 fn triangulation_and_hull_workflow_remains_valid() -> Result<(), WorkflowTestError> {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([0.35, 0.25, 0.20])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([0.20, 0.60, 0.25])?,
+        vertex!([0.0, 0.0, 0.0])?,
+        vertex!([1.0, 0.0, 0.0])?,
+        vertex!([0.0, 1.0, 0.0])?,
+        vertex!([0.0, 0.0, 1.0])?,
+        vertex!([0.35, 0.25, 0.20])?,
+        vertex!([0.20, 0.60, 0.25])?,
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 3> = DelaunayTriangulation::try_new(&vertices)?;
@@ -66,33 +71,33 @@ enum WorkflowTestError {
     #[error(transparent)]
     CoordinateValidation(#[from] CoordinateValidationError),
     #[error(transparent)]
-    Validation(#[from] delaunay::prelude::validation::DelaunayTriangulationValidationError),
+    Validation(#[from] DelaunayTriangulationValidationError),
     #[error(transparent)]
-    TopologyIndex(#[from] delaunay::prelude::query::TopologyIndexBuildError),
+    TopologyIndex(#[from] TopologyIndexBuildError),
     #[error(transparent)]
     Query(#[from] QueryError),
     #[error("convex hull construction failed: {source}")]
     ConvexHullConstruction {
         #[source]
-        source: Box<delaunay::prelude::query::ConvexHullConstructionError>,
+        source: Box<ConvexHullConstructionError>,
     },
     #[error("convex hull validation failed: {source}")]
     ConvexHullValidation {
         #[source]
-        source: Box<delaunay::prelude::query::ConvexHullValidationError>,
+        source: Box<ConvexHullValidationError>,
     },
 }
 
-impl From<delaunay::prelude::query::ConvexHullConstructionError> for WorkflowTestError {
-    fn from(source: delaunay::prelude::query::ConvexHullConstructionError) -> Self {
+impl From<ConvexHullConstructionError> for WorkflowTestError {
+    fn from(source: ConvexHullConstructionError) -> Self {
         Self::ConvexHullConstruction {
             source: Box::new(source),
         }
     }
 }
 
-impl From<delaunay::prelude::query::ConvexHullValidationError> for WorkflowTestError {
-    fn from(source: delaunay::prelude::query::ConvexHullValidationError) -> Self {
+impl From<ConvexHullValidationError> for WorkflowTestError {
+    fn from(source: ConvexHullValidationError) -> Self {
         Self::ConvexHullValidation {
             source: Box::new(source),
         }

--- a/tests/insert_with_statistics.rs
+++ b/tests/insert_with_statistics.rs
@@ -15,6 +15,7 @@
 //! - Bootstrap phase (< D+1 vertices)
 //! - Post-bootstrap phase (≥ D+1 vertices)
 
+use delaunay::vertex;
 use std::assert_matches;
 
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
@@ -32,7 +33,7 @@ fn delaunay_insert_with_statistics_basic_2d() {
 
     // Insert first vertex
     let (outcome, stats) = dt
-        .insert_with_statistics(delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap())
+        .insert_with_statistics(vertex!([0.0, 0.0]).unwrap())
         .expect("insertion should succeed");
 
     assert_matches!(outcome, InsertionOutcome::Inserted { .. });
@@ -46,7 +47,7 @@ fn delaunay_insert_with_statistics_basic_2d() {
 
     // Insert second vertex
     let (outcome, stats) = dt
-        .insert_with_statistics(delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap())
+        .insert_with_statistics(vertex!([1.0, 0.0]).unwrap())
         .expect("insertion should succeed");
 
     assert_matches!(outcome, InsertionOutcome::Inserted { .. });
@@ -55,7 +56,7 @@ fn delaunay_insert_with_statistics_basic_2d() {
 
     // Insert third vertex (completes simplex)
     let (outcome, stats) = dt
-        .insert_with_statistics(delaunay::prelude::Vertex::<(), _>::try_new([0.5, 1.0]).unwrap())
+        .insert_with_statistics(vertex!([0.5, 1.0]).unwrap())
         .expect("insertion should succeed");
 
     assert_matches!(outcome, InsertionOutcome::Inserted { hint, .. } if hint.is_some());
@@ -71,22 +72,14 @@ fn delaunay_insert_with_statistics_hint_caching_3d() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     // Build initial simplex
-    dt.insert_with_statistics(
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-    )
-    .unwrap();
-    dt.insert_with_statistics(
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-    )
-    .unwrap();
-    dt.insert_with_statistics(
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-    )
-    .unwrap();
+    dt.insert_with_statistics(vertex!([0.0, 0.0, 0.0]).unwrap())
+        .unwrap();
+    dt.insert_with_statistics(vertex!([1.0, 0.0, 0.0]).unwrap())
+        .unwrap();
+    dt.insert_with_statistics(vertex!([0.0, 1.0, 0.0]).unwrap())
+        .unwrap();
     let (outcome, _) = dt
-        .insert_with_statistics(
-            delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        )
+        .insert_with_statistics(vertex!([0.0, 0.0, 1.0]).unwrap())
         .unwrap();
 
     // After simplex creation, hint should be available
@@ -94,9 +87,7 @@ fn delaunay_insert_with_statistics_hint_caching_3d() {
 
     // Insert interior point - should benefit from hint
     let (outcome, stats) = dt
-        .insert_with_statistics(
-            delaunay::prelude::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
-        )
+        .insert_with_statistics(vertex!([0.25, 0.25, 0.25]).unwrap())
         .unwrap();
 
     assert_matches!(outcome, InsertionOutcome::Inserted { hint: Some(_), .. });
@@ -112,13 +103,13 @@ fn delaunay_insert_with_statistics_multiple_vertices_4d() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.8, 0.1, 0.1, 0.1]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
+        vertex!([0.8, 0.1, 0.1, 0.1]).unwrap(),
     ];
 
     let input_count = vertices.len();
@@ -156,13 +147,13 @@ fn delaunay_insert_with_statistics_handles_degenerate_k2_flips_4d() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.8, 0.1, 0.1, 0.1]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
+        vertex!([0.8, 0.1, 0.1, 0.1]).unwrap(),
     ];
 
     for v in vertices {
@@ -180,13 +171,12 @@ fn delaunay_insert_with_statistics_duplicate_coordinates_2d() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     // Insert first vertex
-    dt.insert_with_statistics(delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap())
+    dt.insert_with_statistics(vertex!([1.0, 2.0]).unwrap())
         .expect("first insertion should succeed");
 
     // The strict statistics API reports skipped insertions as errors so callers
     // using `?` cannot miss them.
-    let result =
-        dt.insert_with_statistics(delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap());
+    let result = dt.insert_with_statistics(vertex!([1.0, 2.0]).unwrap());
     let duplicate_coordinates = CoordinateValues::from([1.0, 2.0]);
     assert!(
         matches!(
@@ -198,9 +188,7 @@ fn delaunay_insert_with_statistics_duplicate_coordinates_2d() {
     );
 
     // The explicitly best-effort API preserves the skipped outcome plus telemetry.
-    let result = dt.insert_best_effort_with_statistics(
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
-    );
+    let result = dt.insert_best_effort_with_statistics(vertex!([1.0, 2.0]).unwrap());
 
     match result {
         Ok((
@@ -231,10 +219,10 @@ fn delaunay_insert_with_statistics_bootstrap_happy_path_3d() {
 
     // Build simplex with well-separated points
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
 
     for v in vertices {
@@ -258,9 +246,7 @@ fn delaunay_insert_with_statistics_statistics_fields_3d() {
             coords[i - 1] = 1.0;
         }
 
-        let (outcome, stats) = dt
-            .insert_with_statistics(delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap())
-            .unwrap();
+        let (outcome, stats) = dt.insert_with_statistics(vertex!(coords).unwrap()).unwrap();
 
         // Verify all statistics fields
         assert_matches!(outcome, InsertionOutcome::Inserted { .. });
@@ -288,11 +274,11 @@ fn statistics_invariants() {
 
     // Build simplex
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.25, 0.25, 0.25]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.25, 0.25, 0.25]).unwrap(),
     ];
 
     for v in vertices {
@@ -346,10 +332,10 @@ fn insert_with_statistics_2d_coverage() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5]).unwrap(),
     ];
 
     for v in vertices {
@@ -366,11 +352,11 @@ fn insert_with_statistics_3d_coverage() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.5, 0.5, 0.5]).unwrap(),
+        vertex!([0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.5, 0.5, 0.5]).unwrap(),
     ];
 
     for v in vertices {
@@ -387,12 +373,12 @@ fn insert_with_statistics_4d_coverage() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.2, 0.2, 0.2, 0.2]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.2, 0.2, 0.2, 0.2]).unwrap(),
     ];
 
     for v in vertices {
@@ -409,12 +395,12 @@ fn insert_with_statistics_5d_coverage() {
         DelaunayTriangulation::empty_with_topology_guarantee(TopologyGuarantee::PLManifold);
 
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 0.0, 0.0, 1.0]).unwrap(),
     ];
 
     for v in vertices {

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -117,6 +117,7 @@ use delaunay::prelude::insertion::{InsertionOutcome, InsertionStatistics};
 use delaunay::prelude::repair::{DelaunayCheckPolicy, DelaunayRepairHeuristicConfig};
 use delaunay::prelude::tds::{InvariantKind, TriangulationValidationReport};
 use delaunay::prelude::validation::ValidationCadence;
+use delaunay::vertex;
 use rand::{SeedableRng, rngs::StdRng, seq::SliceRandom};
 #[cfg(feature = "slow-tests")]
 use std::assert_matches;
@@ -1319,7 +1320,7 @@ where
     let t_vertices = Instant::now();
     let mut vertices: Vec<Vertex<(), D>> = points
         .into_iter()
-        .map(|p| delaunay::prelude::Vertex::<(), _>::try_new(p.into()).unwrap())
+        .map(|p| vertex!(p.into()).unwrap())
         .collect();
     println!(
         "Built {} vertices in {:?}",
@@ -1770,7 +1771,7 @@ fn regression_issue_228_3d_1000_flip_repair_convergence() {
         .expect("point generation should succeed");
     let vertices: Vec<Vertex<(), 3>> = points
         .into_iter()
-        .map(|p| delaunay::prelude::Vertex::<(), _>::try_new(p.into()).unwrap())
+        .map(|p| vertex!(p.into()).unwrap())
         .collect();
 
     // Use the default kernel (AdaptiveKernel — exact+SoS predicates) to match the
@@ -1813,7 +1814,7 @@ fn regression_issue_230_4d_100_orientation() {
         .expect("point generation should succeed");
     let vertices: Vec<Vertex<(), 4>> = points
         .into_iter()
-        .map(|p| delaunay::prelude::Vertex::<(), _>::try_new(p.into()).unwrap())
+        .map(|p| vertex!(p.into()).unwrap())
         .collect();
 
     let kernel = RobustKernel::<f64>::new();

--- a/tests/pachner_roundtrip.rs
+++ b/tests/pachner_roundtrip.rs
@@ -2,11 +2,12 @@
 
 //! Public API roundtrip tests for Pachner/bistellar flips.
 
+use delaunay::vertex;
 use std::assert_matches;
 
 use delaunay::prelude::construction::{
     ConstructionOptions, DelaunayError, DelaunayResult, DelaunayTriangulation,
-    DelaunayTriangulationBuilder, InsertionOrderStrategy, TopologyGuarantee, Vertex, vertex,
+    DelaunayTriangulationBuilder, InsertionOrderStrategy, TopologyGuarantee, Vertex,
 };
 use delaunay::prelude::geometry::RobustKernel;
 use delaunay::prelude::pachner::{
@@ -287,7 +288,7 @@ fn build_dt_4d(points: &[[f64; 4]], fixture_name: &str) -> Dt4 {
 fn build_flippable_dt_2d() -> Dt2 {
     let vertices = FLIPPABLE_POINTS_2D
         .iter()
-        .map(|coords| Vertex::<(), 2>::try_new(*coords).expect("stable 2D fixture coordinates"))
+        .map(|coords| vertex!(*coords).expect("stable 2D fixture coordinates"))
         .collect::<Vec<_>>();
     let simplices = vec![vec![0, 1, 2], vec![0, 2, 3]];
 

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -1429,6 +1429,23 @@ fn construction_prelude_covers_typed_explicit_errors() {
             if matches!(source.as_ref(), InvariantError::Tds(TdsError::FacetSharingViolation { .. }))
     );
 
+    let explicit_embedding = ExplicitConstructionError::EmbeddingValidation {
+        source: Box::new(ConstructionDelaunayTriangulationValidationError::Tds(
+            Box::new(TdsError::InconsistentDataStructure {
+                message: "embedding validation failed".to_string(),
+            }),
+        )),
+    };
+    assert_matches!(
+        explicit_embedding,
+        ExplicitConstructionError::EmbeddingValidation { source }
+            if matches!(
+                source.as_ref(),
+                ConstructionDelaunayTriangulationValidationError::Tds(tds)
+                    if matches!(tds.as_ref(), TdsError::InconsistentDataStructure { .. })
+            )
+    );
+
     let explicit_tds_construction = ExplicitConstructionError::TdsAssembly {
         source: Box::new(TdsConstructionError::ValidationError(
             TdsError::FacetSharingViolation {

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -40,6 +40,7 @@ use delaunay::prelude::geometry::*;
 use delaunay::prelude::insertion::InsertionOutcome;
 use delaunay::prelude::validation::ValidationPolicy;
 use delaunay::try_vertices_from_points;
+use delaunay::vertex;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestCaseError, TestRunner};
 use rand::{SeedableRng, seq::SliceRandom};
@@ -423,9 +424,7 @@ fn assert_on_suspicion_sequence_valid<const D: usize>(
     dt.set_validation_policy(ValidationPolicy::OnSuspicion);
 
     for (idx, point) in points.into_iter().enumerate() {
-        let result = dt.insert_best_effort_with_statistics(
-            delaunay::prelude::Vertex::<(), _>::try_new(point.into()).unwrap(),
-        );
+        let result = dt.insert_best_effort_with_statistics(vertex!(point.into()).unwrap());
 
         if dt.number_of_simplices() > 0 {
             let validation = dt.validate();
@@ -698,7 +697,7 @@ macro_rules! gen_incremental_insertion_validity {
                     prop_assume!(has_no_coordinate_hyperplane_degeneracy(&initial_vertices));
 
                     let additional_vertex =
-                        delaunay::prelude::Vertex::<(), _>::try_new(additional_point.into())
+                        vertex!(additional_point.into())
                             .unwrap();
 
                     // Avoid duplicate insertion cases here; duplicate-handling is tested in dedicated suites.
@@ -769,7 +768,7 @@ proptest! {
         prop_assume!(has_no_cospherical_5_tuples_3d(&initial_vertices));
 
         let additional_vertex =
-            delaunay::prelude::Vertex::<(), _>::try_new(additional_point.into()).unwrap();
+            vertex!(additional_point.into()).unwrap();
 
         // Avoid duplicate insertion cases here; duplicate-handling is tested in dedicated suites.
         let add_coords = *additional_vertex.point().coords();

--- a/tests/proptest_euler_characteristic.rs
+++ b/tests/proptest_euler_characteristic.rs
@@ -19,6 +19,7 @@
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
 use delaunay::prelude::generators::try_generate_random_triangulation_with_topology_guarantee;
 use delaunay::topology::characteristics::{euler, validation};
+use delaunay::vertex;
 use proptest::prelude::*;
 use std::num::NonZeroUsize;
 
@@ -67,7 +68,7 @@ macro_rules! test_euler_properties {
                 #[test]
                 fn [<prop_euler_matches_classification_ $dim d>](
                     vertices in prop::collection::vec(
-                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap()),
+                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| vertex!(coords).unwrap()),
                         $min_vertices..$max_vertices
                     )
                 ) {
@@ -101,7 +102,7 @@ macro_rules! test_euler_properties {
                 #[test]
                 fn [<prop_simplex_counts_consistent_ $dim d>](
                     vertices in prop::collection::vec(
-                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap()),
+                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| vertex!(coords).unwrap()),
                         $min_vertices..$max_vertices
                     )
                 ) {
@@ -141,7 +142,7 @@ macro_rules! test_euler_properties {
                 #[test]
                 fn [<prop_classification_chi_consistent_ $dim d>](
                     vertices in prop::collection::vec(
-                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap()),
+                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| vertex!(coords).unwrap()),
                         $min_vertices..$max_vertices
                     )
                 ) {

--- a/tests/proptest_flips.rs
+++ b/tests/proptest_flips.rs
@@ -15,6 +15,7 @@ use delaunay::prelude::construction::{
 };
 use delaunay::prelude::geometry::{AdaptiveKernel, FastKernel, Kernel, Point, RobustKernel};
 use delaunay::try_vertices_from_points;
+use delaunay::vertex;
 use proptest::prelude::*;
 use std::collections::{BTreeSet, HashMap};
 
@@ -76,7 +77,7 @@ fn interior_simplex_vertex<const D: usize>(
     for (axis, edge_length) in edge_lengths.iter().copied().enumerate() {
         coordinates[axis] += edge_length / denominator;
     }
-    Vertex::try_new(coordinates).expect("finite point coordinates")
+    vertex!(coordinates).expect("finite point coordinates")
 }
 
 /// Captures the public vertex/simplex incidence needed to check round-trips.

--- a/tests/proptest_triangulation.rs
+++ b/tests/proptest_triangulation.rs
@@ -35,10 +35,12 @@
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
 use ::uuid::Uuid;
+use delaunay::geometry::quality::QualityError;
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
 use delaunay::prelude::geometry::*;
 use delaunay::prelude::tds::SimplexKey;
 use delaunay::try_vertices_from_points;
+use delaunay::vertex;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestCaseError, TestRunner};
 use std::cell::RefCell;
@@ -628,8 +630,8 @@ macro_rules! test_quality_properties {
                                 (Ok(_), Ok(_)) => (),  // Both succeed - OK
                                 (Err(rr_err), Err(nv_err)) => {
                                     // Both fail - verify they're both degeneracy errors or both other errors
-                                    let rr_is_degen = matches!(rr_err, delaunay::geometry::quality::QualityError::DegenerateSimplex { .. });
-                                    let nv_is_degen = matches!(nv_err, delaunay::geometry::quality::QualityError::DegenerateSimplex { .. });
+                                    let rr_is_degen = matches!(rr_err, QualityError::DegenerateSimplex { .. });
+                                    let nv_is_degen = matches!(nv_err, QualityError::DegenerateSimplex { .. });
 
                                     if rr_is_degen || nv_is_degen {
                                         prop_assert!(
@@ -688,7 +690,7 @@ macro_rules! test_facet_topology_invariant {
                 #[test]
                 fn [<prop_no_over_shared_facets_ $dim d>](
                     vertices in prop::collection::vec(
-                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap()),
+                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| vertex!(coords).unwrap()),
                         $min_vertices..$max_vertices
                     )
                 ) {
@@ -718,7 +720,7 @@ macro_rules! test_facet_topology_invariant {
                 #[test]
                 fn [<prop_repair_fixes_all_issues_ $dim d>](
                     vertices in prop::collection::vec(
-                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap()),
+                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| vertex!(coords).unwrap()),
                         $min_vertices..$max_vertices
                     )
                 ) {
@@ -754,7 +756,7 @@ macro_rules! test_facet_topology_invariant {
                 #[test]
                 fn [<prop_empty_simplex_list_no_issues_ $dim d>](
                     vertices in prop::collection::vec(
-                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap()),
+                        prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| vertex!(coords).unwrap()),
                         $min_vertices..$max_vertices
                     )
                 ) {
@@ -810,7 +812,7 @@ macro_rules! gen_high_dim_facet_topology_smoke {
                 let target_cases = config.cases;
                 let mut runner = TestRunner::new(config);
                 let strategy = prop::collection::vec(
-                    prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap()),
+                    prop::array::[<uniform $dim>](finite_coordinate()).prop_map(|coords| vertex!(coords).unwrap()),
                     $min_vertices..=$max_vertices,
                 );
                 let stats = RefCell::new(SmokeStats::default());

--- a/tests/proptest_vertex.rs
+++ b/tests/proptest_vertex.rs
@@ -57,15 +57,15 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertex equality is reflexive (v == v)
                 #[test]
                 fn [<prop_vertex_equality_reflexive_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let vertex: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
                     prop_assert_eq!(vertex, vertex, "{}D: Vertex should equal itself", $dim);
                 }
 
                 /// Property: Vertex equality is symmetric (v1 == v2 implies v2 == v1)
                 #[test]
                 fn [<prop_vertex_equality_symmetric_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let v1: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
-                    let v2: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let v1: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
+                    let v2: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
                     prop_assert_eq!(v1, v2, "{}D: Vertices with same coords should be equal", $dim);
                     prop_assert_eq!(v2, v1, "{}D: Equality should be symmetric", $dim);
                 }
@@ -73,9 +73,9 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertex equality is transitive (v1 == v2 and v2 == v3 implies v1 == v3)
                 #[test]
                 fn [<prop_vertex_equality_transitive_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let v1: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
-                    let v2: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
-                    let v3: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let v1: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
+                    let v2: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
+                    let v3: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
 
                     prop_assert_eq!(v1, v2, "{}D: v1 should equal v2", $dim);
                     prop_assert_eq!(v2, v3, "{}D: v2 should equal v3", $dim);
@@ -85,8 +85,8 @@ macro_rules! test_vertex_properties {
                 /// Property: Equal vertices have equal hashes (Eq/Hash contract)
                 #[test]
                 fn [<prop_vertex_hash_consistency_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let v1: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
-                    let v2: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let v1: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
+                    let v2: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
 
                     prop_assert_eq!(v1, v2, "{}D: Vertices should be equal", $dim);
 
@@ -101,8 +101,8 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertices with different coordinates have different equality
                 #[test]
                 fn [<prop_vertex_inequality_ $dim d>](coords1 in prop::array::[<uniform $dim>](finite_coordinate()), coords2 in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let v1: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords1).unwrap();
-                    let v2: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords2).unwrap();
+                    let v1: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords1).unwrap();
+                    let v2: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords2).unwrap();
 
                     // If coordinates differ (component-wise), vertices should not be equal
                     if coords1.iter().zip(coords2.iter()).any(|(a, b)| (a - b).abs() > 1e-12) {
@@ -115,7 +115,7 @@ macro_rules! test_vertex_properties {
                 fn [<prop_vertex_uuid_uniqueness_ $dim d>](coords_list in prop::collection::vec(prop::array::[<uniform $dim>](finite_coordinate()), 1..=20_usize)) {
                     let vertices: Vec<Vertex<(), $dim>> = coords_list
                         .into_iter()
-                        .map(|coords| delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap())
+                        .map(|coords| Vertex::<(), _>::try_new(coords).unwrap())
                         .collect();
 
                     let mut seen_uuids = HashSet::new();
@@ -142,13 +142,13 @@ macro_rules! test_vertex_properties {
 
                     // Insert vertices with their indices
                     for (i, coords) in coords_list.iter().enumerate() {
-                        let vertex: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(*coords).unwrap();
+                        let vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new(*coords).unwrap();
                         map.insert(vertex, i);
                     }
 
                     // Lookup using new vertices with same coordinates
                     for (expected_index, coords) in coords_list.iter().enumerate() {
-                        let lookup_vertex: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(*coords).unwrap();
+                        let lookup_vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new(*coords).unwrap();
                         if let Some(&actual_index) = map.get(&lookup_vertex) {
                             prop_assert_eq!(
                                 actual_index,
@@ -168,14 +168,14 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertex dimension matches const parameter
                 #[test]
                 fn [<prop_vertex_dimension_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let vertex: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
                     prop_assert_eq!(vertex.dim(), $dim, "{}D: Vertex dimension should match D", $dim);
                 }
 
                 /// Property: Valid vertices pass validation
                 #[test]
                 fn [<prop_vertex_validation_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let vertex: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
                     prop_assert!(
                         vertex.is_valid().is_ok(),
                         "{}D: Vertex with finite coordinates should be valid",
@@ -186,8 +186,8 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertex ordering is consistent with lexicographic coordinate order
                 #[test]
                 fn [<prop_vertex_ordering_ $dim d>](coords1 in prop::array::[<uniform $dim>](finite_coordinate()), coords2 in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let v1: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords1).unwrap();
-                    let v2: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords2).unwrap();
+                    let v1: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords1).unwrap();
+                    let v2: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords2).unwrap();
 
                     // Compare vertices
                     let vertex_cmp = v1.partial_cmp(&v2);
@@ -205,7 +205,7 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertex data is preserved
                 #[test]
                 fn [<prop_vertex_data_preservation_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate()), data in prop::num::i32::ANY) {
-                    let vertex: Vertex<i32, $dim> = delaunay::prelude::Vertex::<_, _>::try_new_with_data(coords, data).unwrap();
+                    let vertex: Vertex<i32, $dim> = Vertex::<_, _>::try_new_with_data(coords, data).unwrap();
                     prop_assert_eq!(
                     vertex.data().copied(),
                         Some(data),
@@ -217,7 +217,7 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertex point() returns correct coordinates
                 #[test]
                 fn [<prop_vertex_point_access_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let vertex: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
                     let point = vertex.point();
                     let point_coords = *point.coords();
 
@@ -233,7 +233,7 @@ macro_rules! test_vertex_properties {
                 /// Property: Vertices can be converted to coordinate arrays
                 #[test]
                 fn [<prop_vertex_to_array_conversion_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
-                    let vertex: Vertex<(), $dim> = delaunay::prelude::Vertex::<(), _>::try_new(coords).unwrap();
+                    let vertex: Vertex<(), $dim> = Vertex::<(), _>::try_new(coords).unwrap();
                     let array: [f64; $dim] = vertex.into();
 
                     for (i, (&original, &converted)) in coords.iter().zip(array.iter()).enumerate() {

--- a/tests/public_topology_api.rs
+++ b/tests/public_topology_api.rs
@@ -8,9 +8,11 @@
 
 use delaunay::prelude::DelaunayTriangulationConstructionError;
 use delaunay::prelude::TopologyGuarantee;
+use delaunay::prelude::Vertex;
 use delaunay::prelude::geometry::CoordinateConversionError;
 use delaunay::prelude::query::*;
 use delaunay::prelude::tds::TdsError;
+use delaunay::vertex;
 use std::collections::HashSet;
 
 #[derive(Debug, thiserror::Error)]
@@ -37,11 +39,11 @@ enum PublicTopologyApiTestError {
 fn standard_simplex_vertices<const D: usize>()
 -> Result<Vec<Vertex<(), D>>, CoordinateConversionError> {
     let mut vertices = Vec::with_capacity(D + 1);
-    vertices.push(Vertex::<(), _>::try_new([0.0; D])?);
+    vertices.push(vertex!([0.0; D])?);
     for axis in 0..D {
         let mut coords = [0.0; D];
         coords[axis] = 1.0;
-        vertices.push(Vertex::<(), _>::try_new(coords)?);
+        vertices.push(vertex!(coords)?);
     }
     Ok(vertices)
 }
@@ -118,10 +120,10 @@ gen_split_topology_single_simplex_tests!(2, 3, 4, 5);
 fn edges_and_incident_edges_on_single_tetrahedron() -> Result<(), PublicTopologyApiTestError> {
     // Single tetrahedron: 4 vertices, 1 simplex, 6 unique edges.
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 1.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 1.0])?,
+        vertex!([0.0, 0.0, 0.0])?,
+        vertex!([1.0, 0.0, 0.0])?,
+        vertex!([0.0, 1.0, 0.0])?,
+        vertex!([0.0, 0.0, 1.0])?,
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 3> =
@@ -184,12 +186,12 @@ fn split_topology_indexes_on_double_tetrahedron() -> Result<(), PublicTopologyAp
     // Two tetrahedra sharing a triangular facet.
     let vertices: Vec<_> = vec![
         // Shared triangle
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([2.0, 0.0, 0.0])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 2.0, 0.0])?,
+        vertex!([0.0, 0.0, 0.0])?,
+        vertex!([2.0, 0.0, 0.0])?,
+        vertex!([1.0, 2.0, 0.0])?,
         // Two apices
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.7, 1.5])?,
-        delaunay::prelude::Vertex::<(), _>::try_new([1.0, 0.7, -1.5])?,
+        vertex!([1.0, 0.7, 1.5])?,
+        vertex!([1.0, 0.7, -1.5])?,
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 3> =

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -5,8 +5,9 @@
 //! feature flags, or profile isolation.
 
 use delaunay::prelude::construction::{
-    ConstructionOptions, DelaunayTriangulation, DelaunayTriangulationBuilder,
-    InsertionOrderStrategy, RetryPolicy, TopologyGuarantee, Vertex,
+    ConstructionOptions, DelaunayRepairPolicy, DelaunayTriangulation, DelaunayTriangulationBuilder,
+    DelaunayTriangulationConstructionError, ExplicitConstructionError, InsertionOrderStrategy,
+    RetryPolicy, TopologyGuarantee, Vertex,
 };
 #[cfg(feature = "diagnostics")]
 use delaunay::prelude::diagnostics::debug_print_first_delaunay_violation;
@@ -17,6 +18,7 @@ use delaunay::prelude::ordering::{
     HilbertBitDepth, hilbert_indices_prequantized, hilbert_quantize_batch_in_range,
     hilbert_quantize_in_range,
 };
+use std::num::NonZeroUsize;
 
 /// Replays a full Hilbert ordering while keeping only the prefix that first
 /// exposed issue #307, so the regression stays fast and deterministic.
@@ -81,6 +83,306 @@ fn coordinate_bounds<const D: usize>(points: &[Point<D>]) -> CoordinateRange<f64
         });
     CoordinateRange::try_new(min, max)
         .expect("generated regression points should span a finite non-empty range")
+}
+
+fn open_cdt_strip_vertex(
+    slice: u32,
+    index: u32,
+    vertices_per_slice: u32,
+    slice_count: u32,
+    vertical_jitter: f64,
+) -> ([f64; 2], u32) {
+    let min_spacing = 1.0_f64 / f64::from(vertices_per_slice - 1);
+    let side_jitter = min_spacing / 4.0;
+    let interior_jitter = min_spacing / (16.0 * f64::from(slice_count));
+    let spacing = 1.0_f64 / f64::from(vertices_per_slice - 1);
+    let temporal_index = f64::from(slice);
+    let temporal_span = f64::from(slice_count - 1);
+    let side_arc = if temporal_span.abs() < f64::EPSILON {
+        0.0
+    } else {
+        side_jitter * temporal_index * (temporal_span - temporal_index) / temporal_span.powi(2)
+    };
+    let x = if index == 0 || index == vertices_per_slice - 1 {
+        let boundary = f64::from(index).mul_add(spacing, side_jitter);
+        if index == 0 {
+            boundary - side_arc
+        } else {
+            boundary + side_arc
+        }
+    } else {
+        let sign = if (index + slice).is_multiple_of(2) {
+            1.0
+        } else {
+            -1.0
+        };
+        f64::from(index).mul_add(spacing, side_jitter) + sign * interior_jitter
+    };
+    let spatial_index = f64::from(index);
+    let arc = vertical_jitter * spatial_index * f64::from(vertices_per_slice - 1 - index)
+        / f64::from((vertices_per_slice - 1).pow(2));
+    let base_y = f64::from(slice);
+    let y = if slice == 0 {
+        base_y - arc
+    } else if slice + 1 == slice_count {
+        base_y + arc
+    } else {
+        let sign = if (index + slice).is_multiple_of(2) {
+            1.0
+        } else {
+            -1.0
+        };
+        (sign * arc).mul_add(0.5, base_y)
+    };
+    ([x, y], slice)
+}
+
+fn exact_open_cdt_strip_vertices(vertices_per_slice: u32, slice_count: u32) -> Vec<Vertex<u32, 2>> {
+    let total_vertices = usize::try_from(vertices_per_slice)
+        .expect("test vertices per slice fits usize")
+        .saturating_mul(usize::try_from(slice_count).expect("test slice count fits usize"));
+    let mut vertices = Vec::with_capacity(total_vertices);
+    for slice in 0..slice_count {
+        for index in 0..vertices_per_slice {
+            let ([x, y], label) =
+                open_cdt_strip_vertex(slice, index, vertices_per_slice, slice_count, 0.0);
+            vertices
+                .push(delaunay::vertex![x, y; data = label].expect("finite layered strip vertex"));
+        }
+    }
+    vertices
+}
+
+fn exact_open_cdt_strip_simplices(vertices_per_slice: u32, slice_count: u32) -> Vec<Vec<usize>> {
+    let vertices_per_slice =
+        usize::try_from(vertices_per_slice).expect("test vertices per slice fits usize");
+    let slice_count = usize::try_from(slice_count).expect("test slice count fits usize");
+    let mut simplices = Vec::with_capacity(
+        2 * vertices_per_slice
+            .saturating_sub(1)
+            .saturating_mul(slice_count.saturating_sub(1)),
+    );
+
+    for slice in 0..slice_count.saturating_sub(1) {
+        for index in 0..vertices_per_slice.saturating_sub(1) {
+            let lower_left = slice * vertices_per_slice + index;
+            let lower_right = lower_left + 1;
+            let upper_left = (slice + 1) * vertices_per_slice + index;
+            let upper_right = upper_left + 1;
+            simplices.push(vec![lower_left, lower_right, upper_right]);
+            simplices.push(vec![lower_left, upper_right, upper_left]);
+        }
+    }
+
+    simplices
+}
+
+fn sorted_vertex_signatures(vertices: &[Vertex<u32, 2>]) -> Vec<(u64, u64, u32)> {
+    let mut signatures: Vec<_> = vertices
+        .iter()
+        .map(|vertex| {
+            let coords = vertex.point().coords();
+            (
+                coords[0].to_bits(),
+                coords[1].to_bits(),
+                *vertex.data().expect("strip vertices are labeled"),
+            )
+        })
+        .collect();
+    signatures.sort_unstable();
+    signatures
+}
+
+fn sorted_triangulation_vertex_signatures(
+    dt: &DelaunayTriangulation<RobustKernel<f64>, u32, i32, 2>,
+) -> Vec<(u64, u64, u32)> {
+    let mut signatures: Vec<_> = dt
+        .vertices()
+        .map(|(_, vertex)| {
+            let coords = vertex.point().coords();
+            (
+                coords[0].to_bits(),
+                coords[1].to_bits(),
+                *vertex.data().expect("strip vertices are labeled"),
+            )
+        })
+        .collect();
+    signatures.sort_unstable();
+    signatures
+}
+
+fn assert_strip_vertices_use_exact_time_labels(vertices: &[Vertex<u32, 2>]) {
+    for vertex in vertices {
+        let coords = vertex.point().coords();
+        let label = *vertex.data().expect("strip vertices are labeled");
+        assert_eq!(
+            coords[1].to_bits(),
+            f64::from(label).to_bits(),
+            "strip vertex y coordinate should exactly encode its time label: vertex={vertex:?}",
+        );
+    }
+}
+
+fn assert_triangulation_vertices_use_exact_time_labels(
+    dt: &DelaunayTriangulation<RobustKernel<f64>, u32, i32, 2>,
+) {
+    for (_, vertex) in dt.vertices() {
+        let coords = vertex.point().coords();
+        let label = *vertex.data().expect("strip vertices are labeled");
+        assert_eq!(
+            coords[1].to_bits(),
+            f64::from(label).to_bits(),
+            "constructed strip vertex y coordinate should exactly encode its time label: vertex={vertex:?}",
+        );
+    }
+}
+
+#[test]
+fn regression_issue_447_exact_layered_strip_preserves_collinear_boundary_vertices() {
+    let vertices = exact_open_cdt_strip_vertices(5, 3);
+    let kernel = RobustKernel::<f64>::new();
+    let input_signatures = sorted_vertex_signatures(&vertices);
+    assert_strip_vertices_use_exact_time_labels(&vertices);
+    let exact_degenerate_options =
+        ConstructionOptions::default().without_final_delaunay_enforcement();
+    assert!(
+        !exact_degenerate_options.enforces_final_delaunay(),
+        "exact degenerate construction mode should document that Level 5 enforcement is disabled",
+    );
+
+    let (default_dt, default_stats) =
+        DelaunayTriangulation::<_, u32, i32, 2>::try_with_options_and_statistics(
+            &kernel,
+            &vertices,
+            TopologyGuarantee::DEFAULT,
+            exact_degenerate_options,
+        )
+        .expect("exact layered CDT strip point construction should succeed");
+
+    assert_eq!(
+        default_dt.number_of_vertices(),
+        vertices.len(),
+        "exact degenerate construction should preserve all distinct strip vertices; stats={default_stats:?}",
+    );
+    assert_eq!(
+        default_stats.total_skipped(),
+        0,
+        "exact degenerate construction should not skip collinear strip vertices; stats={default_stats:?}",
+    );
+    assert_eq!(
+        default_stats.used_perturbation, 0,
+        "exact degenerate construction should not physically perturb strip vertices; stats={default_stats:?}",
+    );
+    assert_eq!(
+        sorted_triangulation_vertex_signatures(&default_dt),
+        input_signatures,
+        "exact degenerate construction should preserve exact strip coordinate bits and labels; stats={default_stats:?}",
+    );
+    assert_triangulation_vertices_use_exact_time_labels(&default_dt);
+    default_dt
+        .as_triangulation()
+        .validate()
+        .expect("exact degenerate strip should satisfy Levels 1-4");
+
+    let input_options = ConstructionOptions::default()
+        .with_insertion_order(InsertionOrderStrategy::Input)
+        .with_retry_policy(RetryPolicy::Disabled)
+        .without_final_delaunay_enforcement();
+    let (input_dt, input_stats) =
+        DelaunayTriangulation::<_, u32, i32, 2>::try_with_options_and_statistics(
+            &kernel,
+            &vertices,
+            TopologyGuarantee::Pseudomanifold,
+            input_options,
+        )
+        .expect("input-order exact layered CDT strip construction should succeed");
+
+    assert_eq!(
+        input_dt.number_of_vertices(),
+        vertices.len(),
+        "input-order construction should preserve all exact strip vertices; stats={input_stats:?}",
+    );
+    assert_eq!(
+        input_stats.total_skipped(),
+        0,
+        "input-order construction should not skip collinear strip vertices; stats={input_stats:?}",
+    );
+    assert_eq!(
+        input_stats.used_perturbation, 0,
+        "input-order construction should not physically perturb strip vertices; stats={input_stats:?}",
+    );
+    assert_eq!(
+        sorted_triangulation_vertex_signatures(&input_dt),
+        input_signatures,
+        "input-order construction should preserve exact strip coordinate bits and labels; stats={input_stats:?}",
+    );
+    assert_triangulation_vertices_use_exact_time_labels(&input_dt);
+    input_dt
+        .as_triangulation()
+        .validate()
+        .expect("input-order exact strip should satisfy Levels 1-4");
+}
+
+#[test]
+fn regression_issue_447_explicit_exact_strip_default_strict_level5_fails() {
+    let vertices = exact_open_cdt_strip_vertices(5, 3);
+    let simplices = exact_open_cdt_strip_simplices(5, 3);
+
+    let err = DelaunayTriangulationBuilder::try_from_vertices_and_simplices(&vertices, &simplices)
+        .expect("exact CDT strip explicit simplex specs should validate")
+        .build::<i32>()
+        .expect_err("strict explicit construction should reject the non-Delaunay CDT strip");
+
+    assert!(
+        matches!(
+            err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::DelaunayValidation { .. }
+            )
+        ),
+        "strict explicit construction should fail at Level 5 Delaunay validation, got: {err:?}",
+    );
+}
+
+#[test]
+fn regression_issue_447_explicit_exact_strip_preserves_vertices_without_level5_enforcement() {
+    let vertices = exact_open_cdt_strip_vertices(5, 3);
+    let simplices = exact_open_cdt_strip_simplices(5, 3);
+    let kernel = RobustKernel::<f64>::new();
+    let input_signatures = sorted_vertex_signatures(&vertices);
+    assert_strip_vertices_use_exact_time_labels(&vertices);
+
+    let dt = DelaunayTriangulationBuilder::try_from_vertices_and_simplices(&vertices, &simplices)
+        .expect("exact CDT strip explicit simplex specs should validate")
+        .construction_options(
+            ConstructionOptions::default()
+                .without_final_delaunay_enforcement()
+                .with_batch_repair_policy(DelaunayRepairPolicy::EveryN(
+                    NonZeroUsize::new(2).unwrap(),
+                )),
+        )
+        .build_with_kernel::<_, i32>(&kernel)
+        .expect("explicit exact CDT strip should import under the non-enforcing policy");
+
+    assert_eq!(
+        dt.number_of_vertices(),
+        vertices.len(),
+        "explicit construction should preserve every exact strip vertex",
+    );
+    assert_eq!(
+        dt.number_of_simplices(),
+        simplices.len(),
+        "explicit construction should preserve the supplied strip connectivity",
+    );
+    assert_eq!(
+        sorted_triangulation_vertex_signatures(&dt),
+        input_signatures,
+        "explicit construction should preserve exact strip coordinate bits and labels",
+    );
+    assert_triangulation_vertices_use_exact_time_labels(&dt);
+    dt.as_triangulation()
+        .validate()
+        .expect("explicit exact CDT strip should satisfy Levels 1-4");
 }
 
 /// Locks the equivalence between the single-pass proof-carrying batch quantizer

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -5,9 +5,9 @@
 //! feature flags, or profile isolation.
 
 use delaunay::prelude::construction::{
-    ConstructionOptions, DelaunayRepairPolicy, DelaunayTriangulation, DelaunayTriangulationBuilder,
-    DelaunayTriangulationConstructionError, ExplicitConstructionError, InsertionOrderStrategy,
-    RetryPolicy, TopologyGuarantee, Vertex,
+    ConstructionOptions, ConstructionStatistics, DelaunayRepairPolicy, DelaunayTriangulation,
+    DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
+    ExplicitConstructionError, InsertionOrderStrategy, RetryPolicy, TopologyGuarantee, Vertex,
 };
 #[cfg(feature = "diagnostics")]
 use delaunay::prelude::diagnostics::debug_print_first_delaunay_violation;
@@ -18,6 +18,7 @@ use delaunay::prelude::ordering::{
     HilbertBitDepth, hilbert_indices_prequantized, hilbert_quantize_batch_in_range,
     hilbert_quantize_in_range,
 };
+use delaunay::vertex;
 use std::num::NonZeroUsize;
 
 /// Replays a full Hilbert ordering while keeping only the prefix that first
@@ -68,7 +69,7 @@ fn hilbert_ordered_prefix<const D: usize>(
     keyed
         .into_iter()
         .take(prefix_len)
-        .map(|(_, _, point, _)| delaunay::prelude::Vertex::<(), _>::try_new(point.into()).unwrap())
+        .map(|(_, _, point, _)| vertex!(point.into()).unwrap())
         .collect()
 }
 
@@ -146,8 +147,7 @@ fn exact_open_cdt_strip_vertices(vertices_per_slice: u32, slice_count: u32) -> V
         for index in 0..vertices_per_slice {
             let ([x, y], label) =
                 open_cdt_strip_vertex(slice, index, vertices_per_slice, slice_count, 0.0);
-            vertices
-                .push(delaunay::vertex![x, y; data = label].expect("finite layered strip vertex"));
+            vertices.push(vertex![x, y; data = label].expect("finite layered strip vertex"));
         }
     }
     vertices
@@ -237,6 +237,37 @@ fn assert_triangulation_vertices_use_exact_time_labels(
     }
 }
 
+fn assert_exact_strip_construction_result(
+    case: &str,
+    dt: &DelaunayTriangulation<RobustKernel<f64>, u32, i32, 2>,
+    stats: &ConstructionStatistics,
+    input_signatures: &[(u64, u64, u32)],
+) {
+    assert_eq!(
+        dt.number_of_vertices(),
+        input_signatures.len(),
+        "{case} construction should preserve all distinct strip vertices; stats={stats:?}",
+    );
+    assert_eq!(
+        stats.total_skipped(),
+        0,
+        "{case} construction should not skip collinear strip vertices; stats={stats:?}",
+    );
+    assert_eq!(
+        stats.used_perturbation, 0,
+        "{case} construction should not physically perturb strip vertices; stats={stats:?}",
+    );
+    assert_eq!(
+        sorted_triangulation_vertex_signatures(dt).as_slice(),
+        input_signatures,
+        "{case} construction should preserve exact strip coordinate bits and labels; stats={stats:?}",
+    );
+    assert_triangulation_vertices_use_exact_time_labels(dt);
+    dt.as_triangulation()
+        .validate()
+        .expect("exact degenerate strip should satisfy Levels 1-4");
+}
+
 #[test]
 fn regression_issue_447_exact_layered_strip_preserves_collinear_boundary_vertices() {
     let vertices = exact_open_cdt_strip_vertices(5, 3);
@@ -259,30 +290,12 @@ fn regression_issue_447_exact_layered_strip_preserves_collinear_boundary_vertice
         )
         .expect("exact layered CDT strip point construction should succeed");
 
-    assert_eq!(
-        default_dt.number_of_vertices(),
-        vertices.len(),
-        "exact degenerate construction should preserve all distinct strip vertices; stats={default_stats:?}",
+    assert_exact_strip_construction_result(
+        "exact degenerate",
+        &default_dt,
+        &default_stats,
+        &input_signatures,
     );
-    assert_eq!(
-        default_stats.total_skipped(),
-        0,
-        "exact degenerate construction should not skip collinear strip vertices; stats={default_stats:?}",
-    );
-    assert_eq!(
-        default_stats.used_perturbation, 0,
-        "exact degenerate construction should not physically perturb strip vertices; stats={default_stats:?}",
-    );
-    assert_eq!(
-        sorted_triangulation_vertex_signatures(&default_dt),
-        input_signatures,
-        "exact degenerate construction should preserve exact strip coordinate bits and labels; stats={default_stats:?}",
-    );
-    assert_triangulation_vertices_use_exact_time_labels(&default_dt);
-    default_dt
-        .as_triangulation()
-        .validate()
-        .expect("exact degenerate strip should satisfy Levels 1-4");
 
     let input_options = ConstructionOptions::default()
         .with_insertion_order(InsertionOrderStrategy::Input)
@@ -297,30 +310,40 @@ fn regression_issue_447_exact_layered_strip_preserves_collinear_boundary_vertice
         )
         .expect("input-order exact layered CDT strip construction should succeed");
 
+    assert_exact_strip_construction_result(
+        "input-order",
+        &input_dt,
+        &input_stats,
+        &input_signatures,
+    );
+
+    let no_stats_dt =
+        DelaunayTriangulation::<_, u32, i32, 2>::try_with_topology_guarantee_and_options(
+            &kernel,
+            &vertices,
+            TopologyGuarantee::Pseudomanifold,
+            ConstructionOptions::default()
+                .with_insertion_order(InsertionOrderStrategy::Input)
+                .with_retry_policy(RetryPolicy::Disabled)
+                .without_final_delaunay_enforcement(),
+        )
+        .expect("non-stat exact layered CDT strip construction should honor non-enforcing policy");
+
     assert_eq!(
-        input_dt.number_of_vertices(),
+        no_stats_dt.number_of_vertices(),
         vertices.len(),
-        "input-order construction should preserve all exact strip vertices; stats={input_stats:?}",
+        "non-stat construction should preserve all exact strip vertices",
     );
     assert_eq!(
-        input_stats.total_skipped(),
-        0,
-        "input-order construction should not skip collinear strip vertices; stats={input_stats:?}",
-    );
-    assert_eq!(
-        input_stats.used_perturbation, 0,
-        "input-order construction should not physically perturb strip vertices; stats={input_stats:?}",
-    );
-    assert_eq!(
-        sorted_triangulation_vertex_signatures(&input_dt),
+        sorted_triangulation_vertex_signatures(&no_stats_dt),
         input_signatures,
-        "input-order construction should preserve exact strip coordinate bits and labels; stats={input_stats:?}",
+        "non-stat construction should preserve exact strip coordinate bits and labels",
     );
-    assert_triangulation_vertices_use_exact_time_labels(&input_dt);
-    input_dt
+    assert_triangulation_vertices_use_exact_time_labels(&no_stats_dt);
+    no_stats_dt
         .as_triangulation()
         .validate()
-        .expect("input-order exact strip should satisfy Levels 1-4");
+        .expect("non-stat exact strip should satisfy Levels 1-4");
 }
 
 #[test]
@@ -455,30 +478,12 @@ fn regression_hilbert_batch_quantize_matches_two_step_path() {
 #[test]
 fn regression_empty_circumsphere_2d_minimal_case() {
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([
-            48.564_246_621_452_234,
-            23.481_505_128_710_488,
-        ])
-        .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
-            -9.807_184_344_740_996,
-            -36.451_902_443_093_33,
-        ])
-        .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
-            75.784_620_110_257_45,
-            25.382_048_382_678_306,
-        ])
-        .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([
-            50.330_335_525_698_53,
-            25.294_356_716_784_847,
-        ])
-        .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([77.411_339_748_608_4, -86.531_849_594_875_54])
-            .unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([-93.661_180_847_043, 1.562_430_007_326_195_9])
-            .unwrap(),
+        vertex!([48.564_246_621_452_234, 23.481_505_128_710_488]).unwrap(),
+        vertex!([-9.807_184_344_740_996, -36.451_902_443_093_33]).unwrap(),
+        vertex!([75.784_620_110_257_45, 25.382_048_382_678_306]).unwrap(),
+        vertex!([50.330_335_525_698_53, 25.294_356_716_784_847]).unwrap(),
+        vertex!([77.411_339_748_608_4, -86.531_849_594_875_54]).unwrap(),
+        vertex!([-93.661_180_847_043, 1.562_430_007_326_195_9]).unwrap(),
     ];
 
     let mut dt: DelaunayTriangulation<_, (), (), 2> =
@@ -508,10 +513,10 @@ fn regression_empty_circumsphere_2d_minimal_case() {
 fn regression_issue_120_minimal_failing_input_2d() {
     // From docs/archive/issue_120_investigation.md (Example Failure Case (2D)).
     let vertices = vec![
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([-54.687, 0.0]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([-85.026, 36.185]).unwrap(),
-        delaunay::prelude::Vertex::<(), _>::try_new([0.0, 38.424]).unwrap(),
+        vertex!([0.0, 0.0]).unwrap(),
+        vertex!([-54.687, 0.0]).unwrap(),
+        vertex!([-85.026, 36.185]).unwrap(),
+        vertex!([0.0, 38.424]).unwrap(),
     ];
 
     let dt: DelaunayTriangulation<_, (), (), 2> =
@@ -541,7 +546,7 @@ fn regression_periodic_neighbor_validation_uses_lifted_vertex_offsets() {
     let vertices: Vec<Vertex<(), 2>> = (0..7)
         .map(|index| {
             let index_f64 = f64::from(u32::try_from(index).expect("test index fits in u32"));
-            delaunay::prelude::Vertex::<(), _>::try_new([
+            vertex!([
                 0.9_f64.mul_add(((index_f64 + 1.0) * 0.618_033_988_749_894_8).fract(), 0.05),
                 0.9_f64.mul_add(((index_f64 + 1.0) * 0.414_213_562_373_095_03).fract(), 0.05),
             ])
@@ -585,7 +590,7 @@ fn regression_issue_306_3d_construction_succeeds() {
         .expect("point generation should succeed");
     let vertices: Vec<Vertex<(), 3>> = points
         .into_iter()
-        .map(|p| delaunay::prelude::Vertex::<(), _>::try_new(p.into()).unwrap())
+        .map(|p| vertex!(p.into()).unwrap())
         .collect();
 
     let dt: Result<DelaunayTriangulation<_, (), (), 3>, _> =
@@ -672,7 +677,7 @@ fn regression_issue_204_4d_500_local_repair_budget() {
         .expect("point generation should succeed");
     let vertices: Vec<Vertex<(), 4>> = points
         .into_iter()
-        .map(|p| delaunay::prelude::Vertex::<(), _>::try_new(p.into()).unwrap())
+        .map(|p| vertex!(p.into()).unwrap())
         .collect();
 
     let (dt, stats) =

--- a/tests/semgrep/src/project_rules/workflow_vertex_macro.rs
+++ b/tests/semgrep/src/project_rules/workflow_vertex_macro.rs
@@ -10,6 +10,10 @@ impl<U, const D: usize> Vertex<U, D> {
     pub fn try_new(_coords: [f64; D]) -> Result<Self, VertexValidationError> {
         Ok(Self { data: None })
     }
+
+    pub fn try_new_with_data(_coords: [f64; D], data: U) -> Result<Self, VertexValidationError> {
+        Ok(Self { data: Some(data) })
+    }
 }
 
 pub fn workflow_vertex_constructor_bad() -> Result<Vertex<(), 3>, VertexValidationError> {
@@ -20,4 +24,14 @@ pub fn workflow_vertex_constructor_bad() -> Result<Vertex<(), 3>, VertexValidati
 pub fn workflow_vertex_macro_ok() -> Result<Vertex<(), 3>, VertexValidationError> {
     // ok: delaunay.rust.prefer-vertex-macro-for-workflow-fixtures
     vertex![0.0, 0.0, 0.0]
+}
+
+pub fn workflow_vertex_text_ok() -> &'static str {
+    // ok: delaunay.rust.prefer-vertex-macro-for-workflow-fixtures
+    "Vertex::<(), _>::try_new([0.0, 0.0, 0.0])"
+}
+
+pub fn workflow_vertex_constructor_with_data_bad() -> Result<Vertex<u8, 3>, VertexValidationError> {
+    // ruleid: delaunay.rust.prefer-vertex-macro-for-workflow-fixtures
+    Vertex::<u8, _>::try_new_with_data([0.0, 0.0, 0.0], 1)
 }

--- a/tests/semgrep/src/project_rules/workflow_vertex_macro.rs
+++ b/tests/semgrep/src/project_rules/workflow_vertex_macro.rs
@@ -6,6 +6,12 @@ pub struct Vertex<U, const D: usize> {
 
 pub struct VertexValidationError;
 
+pub mod delaunay {
+    pub mod prelude {
+        pub use crate::Vertex;
+    }
+}
+
 impl<U, const D: usize> Vertex<U, D> {
     pub fn try_new(_coords: [f64; D]) -> Result<Self, VertexValidationError> {
         Ok(Self { data: None })
@@ -34,4 +40,9 @@ pub fn workflow_vertex_text_ok() -> &'static str {
 pub fn workflow_vertex_constructor_with_data_bad() -> Result<Vertex<u8, 3>, VertexValidationError> {
     // ruleid: delaunay.rust.prefer-vertex-macro-for-workflow-fixtures
     Vertex::<u8, _>::try_new_with_data([0.0, 0.0, 0.0], 1)
+}
+
+pub fn workflow_vertex_qualified_constructor_bad() -> Result<Vertex<(), 3>, VertexValidationError> {
+    // ruleid: delaunay.rust.prefer-vertex-macro-for-workflow-fixtures
+    delaunay::prelude::Vertex::<(), _>::try_new([0.0, 0.0, 0.0])
 }

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -5,6 +5,7 @@
 
 #![forbid(unsafe_code)]
 
+use delaunay::vertex;
 use std::assert_matches;
 use std::collections::HashMap;
 use std::f64::consts::TAU;
@@ -31,9 +32,9 @@ use delaunay::prelude::validation::{TriangulationValidationError, ValidationPoli
 #[test]
 fn test_builder_euclidean_matches_new_2d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
 
     let dt_new = DelaunayTriangulation::try_new(&vertices).expect("new() should succeed");
@@ -53,10 +54,10 @@ fn test_builder_euclidean_matches_new_2d() {
 #[test]
 fn test_builder_euclidean_3d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
     let dt = DelaunayTriangulationBuilder::new(&vertices)
         .build::<()>()
@@ -70,9 +71,9 @@ fn test_builder_euclidean_3d() {
 #[test]
 fn test_builder_topology_guarantee_propagated() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let dt = DelaunayTriangulationBuilder::new(&vertices)
         .topology_guarantee(TopologyGuarantee::Pseudomanifold)
@@ -86,9 +87,9 @@ fn test_builder_topology_guarantee_propagated() {
 #[test]
 fn test_builder_validation_policy_derived_from_topology_guarantee() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
 
     let dt = DelaunayTriangulationBuilder::new(&vertices)
@@ -104,9 +105,9 @@ fn test_builder_validation_policy_derived_from_topology_guarantee() {
 #[test]
 fn test_builder_custom_construction_options() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let opts = ConstructionOptions::default().with_insertion_order(InsertionOrderStrategy::Input);
     let dt = DelaunayTriangulationBuilder::new(&vertices)
@@ -125,9 +126,9 @@ fn test_builder_custom_construction_options() {
 #[test]
 fn test_builder_convenience() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let dt = DelaunayTriangulation::builder(&vertices)
         .build::<()>()
@@ -140,10 +141,10 @@ fn test_builder_convenience() {
 #[test]
 fn test_builder_canonicalized_toroidal_convenience() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.2_f64, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([1.8, 0.1]).unwrap(), // → (0.8, 0.1)
-        Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
-        Vertex::<(), _>::try_new([-0.4, 0.9]).unwrap(), // → (0.6, 0.9)
+        vertex!([0.2_f64, 0.3]).unwrap(),
+        vertex!([1.8, 0.1]).unwrap(), // → (0.8, 0.1)
+        vertex!([0.5, 0.7]).unwrap(),
+        vertex!([-0.4, 0.9]).unwrap(), // → (0.6, 0.9)
     ];
     let dt = DelaunayTriangulation::builder(&vertices)
         .try_canonicalized_toroidal([1.0, 1.0])
@@ -164,17 +165,17 @@ fn test_builder_canonicalized_toroidal_convenience() {
 fn test_builder_canonicalized_toroidal_canonicalizes_coordinates() {
     // Canonical (already-wrapped) coordinates
     let canonical_vertices = vec![
-        Vertex::<(), _>::try_new([0.2_f64, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.1]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
-        Vertex::<(), _>::try_new([0.6, 0.9]).unwrap(),
+        vertex!([0.2_f64, 0.3]).unwrap(),
+        vertex!([0.8, 0.1]).unwrap(),
+        vertex!([0.5, 0.7]).unwrap(),
+        vertex!([0.6, 0.9]).unwrap(),
     ];
     // Out-of-domain equivalents
     let shifted_vertices = vec![
-        Vertex::<(), _>::try_new([2.2_f64, 3.3]).unwrap(), // → (0.2, 0.3)
-        Vertex::<(), _>::try_new([-0.2, 1.1]).unwrap(),    // → (0.8, 0.1)
-        Vertex::<(), _>::try_new([1.5, 0.7]).unwrap(),     // → (0.5, 0.7)
-        Vertex::<(), _>::try_new([-0.4, 2.9]).unwrap(),    // → (0.6, 0.9)
+        vertex!([2.2_f64, 3.3]).unwrap(), // → (0.2, 0.3)
+        vertex!([-0.2, 1.1]).unwrap(),    // → (0.8, 0.1)
+        vertex!([1.5, 0.7]).unwrap(),     // → (0.5, 0.7)
+        vertex!([-0.4, 2.9]).unwrap(),    // → (0.6, 0.9)
     ];
 
     let dt_canonical = DelaunayTriangulationBuilder::new(&canonical_vertices)
@@ -205,10 +206,10 @@ fn test_builder_canonicalized_toroidal_canonicalizes_coordinates() {
 #[test]
 fn test_builder_canonicalized_toroidal_validates_2d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.2_f64, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.1]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
-        Vertex::<(), _>::try_new([0.1, 0.9]).unwrap(),
+        vertex!([0.2_f64, 0.3]).unwrap(),
+        vertex!([0.8, 0.1]).unwrap(),
+        vertex!([0.5, 0.7]).unwrap(),
+        vertex!([0.1, 0.9]).unwrap(),
     ];
     let dt = DelaunayTriangulationBuilder::new(&vertices)
         .try_canonicalized_toroidal([1.0, 1.0])
@@ -226,10 +227,10 @@ fn test_builder_canonicalized_toroidal_validates_2d() {
 #[test]
 fn test_builder_canonicalized_toroidal_delaunay_property_valid_2d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.2_f64, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.1]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
-        Vertex::<(), _>::try_new([0.1, 0.9]).unwrap(),
+        vertex!([0.2_f64, 0.3]).unwrap(),
+        vertex!([0.8, 0.1]).unwrap(),
+        vertex!([0.5, 0.7]).unwrap(),
+        vertex!([0.1, 0.9]).unwrap(),
     ];
     let dt = DelaunayTriangulationBuilder::new(&vertices)
         .try_canonicalized_toroidal([1.0, 1.0])
@@ -247,10 +248,10 @@ fn test_builder_canonicalized_toroidal_delaunay_property_valid_2d() {
 #[test]
 fn test_builder_canonicalized_toroidal_2d_euler_dimension() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.2_f64, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.1]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, 0.7]).unwrap(),
-        Vertex::<(), _>::try_new([0.1, 0.9]).unwrap(),
+        vertex!([0.2_f64, 0.3]).unwrap(),
+        vertex!([0.8, 0.1]).unwrap(),
+        vertex!([0.5, 0.7]).unwrap(),
+        vertex!([0.1, 0.9]).unwrap(),
     ];
     let dt = DelaunayTriangulationBuilder::new(&vertices)
         .try_canonicalized_toroidal([1.0, 1.0])
@@ -269,9 +270,9 @@ fn test_builder_canonicalized_toroidal_2d_euler_dimension() {
 #[test]
 fn test_builder_canonicalized_toroidal_matches_euclidean_on_canonical_input() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.1_f64, 0.2]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([0.4, 0.9]).unwrap(),
+        vertex!([0.1_f64, 0.2]).unwrap(),
+        vertex!([0.8, 0.3]).unwrap(),
+        vertex!([0.4, 0.9]).unwrap(),
     ];
     let dt_euclidean = DelaunayTriangulationBuilder::new(&vertices)
         .build::<()>()
@@ -300,14 +301,14 @@ fn test_builder_canonicalized_toroidal_matches_euclidean_on_canonical_input() {
 #[test]
 fn test_builder_canonicalized_toroidal_larger_point_set_2d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.1_f64, 0.2]).unwrap(),
-        Vertex::<(), _>::try_new([0.6, 0.1]).unwrap(),
-        Vertex::<(), _>::try_new([0.9, 0.4]).unwrap(),
-        Vertex::<(), _>::try_new([0.7, 0.8]).unwrap(),
-        Vertex::<(), _>::try_new([0.3, 0.7]).unwrap(),
-        Vertex::<(), _>::try_new([0.48, 0.52]).unwrap(),
-        Vertex::<(), _>::try_new([0.15, 0.85]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.65]).unwrap(),
+        vertex!([0.1_f64, 0.2]).unwrap(),
+        vertex!([0.6, 0.1]).unwrap(),
+        vertex!([0.9, 0.4]).unwrap(),
+        vertex!([0.7, 0.8]).unwrap(),
+        vertex!([0.3, 0.7]).unwrap(),
+        vertex!([0.48, 0.52]).unwrap(),
+        vertex!([0.15, 0.85]).unwrap(),
+        vertex!([0.8, 0.65]).unwrap(),
     ];
     let dt = DelaunayTriangulationBuilder::new(&vertices)
         .try_canonicalized_toroidal([1.0, 1.0])
@@ -327,11 +328,11 @@ fn test_builder_canonicalized_toroidal_larger_point_set_2d() {
 #[test]
 fn test_builder_canonicalized_toroidal_robust_kernel_3d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.2_f64, 0.3, 0.4]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.1, 0.2]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, 0.7, 0.6]).unwrap(),
-        Vertex::<(), _>::try_new([0.1, 0.9, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([0.6, 0.4, 0.8]).unwrap(),
+        vertex!([0.2_f64, 0.3, 0.4]).unwrap(),
+        vertex!([0.8, 0.1, 0.2]).unwrap(),
+        vertex!([0.5, 0.7, 0.6]).unwrap(),
+        vertex!([0.1, 0.9, 0.3]).unwrap(),
+        vertex!([0.6, 0.4, 0.8]).unwrap(),
     ];
     let kernel = RobustKernel::new();
     let dt = DelaunayTriangulationBuilder::new(&vertices)
@@ -368,7 +369,7 @@ fn toroidal_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
                 let phase = (index_f64 + 1.0) * stride;
                 coords[axis] = 0.9_f64.mul_add(phase.fract(), 0.05);
             }
-            Vertex::<(), _>::try_new(coords).unwrap()
+            vertex!(coords).unwrap()
         })
         .collect()
 }
@@ -520,13 +521,13 @@ gen_toroidal_validation_test!(2, levels_1_to_4, true);
 )]
 fn test_builder_toroidal_3d_fails_fast_until_scalable_quotient() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.2_f64, 0.3, 0.4]).unwrap(),
-        Vertex::<(), _>::try_new([0.8, 0.1, 0.2]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, 0.7, 0.6]).unwrap(),
-        Vertex::<(), _>::try_new([0.1, 0.9, 0.3]).unwrap(),
-        Vertex::<(), _>::try_new([0.6, 0.4, 0.8]).unwrap(),
-        Vertex::<(), _>::try_new([0.3, 0.5, 0.9]).unwrap(),
-        Vertex::<(), _>::try_new([0.9, 0.2, 0.6]).unwrap(),
+        vertex!([0.2_f64, 0.3, 0.4]).unwrap(),
+        vertex!([0.8, 0.1, 0.2]).unwrap(),
+        vertex!([0.5, 0.7, 0.6]).unwrap(),
+        vertex!([0.1, 0.9, 0.3]).unwrap(),
+        vertex!([0.6, 0.4, 0.8]).unwrap(),
+        vertex!([0.3, 0.5, 0.9]).unwrap(),
+        vertex!([0.9, 0.2, 0.6]).unwrap(),
     ];
     let kernel = RobustKernel::new();
     let err = DelaunayTriangulationBuilder::new(&vertices)
@@ -625,7 +626,7 @@ fn test_explicit_toroidal_heawood_torus_rejected() {
     let vertices: Vec<_> = (0..7)
         .map(|i| {
             let angle = TAU * f64::from(i) / 7.0;
-            Vertex::<(), _>::try_new([angle.cos(), angle.sin()]).unwrap()
+            vertex!([angle.cos(), angle.sin()]).unwrap()
         })
         .collect();
 
@@ -663,7 +664,7 @@ fn test_explicit_toroidal_torus_euler_mismatch_without_override() {
     let vertices: Vec<_> = (0..7)
         .map(|i| {
             let angle = TAU * f64::from(i) / 7.0;
-            Vertex::<(), _>::try_new([angle.cos(), angle.sin()]).unwrap()
+            vertex!([angle.cos(), angle.sin()]).unwrap()
         })
         .collect();
 
@@ -725,10 +726,10 @@ fn explicit_builder_parse_error<U, const D: usize>(
 #[test]
 fn test_explicit_2d_two_triangle_quad() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2], vec![0, 2, 3]];
 
@@ -771,10 +772,10 @@ fn test_explicit_2d_two_triangle_quad() {
 #[test]
 fn test_explicit_normalizes_incoherent_simplex_order() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let mut simplices = vec![vec![0, 1, 2], vec![0, 2, 3]];
     simplices[1].swap(0, 1);
@@ -794,11 +795,11 @@ fn test_explicit_normalizes_incoherent_simplex_order() {
 #[test]
 fn test_explicit_3d_two_tetrahedra() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 1.0, -1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0, -1.0]).unwrap(),
     ];
     // Two tetrahedra sharing face (0, 1, 2)
     let simplices = vec![vec![0, 1, 2, 3], vec![0, 1, 2, 4]];
@@ -820,11 +821,11 @@ fn test_explicit_3d_two_tetrahedra() {
 #[test]
 fn test_explicit_round_trip_3d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 1.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0, 1.0]).unwrap(),
     ];
 
     let dt_original =
@@ -878,10 +879,10 @@ fn test_explicit_round_trip_3d() {
 #[test]
 fn test_explicit_round_trip_2d() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
     ];
 
     // Build via standard Delaunay.
@@ -938,8 +939,8 @@ fn test_explicit_round_trip_2d() {
 #[test]
 fn test_explicit_error_empty_simplices() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
     ];
     let simplices: Vec<Vec<usize>> = vec![];
 
@@ -953,9 +954,9 @@ fn test_explicit_error_empty_simplices() {
 #[test]
 fn test_explicit_error_wrong_arity() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     // 2D expects 3 vertices per simplex, but we provide 2.
     let simplices = vec![vec![0, 1]];
@@ -970,9 +971,9 @@ fn test_explicit_error_wrong_arity() {
 #[test]
 fn test_explicit_error_index_out_of_bounds() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 99]]; // 99 is out of bounds
 
@@ -989,9 +990,9 @@ fn test_explicit_error_index_out_of_bounds() {
 #[test]
 fn test_explicit_error_duplicate_vertex_in_simplex() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 1]]; // Duplicate vertex 1
 
@@ -1005,9 +1006,9 @@ fn test_explicit_error_duplicate_vertex_in_simplex() {
 #[test]
 fn test_explicit_2d_single_triangle() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1025,10 +1026,10 @@ fn test_explicit_2d_single_triangle() {
 #[test]
 fn test_explicit_3d_single_tetrahedron() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0, 0.0]).unwrap(),
+        vertex!([1.0, 0.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0, 0.0]).unwrap(),
+        vertex!([0.0, 0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2, 3]];
 
@@ -1054,10 +1055,10 @@ fn test_explicit_3d_single_tetrahedron() {
 #[test]
 fn test_explicit_non_delaunay_mesh() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([4.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([4.0, 2.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 2.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([4.0, 0.0]).unwrap(),
+        vertex!([4.0, 2.0]).unwrap(),
+        vertex!([1.0, 2.0]).unwrap(),
     ];
     // Diagonal AC = (0,0)-(4,2): non-Delaunay because D=(1,2) is inside
     // the circumcircle of triangle ABC.
@@ -1087,9 +1088,9 @@ fn test_explicit_non_delaunay_mesh() {
 #[test]
 fn test_explicit_topology_guarantee_propagated() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1106,9 +1107,9 @@ fn test_explicit_topology_guarantee_propagated() {
 #[test]
 fn test_explicit_preserves_vertex_data() {
     let vertices: Vec<Vertex<i32, 2>> = vec![
-        Vertex::try_new_with_data([0.0, 0.0], 10_i32).unwrap(),
-        Vertex::try_new_with_data([1.0, 0.0], 20_i32).unwrap(),
-        Vertex::try_new_with_data([0.0, 1.0], 30_i32).unwrap(),
+        vertex!([0.0, 0.0]; data = 10_i32).unwrap(),
+        vertex!([1.0, 0.0]; data = 20_i32).unwrap(),
+        vertex!([0.0, 1.0]; data = 30_i32).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1134,9 +1135,9 @@ fn test_explicit_preserves_vertex_data() {
 fn test_explicit_validate_delaunay_mesh() {
     // Use a known Delaunay configuration: the standard simplex.
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, 0.866_025_403_784_438_6]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.5, 0.866_025_403_784_438_6]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1155,10 +1156,10 @@ fn test_explicit_validate_delaunay_mesh() {
 #[test]
 fn test_explicit_unreferenced_vertices_rejected() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([5.0, 5.0]).unwrap(), // Not referenced by any simplex
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([5.0, 5.0]).unwrap(), // Not referenced by any simplex
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1181,7 +1182,7 @@ fn test_explicit_unreferenced_vertices_rejected() {
 /// Error variant: empty simplices returns ExplicitConstruction(EmptySimplices).
 #[test]
 fn test_explicit_error_variant_empty_simplices() {
-    let vertices = vec![Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap()];
+    let vertices = vec![vertex!([0.0_f64, 0.0]).unwrap()];
     let simplices: Vec<Vec<usize>> = vec![];
 
     let err = explicit_builder_parse_error(&vertices, &simplices);
@@ -1196,9 +1197,9 @@ fn test_explicit_error_variant_empty_simplices() {
 #[test]
 fn test_explicit_error_variant_wrong_arity() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1]]; // 2D expects 3 vertices
 
@@ -1223,11 +1224,11 @@ fn test_explicit_error_variant_non_manifold_facet() {
     // Three triangles sharing the same edge (0,1) — facet shared by 3 simplices
     // violates the 2-manifold property.
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 1.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.5, -1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
+        vertex!([0.5, -1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2], vec![0, 1, 3], vec![0, 1, 4]];
 
@@ -1257,9 +1258,9 @@ fn test_explicit_error_variant_non_manifold_facet() {
 #[test]
 fn test_explicit_error_variant_duplicate_vertex_in_simplex() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 1]]; // Duplicate vertex 1
 
@@ -1278,9 +1279,9 @@ fn test_explicit_error_variant_duplicate_vertex_in_simplex() {
 #[test]
 fn test_explicit_error_variant_incompatible_topology() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1306,9 +1307,9 @@ fn test_explicit_error_variant_incompatible_topology() {
 #[test]
 fn test_explicit_error_variant_unsupported_construction_options() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1329,15 +1330,36 @@ fn test_explicit_error_variant_unsupported_construction_options() {
         ),
         "Expected UnsupportedConstructionOptions, got: {err}"
     );
+
+    let mixed_err =
+        DelaunayTriangulationBuilder::try_from_vertices_and_simplices(&vertices, &simplices)
+            .unwrap()
+            .construction_options(
+                ConstructionOptions::default()
+                    .without_final_delaunay_enforcement()
+                    .with_insertion_order(InsertionOrderStrategy::Input),
+            )
+            .build::<()>()
+            .unwrap_err();
+
+    assert!(
+        matches!(
+            mixed_err,
+            DelaunayTriangulationConstructionError::ExplicitConstruction(
+                ExplicitConstructionError::UnsupportedConstructionOptions
+            )
+        ),
+        "Expected mixed non-enforcing point-insertion options to be rejected, got: {mixed_err}",
+    );
 }
 
 /// Error variant: duplicate maximal simplices are rejected during TDS insertion.
 #[test]
 fn test_explicit_error_variant_duplicate_simplices_structural_validation() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2], vec![0, 1, 2]];
 
@@ -1363,9 +1385,9 @@ fn test_explicit_error_variant_duplicate_simplices_structural_validation() {
 #[test]
 fn test_explicit_error_variant_geometric_nondegeneracy() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([2.0, 0.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([2.0, 0.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 2]];
 
@@ -1440,9 +1462,9 @@ fn test_explicit_error_variant_orientation_normalization_summary() {
 #[test]
 fn test_explicit_error_variant_index_out_of_bounds() {
     let vertices = vec![
-        Vertex::<(), _>::try_new([0.0_f64, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([1.0, 0.0]).unwrap(),
-        Vertex::<(), _>::try_new([0.0, 1.0]).unwrap(),
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
     ];
     let simplices = vec![vec![0, 1, 99]];
 


### PR DESCRIPTION
- Add a non-enforcing construction option that returns valid Levels 1-4 triangulations without automatic Level 5 Delaunay repair.
- Split exact 2D hull-edge insertions before symbolic perturbation can route them through interior insertion.
- Allow explicit simplex imports to opt out of Level 5 validation while keeping strict Delaunay validation as the default.

Closes #447