### PR TITLE
feat(api)!: add Pachner feasibility checks

### DIFF
--- a/benches/pachner_stress.rs
+++ b/benches/pachner_stress.rs
@@ -14,8 +14,8 @@ use criterion::{
 };
 use delaunay::prelude::construction::{Vertex, vertex};
 use delaunay::prelude::pachner::{
-    EdgeKey, FacetHandle, PachnerMove, PachnerMoves, RidgeHandle, SimplexKey, TriangleHandle,
-    VertexKey,
+    EdgeKey, FacetHandle, PachnerMove, PachnerMoveResult, PachnerMoves, RidgeHandle, SimplexKey,
+    TriangleHandle, VertexKey,
 };
 
 /// Shared benchmark setup error helpers.
@@ -118,12 +118,13 @@ fn k1_remove_fixture(
 ) -> (FlipTriangulation<4>, VertexKey) {
     let mut dt = base_dt.clone();
     let vertex_uuid = vertex.uuid();
-    let inserted = dt
-        .attempt_pachner(PachnerMove::K1Insert {
+    let inserted = attempt_pachner_move(
+        &mut dt,
+        PachnerMove::K1Insert {
             simplex_key,
             vertex,
-        })
-        .or_abort();
+        },
+    );
     let vertex_key = dt
         .tds()
         .vertex_key_from_uuid(&vertex_uuid)
@@ -140,7 +141,7 @@ fn k2_inverse_fixture(
     facet: FacetHandle,
 ) -> (FlipTriangulation<4>, EdgeKey) {
     let mut dt = base_dt.clone();
-    let info = dt.attempt_pachner(PachnerMove::K2 { facet }).or_abort();
+    let info = attempt_pachner_move(&mut dt, PachnerMove::K2 { facet });
     let edge = inserted_edge(&dt, &info.inserted_face_vertices);
 
     (dt, edge)
@@ -152,10 +153,21 @@ fn k3_inverse_fixture(
     ridge: RidgeHandle,
 ) -> (FlipTriangulation<4>, TriangleHandle) {
     let mut dt = base_dt.clone();
-    let info = dt.attempt_pachner(PachnerMove::K3 { ridge }).or_abort();
+    let info = attempt_pachner_move(&mut dt, PachnerMove::K3 { ridge });
     let triangle = inserted_triangle(&info.inserted_face_vertices);
 
     (dt, triangle)
+}
+
+/// Parses and commits one Pachner request on the same topology owner.
+fn attempt_pachner_move(
+    dt: &mut FlipTriangulation<4>,
+    pachner_move: PachnerMove<(), 4>,
+) -> PachnerMoveResult<4> {
+    dt.propose_pachner(pachner_move)
+        .or_abort()
+        .attempt_on(dt)
+        .or_abort()
 }
 
 /// Converts a reported inserted face into an inverse k=2 edge handle.
@@ -185,7 +197,7 @@ fn clone_batch(base_dt: &FlipTriangulation<4>) -> Vec<FlipTriangulation<4>> {
     vec![base_dt.clone(); MOVES_PER_SAMPLE]
 }
 
-/// Registers one stress case that repeats the same detached Pachner proposal.
+/// Registers one stress case that repeats the same raw Pachner request.
 fn bench_pachner_move(
     group: &mut BenchmarkGroup<'_, WallTime>,
     name: &'static str,
@@ -197,7 +209,7 @@ fn bench_pachner_move(
             || clone_batch(base_dt),
             |mut triangulations| {
                 for dt in &mut triangulations {
-                    let result = dt.attempt_pachner(pachner_move).or_abort();
+                    let result = attempt_pachner_move(dt, pachner_move);
                     black_box(&result);
                 }
                 black_box(triangulations);

--- a/docs/api_design.md
+++ b/docs/api_design.md
@@ -171,6 +171,11 @@ for topology guarantee and validation policy details.
 The local edit API is exposed through the `PachnerMoves` trait in
 `prelude::pachner`:
 
+The canonical public workflow is fluent and staged: parse a raw
+`PachnerMove` into a provenanced `PachnerProposal`, then dry-run or attempt the
+proposal through the proposal object. This keeps mutation explicit while
+preserving owner/generation evidence between stages.
+
 ```rust
 use delaunay::prelude::construction::{
     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError, vertex,
@@ -204,26 +209,34 @@ fn main() -> Result<(), ExampleError> {
     let Some((simplex_key, _)) = dt.simplices().next() else {
         return Ok(());
     };
-    let info = dt.attempt_pachner(PachnerMove::K1Insert {
-        simplex_key,
-        vertex: vertex![0.25, 0.25, 0.25]?,
-    })?;
+    let info = dt
+        .propose_pachner(PachnerMove::K1Insert {
+            simplex_key,
+            vertex: vertex![0.25, 0.25, 0.25]?,
+        })?
+        .attempt_on(&mut dt)?;
 
     // k=1 inverse: Remove a vertex (collapses its star)
     let vertex_key = info.inserted_face_vertices[0];
-    dt.attempt_pachner(PachnerMove::K1Remove { vertex_key })?;
+    dt.propose_pachner(PachnerMove::K1Remove { vertex_key })?
+        .attempt_on(&mut dt)?;
 
     // k=2 move: Flip a facet (2 simplices ↔ D simplices)
     let facet = /* FacetHandle */;
-    let info = dt.attempt_pachner(PachnerMove::K2 { facet })?;
+    let info = dt
+        .propose_pachner(PachnerMove::K2 { facet })?
+        .attempt_on(&mut dt)?;
 
     // k=2 inverse: Flip from an edge star (D simplices ↔ 2 simplices)
     let edge = EdgeKey::try_new(info.inserted_face_vertices[0], info.inserted_face_vertices[1])?;
-    dt.attempt_pachner(PachnerMove::K2Inverse { edge })?;
+    dt.propose_pachner(PachnerMove::K2Inverse { edge })?
+        .attempt_on(&mut dt)?;
 
     // k=3 move: Flip a ridge (3 simplices ↔ D-1 simplices, requires D ≥ 3)
     let ridge = /* RidgeHandle */;
-    let info = dt.attempt_pachner(PachnerMove::K3 { ridge })?;
+    let info = dt
+        .propose_pachner(PachnerMove::K3 { ridge })?
+        .attempt_on(&mut dt)?;
 
     // k=3 inverse: Flip from a triangle star (D-1 simplices ↔ 3 simplices)
     let triangle = TriangleHandle::try_new(
@@ -231,7 +244,8 @@ fn main() -> Result<(), ExampleError> {
         info.inserted_face_vertices[1],
         info.inserted_face_vertices[2],
     )?;
-    dt.attempt_pachner(PachnerMove::K3Inverse { triangle })?;
+    dt.propose_pachner(PachnerMove::K3Inverse { triangle })?
+        .attempt_on(&mut dt)?;
     Ok(())
 }
 ```
@@ -277,10 +291,46 @@ fn main() -> Result<(), ExampleError> {
 ### Key Characteristics
 
 - **Explicit control**: You specify exactly which flip to perform
+- **Provenanced proposals**: Raw `PachnerMove` values are parsed into
+  `PachnerProposal` values before dry-run or mutation
 - **No automatic property preservation**: The Delaunay property is **not** maintained automatically
 - **Reversible**: Each forward move has a corresponding inverse
 - **Geometric validation**: Flips check for degeneracy and manifold preservation
 - **Flexible**: Can be used to build custom repair or optimization algorithms
+
+### Proposal Provenance
+
+`PachnerMove` is a raw detached request. It can be stored, randomized, or queued,
+but it is not proof that its handles are still live or that they came from the
+target triangulation. `propose_pachner(...)` is the raw-to-provenanced
+boundary: it validates the local move preconditions, then stamps the resulting
+`PachnerProposal` with the current topology owner and structural generation
+while carrying the proven feasibility report inward.
+
+Two runtime-only TDS primitives provide that provenance:
+
+- `TopologyOwnerId` is an opaque identity for one live topology owner. Ordinary
+  clones and deserialization get fresh identities, while internal rollback
+  snapshots preserve identity so failure-atomic mutation paths can restore the
+  same owner.
+- The topology generation increments on structural mutation. It is an
+  invalidation stamp for caches, proposals, and detached topology artifacts; it
+  is not serialized.
+
+`PachnerProposal::can_attempt_on(...)` and `PachnerProposal::attempt_on(...)`
+are the dry-run and mutation paths. They reject proposals from another owner
+with `FlipError::WrongTopologyOwner` and proposals from an older generation with
+`FlipError::StaleTopologyProposal` before interpreting runtime-local keys.
+`can_attempt_on(...)` returns the feasibility proof stored in the proposal after
+that provenance check; `attempt_on(...)` still revalidates through the selected
+primitive mutation path before changing topology.
+
+This design supports future concurrent proposal workflows: worker threads can
+compute or filter candidate moves against an immutable snapshot, then a
+coordinator can attempt selected proposals against the canonical owner and treat
+losing stale proposals as typed, expected failures. It does not by itself make
+topology mutation concurrent; shared mutable access still needs an explicit
+synchronization or transaction design.
 
 ### Important Caveats
 
@@ -338,7 +388,8 @@ fn main() -> Result<(), ExampleError> {
 
     // 3. Make custom topology edits (Pachner Move API)
     let facet = /* ... */;
-    dt.attempt_pachner(PachnerMove::K2 { facet })?;
+    dt.propose_pachner(PachnerMove::K2 { facet })?
+        .attempt_on(&mut dt)?;
 
     // 4. Verify Delaunay property if needed
     if let Err(e) = dt.is_valid_delaunay() {

--- a/docs/dev/rust.md
+++ b/docs/dev/rust.md
@@ -14,6 +14,7 @@ Agents must follow these rules when modifying or adding Rust code.
 - [Numeric Conversions](#numeric-conversions)
 - [Borrowing and Ownership](#borrowing-and-ownership)
 - [Error Handling](#error-handling)
+- [Fluent Workflow APIs](#fluent-workflow-apis)
 - [Constructor Naming](#constructor-naming)
 - [Panic Policy](#panic-policy)
 - [Error Types](#error-types)
@@ -335,6 +336,43 @@ builder
     .with_seed(seed)
     .build()?;
 ```
+
+---
+
+## Fluent Workflow APIs
+
+Fluent APIs are a reviewed design preference for public workflows, not a
+repository-wide requirement. Prefer staged method chains when the operation
+naturally proceeds through configuration, proposal, transaction, dry-run,
+commit, execution, or report phases.
+
+Good fluent APIs make the valid sequence obvious and keep fallibility visible:
+
+```rust
+let result = owner
+    .propose_change(raw_request)?
+    .attempt_on(&mut owner)?;
+```
+
+Use fluent stages when they preserve useful evidence, such as a builder that
+stores validated options, a proposal that carries owner/generation provenance,
+or a transaction guard that owns rollback state. Coordinate this with
+parse-don't-validate design: once raw input has been parsed into a
+proof-bearing value, later stages should consume or borrow that value rather
+than reaccepting the raw input.
+
+Keep mutation explicit at the terminal method. Prefer names such as `build`,
+`attempt_on`, `apply_to`, `commit`, `execute`, or `finish` when that method is
+the point where side effects happen. Public samples should not hide mutation in
+closures such as `and_then`, `map`, `inspect`, or `for_each` when a named stage
+would be clearer.
+
+Do not force fluent style onto accessors, iterators, simple queries, passive
+reports, primitive/expert APIs, standard trait implementations, or one-step
+operations with no meaningful intermediate state. Keep non-fluent functions
+when they provide real orthogonality, such as trait dispatch hooks or low-level
+primitive operations; remove or hide them when they only duplicate the fluent
+workflow and broaden public surface without adding capability.
 
 ---
 

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -173,6 +173,10 @@ These are not currently implemented:
 - Constrained Delaunay triangulations.
 - Voronoi diagram extraction.
 - Built-in visualization.
+- Multi-threaded construction, proposal coordination, or concurrent topology
+  mutation APIs. Runtime owner/generation provenance exists for caches and
+  detached Pachner proposals, but parallel execution still requires a dedicated
+  synchronization and transaction design.
 - Massively parallel, GPU, or out-of-core construction.
 - Full spherical or hyperbolic triangulation semantics.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,9 @@ Key takeaways from v0.7.8:
 ### v0.8.0 paper-facing API and topology push
 
 v0.8.0 is the next feature-bearing release and is expected to carry the larger
-work intentionally deferred from v0.7.8 cleanup:
+work intentionally deferred from v0.7.8 cleanup. It will require Rust 1.97.0;
+the final release gate is an explicit audit of the 1.97.0 toolchain surface
+before shipping.
 
 - **Pachner/Edit API shape (#252/#253/#350/#337):** unify the Pachner move API,
   expand public flip benchmark coverage, add Monte-Carlo stress benchmarks, and
@@ -51,8 +53,11 @@ work intentionally deferred from v0.7.8 cleanup:
   `SphericalSpace::canonicalize_point()`.
 - **Iterator cleanup (#353):** prefer iterator-based collection-building paths
   where that improves clarity and allocation behavior.
-- **Rust test cleanup (#329):** adopt stable `assert_matches!` in tests now
-  that the MSRV supports it.
+- **Rust 1.97.0 release gate (#329/#496):** raise the v0.8.0 MSRV to Rust
+  1.97.0, finish the baseline `assert_matches!` cleanup, audit the new
+  integer/`NonZero` bit helpers against Hilbert bit-depth/index invariants,
+  review `RepeatN::default` and Cargo 1.97 tooling changes for useful adoption,
+  and re-benchmark predicate `cold_path` decisions under the 1.97.0 compiler.
 
 ### v0.9.0 and later horizon
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -502,16 +502,20 @@ fn main() -> Result<(), FlipExampleError> {
     let Some((simplex_key, _)) = dt.simplices().next() else {
         return Ok(());
     };
-    let info = dt.attempt_pachner(PachnerMove::K1Insert {
-        simplex_key,
-        vertex: vertex![0.1, 0.1, 0.1]?,
-    })?;
+    let info = dt
+        .propose_pachner(PachnerMove::K1Insert {
+            simplex_key,
+            vertex: vertex![0.1, 0.1, 0.1]?,
+        })?
+        .attempt_on(&mut dt)?;
     let inserted_vertex = info.inserted_face_vertices[0];
 
     // k=1 inverse: remove the inserted vertex (collapse its star).
-    let removed = dt.attempt_pachner(PachnerMove::K1Remove {
-        vertex_key: inserted_vertex,
-    })?;
+    let removed = dt
+        .propose_pachner(PachnerMove::K1Remove {
+            vertex_key: inserted_vertex,
+        })?
+        .attempt_on(&mut dt)?;
     assert!(!removed.removed_simplices.is_empty());
 
     // Validate the stack (Levels 1–3) after topological edits.

--- a/examples/delaunayize_repair.rs
+++ b/examples/delaunayize_repair.rs
@@ -177,9 +177,10 @@ fn flip_then_repair_2d() -> Result<(), DelaunayizeRepairExampleError> {
     let mut violating_facet = None;
     for facet in facets {
         let mut trial = dt.clone();
-        if trial.attempt_pachner(PachnerMove::K2 { facet }).is_ok()
-            && trial.is_valid_delaunay().is_err()
-        {
+        let Ok(proposal) = trial.propose_pachner(PachnerMove::K2 { facet }) else {
+            continue;
+        };
+        if proposal.attempt_on(&mut trial).is_ok() && trial.is_valid_delaunay().is_err() {
             violating_facet = Some(facet);
             break;
         }
@@ -190,7 +191,9 @@ fn flip_then_repair_2d() -> Result<(), DelaunayizeRepairExampleError> {
         return Ok(());
     };
 
-    let selected_flip = dt.attempt_pachner(PachnerMove::K2 { facet })?;
+    let selected_flip = dt
+        .propose_pachner(PachnerMove::K2 { facet })?
+        .attempt_on(&mut dt)?;
     assert!(!selected_flip.new_simplices.is_empty());
     match dt.is_valid_delaunay() {
         Ok(()) => {

--- a/examples/diagnostics.rs
+++ b/examples/diagnostics.rs
@@ -142,7 +142,10 @@ fn build_non_delaunay_triangulation_2d()
                 };
                 let facet = FacetHandle::try_new(dt.tds(), simplex_key, facet_index)?;
                 let mut trial = dt.clone();
-                if trial.attempt_pachner(PachnerMove::K2 { facet }).is_ok()
+                let Ok(proposal) = trial.propose_pachner(PachnerMove::K2 { facet }) else {
+                    continue;
+                };
+                if proposal.attempt_on(&mut trial).is_ok()
                     && trial.as_triangulation().validate().is_ok()
                     && matches!(
                         trial.is_valid_delaunay(),

--- a/examples/topology_editing.rs
+++ b/examples/topology_editing.rs
@@ -32,13 +32,21 @@ use delaunay::prelude::geometry::{
 };
 use delaunay::prelude::insertion::InsertionError;
 use delaunay::prelude::pachner::{
-    EdgeKey, EdgeKeyError, FacetError, FacetHandle, FlipError, PachnerMove, PachnerMoves,
-    RidgeHandle, VertexKey,
+    EdgeKey, EdgeKeyError, FacetError, FacetHandle, FlipError, PachnerMove, PachnerMoveResult,
+    PachnerMoves, RidgeHandle, VertexKey,
 };
 use delaunay::prelude::tds::TdsError;
 use delaunay::prelude::validation::DelaunayTriangulationValidationError;
 
 type ExampleResult<T = ()> = Result<T, TopologyEditingExampleError>;
+
+/// Parses and commits one Pachner request on the same topology owner.
+fn attempt_pachner_move<const D: usize>(
+    dt: &mut impl PachnerMoves<D, VertexData = ()>,
+    pachner_move: PachnerMove<(), D>,
+) -> Result<PachnerMoveResult<D>, FlipError> {
+    dt.propose_pachner(pachner_move)?.attempt_on(dt)
+}
 
 #[derive(Debug, thiserror::Error)]
 enum TopologyEditingExampleError {
@@ -201,10 +209,12 @@ fn pachner_2d_k1() -> ExampleResult {
         circumcenter_coords[0], circumcenter_coords[1]
     );
 
-    let flip_info = dt.attempt_pachner(PachnerMove::K1Insert {
-        simplex_key,
-        vertex: vertex!(circumcenter_coords)?,
-    })?;
+    let flip_info = dt
+        .propose_pachner(PachnerMove::K1Insert {
+            simplex_key,
+            vertex: vertex!(circumcenter_coords)?,
+        })?
+        .attempt_on(&mut dt)?;
 
     println!("After k=1 forward:");
     print_stats_2d(&dt);
@@ -219,9 +229,11 @@ fn pachner_2d_k1() -> ExampleResult {
     // Apply inverse k=1 flip (remove vertex)
     println!("\nApplying k=1 inverse (remove vertex):");
     let vertex_to_remove = flip_info.inserted_face_vertices[0];
-    let inverse_info = dt.attempt_pachner(PachnerMove::K1Remove {
-        vertex_key: vertex_to_remove,
-    })?;
+    let inverse_info = dt
+        .propose_pachner(PachnerMove::K1Remove {
+            vertex_key: vertex_to_remove,
+        })?
+        .attempt_on(&mut dt)?;
     assert!(!inverse_info.removed_simplices.is_empty());
 
     println!("After k=1 inverse:");
@@ -263,7 +275,9 @@ fn pachner_2d_k2() -> ExampleResult {
     })?;
 
     println!("\nApplying k=2 flip (flipping diagonal edge):");
-    let flip_info = dt.attempt_pachner(PachnerMove::K2 { facet })?;
+    let flip_info = dt
+        .propose_pachner(PachnerMove::K2 { facet })?
+        .attempt_on(&mut dt)?;
 
     println!("After k=2 forward:");
     print_stats_2d(&dt);
@@ -408,10 +422,12 @@ fn pachner_3d_k1() -> ExampleResult {
         "\nApplying k=1 flip (split tetrahedron at circumcenter [{:.2}, {:.2}, {:.2}]):",
         circumcenter_coords[0], circumcenter_coords[1], circumcenter_coords[2]
     );
-    let flip_info = dt.attempt_pachner(PachnerMove::K1Insert {
-        simplex_key,
-        vertex: vertex!(circumcenter_coords)?,
-    })?;
+    let flip_info = dt
+        .propose_pachner(PachnerMove::K1Insert {
+            simplex_key,
+            vertex: vertex!(circumcenter_coords)?,
+        })?
+        .attempt_on(&mut dt)?;
 
     println!("After k=1 forward:");
     print_stats_3d(&dt);
@@ -423,9 +439,11 @@ fn pachner_3d_k1() -> ExampleResult {
     // Apply inverse
     println!("\nApplying k=1 inverse:");
     let vertex_to_remove = flip_info.inserted_face_vertices[0];
-    let inverse_info = dt.attempt_pachner(PachnerMove::K1Remove {
-        vertex_key: vertex_to_remove,
-    })?;
+    let inverse_info = dt
+        .propose_pachner(PachnerMove::K1Remove {
+            vertex_key: vertex_to_remove,
+        })?
+        .attempt_on(&mut dt)?;
     assert!(!inverse_info.removed_simplices.is_empty());
 
     println!("After k=1 inverse:");
@@ -459,7 +477,7 @@ fn pachner_3d_k2() -> ExampleResult {
 
     // Find an interior facet to flip
     if let Some(facet) = find_interior_facet(&dt)? {
-        match dt.attempt_pachner(PachnerMove::K2 { facet }) {
+        match attempt_pachner_move(&mut dt, PachnerMove::K2 { facet }) {
             Ok(flip_info) => {
                 println!("\nApplied k=2 flip:");
                 print_stats_3d(&dt);
@@ -474,7 +492,7 @@ fn pachner_3d_k2() -> ExampleResult {
                     flip_info.inserted_face_vertices[1],
                 )?;
 
-                match dt.attempt_pachner(PachnerMove::K2Inverse { edge }) {
+                match attempt_pachner_move(&mut dt, PachnerMove::K2Inverse { edge }) {
                     Ok(_) => {
                         println!("After k=2 inverse:");
                         print_stats_3d(&dt);
@@ -531,7 +549,7 @@ fn pachner_3d_k3() -> ExampleResult {
 
     // Try to find and flip a ridge
     if let Some(ridge) = find_flippable_ridge_3d(&dt)? {
-        match dt.attempt_pachner(PachnerMove::K3 { ridge }) {
+        match attempt_pachner_move(&mut dt, PachnerMove::K3 { ridge }) {
             Ok(flip_info) => {
                 println!("\n✓ k=3 flip succeeded:");
                 print_stats_3d(&dt);

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -70,11 +70,14 @@ use std::collections::VecDeque;
 use std::env;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::iter::once;
 use std::time::{Duration, Instant};
 use thiserror::Error;
 
 type VertexKeyList = SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>;
 type RemovedSimplexVertexSnapshot = SmallBuffer<VertexKeyList, MAX_PRACTICAL_DIMENSION_SIZE>;
+type ReplacementSimplexVertices = SmallBuffer<VertexKeyList, MAX_PRACTICAL_DIMENSION_SIZE>;
+type ExternalFacetBuffer = SmallBuffer<FacetHandle, 64>;
 type ReplacementPeriodicOffsets<const D: usize> =
     SmallBuffer<Option<PeriodicOffsetBuffer<D>>, MAX_PRACTICAL_DIMENSION_SIZE>;
 
@@ -429,31 +432,24 @@ where
     )
 }
 
-/// Shared implementation for failure-atomic bistellar mutation.
+/// Builds and validates the replacement side of a bistellar flip without mutating storage.
 ///
-/// The original TDS is mutated only after the trial TDS has been fully rewired
-/// and locally validated. Passing `trial_workspace` lets hot repair paths reuse
-/// rollback storage; leaving it `None` keeps the standalone API's independent
-/// trial allocation behavior.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "Flip mutation needs explicit move, cavity, policy, validation inputs, and optional scratch storage"
-)]
+/// This shared preparation step is the source of truth for both immutable
+/// feasibility checks and the mutating executor's deterministic pre-commit
+/// checks.
 #[expect(
     clippy::too_many_lines,
-    reason = "Keep flip construction, validation, and wiring together for clarity"
+    reason = "Keep exact feasibility checks aligned with the mutating flip preflight"
 )]
-fn apply_bistellar_flip_with_k_inner<U, V, const D: usize>(
-    tds: &mut Tds<U, V, D>,
+fn prepare_bistellar_flip<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
     k_move: usize,
     removed_face_vertices: &[VertexKey],
     inserted_face_vertices: &[VertexKey],
     removed_simplices: &SimplexKeyBuffer,
     direction: FlipDirection,
     orientation_policy: ReplacementOrientationPolicy,
-    validation_scope: FlipValidationScope,
-    trial_workspace: Option<&mut Tds<U, V, D>>,
-) -> Result<AppliedFlip<D>, FlipError>
+) -> Result<PreparedFlip<D>, FlipError>
 where
     U: DataType,
     V: DataType,
@@ -534,10 +530,8 @@ where
         });
     }
 
-    let mut new_simplex_vertices: SmallBuffer<
-        SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>,
-        MAX_PRACTICAL_DIMENSION_SIZE,
-    > = SmallBuffer::with_capacity(removed_face_vertices.len());
+    let mut new_simplex_vertices =
+        ReplacementSimplexVertices::with_capacity(removed_face_vertices.len());
 
     for &omit in removed_face_vertices {
         let mut vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE> =
@@ -641,6 +635,65 @@ where
     // `None`, which would strip the most useful context from predecessor-flip
     // traces (see #204 investigation).
     let removed_simplex_vertices = snapshot_removed_simplex_vertices(tds, removed_simplices)?;
+    let inserted_face_vertex_list: VertexKeyList = inserted_face_vertices.iter().copied().collect();
+
+    Ok(PreparedFlip {
+        kind: BistellarFlipKind { k: k_move, d: D },
+        direction,
+        removed_simplices: removed_simplices.iter().copied().collect(),
+        removed_face_vertices: removed_face_vertices.iter().copied().collect(),
+        inserted_face_vertices: inserted_face_vertex_list,
+        new_simplex_vertices,
+        new_simplex_offsets,
+        external_facets,
+        removed_simplex_vertices,
+    })
+}
+
+/// Shared implementation for failure-atomic bistellar mutation.
+///
+/// The original TDS is mutated only after the trial TDS has been fully rewired
+/// and locally validated. Passing `trial_workspace` lets hot repair paths reuse
+/// rollback storage; leaving it `None` keeps the standalone API's independent
+/// trial allocation behavior.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "Flip mutation needs explicit move, cavity, policy, validation inputs, and optional scratch storage"
+)]
+fn apply_bistellar_flip_with_k_inner<U, V, const D: usize>(
+    tds: &mut Tds<U, V, D>,
+    k_move: usize,
+    removed_face_vertices: &[VertexKey],
+    inserted_face_vertices: &[VertexKey],
+    removed_simplices: &SimplexKeyBuffer,
+    direction: FlipDirection,
+    orientation_policy: ReplacementOrientationPolicy,
+    validation_scope: FlipValidationScope,
+    trial_workspace: Option<&mut Tds<U, V, D>>,
+) -> Result<AppliedFlip<D>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    let PreparedFlip {
+        kind,
+        direction,
+        removed_simplices,
+        removed_face_vertices,
+        inserted_face_vertices,
+        new_simplex_vertices,
+        new_simplex_offsets,
+        external_facets,
+        removed_simplex_vertices,
+    } = prepare_bistellar_flip(
+        tds,
+        k_move,
+        removed_face_vertices,
+        inserted_face_vertices,
+        removed_simplices,
+        direction,
+        orientation_policy,
+    )?;
 
     let apply_to_trial = |trial: &mut Tds<U, V, D>| -> Result<SimplexKeyBuffer, FlipError> {
         let mut new_simplices = SimplexKeyBuffer::new();
@@ -664,12 +717,12 @@ where
             trial,
             &new_simplices,
             external_facets.iter().copied(),
-            Some(removed_simplices),
+            Some(&removed_simplices),
         )
         .map_err(FlipNeighborWiringError::from)?;
 
         trial
-            .remove_simplices_by_keys(removed_simplices)
+            .remove_simplices_by_keys(&removed_simplices)
             .map_err(|source| FlipError::from(FlipMutationError::SimplexRemoval { source }))?;
 
         let validation_result = match validation_scope {
@@ -678,7 +731,7 @@ where
                 trial,
                 &new_simplices,
                 &external_facets,
-                removed_simplices,
+                &removed_simplices,
             ),
         };
         validation_result.map_err(|source| {
@@ -722,12 +775,12 @@ where
 
     Ok(AppliedFlip {
         info: FlipInfo {
-            kind: BistellarFlipKind { k: k_move, d: D },
+            kind,
             direction,
-            removed_simplices: removed_simplices.iter().copied().collect(),
+            removed_simplices,
             new_simplices,
-            removed_face_vertices: removed_face_vertices.iter().copied().collect(),
-            inserted_face_vertices: inserted_face_vertices.iter().copied().collect(),
+            removed_face_vertices,
+            inserted_face_vertices,
         },
         removed_simplex_vertices,
     })
@@ -2324,6 +2377,59 @@ where
         FlipValidationScope::FullTds,
     )?
     .info)
+}
+
+/// Validate a generic k-move without mutating the TDS.
+///
+/// # Errors
+///
+/// Returns a [`FlipError`] if the flip would fail during deterministic
+/// pre-mutation validation.
+pub(crate) fn validate_bistellar_flip<U, V, const D: usize, const K_MOVE: usize>(
+    tds: &Tds<U, V, D>,
+    context: &FlipContext<D, K_MOVE>,
+) -> Result<FlipFeasibility<D>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    Ok(prepare_bistellar_flip(
+        tds,
+        K_MOVE,
+        &context.removed_face_vertices,
+        &context.inserted_face_vertices,
+        &context.removed_simplices,
+        context.direction,
+        ReplacementOrientationPolicy::AllowSigned,
+    )?
+    .into_feasibility())
+}
+
+/// Validate a runtime-k move without mutating the TDS.
+///
+/// # Errors
+///
+/// Returns a [`FlipError`] if the flip would fail during deterministic
+/// pre-mutation validation.
+pub(crate) fn validate_bistellar_flip_dynamic<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    k_move: usize,
+    context: &FlipContextDyn<D>,
+) -> Result<FlipFeasibility<D>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    Ok(prepare_bistellar_flip(
+        tds,
+        k_move,
+        &context.removed_face_vertices,
+        &context.inserted_face_vertices,
+        &context.removed_simplices,
+        context.direction,
+        ReplacementOrientationPolicy::AllowSigned,
+    )?
+    .into_feasibility())
 }
 
 /// Apply a k=2 Delaunay-repair move with positive replacement geometry.
@@ -4181,10 +4287,100 @@ pub struct FlipInfo<const D: usize> {
     pub inserted_face_vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>,
 }
 
-#[derive(Debug, Clone)]
+/// Metadata returned by immutable bistellar flip feasibility checks.
+///
+/// A feasibility report describes the local move that passed deterministic
+/// pre-mutation validation. It intentionally omits `new_simplices`, because
+/// those runtime keys are allocated only by the mutating flip executor.
+/// For forward k=1 insertion, [`inserted_face_vertices`](Self::inserted_face_vertices)
+/// is `None` for the same reason: the inserted vertex key does not exist until
+/// the mutation commits. Other move kinds report the already-live inserted face.
+/// Feasibility checks build only local replacement buffers and do not clone the
+/// full triangulation.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::flips::{BistellarFlipKind, BistellarFlips, FlipDirection};
+/// use delaunay::prelude::construction::{
+///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+/// };
+///
+/// # fn main() -> DelaunayResult<()> {
+/// let vertices = vec![
+///     delaunay::vertex![0.0, 0.0]?,
+///     delaunay::vertex![1.0, 0.0]?,
+///     delaunay::vertex![0.0, 1.0]?,
+/// ];
+/// let dt = DelaunayTriangulationBuilder::new(&vertices)
+///     .topology_guarantee(TopologyGuarantee::PLManifold)
+///     .build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
+///
+/// let vertex = delaunay::vertex![0.25, 0.25]?;
+/// let feasibility = dt.can_flip_k1_insert(simplex_key, &vertex)?;
+/// assert_eq!(feasibility.kind, BistellarFlipKind::k1(2));
+/// assert_eq!(feasibility.direction, FlipDirection::Forward);
+/// assert!(feasibility.inserted_face_vertices.is_none());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use]
+#[non_exhaustive]
+pub struct FlipFeasibility<const D: usize> {
+    /// Flip kind (k, d).
+    pub kind: BistellarFlipKind,
+    /// Flip direction.
+    pub direction: FlipDirection,
+    /// Simplices that the corresponding mutating flip would remove.
+    pub removed_simplices: SimplexKeyBuffer,
+    /// The removed-face simplex shared by the removed simplices.
+    pub removed_face_vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>,
+    /// The inserted complementary face when all of its vertices already exist.
+    ///
+    /// This is `None` for forward k=1 insertion because the inserted vertex key
+    /// is allocated by the mutating executor.
+    pub inserted_face_vertices: Option<SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
+}
+
+#[derive(Debug)]
 struct AppliedFlip<const D: usize> {
     info: FlipInfo<D>,
     removed_simplex_vertices: RemovedSimplexVertexSnapshot,
+}
+
+/// Fully validated local flip preflight shared by dry-run and mutating paths.
+///
+/// Keeping this state in one helper type makes [`FlipFeasibility`] report the
+/// same deterministic pre-mutation decision that the executor uses before it
+/// performs its failure-atomic trial mutation.
+#[derive(Debug)]
+struct PreparedFlip<const D: usize> {
+    kind: BistellarFlipKind,
+    direction: FlipDirection,
+    removed_simplices: SimplexKeyBuffer,
+    removed_face_vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>,
+    inserted_face_vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>,
+    new_simplex_vertices: ReplacementSimplexVertices,
+    new_simplex_offsets: ReplacementPeriodicOffsets<D>,
+    external_facets: ExternalFacetBuffer,
+    removed_simplex_vertices: RemovedSimplexVertexSnapshot,
+}
+
+impl<const D: usize> PreparedFlip<D> {
+    /// Convert a prepared immutable preflight into the public dry-run report.
+    fn into_feasibility(self) -> FlipFeasibility<D> {
+        FlipFeasibility {
+            kind: self.kind,
+            direction: self.direction,
+            removed_simplices: self.removed_simplices,
+            removed_face_vertices: self.removed_face_vertices,
+            inserted_face_vertices: Some(self.inserted_face_vertices),
+        }
+    }
 }
 
 /// Const-generic flip context for a k-move (forward or inverse).
@@ -5557,7 +5753,7 @@ where
         SmallBuffer::with_capacity(1);
     inserted_face_vertices.push(inserted_vertex);
 
-    let removed_simplices: SimplexKeyBuffer = std::iter::once(simplex_key).collect();
+    let removed_simplices: SimplexKeyBuffer = once(simplex_key).collect();
 
     Ok(FlipContext {
         removed_face_vertices,
@@ -5993,6 +6189,23 @@ where
     apply_bistellar_flip::<U, V, D, 2>(tds, context)
 }
 
+/// Validate a k=2 bistellar flip without mutating the TDS.
+///
+/// # Errors
+///
+/// Returns a [`FlipError`] if the flip would fail during deterministic
+/// pre-mutation validation.
+pub(crate) fn validate_bistellar_flip_k2<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    context: &FlipContext<D, 2>,
+) -> Result<FlipFeasibility<D>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    validate_bistellar_flip::<U, V, D, 2>(tds, context)
+}
+
 /// Build flip context for a k=3 (ridge) flip.
 ///
 /// # Errors
@@ -6361,6 +6574,89 @@ where
     apply_bistellar_flip::<U, V, D, 3>(tds, context)
 }
 
+/// Validate a k=3 bistellar flip without mutating the TDS.
+///
+/// # Errors
+///
+/// Returns a [`FlipError`] if the flip would fail during deterministic
+/// pre-mutation validation.
+pub(crate) fn validate_bistellar_flip_k3<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    context: &FlipContext<D, 3>,
+) -> Result<FlipFeasibility<D>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    validate_bistellar_flip::<U, V, D, 3>(tds, context)
+}
+
+/// Validate a forward k=1 move (simplex split) without mutating the TDS.
+///
+/// # Errors
+///
+/// Returns a [`FlipError`] if the simplex is missing, the vertex UUID is already
+/// present, or the replacement simplices would be degenerate.
+pub(crate) fn validate_bistellar_flip_k1_insert<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    simplex_key: SimplexKey,
+    vertex: &Vertex<U, D>,
+) -> Result<FlipFeasibility<D>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    if D < 1 {
+        return Err(FlipError::UnsupportedDimension { dimension: D });
+    }
+
+    let vertex_uuid = vertex.uuid();
+    if tds.vertex_key_from_uuid(&vertex_uuid).is_some() {
+        return Err(FlipError::from(FlipMutationError::VertexInsertion {
+            source: TdsConstructionFailure::DuplicateUuid {
+                entity: EntityKind::Vertex,
+                uuid: vertex_uuid,
+            },
+        }));
+    }
+
+    let simplex = tds
+        .simplex(simplex_key)
+        .ok_or(FlipError::MissingSimplex { simplex_key })?;
+    let removed_face_vertices: VertexKeyList = simplex.vertices().iter().copied().collect();
+
+    for &omit in &removed_face_vertices {
+        let mut points: SmallBuffer<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE> =
+            SmallBuffer::with_capacity(D + 1);
+        points.push(*vertex.point());
+        for &vkey in &removed_face_vertices {
+            if vkey != omit {
+                points.push(vertex_point(tds, vkey)?);
+            }
+        }
+
+        match robust_orientation(&points) {
+            Ok(Orientation::POSITIVE | Orientation::NEGATIVE) => {}
+            Ok(Orientation::DEGENERATE) => return Err(FlipError::DegenerateSimplex),
+            Err(error) => {
+                return Err(FlipPredicateError::coordinate_conversion(
+                    FlipPredicateOperation::ReplacementSimplexOrientation,
+                    error,
+                )
+                .into());
+            }
+        }
+    }
+
+    Ok(FlipFeasibility {
+        kind: BistellarFlipKind::k1(D),
+        direction: FlipDirection::Forward,
+        removed_simplices: once(simplex_key).collect(),
+        removed_face_vertices,
+        inserted_face_vertices: None,
+    })
+}
+
 /// Apply a forward k=1 move (simplex split) by inserting a new vertex.
 ///
 /// # Errors
@@ -6428,6 +6724,28 @@ where
     let _ = tds.remove_vertex(vertex_key);
 
     Ok(info)
+}
+
+/// Validate an inverse k=1 move (vertex collapse) without mutating the TDS.
+///
+/// # Errors
+///
+/// Returns a [`FlipError`] if the vertex star is invalid or the replacement
+/// simplex would be degenerate.
+pub(crate) fn validate_bistellar_flip_k1_inverse<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    vertex_key: VertexKey,
+) -> Result<FlipFeasibility<D>, FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    if D < 1 {
+        return Err(FlipError::UnsupportedDimension { dimension: D });
+    }
+
+    let context = build_k1_inverse_context(tds, vertex_key)?;
+    validate_bistellar_flip_dynamic(tds, D + 1, &context)
 }
 
 /// Repair Delaunay violations using a k=2 flip queue.
@@ -10650,13 +10968,13 @@ mod tests {
                         .insert_simplex_with_mapping(Simplex::try_new_with_data(vertices.clone(), None).unwrap())
                         .unwrap();
 
-                    let removed_simplices: SimplexKeyBuffer = std::iter::once(simplex_key).collect();
+                    let removed_simplices: SimplexKeyBuffer = once(simplex_key).collect();
                     let snapshot = snapshot_removed_simplex_vertices(&tds, &removed_simplices).unwrap();
                     assert_eq!(snapshot.len(), 1);
                     assert_eq!(snapshot[0].iter().copied().collect::<Vec<_>>(), vertices);
 
                     let missing_simplex = SimplexKey::from(KeyData::from_ffi(999_999 + $dim));
-                    let missing_simplices: SimplexKeyBuffer = std::iter::once(missing_simplex).collect();
+                    let missing_simplices: SimplexKeyBuffer = once(missing_simplex).collect();
                     let err = snapshot_removed_simplex_vertices(&tds, &missing_simplices).unwrap_err();
                     assert_matches!(
                         err,
@@ -10680,8 +10998,8 @@ mod tests {
                         info: FlipInfo {
                             kind: BistellarFlipKind::k2($dim),
                             direction: FlipDirection::Forward,
-                            removed_simplices: std::iter::once(removed_simplex).collect(),
-                            new_simplices: std::iter::once(new_simplex).collect(),
+                            removed_simplices: once(removed_simplex).collect(),
+                            new_simplices: once(new_simplex).collect(),
                             removed_face_vertices: [v3, v1].into_iter().collect(),
                             inserted_face_vertices: [v4, v2].into_iter().collect(),
                         },
@@ -10834,8 +11152,8 @@ mod tests {
                 info: FlipInfo {
                     kind: BistellarFlipKind::k2(3),
                     direction: FlipDirection::Forward,
-                    removed_simplices: std::iter::once(self.upper_tetrahedron).collect(),
-                    new_simplices: std::iter::once(self.lower_neighbor).collect(),
+                    removed_simplices: once(self.upper_tetrahedron).collect(),
+                    new_simplices: once(self.lower_neighbor).collect(),
                     removed_face_vertices: [
                         self.origin_vertex,
                         self.x_axis_vertex,
@@ -12009,7 +12327,7 @@ mod tests {
         let first_inserted_sample = InsertedSimplexSkipSample {
             location: RepairSkipLocation::Facet(facet),
             removed_face: [v0, v1].into_iter().collect(),
-            inserted_face: std::iter::once(v2).collect(),
+            inserted_face: once(v2).collect(),
         };
         diagnostics.record_inserted_simplex_skip(first_inserted_sample.clone());
         assert_eq!(diagnostics.inserted_simplex_skips, 1);
@@ -12020,7 +12338,7 @@ mod tests {
 
         diagnostics.record_inserted_simplex_skip(InsertedSimplexSkipSample {
             location: RepairSkipLocation::Edge(edge),
-            removed_face: std::iter::once(v1).collect(),
+            removed_face: once(v1).collect(),
             inserted_face: [v0, v2].into_iter().collect(),
         });
         assert_eq!(diagnostics.inserted_simplex_skips, 2);
@@ -12073,7 +12391,7 @@ mod tests {
         let triangle = TriangleHandle::try_new(v0, v1, v2).unwrap();
 
         let removed_face: VertexKeyList = [v0, v1].into_iter().collect();
-        let inserted_face: VertexKeyList = std::iter::once(v2).collect();
+        let inserted_face: VertexKeyList = once(v2).collect();
         let inserted_sample = InsertedSimplexSkipSample {
             location: RepairSkipLocation::Facet(facet),
             removed_face: removed_face.clone(),
@@ -13068,6 +13386,17 @@ mod tests {
 
         let facet = FacetHandle::from_validated(c1, 2); // facet opposite vertex index 2 (edge AB)
         let context = build_k2_flip_context(&tds, facet).unwrap();
+        let feasibility = validate_bistellar_flip_k2(&tds, &context).unwrap();
+        assert_eq!(feasibility.kind, BistellarFlipKind::k2(2));
+        assert_eq!(feasibility.direction, FlipDirection::Forward);
+        assert_eq!(feasibility.removed_simplices.len(), 2);
+        assert_eq!(
+            feasibility
+                .inserted_face_vertices
+                .as_ref()
+                .map(SmallBuffer::len),
+            Some(2)
+        );
         let info = apply_bistellar_flip_k2(&mut tds, &context).unwrap();
 
         assert_eq!(info.removed_simplices.len(), 2);
@@ -13119,6 +13448,8 @@ mod tests {
 
         let facet = FacetHandle::from_validated(c1, 2); // facet opposite vertex index 2 (edge AB)
         let context = build_k2_flip_context(&tds, facet).unwrap();
+        let feasibility = validate_bistellar_flip_k2(&tds, &context);
+        assert_matches!(feasibility, Err(FlipError::DuplicateSimplex));
         let result = apply_bistellar_flip_k2(&mut tds, &context);
 
         assert_matches!(result, Err(FlipError::DuplicateSimplex));
@@ -13184,6 +13515,11 @@ mod tests {
         let facet = FacetHandle::from_validated(simplex_a, 0);
         let ctx = build_k2_flip_context(&tds, facet).unwrap();
 
+        let feasibility = validate_bistellar_flip_k2(&tds, &ctx);
+        assert_matches!(
+            feasibility,
+            Err(FlipError::InsertedSimplexAlreadyExists { .. })
+        );
         let result = apply_bistellar_flip_k2(&mut tds, &ctx);
 
         assert_matches!(result, Err(FlipError::InsertedSimplexAlreadyExists { .. }));
@@ -13232,6 +13568,8 @@ mod tests {
 
         let facet = FacetHandle::from_validated(c1, 2); // facet opposite vertex index 2 (edge AB)
         let context = build_k2_flip_context(&tds, facet).unwrap();
+        let feasibility = validate_bistellar_flip_k2(&tds, &context);
+        assert_matches!(feasibility, Err(FlipError::NonManifoldFacet));
         let result = apply_bistellar_flip_k2(&mut tds, &context);
 
         assert_matches!(result, Err(FlipError::NonManifoldFacet));
@@ -16247,8 +16585,7 @@ mod tests {
             periodic_inverse_k2_fixture::<4>();
         let topology_model = toroidal_model::<4>();
         let frame_simplex = removed_simplex_frame(&removed_simplices).unwrap();
-        let truncated_removed_simplices: SimplexKeyBuffer =
-            std::iter::once(frame_simplex).collect();
+        let truncated_removed_simplices: SimplexKeyBuffer = once(frame_simplex).collect();
         let lift_result = vertex_point_lifted_into_simplex(
             &tds,
             &topology_model,

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -45,7 +45,7 @@ use crate::core::operations::TopologicalOperation;
 use crate::core::simplex::{NeighborSlot, Simplex, SimplexValidationError};
 use crate::core::tds::{
     EntityKind, NeighborValidationError, SimplexKey, Tds, TdsMutationError, TdsRollbackTransaction,
-    VertexKey,
+    TopologyOwnerId, VertexKey,
 };
 use crate::core::traits::data_type::DataType;
 use crate::core::triangulation::Triangulation;
@@ -3105,6 +3105,14 @@ pub enum FlipContextError {
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FlipFailureKind {
+    /// [`PachnerProposal`](crate::pachner::PachnerProposal) belongs to a
+    /// different topology owner.
+    #[error("wrong topology owner")]
+    WrongTopologyOwner,
+    /// [`PachnerProposal`](crate::pachner::PachnerProposal) was minted before
+    /// the current topology generation.
+    #[error("stale topology proposal")]
+    StaleTopologyProposal,
     /// Flips are not supported for this dimension.
     #[error("unsupported dimension")]
     UnsupportedDimension,
@@ -3894,6 +3902,26 @@ pub enum FlipVertexAdjacencyError {
 #[derive(Clone, Debug, Error, PartialEq)]
 #[non_exhaustive]
 pub enum FlipError {
+    /// A [`PachnerProposal`](crate::pachner::PachnerProposal) was minted from a
+    /// different owner.
+    #[error("Topology proposal owner mismatch: expected {expected:?}, found {found:?}")]
+    WrongTopologyOwner {
+        /// Owner identity of the triangulation receiving the proposal.
+        expected: TopologyOwnerId,
+        /// Owner identity stored in the detached proposal.
+        found: TopologyOwnerId,
+    },
+    /// A [`PachnerProposal`](crate::pachner::PachnerProposal) was minted from an
+    /// older structural generation.
+    #[error(
+        "Topology proposal generation {proposal_generation} is stale for current generation {current_generation}"
+    )]
+    StaleTopologyProposal {
+        /// Structural generation stored in the detached proposal.
+        proposal_generation: u64,
+        /// Current structural generation of the target triangulation.
+        current_generation: u64,
+    },
     /// Flips are not supported for this dimension.
     #[error("Bistellar flip not supported for D={dimension}")]
     UnsupportedDimension {
@@ -4182,6 +4210,8 @@ impl From<FlipMutationError> for FlipError {
 impl From<&FlipError> for FlipFailureKind {
     fn from(source: &FlipError) -> Self {
         match source {
+            FlipError::WrongTopologyOwner { .. } => Self::WrongTopologyOwner,
+            FlipError::StaleTopologyProposal { .. } => Self::StaleTopologyProposal,
             FlipError::UnsupportedDimension { .. } => Self::UnsupportedDimension,
             FlipError::BoundaryFacet { .. } => Self::BoundaryFacet,
             FlipError::MissingSimplex { .. } => Self::MissingSimplex,

--- a/src/core/simplex.rs
+++ b/src/core/simplex.rs
@@ -82,6 +82,8 @@ use serde::{
     de::{self, IgnoredAny, MapAccess, Visitor},
     ser::SerializeStruct,
 };
+#[cfg(test)]
+use std::iter::once;
 use std::{
     cmp,
     fmt::{self, Debug},
@@ -3029,12 +3031,9 @@ mod tests {
 
         let uuid1 = simplex1.uuid();
         let uuid2 = simplex2.uuid();
-        let hashmap = Simplex::try_into_hashmap(
-            std::iter::once(simplex1)
-                .chain(std::iter::once(simplex2))
-                .chain(simplices_iter),
-        )
-        .unwrap();
+        let hashmap =
+            Simplex::try_into_hashmap(once(simplex1).chain(once(simplex2)).chain(simplices_iter))
+                .unwrap();
 
         assert!(hashmap.len() >= 2);
         assert!(hashmap.contains_key(&uuid1));

--- a/src/core/tds/storage.rs
+++ b/src/core/tds/storage.rs
@@ -350,6 +350,70 @@ use std::{
 };
 use uuid::Uuid;
 
+/// Opaque runtime identity for one live topology owner.
+///
+/// `TopologyOwnerId` is a proof token, not durable serialized identity. It is
+/// minted from a live [`Tds`]. Cloning a `TopologyOwnerId` preserves the same
+/// proof token, while cloning or deserializing the owning `Tds` mints a fresh
+/// token so detached proposals from one storage owner cannot be mistaken for
+/// proposals from another owner.
+///
+/// # Examples
+///
+/// ```
+/// use delaunay::prelude::tds::Tds;
+///
+/// let tds: Tds<(), (), 2> = Tds::empty();
+/// let cloned = tds.clone();
+///
+/// assert_ne!(tds.topology_owner_id(), cloned.topology_owner_id());
+/// ```
+#[derive(Clone, Debug)]
+#[must_use]
+pub struct TopologyOwnerId {
+    identity: Arc<Uuid>,
+}
+
+impl TopologyOwnerId {
+    /// Creates an owner token from the live runtime identity stored in a [`Tds`].
+    pub(crate) fn from_identity(identity: &Arc<Uuid>) -> Self {
+        Self {
+            identity: Arc::clone(identity),
+        }
+    }
+}
+
+impl PartialEq for TopologyOwnerId {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.identity, &other.identity)
+    }
+}
+
+impl Eq for TopologyOwnerId {}
+
+/// Trait for values that own a canonical topology storage identity.
+///
+/// Pachner proposals and other detached topology artifacts use this trait to
+/// reject cross-owner reuse before interpreting runtime-local keys.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::prelude::tds::{Tds, TopologyOwner};
+///
+/// let tds: Tds<(), (), 2> = Tds::empty();
+///
+/// assert_eq!(tds.topology_owner_id(), tds.topology_owner_id());
+/// assert_eq!(tds.topology_generation(), tds.generation());
+/// ```
+pub trait TopologyOwner {
+    /// Returns the runtime identity token for the canonical topology owner.
+    fn topology_owner_id(&self) -> TopologyOwnerId;
+
+    /// Returns the current structural generation for the canonical topology owner.
+    fn topology_generation(&self) -> u64;
+}
+
 #[derive(Debug)]
 /// The `Tds` struct represents a triangulation data structure with vertices
 /// and simplices, where the vertices and simplices are identified by UUIDs.
@@ -1552,6 +1616,26 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         self.generation.load(Ordering::Relaxed)
     }
 
+    /// Returns the opaque runtime identity token for this topology owner.
+    ///
+    /// Cloning a [`Tds`] creates a fresh owner identity, while internal rollback
+    /// snapshots preserve the identity of the owner they protect.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use delaunay::prelude::tds::Tds;
+    ///
+    /// let tds: Tds<(), (), 3> = Tds::empty();
+    /// let owner = tds.topology_owner_id();
+    ///
+    /// assert_eq!(owner, tds.topology_owner_id());
+    /// ```
+    #[inline]
+    pub fn topology_owner_id(&self) -> TopologyOwnerId {
+        TopologyOwnerId::from_identity(&self.identity)
+    }
+
     /// Returns the runtime identity used by cache owners to reject handles from another TDS.
     #[inline]
     pub(crate) const fn identity(&self) -> &Arc<Uuid> {
@@ -1569,6 +1653,18 @@ impl<U, V, const D: usize> Tds<U, V, D> {
 }
 
 impl<U, V, const D: usize> Tds<U, V, D> {}
+
+impl<U, V, const D: usize> TopologyOwner for Tds<U, V, D> {
+    #[inline]
+    fn topology_owner_id(&self) -> TopologyOwnerId {
+        Self::topology_owner_id(self)
+    }
+
+    #[inline]
+    fn topology_generation(&self) -> u64 {
+        self.generation()
+    }
+}
 
 impl<U, V, const D: usize> Tds<U, V, D> {
     /// Returns a validated borrowed view of a simplex's vertex keys.

--- a/src/core/triangulation.rs
+++ b/src/core/triangulation.rs
@@ -12,7 +12,9 @@
 
 #![forbid(unsafe_code)]
 
-use crate::core::tds::{SimplexKey, Tds, TdsMutationError, VertexKey};
+use crate::core::tds::{
+    SimplexKey, Tds, TdsMutationError, TopologyOwner, TopologyOwnerId, VertexKey,
+};
 use crate::core::validation::{TopologyGuarantee, ValidationPolicy};
 use crate::geometry::kernel::Kernel;
 use crate::topology::traits::topological_space::GlobalTopology;
@@ -44,6 +46,18 @@ pub struct Triangulation<K, U, V, const D: usize> {
     pub(crate) global_topology: GlobalTopology<D>,
     pub(crate) validation_policy: ValidationPolicy,
     pub(crate) topology_guarantee: TopologyGuarantee,
+}
+
+impl<K, U, V, const D: usize> TopologyOwner for Triangulation<K, U, V, D> {
+    #[inline]
+    fn topology_owner_id(&self) -> TopologyOwnerId {
+        self.tds.topology_owner_id()
+    }
+
+    #[inline]
+    fn topology_generation(&self) -> u64 {
+        self.tds.generation()
+    }
 }
 
 // =============================================================================

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -110,6 +110,7 @@ use rand::seq::SliceRandom;
 use std::{
     env,
     hash::{Hash, Hasher},
+    iter::once,
     num::NonZeroUsize,
     time::{Duration, Instant},
 };
@@ -2385,11 +2386,7 @@ fn dedup_vertices_epsilon_quantized<U, const D: usize>(
         let coords = v.point().coords();
         let Some(base_key) = quantize_coords(coords, inv_cell) else {
             return dedup_vertices_epsilon_n2(
-                unique
-                    .into_iter()
-                    .chain(std::iter::once(v))
-                    .chain(iter)
-                    .collect(),
+                unique.into_iter().chain(once(v)).chain(iter).collect(),
                 epsilon,
             );
         };

--- a/src/delaunay/flips.rs
+++ b/src/delaunay/flips.rs
@@ -14,8 +14,8 @@ pub use crate::core::algorithms::flips::{
     DelaunayRepairHeuristicVertexContext, DelaunayRepairOrientationCanonicalizationFailure,
     DelaunayRepairOrientationCanonicalizationFailureKind, DelaunayRepairPostconditionFailure,
     DelaunayRepairStats, DelaunayRepairVerificationContext, FlipContextError, FlipDirection,
-    FlipEdgeAdjacencyError, FlipError, FlipFailureKind, FlipInfo, FlipMutationError,
-    FlipNeighborCavityFailureKind, FlipNeighborDelaunayValidationFailureKind,
+    FlipEdgeAdjacencyError, FlipError, FlipFailureKind, FlipFeasibility, FlipInfo,
+    FlipMutationError, FlipNeighborCavityFailureKind, FlipNeighborDelaunayValidationFailureKind,
     FlipNeighborHullExtensionFailureKind, FlipNeighborRepairDiagnostics, FlipNeighborRepairFailure,
     FlipNeighborWiringError, FlipOrientationCheckStage, FlipPredicateError, FlipPredicateOperation,
     FlipTriangleAdjacencyError, FlipVertexAdjacencyError, RepairQueueOrder, RidgeHandle,
@@ -28,6 +28,8 @@ use crate::core::algorithms::flips::{
     apply_bistellar_flip_dynamic, apply_bistellar_flip_k1, apply_bistellar_flip_k1_inverse,
     apply_bistellar_flip_k2, apply_bistellar_flip_k3, build_k2_flip_context,
     build_k2_flip_context_from_edge, build_k3_flip_context, build_k3_flip_context_from_triangle,
+    validate_bistellar_flip_dynamic, validate_bistellar_flip_k1_insert,
+    validate_bistellar_flip_k1_inverse, validate_bistellar_flip_k2, validate_bistellar_flip_k3,
 };
 #[cfg(test)]
 use crate::core::facet::FacetError;
@@ -123,6 +125,56 @@ pub trait BistellarFlips<const D: usize> {
         vertex: Vertex<Self::VertexData, D>,
     ) -> Result<FlipInfo<D>, FlipError>;
 
+    /// Validate a forward k=1 move (simplex split) without mutating topology.
+    ///
+    /// This checks the same deterministic pre-mutation conditions as
+    /// [`Self::flip_k1_insert`] on the same triangulation state, including
+    /// simplex liveness, duplicate inserted-vertex UUIDs, and exact
+    /// replacement-simplex degeneracy. The returned feasibility report omits
+    /// the inserted vertex key because that key is allocated only by the
+    /// mutating executor.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError`] when the corresponding mutating operation would
+    /// fail during deterministic pre-mutation validation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::flips::{BistellarFlipKind, BistellarFlips, FlipDirection};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     delaunay::vertex![0.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![1.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 1.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 0.0, 1.0]?,
+    /// ];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let vertex = delaunay::vertex![0.25, 0.25, 0.25]?;
+    ///
+    /// let feasibility = dt.can_flip_k1_insert(simplex_key, &vertex)?;
+    /// assert_eq!(feasibility.kind, BistellarFlipKind::k1(3));
+    /// assert_eq!(feasibility.direction, FlipDirection::Forward);
+    /// assert!(feasibility.inserted_face_vertices.is_none());
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn can_flip_k1_insert(
+        &self,
+        simplex_key: SimplexKey,
+        vertex: &Vertex<Self::VertexData, D>,
+    ) -> Result<FlipFeasibility<D>, FlipError>;
+
     /// Apply an inverse k=1 move (vertex collapse).
     ///
     /// # Errors
@@ -168,6 +220,50 @@ pub trait BistellarFlips<const D: usize> {
     /// # }
     /// ```
     fn flip_k1_remove(&mut self, vertex_key: VertexKey) -> Result<FlipInfo<D>, FlipError>;
+
+    /// Validate an inverse k=1 move (vertex collapse) without mutating topology.
+    ///
+    /// This checks the same deterministic pre-mutation conditions as
+    /// [`Self::flip_k1_remove`] on the same triangulation state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError`] when the corresponding mutating operation would
+    /// fail during deterministic pre-mutation validation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::flips::{BistellarFlipKind, BistellarFlips, FlipDirection};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     delaunay::vertex![0.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![1.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 1.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 0.0, 1.0]?,
+    /// ];
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let inserted = dt.flip_k1_insert(simplex_key, delaunay::vertex![0.25, 0.25, 0.25]?)?;
+    /// let [inserted_vertex] = inserted.inserted_face_vertices.as_slice() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let feasibility = dt.can_flip_k1_remove(*inserted_vertex)?;
+    /// assert_eq!(feasibility.kind, BistellarFlipKind::k1(3).inverse());
+    /// assert_eq!(feasibility.direction, FlipDirection::Inverse);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn can_flip_k1_remove(&self, vertex_key: VertexKey) -> Result<FlipFeasibility<D>, FlipError>;
 
     /// Apply a k=2 facet flip (forward).
     ///
@@ -218,6 +314,68 @@ pub trait BistellarFlips<const D: usize> {
     /// ```
     fn flip_k2(&mut self, facet: FacetHandle) -> Result<FlipInfo<D>, FlipError>;
 
+    /// Validate a k=2 facet flip without mutating topology.
+    ///
+    /// This checks the same deterministic pre-mutation conditions as
+    /// [`Self::flip_k2`] on the same triangulation state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError`] when the corresponding mutating operation would
+    /// fail during deterministic pre-mutation validation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::flips::{BistellarFlipKind, BistellarFlips, FacetHandle};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder,
+    ///     DelaunayTriangulationConstructionError,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     delaunay::vertex![0.0, 0.0]?,
+    ///     delaunay::vertex![1.0, 0.0]?,
+    ///     delaunay::vertex![1.0, 1.0]?,
+    ///     delaunay::vertex![0.0, 1.0]?,
+    /// ];
+    /// let simplices = vec![vec![0, 1, 2], vec![0, 2, 3]];
+    /// let dt = DelaunayTriangulationBuilder::try_from_vertices_and_simplices(
+    ///     &vertices,
+    ///     &simplices,
+    /// )
+    /// .map_err(DelaunayTriangulationConstructionError::from)?
+    /// .build::<()>()?;
+    ///
+    /// let mut accepted = None;
+    /// 'simplices: for (simplex_key, simplex) in dt.simplices() {
+    ///     let Some(neighbors) = simplex.neighbors() else {
+    ///         continue;
+    ///     };
+    ///     for (facet_index, neighbor) in neighbors.enumerate() {
+    ///         if neighbor.is_none() {
+    ///             continue;
+    ///         }
+    ///         let Ok(facet_index) = u8::try_from(facet_index) else {
+    ///             continue;
+    ///         };
+    ///         let Ok(facet) = FacetHandle::try_new(dt.tds(), simplex_key, facet_index) else {
+    ///             continue;
+    ///         };
+    ///         if let Ok(feasibility) = dt.can_flip_k2(facet) {
+    ///             accepted = Some(feasibility);
+    ///             break 'simplices;
+    ///         }
+    ///     }
+    /// }
+    ///
+    /// assert_eq!(accepted.map(|feasibility| feasibility.kind), Some(BistellarFlipKind::k2(2)));
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn can_flip_k2(&self, facet: FacetHandle) -> Result<FlipFeasibility<D>, FlipError>;
+
     /// Apply a k=3 ridge flip (forward).
     ///
     /// # Errors
@@ -256,6 +414,48 @@ pub trait BistellarFlips<const D: usize> {
     /// ```
     fn flip_k3(&mut self, ridge: RidgeHandle) -> Result<FlipInfo<D>, FlipError>;
 
+    /// Validate a k=3 ridge flip without mutating topology.
+    ///
+    /// This checks the same deterministic pre-mutation conditions as
+    /// [`Self::flip_k3`] on the same triangulation state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError`] when the corresponding mutating operation would
+    /// fail during deterministic pre-mutation validation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::flips::{BistellarFlips, FlipError, RidgeHandle};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     delaunay::vertex![0.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![1.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 1.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 0.0, 1.0]?,
+    /// ];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let Ok(ridge) = RidgeHandle::try_new(dt.tds(), simplex_key, 0, 1) else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let result = dt.can_flip_k3(ridge);
+    /// std::assert_matches!(result, Err(FlipError::InvalidRidgeMultiplicity { .. }));
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn can_flip_k3(&self, ridge: RidgeHandle) -> Result<FlipFeasibility<D>, FlipError>;
+
     /// Apply an inverse k=2 flip from an edge star (D >= 3).
     ///
     /// # Errors
@@ -263,6 +463,52 @@ pub trait BistellarFlips<const D: usize> {
     /// Returns [`FlipError`] if the edge star is invalid or the inverse flip
     /// would create invalid topology.
     fn flip_k2_inverse_from_edge(&mut self, edge: EdgeKey) -> Result<FlipInfo<D>, FlipError>;
+
+    /// Validate an inverse k=2 edge-star flip without mutating topology.
+    ///
+    /// This checks the same deterministic pre-mutation conditions as
+    /// [`Self::flip_k2_inverse_from_edge`] on the same triangulation state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError`] when the corresponding mutating operation would
+    /// fail during deterministic pre-mutation validation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::flips::{BistellarFlips, EdgeKey, FlipError};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     delaunay::vertex![0.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![1.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 1.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 0.0, 1.0]?,
+    /// ];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let [a, b, ..] = simplex.vertices() else {
+    ///     return Ok(());
+    /// };
+    /// let Ok(edge) = EdgeKey::try_new(dt.tds(), *a, *b) else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let result = dt.can_flip_k2_inverse_from_edge(edge);
+    /// std::assert_matches!(result, Err(FlipError::InvalidEdgeMultiplicity { .. }));
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn can_flip_k2_inverse_from_edge(&self, edge: EdgeKey)
+    -> Result<FlipFeasibility<D>, FlipError>;
 
     /// Apply an inverse k=3 flip from a triangle star (D >= 4).
     ///
@@ -276,6 +522,57 @@ pub trait BistellarFlips<const D: usize> {
         &mut self,
         triangle: TriangleHandle,
     ) -> Result<FlipInfo<D>, FlipError>;
+
+    /// Validate an inverse k=3 triangle-star flip without mutating topology.
+    ///
+    /// If `D < 4`, this returns [`FlipError::UnsupportedDimension`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError`] when the corresponding mutating operation would
+    /// fail during deterministic pre-mutation validation.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::flips::{BistellarFlips, FlipError, TriangleHandle};
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     delaunay::vertex![0.0, 0.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![1.0, 0.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 1.0, 0.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 0.0, 1.0, 0.0]?,
+    ///     delaunay::vertex![0.0, 0.0, 0.0, 1.0]?,
+    /// ];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((_, simplex)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    /// let [a, b, c, ..] = simplex.vertices() else {
+    ///     return Ok(());
+    /// };
+    /// let Ok(triangle) = TriangleHandle::try_new(*a, *b, *c) else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let result = dt.can_flip_k3_inverse_from_triangle(triangle);
+    /// std::assert_matches!(
+    ///     result,
+    ///     Err(FlipError::InvalidTriangleMultiplicity { .. })
+    /// );
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn can_flip_k3_inverse_from_triangle(
+        &self,
+        triangle: TriangleHandle,
+    ) -> Result<FlipFeasibility<D>, FlipError>;
 }
 
 impl<K, U, V, const D: usize> BistellarFlips<D> for Triangulation<K, U, V, D>
@@ -293,8 +590,20 @@ where
         apply_bistellar_flip_k1(&mut self.tds, simplex_key, vertex)
     }
 
+    fn can_flip_k1_insert(
+        &self,
+        simplex_key: SimplexKey,
+        vertex: &Vertex<U, D>,
+    ) -> Result<FlipFeasibility<D>, FlipError> {
+        validate_bistellar_flip_k1_insert(&self.tds, simplex_key, vertex)
+    }
+
     fn flip_k1_remove(&mut self, vertex_key: VertexKey) -> Result<FlipInfo<D>, FlipError> {
         apply_bistellar_flip_k1_inverse(&mut self.tds, vertex_key)
+    }
+
+    fn can_flip_k1_remove(&self, vertex_key: VertexKey) -> Result<FlipFeasibility<D>, FlipError> {
+        validate_bistellar_flip_k1_inverse(&self.tds, vertex_key)
     }
 
     fn flip_k2(&mut self, facet: FacetHandle) -> Result<FlipInfo<D>, FlipError> {
@@ -302,14 +611,32 @@ where
         apply_bistellar_flip_k2(&mut self.tds, &context)
     }
 
+    fn can_flip_k2(&self, facet: FacetHandle) -> Result<FlipFeasibility<D>, FlipError> {
+        let context = build_k2_flip_context(&self.tds, facet)?;
+        validate_bistellar_flip_k2(&self.tds, &context)
+    }
+
     fn flip_k3(&mut self, ridge: RidgeHandle) -> Result<FlipInfo<D>, FlipError> {
         let context = build_k3_flip_context(&self.tds, ridge)?;
         apply_bistellar_flip_k3(&mut self.tds, &context)
     }
 
+    fn can_flip_k3(&self, ridge: RidgeHandle) -> Result<FlipFeasibility<D>, FlipError> {
+        let context = build_k3_flip_context(&self.tds, ridge)?;
+        validate_bistellar_flip_k3(&self.tds, &context)
+    }
+
     fn flip_k2_inverse_from_edge(&mut self, edge: EdgeKey) -> Result<FlipInfo<D>, FlipError> {
         let context = build_k2_flip_context_from_edge(&self.tds, edge)?;
         apply_bistellar_flip_dynamic(&mut self.tds, D, &context)
+    }
+
+    fn can_flip_k2_inverse_from_edge(
+        &self,
+        edge: EdgeKey,
+    ) -> Result<FlipFeasibility<D>, FlipError> {
+        let context = build_k2_flip_context_from_edge(&self.tds, edge)?;
+        validate_bistellar_flip_dynamic(&self.tds, D, &context)
     }
 
     fn flip_k3_inverse_from_triangle(
@@ -329,6 +656,25 @@ where
             .ok_or(FlipError::UnsupportedDimension { dimension: D })?;
 
         apply_bistellar_flip_dynamic(&mut self.tds, k_move, &context)
+    }
+
+    fn can_flip_k3_inverse_from_triangle(
+        &self,
+        triangle: TriangleHandle,
+    ) -> Result<FlipFeasibility<D>, FlipError> {
+        if D < 4 {
+            return Err(FlipError::UnsupportedDimension { dimension: D });
+        }
+
+        let context = build_k3_flip_context_from_triangle(&self.tds, triangle)?;
+
+        // Avoid const-eval underflow for invalid instantiations (e.g. D=0), even though
+        // the public contract for this method requires D>=4.
+        let k_move = D
+            .checked_sub(1)
+            .ok_or(FlipError::UnsupportedDimension { dimension: D })?;
+
+        validate_bistellar_flip_dynamic(&self.tds, k_move, &context)
     }
 }
 
@@ -351,12 +697,24 @@ where
         result
     }
 
+    fn can_flip_k1_insert(
+        &self,
+        simplex_key: SimplexKey,
+        vertex: &Vertex<U, D>,
+    ) -> Result<FlipFeasibility<D>, FlipError> {
+        self.tri.can_flip_k1_insert(simplex_key, vertex)
+    }
+
     fn flip_k1_remove(&mut self, vertex_key: VertexKey) -> Result<FlipInfo<D>, FlipError> {
         let result = self.tri.flip_k1_remove(vertex_key);
         if result.is_ok() {
             self.invalidate_repair_caches();
         }
         result
+    }
+
+    fn can_flip_k1_remove(&self, vertex_key: VertexKey) -> Result<FlipFeasibility<D>, FlipError> {
+        self.tri.can_flip_k1_remove(vertex_key)
     }
 
     fn flip_k2(&mut self, facet: FacetHandle) -> Result<FlipInfo<D>, FlipError> {
@@ -367,6 +725,10 @@ where
         result
     }
 
+    fn can_flip_k2(&self, facet: FacetHandle) -> Result<FlipFeasibility<D>, FlipError> {
+        self.tri.can_flip_k2(facet)
+    }
+
     fn flip_k3(&mut self, ridge: RidgeHandle) -> Result<FlipInfo<D>, FlipError> {
         let result = self.tri.flip_k3(ridge);
         if result.is_ok() {
@@ -375,12 +737,23 @@ where
         result
     }
 
+    fn can_flip_k3(&self, ridge: RidgeHandle) -> Result<FlipFeasibility<D>, FlipError> {
+        self.tri.can_flip_k3(ridge)
+    }
+
     fn flip_k2_inverse_from_edge(&mut self, edge: EdgeKey) -> Result<FlipInfo<D>, FlipError> {
         let result = self.tri.flip_k2_inverse_from_edge(edge);
         if result.is_ok() {
             self.invalidate_locate_hint_cache();
         }
         result
+    }
+
+    fn can_flip_k2_inverse_from_edge(
+        &self,
+        edge: EdgeKey,
+    ) -> Result<FlipFeasibility<D>, FlipError> {
+        self.tri.can_flip_k2_inverse_from_edge(edge)
     }
 
     fn flip_k3_inverse_from_triangle(
@@ -392,6 +765,13 @@ where
             self.invalidate_locate_hint_cache();
         }
         result
+    }
+
+    fn can_flip_k3_inverse_from_triangle(
+        &self,
+        triangle: TriangleHandle,
+    ) -> Result<FlipFeasibility<D>, FlipError> {
+        self.tri.can_flip_k3_inverse_from_triangle(triangle)
     }
 }
 

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -37,6 +37,8 @@ use crate::triangulation::DelaunayTriangulation;
 #[cfg(test)]
 use crate::validation::DelaunayTriangulationCandidate;
 use std::env;
+#[cfg(test)]
+use std::iter::once;
 
 fn ridge_link_repair_validation_error(err: ManifoldError) -> InsertionError {
     match TriangulationValidationError::try_from(err) {
@@ -1065,7 +1067,7 @@ mod tests {
 
         let local_run = DelaunayRepairRun {
             stats: stats.clone(),
-            touched_simplices: std::iter::once(nonincident).collect(),
+            touched_simplices: once(nonincident).collect(),
             used_full_reseed: true,
         };
         assert!(
@@ -1075,7 +1077,7 @@ mod tests {
 
         let invalid_scope_run = DelaunayRepairRun {
             stats,
-            touched_simplices: std::iter::once(incident_to_invalid_ridge).collect(),
+            touched_simplices: once(incident_to_invalid_ridge).collect(),
             used_full_reseed: true,
         };
         assert!(

--- a/src/delaunay/pachner.rs
+++ b/src/delaunay/pachner.rs
@@ -2,15 +2,14 @@
 //!
 //! This module is the Monte-Carlo-oriented layer above the explicit bistellar
 //! flip primitives in [`crate::flips`]. It lets callers choose a local
-//! [`PachnerMove`](crate::pachner::PachnerMove) value first and attempt it
-//! through one dispatch method while preserving the primitive flip APIs for
-//! deterministic editing workflows. Move requests that contain topology handles
-//! are detached proposals:
-//! [`PachnerMoves::attempt_pachner`](crate::pachner::PachnerMoves::attempt_pachner)
-//! revalidates them against the target triangulation before mutating storage.
-//! Use borrowed topology views for immediate observation; collapse them to
+//! [`PachnerMove`](crate::pachner::PachnerMove) request first, parse it into a
+//! provenanced [`PachnerProposal`](crate::pachner::PachnerProposal), and then
+//! attempt the proposal through a fluent terminal method while preserving the
+//! primitive flip APIs for deterministic editing workflows. Move requests that
+//! contain topology handles are raw detached input: use borrowed topology views
+//! for immediate observation, and collapse them to
 //! [`PachnerMove`](crate::pachner::PachnerMove) only when a queued or randomized
-//! workflow needs a storable proposal.
+//! workflow needs a storable request.
 
 #![forbid(unsafe_code)]
 
@@ -20,18 +19,17 @@ use crate::flips::{
     BistellarFlipKind, BistellarFlips, FlipDirection, FlipError, FlipFeasibility, FlipInfo,
     RidgeHandle, TriangleHandle,
 };
-use crate::tds::{EdgeKey, FacetHandle, SimplexKey, VertexKey};
+use crate::tds::{EdgeKey, FacetHandle, SimplexKey, TopologyOwner, TopologyOwnerId, VertexKey};
 
-/// Unified Pachner move request for explicit triangulation editing.
+/// Raw Pachner move request for explicit triangulation editing.
 ///
 /// The enum stores the vertex payload or detached topology handle needed by
 /// the corresponding low-level flip primitive. Forward k=1 moves need an owned
 /// [`Vertex`] because they create new geometry; the other moves refer to local
-/// topology through runtime handles that are revalidated against the target
-/// triangulation when [`PachnerMoves::attempt_pachner`] runs.
-/// A `PachnerMove` is therefore not proof that the referenced topology is still
-/// live; it is a request that the mutation boundary parses into a live move or
-/// rejects with a typed [`FlipError`].
+/// topology through runtime handles. A `PachnerMove` is not proof that the
+/// referenced topology is still live or that it came from a particular
+/// triangulation. Parse it through [`PachnerMoves::propose_pachner`] before
+/// attempting a unified Pachner move.
 ///
 /// # Examples
 ///
@@ -57,10 +55,12 @@ use crate::tds::{EdgeKey, FacetHandle, SimplexKey, VertexKey};
 ///     return Ok(());
 /// };
 ///
-/// let result = dt.attempt_pachner(PachnerMove::K1Insert {
-///     simplex_key,
-///     vertex: vertex![0.2, 0.2, 0.2]?,
-/// })?;
+/// let result = dt
+///     .propose_pachner(PachnerMove::K1Insert {
+///         simplex_key,
+///         vertex: vertex![0.2, 0.2, 0.2]?,
+///     })?
+///     .attempt_on(&mut dt)?;
 /// assert_eq!(result.kind, BistellarFlipKind::k1(3));
 /// assert_eq!(result.direction, FlipDirection::Forward);
 /// assert_eq!(result.inserted_face_vertices.len(), 1);
@@ -106,7 +106,324 @@ pub enum PachnerMove<U, const D: usize> {
     },
 }
 
-/// Result returned by [`PachnerMoves::attempt_pachner`].
+/// Provenanced Pachner move proposal parsed from a raw [`PachnerMove`].
+///
+/// A proposal carries the topology owner identity and structural generation of
+/// the triangulation that parsed it. This lets mutation and dry-run APIs reject
+/// proposals from another owner or an older topology version before
+/// interpreting runtime-local keys. It also carries the immutable feasibility
+/// report proven when the raw request was parsed. The raw request is still
+/// revalidated at commit time, so owner/generation checks complement rather
+/// than replace mutating local topology validation.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::prelude::construction::{
+///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+/// };
+/// use delaunay::prelude::pachner::{PachnerMove, PachnerMoves, TopologyOwner, vertex};
+///
+/// # fn main() -> DelaunayResult<()> {
+/// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+/// let dt = DelaunayTriangulationBuilder::new(&vertices)
+///     .topology_guarantee(TopologyGuarantee::PLManifold)
+///     .build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
+///
+/// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
+///     simplex_key,
+///     vertex: vertex![0.25, 0.25]?,
+/// })?;
+/// assert_eq!(proposal.topology_generation(), dt.topology_generation());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use]
+pub struct PachnerProposal<U, const D: usize> {
+    owner_id: TopologyOwnerId,
+    topology_generation: u64,
+    pachner_move: PachnerMove<U, D>,
+    feasibility: PachnerMoveFeasibility<D>,
+}
+
+impl<U, const D: usize> PachnerProposal<U, D> {
+    /// Builds a proposal after the owning triangulation has validated the raw request.
+    const fn from_validated(
+        owner_id: TopologyOwnerId,
+        topology_generation: u64,
+        pachner_move: PachnerMove<U, D>,
+        feasibility: PachnerMoveFeasibility<D>,
+    ) -> Self {
+        Self {
+            owner_id,
+            topology_generation,
+            pachner_move,
+            feasibility,
+        }
+    }
+
+    /// Returns the topology owner identity that parsed this proposal.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    /// use delaunay::prelude::pachner::{PachnerMove, PachnerMoves, TopologyOwner, vertex};
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
+    ///     simplex_key,
+    ///     vertex: vertex![0.25, 0.25]?,
+    /// })?;
+    ///
+    /// assert_eq!(proposal.owner_id(), &dt.topology_owner_id());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub const fn owner_id(&self) -> &TopologyOwnerId {
+        &self.owner_id
+    }
+
+    /// Returns the structural topology generation observed when this proposal was parsed.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    /// use delaunay::prelude::pachner::{PachnerMove, PachnerMoves, TopologyOwner, vertex};
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
+    ///     simplex_key,
+    ///     vertex: vertex![0.25, 0.25]?,
+    /// })?;
+    ///
+    /// assert_eq!(proposal.topology_generation(), dt.topology_generation());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub const fn topology_generation(&self) -> u64 {
+        self.topology_generation
+    }
+
+    /// Returns the raw request stored in this proposal without discarding
+    /// provenance.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    /// use delaunay::prelude::pachner::{PachnerMove, PachnerMoves, vertex};
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
+    ///     simplex_key,
+    ///     vertex: vertex![0.25, 0.25]?,
+    /// })?;
+    ///
+    /// let PachnerMove::K1Insert {
+    ///     simplex_key: stored_key,
+    ///     ..
+    /// } = proposal.request()
+    /// else {
+    ///     unreachable!("proposal should store the original request");
+    /// };
+    /// assert_eq!(*stored_key, simplex_key);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub const fn request(&self) -> &PachnerMove<U, D> {
+        &self.pachner_move
+    }
+
+    /// Consumes this proposal and returns its raw request.
+    ///
+    /// This discards the owner and generation proof. Parse the returned request
+    /// again with [`PachnerMoves::propose_pachner`] before attempting it.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    /// use delaunay::prelude::pachner::{PachnerMove, PachnerMoves, vertex};
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
+    ///     simplex_key,
+    ///     vertex: vertex![0.25, 0.25]?,
+    /// })?;
+    ///
+    /// let request = proposal.into_request();
+    /// let PachnerMove::K1Insert {
+    ///     simplex_key: stored_key,
+    ///     ..
+    /// } = request
+    /// else {
+    ///     unreachable!("proposal should store the original request");
+    /// };
+    /// assert_eq!(stored_key, simplex_key);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn into_request(self) -> PachnerMove<U, D> {
+        self.pachner_move
+    }
+
+    /// Validates this provenanced proposal against a topology owner without mutating it.
+    ///
+    /// This checks owner identity and topology generation before returning the
+    /// deterministic pre-mutation flip conditions proven when the proposal was
+    /// parsed, while preserving the proposal for a later mutation attempt.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError::WrongTopologyOwner`] when this proposal was parsed
+    /// by another topology owner, or [`FlipError::StaleTopologyProposal`] when
+    /// it was parsed before the current structural generation. Raw-request
+    /// validation failures are returned by [`PachnerMoves::propose_pachner`],
+    /// before a proposal exists.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    /// use delaunay::prelude::pachner::{
+    ///     BistellarFlipKind, FlipDirection, PachnerMove, PachnerMoves, vertex,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
+    ///     simplex_key,
+    ///     vertex: vertex![0.25, 0.25]?,
+    /// })?;
+    /// let feasibility = proposal.can_attempt_on(&dt)?;
+    /// assert_eq!(feasibility.kind, BistellarFlipKind::k1(2));
+    /// assert_eq!(feasibility.direction, FlipDirection::Forward);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn can_attempt_on<T>(&self, moves: &T) -> Result<PachnerMoveFeasibility<D>, FlipError>
+    where
+        T: BistellarFlips<D, VertexData = U> + TopologyOwner + ?Sized,
+    {
+        can_attempt_pachner_proposal(moves, self)
+    }
+
+    /// Attempts this provenanced proposal on a topology owner.
+    ///
+    /// Proposal provenance is checked before any runtime-local key is
+    /// interpreted, so wrong-owner and stale-generation errors return before
+    /// mutation.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError::WrongTopologyOwner`] when this proposal was parsed
+    /// by another topology owner, [`FlipError::StaleTopologyProposal`] when it
+    /// was parsed before the current structural generation, or another
+    /// [`FlipError`] from the selected flip primitive when the local
+    /// configuration cannot be mutated. On error, the selected primitive
+    /// preserves its usual failure-atomic mutation contract.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    /// use delaunay::prelude::pachner::{
+    ///     BistellarFlipKind, FlipDirection, PachnerMove, PachnerMoves, vertex,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let result = dt
+    ///     .propose_pachner(PachnerMove::K1Insert {
+    ///         simplex_key,
+    ///         vertex: vertex![0.25, 0.25]?,
+    ///     })?
+    ///     .attempt_on(&mut dt)?;
+    /// assert_eq!(result.kind, BistellarFlipKind::k1(2));
+    /// assert_eq!(result.direction, FlipDirection::Forward);
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub fn attempt_on<T>(self, moves: &mut T) -> Result<PachnerMoveResult<D>, FlipError>
+    where
+        T: BistellarFlips<D, VertexData = U> + TopologyOwner + ?Sized,
+    {
+        attempt_pachner_proposal(moves, self)
+    }
+}
+
+/// Result returned by [`PachnerProposal::attempt_on`].
 ///
 /// The fields mirror [`FlipInfo`] so callers can inspect the exact topology
 /// change without allocating conversion vectors. Use [`From`] to convert
@@ -141,10 +458,12 @@ pub enum PachnerMove<U, const D: usize> {
 ///     return Ok(());
 /// };
 ///
-/// let result = dt.attempt_pachner(PachnerMove::K1Insert {
-///     simplex_key,
-///     vertex: vertex![0.2, 0.2, 0.2]?,
-/// })?;
+/// let result = dt
+///     .propose_pachner(PachnerMove::K1Insert {
+///         simplex_key,
+///         vertex: vertex![0.2, 0.2, 0.2]?,
+///     })?
+///     .attempt_on(&mut dt)?;
 /// assert_eq!(result.kind, BistellarFlipKind::k1(3));
 /// assert_eq!(result.direction, FlipDirection::Forward);
 /// assert_eq!(result.inserted_face_vertices.len(), 1);
@@ -208,11 +527,11 @@ impl<const D: usize> From<PachnerMoveResult<D>> for FlipInfo<D> {
     }
 }
 
-/// Result returned by [`PachnerMoves::can_attempt_pachner`].
+/// Result returned by [`PachnerProposal::can_attempt_on`].
 ///
 /// This report describes the local move that passed immutable feasibility
 /// validation. It intentionally omits post-mutation simplex keys because those
-/// keys are allocated only by [`PachnerMoves::attempt_pachner`]. For forward
+/// keys are allocated only by [`PachnerProposal::attempt_on`]. For forward
 /// k=1 insertion, [`inserted_face_vertices`](Self::inserted_face_vertices) is
 /// `None` because the inserted vertex key is likewise allocated by the
 /// mutating operation.
@@ -236,10 +555,11 @@ impl<const D: usize> From<PachnerMoveResult<D>> for FlipInfo<D> {
 ///     return Ok(());
 /// };
 ///
-/// let feasibility = dt.can_attempt_pachner(&PachnerMove::K1Insert {
+/// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
 ///     simplex_key,
 ///     vertex: vertex![0.25, 0.25]?,
 /// })?;
+/// let feasibility = proposal.can_attempt_on(&dt)?;
 /// assert_eq!(feasibility.kind, BistellarFlipKind::k1(2));
 /// assert_eq!(feasibility.direction, FlipDirection::Forward);
 /// assert!(feasibility.inserted_face_vertices.is_none());
@@ -277,30 +597,28 @@ impl<const D: usize> From<FlipFeasibility<D>> for PachnerMoveFeasibility<D> {
     }
 }
 
-/// Unified Pachner move dispatch for Monte-Carlo-style workflows.
+/// Unified Pachner move proposal parser for Monte-Carlo-style workflows.
 ///
 /// This extension trait is implemented for every type that implements
-/// [`BistellarFlips`]. Successful moves therefore preserve the same cache
-/// invalidation and validation behavior as calling the primitive flip method
-/// directly.
-pub trait PachnerMoves<const D: usize> {
-    /// User data type stored on vertices inserted through k=1 moves.
-    type VertexData;
-
-    /// Attempt one unified Pachner move request.
+/// [`BistellarFlips`] and [`TopologyOwner`]. It parses raw detached
+/// [`PachnerMove`] requests into provenanced [`PachnerProposal`] values. The
+/// proposal exposes the fluent dry-run and mutation terminal methods, so
+/// mutation still consumes a proof-bearing value and rejects cross-owner or
+/// stale proposals before runtime-local keys are interpreted.
+pub trait PachnerMoves<const D: usize>: BistellarFlips<D> + TopologyOwner {
+    /// Parse a raw Pachner move request into a provenanced proposal.
     ///
-    /// The request is a detached proposal. Implementations revalidate its
-    /// handles or keys against `self`, build the short-lived flip context from a
-    /// shared borrow, drop that read-only context borrow, and then mutate through
-    /// the method's `&mut self` borrow.
+    /// This validates deterministic pre-mutation conditions, then stamps the
+    /// proposal with the current topology owner and generation. Mutating APIs
+    /// consume only proposals, not raw requests, so queued moves cannot silently
+    /// cross triangulation owners or topology versions.
     ///
     /// # Errors
     ///
-    /// Returns [`FlipError`] from the selected flip primitive when the requested
-    /// local configuration is stale, belongs to a different triangulation, is
-    /// non-admissible, is geometrically degenerate, or would violate topology
-    /// invariants. On error, the selected flip primitive preserves its usual
-    /// failure-atomic mutation contract.
+    /// Returns [`FlipError`] from the selected flip primitive when the raw
+    /// request is stale, non-admissible, geometrically degenerate, or would
+    /// violate deterministic local topology checks. No proposal is minted on
+    /// error.
     ///
     /// # Examples
     ///
@@ -308,76 +626,10 @@ pub trait PachnerMoves<const D: usize> {
     /// use delaunay::prelude::construction::{
     ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
     /// };
-    /// use delaunay::prelude::pachner::{
-    ///     BistellarFlipKind, FlipDirection, PachnerMove, PachnerMoves, vertex,
-    /// };
+    /// use delaunay::prelude::pachner::{PachnerMove, PachnerMoves, TopologyOwner, vertex};
     ///
     /// # fn main() -> DelaunayResult<()> {
-    /// let vertices = vec![
-    ///     vertex![0.0, 0.0, 0.0]?,
-    ///     vertex![1.0, 0.0, 0.0]?,
-    ///     vertex![0.0, 1.0, 0.0]?,
-    ///     vertex![0.0, 0.0, 1.0]?,
-    /// ];
-    /// let mut dt = DelaunayTriangulationBuilder::new(&vertices)
-    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
-    ///     .build::<()>()?;
-    /// let Some((simplex_key, _)) = dt.simplices().next() else {
-    ///     return Ok(());
-    /// };
-    ///
-    /// let result = dt.attempt_pachner(PachnerMove::K1Insert {
-    ///     simplex_key,
-    ///     vertex: vertex![0.2, 0.2, 0.2]?,
-    /// })?;
-    /// assert_eq!(result.kind, BistellarFlipKind::k1(3));
-    /// assert_eq!(result.direction, FlipDirection::Forward);
-    /// assert_eq!(result.inserted_face_vertices.len(), 1);
-    /// assert_eq!(result.new_simplices.len(), 4);
-    /// # Ok(())
-    /// # }
-    /// ```
-    fn attempt_pachner(
-        &mut self,
-        pachner_move: PachnerMove<Self::VertexData, D>,
-    ) -> Result<PachnerMoveResult<D>, FlipError>;
-
-    /// Validate a unified Pachner move request without mutating topology.
-    ///
-    /// The dry-run path parses the same detached move request as
-    /// [`Self::attempt_pachner`] and checks the deterministic pre-mutation
-    /// conditions used by the selected primitive flip. On an unchanged,
-    /// structurally valid triangulation, `Ok` means the corresponding mutating
-    /// move should not fail for stale handles, invalid local topology,
-    /// duplicate replacement simplices/faces, exact replacement degeneracy, or
-    /// periodic replacement-frame inconsistency. It does not allocate
-    /// post-mutation simplex keys, invalidate caches, or clone the full
-    /// triangulation. This makes it suitable for scanning many local proposals
-    /// before choosing one to commit.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`FlipError`] from the selected flip primitive when the requested
-    /// local configuration is stale, non-admissible, geometrically degenerate,
-    /// or would violate deterministic local topology checks.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use delaunay::prelude::construction::{
-    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
-    /// };
-    /// use delaunay::prelude::pachner::{
-    ///     BistellarFlipKind, FlipDirection, PachnerMove, PachnerMoves, vertex,
-    /// };
-    ///
-    /// # fn main() -> DelaunayResult<()> {
-    /// let vertices = vec![
-    ///     vertex![0.0, 0.0, 0.0]?,
-    ///     vertex![1.0, 0.0, 0.0]?,
-    ///     vertex![0.0, 1.0, 0.0]?,
-    ///     vertex![0.0, 0.0, 1.0]?,
-    /// ];
+    /// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
     /// let dt = DelaunayTriangulationBuilder::new(&vertices)
     ///     .topology_guarantee(TopologyGuarantee::PLManifold)
     ///     .build::<()>()?;
@@ -385,66 +637,126 @@ pub trait PachnerMoves<const D: usize> {
     ///     return Ok(());
     /// };
     ///
-    /// let feasibility = dt.can_attempt_pachner(&PachnerMove::K1Insert {
+    /// let proposal = dt.propose_pachner(PachnerMove::K1Insert {
     ///     simplex_key,
-    ///     vertex: vertex![0.2, 0.2, 0.2]?,
+    ///     vertex: vertex![0.25, 0.25]?,
     /// })?;
-    /// assert_eq!(feasibility.kind, BistellarFlipKind::k1(3));
-    /// assert_eq!(feasibility.direction, FlipDirection::Forward);
-    /// assert!(feasibility.inserted_face_vertices.is_none());
+    /// assert_eq!(proposal.topology_generation(), dt.topology_generation());
     /// # Ok(())
     /// # }
     /// ```
-    fn can_attempt_pachner(
+    fn propose_pachner(
         &self,
-        pachner_move: &PachnerMove<Self::VertexData, D>,
-    ) -> Result<PachnerMoveFeasibility<D>, FlipError>;
+        pachner_move: PachnerMove<Self::VertexData, D>,
+    ) -> Result<PachnerProposal<Self::VertexData, D>, FlipError>;
+}
+
+/// Validates raw Pachner request topology before it is stamped as a proposal.
+///
+/// This keeps proposal parsing and mutation dispatch on the same primitive flip
+/// predicates so public Pachner APIs agree on accepted and rejected local
+/// configurations.
+fn validate_pachner_request<const D: usize, T>(
+    moves: &T,
+    pachner_move: &PachnerMove<T::VertexData, D>,
+) -> Result<FlipFeasibility<D>, FlipError>
+where
+    T: BistellarFlips<D> + ?Sized,
+{
+    match pachner_move {
+        PachnerMove::K1Insert {
+            simplex_key,
+            vertex,
+        } => moves.can_flip_k1_insert(*simplex_key, vertex),
+        PachnerMove::K1Remove { vertex_key } => moves.can_flip_k1_remove(*vertex_key),
+        PachnerMove::K2 { facet } => moves.can_flip_k2(*facet),
+        PachnerMove::K2Inverse { edge } => moves.can_flip_k2_inverse_from_edge(*edge),
+        PachnerMove::K3 { ridge } => moves.can_flip_k3(*ridge),
+        PachnerMove::K3Inverse { triangle } => moves.can_flip_k3_inverse_from_triangle(*triangle),
+    }
+}
+
+/// Rejects proposals whose owner or generation no longer matches the target.
+///
+/// This protects public Pachner APIs from interpreting runtime-local keys after
+/// they cross topology owners or outlive a structural mutation.
+fn validate_pachner_proposal_provenance<const D: usize, T, U>(
+    owner: &T,
+    proposal: &PachnerProposal<U, D>,
+) -> Result<(), FlipError>
+where
+    T: TopologyOwner + ?Sized,
+{
+    let expected = owner.topology_owner_id();
+    if proposal.owner_id() != &expected {
+        return Err(FlipError::WrongTopologyOwner {
+            expected,
+            found: proposal.owner_id().clone(),
+        });
+    }
+
+    let current_generation = owner.topology_generation();
+    if proposal.topology_generation() != current_generation {
+        return Err(FlipError::StaleTopologyProposal {
+            proposal_generation: proposal.topology_generation(),
+            current_generation,
+        });
+    }
+
+    Ok(())
+}
+
+/// Attempts a provenanced proposal after checking it still belongs to `moves`.
+fn attempt_pachner_proposal<const D: usize, T>(
+    moves: &mut T,
+    proposal: PachnerProposal<T::VertexData, D>,
+) -> Result<PachnerMoveResult<D>, FlipError>
+where
+    T: BistellarFlips<D> + TopologyOwner + ?Sized,
+{
+    validate_pachner_proposal_provenance(moves, &proposal)?;
+    let info = match proposal.into_request() {
+        PachnerMove::K1Insert {
+            simplex_key,
+            vertex,
+        } => moves.flip_k1_insert(simplex_key, vertex)?,
+        PachnerMove::K1Remove { vertex_key } => moves.flip_k1_remove(vertex_key)?,
+        PachnerMove::K2 { facet } => moves.flip_k2(facet)?,
+        PachnerMove::K2Inverse { edge } => moves.flip_k2_inverse_from_edge(edge)?,
+        PachnerMove::K3 { ridge } => moves.flip_k3(ridge)?,
+        PachnerMove::K3Inverse { triangle } => moves.flip_k3_inverse_from_triangle(triangle)?,
+    };
+    Ok(info.into())
+}
+
+/// Returns the stored feasibility proof after checking it still belongs to `moves`.
+fn can_attempt_pachner_proposal<const D: usize, T>(
+    moves: &T,
+    proposal: &PachnerProposal<T::VertexData, D>,
+) -> Result<PachnerMoveFeasibility<D>, FlipError>
+where
+    T: BistellarFlips<D> + TopologyOwner + ?Sized,
+{
+    validate_pachner_proposal_provenance(moves, proposal)?;
+    Ok(proposal.feasibility.clone())
 }
 
 impl<const D: usize, T> PachnerMoves<D> for T
 where
-    T: BistellarFlips<D> + ?Sized,
+    T: BistellarFlips<D> + TopologyOwner + ?Sized,
 {
-    type VertexData = T::VertexData;
-
     #[inline]
-    fn attempt_pachner(
-        &mut self,
-        pachner_move: PachnerMove<Self::VertexData, D>,
-    ) -> Result<PachnerMoveResult<D>, FlipError> {
-        let info = match pachner_move {
-            PachnerMove::K1Insert {
-                simplex_key,
-                vertex,
-            } => self.flip_k1_insert(simplex_key, vertex)?,
-            PachnerMove::K1Remove { vertex_key } => self.flip_k1_remove(vertex_key)?,
-            PachnerMove::K2 { facet } => self.flip_k2(facet)?,
-            PachnerMove::K2Inverse { edge } => self.flip_k2_inverse_from_edge(edge)?,
-            PachnerMove::K3 { ridge } => self.flip_k3(ridge)?,
-            PachnerMove::K3Inverse { triangle } => self.flip_k3_inverse_from_triangle(triangle)?,
-        };
-        Ok(info.into())
-    }
-
-    #[inline]
-    fn can_attempt_pachner(
+    fn propose_pachner(
         &self,
-        pachner_move: &PachnerMove<Self::VertexData, D>,
-    ) -> Result<PachnerMoveFeasibility<D>, FlipError> {
-        let feasibility = match pachner_move {
-            PachnerMove::K1Insert {
-                simplex_key,
-                vertex,
-            } => self.can_flip_k1_insert(*simplex_key, vertex)?,
-            PachnerMove::K1Remove { vertex_key } => self.can_flip_k1_remove(*vertex_key)?,
-            PachnerMove::K2 { facet } => self.can_flip_k2(*facet)?,
-            PachnerMove::K2Inverse { edge } => self.can_flip_k2_inverse_from_edge(*edge)?,
-            PachnerMove::K3 { ridge } => self.can_flip_k3(*ridge)?,
-            PachnerMove::K3Inverse { triangle } => {
-                self.can_flip_k3_inverse_from_triangle(*triangle)?
-            }
-        };
-        Ok(feasibility.into())
+        pachner_move: PachnerMove<Self::VertexData, D>,
+    ) -> Result<PachnerProposal<Self::VertexData, D>, FlipError> {
+        let feasibility = validate_pachner_request(self, &pachner_move)?.into();
+        Ok(PachnerProposal::from_validated(
+            self.topology_owner_id(),
+            self.topology_generation(),
+            pachner_move,
+            feasibility,
+        ))
     }
 }
 

--- a/src/delaunay/pachner.rs
+++ b/src/delaunay/pachner.rs
@@ -17,8 +17,8 @@
 use crate::collections::{MAX_PRACTICAL_DIMENSION_SIZE, SimplexKeyBuffer, SmallBuffer};
 use crate::core::vertex::Vertex;
 use crate::flips::{
-    BistellarFlipKind, BistellarFlips, FlipDirection, FlipError, FlipInfo, RidgeHandle,
-    TriangleHandle,
+    BistellarFlipKind, BistellarFlips, FlipDirection, FlipError, FlipFeasibility, FlipInfo,
+    RidgeHandle, TriangleHandle,
 };
 use crate::tds::{EdgeKey, FacetHandle, SimplexKey, VertexKey};
 
@@ -208,6 +208,75 @@ impl<const D: usize> From<PachnerMoveResult<D>> for FlipInfo<D> {
     }
 }
 
+/// Result returned by [`PachnerMoves::can_attempt_pachner`].
+///
+/// This report describes the local move that passed immutable feasibility
+/// validation. It intentionally omits post-mutation simplex keys because those
+/// keys are allocated only by [`PachnerMoves::attempt_pachner`]. For forward
+/// k=1 insertion, [`inserted_face_vertices`](Self::inserted_face_vertices) is
+/// `None` because the inserted vertex key is likewise allocated by the
+/// mutating operation.
+///
+/// # Examples
+///
+/// ```rust
+/// use delaunay::prelude::construction::{
+///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+/// };
+/// use delaunay::prelude::pachner::{
+///     BistellarFlipKind, FlipDirection, PachnerMove, PachnerMoves, vertex,
+/// };
+///
+/// # fn main() -> DelaunayResult<()> {
+/// let vertices = vec![vertex![0.0, 0.0]?, vertex![1.0, 0.0]?, vertex![0.0, 1.0]?];
+/// let dt = DelaunayTriangulationBuilder::new(&vertices)
+///     .topology_guarantee(TopologyGuarantee::PLManifold)
+///     .build::<()>()?;
+/// let Some((simplex_key, _)) = dt.simplices().next() else {
+///     return Ok(());
+/// };
+///
+/// let feasibility = dt.can_attempt_pachner(&PachnerMove::K1Insert {
+///     simplex_key,
+///     vertex: vertex![0.25, 0.25]?,
+/// })?;
+/// assert_eq!(feasibility.kind, BistellarFlipKind::k1(2));
+/// assert_eq!(feasibility.direction, FlipDirection::Forward);
+/// assert!(feasibility.inserted_face_vertices.is_none());
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[must_use]
+#[non_exhaustive]
+pub struct PachnerMoveFeasibility<const D: usize> {
+    /// Flip kind (k, d).
+    pub kind: BistellarFlipKind,
+    /// Flip direction.
+    pub direction: FlipDirection,
+    /// Simplex keys the corresponding mutating move would remove.
+    pub removed_simplices: SimplexKeyBuffer,
+    /// Vertices of the removed face shared by removed simplices.
+    pub removed_face_vertices: SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>,
+    /// Vertices of the inserted complementary face when all are already live.
+    ///
+    /// This is `None` for forward k=1 insertion because the inserted vertex key
+    /// is allocated only by the mutating operation.
+    pub inserted_face_vertices: Option<SmallBuffer<VertexKey, MAX_PRACTICAL_DIMENSION_SIZE>>,
+}
+
+impl<const D: usize> From<FlipFeasibility<D>> for PachnerMoveFeasibility<D> {
+    fn from(feasibility: FlipFeasibility<D>) -> Self {
+        Self {
+            kind: feasibility.kind,
+            direction: feasibility.direction,
+            removed_simplices: feasibility.removed_simplices,
+            removed_face_vertices: feasibility.removed_face_vertices,
+            inserted_face_vertices: feasibility.inserted_face_vertices,
+        }
+    }
+}
+
 /// Unified Pachner move dispatch for Monte-Carlo-style workflows.
 ///
 /// This extension trait is implemented for every type that implements
@@ -272,6 +341,64 @@ pub trait PachnerMoves<const D: usize> {
         &mut self,
         pachner_move: PachnerMove<Self::VertexData, D>,
     ) -> Result<PachnerMoveResult<D>, FlipError>;
+
+    /// Validate a unified Pachner move request without mutating topology.
+    ///
+    /// The dry-run path parses the same detached move request as
+    /// [`Self::attempt_pachner`] and checks the deterministic pre-mutation
+    /// conditions used by the selected primitive flip. On an unchanged,
+    /// structurally valid triangulation, `Ok` means the corresponding mutating
+    /// move should not fail for stale handles, invalid local topology,
+    /// duplicate replacement simplices/faces, exact replacement degeneracy, or
+    /// periodic replacement-frame inconsistency. It does not allocate
+    /// post-mutation simplex keys, invalidate caches, or clone the full
+    /// triangulation. This makes it suitable for scanning many local proposals
+    /// before choosing one to commit.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`FlipError`] from the selected flip primitive when the requested
+    /// local configuration is stale, non-admissible, geometrically degenerate,
+    /// or would violate deterministic local topology checks.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use delaunay::prelude::construction::{
+    ///     DelaunayResult, DelaunayTriangulationBuilder, TopologyGuarantee,
+    /// };
+    /// use delaunay::prelude::pachner::{
+    ///     BistellarFlipKind, FlipDirection, PachnerMove, PachnerMoves, vertex,
+    /// };
+    ///
+    /// # fn main() -> DelaunayResult<()> {
+    /// let vertices = vec![
+    ///     vertex![0.0, 0.0, 0.0]?,
+    ///     vertex![1.0, 0.0, 0.0]?,
+    ///     vertex![0.0, 1.0, 0.0]?,
+    ///     vertex![0.0, 0.0, 1.0]?,
+    /// ];
+    /// let dt = DelaunayTriangulationBuilder::new(&vertices)
+    ///     .topology_guarantee(TopologyGuarantee::PLManifold)
+    ///     .build::<()>()?;
+    /// let Some((simplex_key, _)) = dt.simplices().next() else {
+    ///     return Ok(());
+    /// };
+    ///
+    /// let feasibility = dt.can_attempt_pachner(&PachnerMove::K1Insert {
+    ///     simplex_key,
+    ///     vertex: vertex![0.2, 0.2, 0.2]?,
+    /// })?;
+    /// assert_eq!(feasibility.kind, BistellarFlipKind::k1(3));
+    /// assert_eq!(feasibility.direction, FlipDirection::Forward);
+    /// assert!(feasibility.inserted_face_vertices.is_none());
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn can_attempt_pachner(
+        &self,
+        pachner_move: &PachnerMove<Self::VertexData, D>,
+    ) -> Result<PachnerMoveFeasibility<D>, FlipError>;
 }
 
 impl<const D: usize, T> PachnerMoves<D> for T
@@ -297,6 +424,27 @@ where
             PachnerMove::K3Inverse { triangle } => self.flip_k3_inverse_from_triangle(triangle)?,
         };
         Ok(info.into())
+    }
+
+    #[inline]
+    fn can_attempt_pachner(
+        &self,
+        pachner_move: &PachnerMove<Self::VertexData, D>,
+    ) -> Result<PachnerMoveFeasibility<D>, FlipError> {
+        let feasibility = match pachner_move {
+            PachnerMove::K1Insert {
+                simplex_key,
+                vertex,
+            } => self.can_flip_k1_insert(*simplex_key, vertex)?,
+            PachnerMove::K1Remove { vertex_key } => self.can_flip_k1_remove(*vertex_key)?,
+            PachnerMove::K2 { facet } => self.can_flip_k2(*facet)?,
+            PachnerMove::K2Inverse { edge } => self.can_flip_k2_inverse_from_edge(*edge)?,
+            PachnerMove::K3 { ridge } => self.can_flip_k3(*ridge)?,
+            PachnerMove::K3Inverse { triangle } => {
+                self.can_flip_k3_inverse_from_triangle(*triangle)?
+            }
+        };
+        Ok(feasibility.into())
     }
 }
 

--- a/src/delaunay/triangulation.rs
+++ b/src/delaunay/triangulation.rs
@@ -7,6 +7,7 @@
 
 use crate::core::collections::spatial_hash_grid::HashGridIndex;
 use crate::core::operations::DelaunayInsertionState;
+use crate::core::tds::{TopologyOwner, TopologyOwnerId};
 use crate::core::triangulation::Triangulation;
 
 /// Delaunay triangulation with incremental insertion support.
@@ -80,4 +81,16 @@ pub struct DelaunayTriangulation<K, U, V, const D: usize> {
     /// cache can survive transactional rollbacks even if they leave behind stale
     /// keys from an insertion that did not commit.
     pub(crate) spatial_index: Option<HashGridIndex<D>>,
+}
+
+impl<K, U, V, const D: usize> TopologyOwner for DelaunayTriangulation<K, U, V, D> {
+    #[inline]
+    fn topology_owner_id(&self) -> TopologyOwnerId {
+        self.tri.topology_owner_id()
+    }
+
+    #[inline]
+    fn topology_generation(&self) -> u64 {
+        self.tri.topology_generation()
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -614,7 +614,7 @@ mod core {
         pub(crate) use rollback::{
             TdsOwnerRollbackTransaction, TdsRollbackOwner, TdsRollbackTransaction,
         };
-        pub use storage::Tds;
+        pub use storage::{Tds, TopologyOwner, TopologyOwnerId};
     }
     /// Generic triangulation combining kernel + Tds.
     pub mod triangulation;
@@ -1421,9 +1421,9 @@ pub mod prelude {
 
     /// Unified Pachner move workflow for Monte-Carlo-style local edits.
     ///
-    /// This focused prelude exports the unified request/result/dispatch API,
-    /// the handles and handle-construction errors needed to construct moves,
-    /// result metadata needed to inspect moves, and [`vertex!`](crate::vertex)
+    /// This focused prelude exports the unified request/proposal/result/dispatch
+    /// API, the handles and handle-construction errors needed to construct
+    /// moves, result metadata needed to inspect moves, and [`vertex!`](crate::vertex)
     /// for k=1 insertion vertices. Low-level flip primitives stay under
     /// [`crate::flips`] for expert/debug workflows.
     ///
@@ -1451,10 +1451,12 @@ pub mod prelude {
     ///     return Ok(());
     /// };
     ///
-    /// let result = dt.attempt_pachner(PachnerMove::K1Insert {
-    ///     simplex_key,
-    ///     vertex: vertex![0.2, 0.2, 0.2]?,
-    /// })?;
+    /// let result = dt
+    ///     .propose_pachner(PachnerMove::K1Insert {
+    ///         simplex_key,
+    ///         vertex: vertex![0.2, 0.2, 0.2]?,
+    ///     })?
+    ///     .attempt_on(&mut dt)?;
     /// assert_eq!(result.kind, BistellarFlipKind::k1(3));
     /// assert_eq!(result.direction, FlipDirection::Forward);
     /// assert_eq!(result.inserted_face_vertices.len(), 1);
@@ -1501,10 +1503,11 @@ pub mod prelude {
             TriangleHandleError,
         };
         pub use crate::pachner::{
-            PachnerMove, PachnerMoveFeasibility, PachnerMoveResult, PachnerMoves,
+            PachnerMove, PachnerMoveFeasibility, PachnerMoveResult, PachnerMoves, PachnerProposal,
         };
         pub use crate::tds::{
-            EdgeKey, EdgeKeyError, FacetError, FacetHandle, SimplexKey, Vertex, VertexKey,
+            EdgeKey, EdgeKeyError, FacetError, FacetHandle, SimplexKey, TopologyOwner,
+            TopologyOwnerId, Vertex, VertexKey,
         };
         pub use crate::vertex;
     }
@@ -1687,6 +1690,9 @@ pub mod prelude {
     }
 
     /// Focused exports for low-level topology data structures.
+    ///
+    /// This prelude also exposes [`TopologyOwner`] and [`TopologyOwnerId`] for
+    /// proposal and borrowed-view workflows that need runtime topology identity.
     ///
     /// # Examples
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1500,7 +1500,9 @@ pub mod prelude {
             BistellarFlipKind, FlipDirection, FlipError, RidgeHandle, TriangleHandle,
             TriangleHandleError,
         };
-        pub use crate::pachner::{PachnerMove, PachnerMoveResult, PachnerMoves};
+        pub use crate::pachner::{
+            PachnerMove, PachnerMoveFeasibility, PachnerMoveResult, PachnerMoves,
+        };
         pub use crate::tds::{
             EdgeKey, EdgeKeyError, FacetError, FacetHandle, SimplexKey, Vertex, VertexKey,
         };

--- a/tests/pachner_roundtrip.rs
+++ b/tests/pachner_roundtrip.rs
@@ -2,7 +2,8 @@
 
 //! Public API roundtrip tests for Pachner/bistellar flips.
 
-use delaunay::vertex;
+use delaunay::flips::FlipMutationError;
+use delaunay::{TdsConstructionFailure, vertex};
 use std::assert_matches;
 
 use delaunay::prelude::construction::{
@@ -12,7 +13,7 @@ use delaunay::prelude::construction::{
 use delaunay::prelude::geometry::RobustKernel;
 use delaunay::prelude::pachner::{
     BistellarFlipKind, EdgeKey, EdgeKeyError, FacetHandle, FlipDirection, FlipError, PachnerMove,
-    PachnerMoveResult, PachnerMoves, SimplexKey, VertexKey,
+    PachnerMoveFeasibility, PachnerMoveResult, PachnerMoves, SimplexKey, VertexKey,
 };
 #[cfg(feature = "slow-tests")]
 use delaunay::prelude::pachner::{RidgeHandle, TriangleHandle};
@@ -20,6 +21,7 @@ use uuid::Uuid;
 
 type Dt4 = DelaunayTriangulation<RobustKernel<f64>, (), (), 4>;
 type Dt2 = DelaunayTriangulation<RobustKernel<f64>, (), (), 2>;
+type Dt<const D: usize> = DelaunayTriangulation<RobustKernel<f64>, (), (), D>;
 
 const FLIPPABLE_POINTS_2D: &[[f64; 2]] = &[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]];
 
@@ -235,6 +237,155 @@ fn edge_to_facet_query_tracks_2d_k2_mutation_freshness() {
     assert_topology_and_delaunay_valid(&dt, "2D k=2 mutation-freshness fixture");
 }
 
+#[test]
+fn pachner_feasibility_agrees_with_successful_2d_k2_attempt() {
+    let dt = build_flippable_dt_2d();
+    let facet = flippable_k2_facet_2d(&dt);
+    let pachner_move = PachnerMove::K2 { facet };
+
+    let feasibility = dt
+        .can_attempt_pachner(&pachner_move)
+        .expect("2D k=2 feasibility should accept selected fixture facet");
+    assert_pachner_feasibility_contract(
+        &feasibility,
+        BistellarFlipKind::k2(2),
+        FlipDirection::Forward,
+    );
+
+    let mut trial = dt;
+    let result = trial
+        .attempt_pachner(pachner_move)
+        .expect("2D k=2 attempt should agree with feasibility");
+    assert_eq!(feasibility.kind, result.kind);
+    assert_eq!(feasibility.direction, result.direction);
+    assert_eq!(feasibility.removed_simplices, result.removed_simplices);
+    assert_eq!(
+        feasibility.removed_face_vertices,
+        result.removed_face_vertices
+    );
+    assert_eq!(
+        feasibility.inserted_face_vertices.as_ref(),
+        Some(&result.inserted_face_vertices)
+    );
+}
+
+#[test]
+fn pachner_feasibility_rejects_boundary_facet_like_attempt_2d() {
+    let dt = build_single_triangle_dt_2d();
+    let (simplex_key, _) = dt
+        .simplices()
+        .next()
+        .expect("single-triangle fixture should contain one simplex");
+    let facet = FacetHandle::try_new(dt.tds(), simplex_key, 0)
+        .expect("single-triangle boundary facet should be a live handle");
+    let pachner_move = PachnerMove::K2 { facet };
+
+    let feasibility = dt.can_attempt_pachner(&pachner_move);
+    assert_matches!(feasibility, Err(FlipError::BoundaryFacet { .. }));
+
+    let mut trial = dt;
+    let attempted = trial.attempt_pachner(pachner_move);
+    assert_matches!(attempted, Err(FlipError::BoundaryFacet { .. }));
+    assert_topology_and_delaunay_valid(&trial, "failed boundary feasibility agreement");
+}
+
+#[test]
+fn pachner_feasibility_rejects_stale_facet_like_attempt_2d() {
+    let mut dt = build_flippable_dt_2d();
+    let facet = flippable_k2_facet_2d(&dt);
+    let first_flip = dt
+        .attempt_pachner(PachnerMove::K2 { facet })
+        .expect("first k=2 attempt should stale the original facet");
+    assert!(!first_flip.new_simplices.is_empty());
+    let stale_move = PachnerMove::K2 { facet };
+
+    let feasibility = dt.can_attempt_pachner(&stale_move);
+    assert_matches!(
+        feasibility,
+        Err(FlipError::MissingSimplex { simplex_key }) if simplex_key == facet.simplex_key()
+    );
+
+    let before_failed_attempt = snapshot_topology_2d(&dt);
+    let attempted = dt.attempt_pachner(stale_move);
+    assert_matches!(
+        attempted,
+        Err(FlipError::MissingSimplex { simplex_key }) if simplex_key == facet.simplex_key()
+    );
+    assert_eq!(snapshot_topology_2d(&dt), before_failed_attempt);
+}
+
+#[test]
+fn pachner_feasibility_agrees_with_toroidal_2d_k1_insert() {
+    let dt = build_canonicalized_toroidal_dt_2d();
+    let simplex_key = first_simplex_generic(&dt);
+    let vertex: Vertex<(), 2> = vertex!(simplex_centroid_generic(&dt, simplex_key))
+        .expect("toroidal simplex centroid should be a finite vertex");
+    let vertex_uuid = vertex.uuid();
+    let pachner_move = PachnerMove::K1Insert {
+        simplex_key,
+        vertex,
+    };
+
+    let feasibility = dt
+        .can_attempt_pachner(&pachner_move)
+        .expect("toroidal k=1 feasibility should accept a simplex centroid");
+    assert_pachner_feasibility_contract(
+        &feasibility,
+        BistellarFlipKind::k1(2),
+        FlipDirection::Forward,
+    );
+    assert!(feasibility.inserted_face_vertices.is_none());
+
+    let mut trial = dt;
+    let result = trial
+        .attempt_pachner(pachner_move)
+        .expect("toroidal k=1 attempt should agree with feasibility");
+    let inserted_vertex = trial
+        .tds()
+        .vertex_key_from_uuid(&vertex_uuid)
+        .expect("successful k=1 attempt should allocate the inserted vertex key");
+    assert_eq!(result.kind, feasibility.kind);
+    assert_eq!(result.direction, feasibility.direction);
+    assert_eq!(result.removed_simplices, feasibility.removed_simplices);
+    assert_eq!(result.inserted_face_vertices.as_slice(), &[inserted_vertex]);
+    trial
+        .as_triangulation()
+        .validate()
+        .expect("toroidal k=1 attempt should preserve topology validity");
+}
+
+#[test]
+fn pachner_feasibility_rejects_duplicate_k1_insert_uuid_without_mutating() {
+    let dt = build_single_triangle_dt_2d();
+    let simplex_key = first_simplex_generic(&dt);
+    let duplicate_vertex = dt
+        .tds()
+        .vertices()
+        .next()
+        .map(|(_, vertex)| *vertex)
+        .expect("single-triangle fixture should contain a live vertex");
+    let duplicate_uuid = duplicate_vertex.uuid();
+    let pachner_move = PachnerMove::K1Insert {
+        simplex_key,
+        vertex: duplicate_vertex,
+    };
+
+    assert_duplicate_vertex_uuid_error(dt.can_attempt_pachner(&pachner_move), duplicate_uuid);
+
+    let mut trial = dt;
+    let before_failed_attempt = snapshot_topology_2d(&trial);
+    assert_duplicate_vertex_uuid_error(trial.attempt_pachner(pachner_move), duplicate_uuid);
+    assert_eq!(snapshot_topology_2d(&trial), before_failed_attempt);
+}
+
+#[test]
+fn pachner_feasibility_public_k1_insert_smoke_2d_to_5d() {
+    assert_public_k1_insert_feasibility_smoke::<2>();
+    assert_public_k1_insert_feasibility_smoke::<3>();
+    assert_public_k1_insert_feasibility_smoke::<4>();
+    assert_public_k1_insert_feasibility_smoke::<5>();
+}
+
 /// Attempts a stale k=1 insert through the public `DelaunayResult` alias.
 fn try_stale_k1_insert(
     dt: &mut Dt4,
@@ -284,6 +435,33 @@ fn build_dt_4d(points: &[[f64; 4]], fixture_name: &str) -> Dt4 {
     .unwrap_or_else(|err| panic!("{fixture_name} 4D fixture should build: {err}"))
 }
 
+/// Builds a minimal Euclidean D-simplex fixture for dimension smoke tests.
+fn build_minimal_simplex_dt<const D: usize>() -> Dt<D> {
+    let vertices = minimal_simplex_vertices::<D>();
+    let options =
+        ConstructionOptions::default().with_insertion_order(InsertionOrderStrategy::Input);
+
+    DelaunayTriangulation::try_with_topology_guarantee_and_options(
+        &RobustKernel::new(),
+        &vertices,
+        TopologyGuarantee::PLManifold,
+        options,
+    )
+    .unwrap_or_else(|err| panic!("{D}D minimal simplex fixture should build: {err}"))
+}
+
+/// Returns the origin plus coordinate unit vectors as a nondegenerate D-simplex.
+fn minimal_simplex_vertices<const D: usize>() -> Vec<Vertex<(), D>> {
+    let mut vertices = Vec::with_capacity(D + 1);
+    vertices.push(vertex!([0.0; D]).expect("origin vertex should be finite"));
+    for axis in 0..D {
+        let mut coords = [0.0; D];
+        coords[axis] = 1.0;
+        vertices.push(vertex!(coords).expect("unit simplex vertex should be finite"));
+    }
+    vertices
+}
+
 /// Builds a deterministic 2D fixture with at least one public k=2 move.
 fn build_flippable_dt_2d() -> Dt2 {
     let vertices = FLIPPABLE_POINTS_2D
@@ -298,6 +476,36 @@ fn build_flippable_dt_2d() -> Dt2 {
         .expect("stable 2D fixture should build");
     assert_topology_and_delaunay_valid(&dt, "stable 2D fixture before local edits");
     dt
+}
+
+/// Builds a single-triangle 2D fixture for boundary-facet rejection checks.
+fn build_single_triangle_dt_2d() -> Dt2 {
+    let vertices = vec![
+        vertex!([0.0, 0.0]).expect("single-triangle fixture coordinate"),
+        vertex!([1.0, 0.0]).expect("single-triangle fixture coordinate"),
+        vertex!([0.0, 1.0]).expect("single-triangle fixture coordinate"),
+    ];
+
+    DelaunayTriangulationBuilder::new(&vertices)
+        .topology_guarantee(TopologyGuarantee::PLManifold)
+        .build_with_kernel::<_, ()>(&RobustKernel::new())
+        .expect("single-triangle fixture should build")
+}
+
+/// Builds a canonicalized 2D toroidal fixture with live periodic topology metadata.
+fn build_canonicalized_toroidal_dt_2d() -> Dt2 {
+    let vertices = vec![
+        vertex!([0.2, 0.3]).expect("toroidal fixture coordinate"),
+        vertex!([1.8, 0.1]).expect("toroidal fixture coordinate"),
+        vertex!([0.5, 0.7]).expect("toroidal fixture coordinate"),
+        vertex!([-0.4, 0.9]).expect("toroidal fixture coordinate"),
+    ];
+
+    DelaunayTriangulationBuilder::new(&vertices)
+        .try_canonicalized_toroidal([1.0, 1.0])
+        .expect("canonicalized toroidal domain should parse")
+        .build_with_kernel::<_, ()>(&RobustKernel::new())
+        .expect("canonicalized toroidal fixture should build")
 }
 
 /// Searches the 2D fixture for an edge facet whose public k=2 move succeeds.
@@ -325,6 +533,150 @@ fn flippable_k2_facet_2d(dt: &Dt2) -> FacetHandle {
         }
     }
     panic!("stable 2D fixture should contain a public k=2 candidate");
+}
+
+/// Captures 2D topology by stable UUIDs so failed attempts can prove non-mutation.
+fn snapshot_topology_2d(dt: &Dt2) -> TopologySnapshot {
+    let tds = dt.tds();
+    let mut vertex_uuids = tds
+        .vertices()
+        .map(|(_, vertex)| vertex.uuid())
+        .collect::<Vec<_>>();
+    vertex_uuids.sort();
+
+    let mut simplex_vertex_uuids = tds
+        .simplices()
+        .map(|(_, simplex)| {
+            let mut uuids = simplex
+                .vertices()
+                .iter()
+                .map(|vertex_key| {
+                    tds.vertex(*vertex_key)
+                        .expect("simplex should reference live vertices")
+                        .uuid()
+                })
+                .collect::<Vec<_>>();
+            uuids.sort();
+            uuids
+        })
+        .collect::<Vec<_>>();
+    simplex_vertex_uuids.sort();
+
+    TopologySnapshot {
+        vertex_uuids,
+        simplex_vertex_uuids,
+    }
+}
+
+/// Verifies the generic Pachner feasibility arities implied by the reported move kind.
+fn assert_pachner_feasibility_contract<const D: usize>(
+    feasibility: &PachnerMoveFeasibility<D>,
+    kind: BistellarFlipKind,
+    direction: FlipDirection,
+) {
+    assert_eq!(feasibility.kind, kind);
+    assert_eq!(feasibility.direction, direction);
+    assert_eq!(feasibility.removed_simplices.len(), kind.k());
+    assert_eq!(feasibility.removed_face_vertices.len(), D + 2 - kind.k());
+    if let Some(inserted_face_vertices) = &feasibility.inserted_face_vertices {
+        assert_eq!(inserted_face_vertices.len(), kind.k());
+    }
+}
+
+/// Verifies duplicate inserted-vertex UUIDs surface through the typed flip error.
+fn assert_duplicate_vertex_uuid_error<T>(result: Result<T, FlipError>, duplicate_uuid: Uuid) {
+    match result {
+        Err(FlipError::TdsMutation { reason })
+            if matches!(
+                reason.as_ref(),
+                FlipMutationError::VertexInsertion {
+                    source: TdsConstructionFailure::DuplicateUuid { uuid, .. },
+                } if *uuid == duplicate_uuid
+            ) => {}
+        Err(err) => {
+            panic!("expected duplicate vertex UUID error for {duplicate_uuid}, got {err:?}")
+        }
+        Ok(_) => panic!("expected duplicate vertex UUID error for {duplicate_uuid}"),
+    }
+}
+
+/// Exercises public `PachnerMove::K1Insert` feasibility and mutation in one dimension.
+fn assert_public_k1_insert_feasibility_smoke<const D: usize>() {
+    let dt = build_minimal_simplex_dt::<D>();
+    let simplex_key = first_simplex_generic(&dt);
+    let vertex: Vertex<(), D> = vertex!(simplex_centroid_generic(&dt, simplex_key))
+        .unwrap_or_else(|err| panic!("{D}D simplex centroid should be finite: {err}"));
+    let vertex_uuid = vertex.uuid();
+    let pachner_move = PachnerMove::K1Insert {
+        simplex_key,
+        vertex,
+    };
+
+    let feasibility = dt
+        .can_attempt_pachner(&pachner_move)
+        .unwrap_or_else(|err| panic!("{D}D public k=1 feasibility should succeed: {err:?}"));
+    assert_pachner_feasibility_contract(
+        &feasibility,
+        BistellarFlipKind::k1(D),
+        FlipDirection::Forward,
+    );
+    assert!(feasibility.inserted_face_vertices.is_none());
+
+    let mut trial = dt;
+    let result = trial
+        .attempt_pachner(pachner_move)
+        .unwrap_or_else(|err| panic!("{D}D public k=1 mutation should succeed: {err:?}"));
+    let inserted_vertex = trial
+        .tds()
+        .vertex_key_from_uuid(&vertex_uuid)
+        .expect("successful k=1 mutation should allocate the requested vertex");
+    assert_eq!(feasibility.kind, result.kind);
+    assert_eq!(feasibility.direction, result.direction);
+    assert_eq!(feasibility.removed_simplices, result.removed_simplices);
+    assert_eq!(
+        feasibility.removed_face_vertices,
+        result.removed_face_vertices
+    );
+    assert_eq!(result.inserted_face_vertices.as_slice(), &[inserted_vertex]);
+    trial
+        .as_triangulation()
+        .validate()
+        .unwrap_or_else(|err| panic!("{D}D k=1 mutation should preserve topology: {err}"));
+    trial
+        .as_triangulation()
+        .is_valid_embedding()
+        .unwrap_or_else(|err| panic!("{D}D k=1 mutation should preserve embedding: {err}"));
+}
+
+/// Returns any live simplex key from a generic D-dimensional fixture.
+fn first_simplex_generic<const D: usize>(dt: &Dt<D>) -> SimplexKey {
+    dt.simplices()
+        .next()
+        .map(|(simplex_key, _)| simplex_key)
+        .expect("fixture should contain simplices")
+}
+
+/// Computes a simplex centroid for generic dimension smoke tests.
+fn simplex_centroid_generic<const D: usize>(dt: &Dt<D>, simplex_key: SimplexKey) -> [f64; D] {
+    let simplex = dt
+        .tds()
+        .simplex(simplex_key)
+        .expect("simplex key should exist");
+    let mut coords = [0.0; D];
+    for &vkey in simplex.vertices() {
+        let vertex = dt.tds().vertex(vkey).expect("vertex key should exist");
+        for (coord, value) in coords.iter_mut().zip(vertex.point().coords()) {
+            *coord += *value;
+        }
+    }
+
+    let vertex_count = u32::try_from(simplex.vertices().len())
+        .map(f64::from)
+        .expect("simplex vertex count should fit in u32");
+    for coord in &mut coords {
+        *coord /= vertex_count;
+    }
+    coords
 }
 
 /// Converts a 2D facet handle into the edge key represented by that facet.

--- a/tests/pachner_roundtrip.rs
+++ b/tests/pachner_roundtrip.rs
@@ -2,7 +2,7 @@
 
 //! Public API roundtrip tests for Pachner/bistellar flips.
 
-use delaunay::flips::FlipMutationError;
+use delaunay::flips::{BistellarFlips, FlipFailureKind, FlipFeasibility, FlipMutationError};
 use delaunay::{TdsConstructionFailure, vertex};
 use std::assert_matches;
 
@@ -13,10 +13,9 @@ use delaunay::prelude::construction::{
 use delaunay::prelude::geometry::RobustKernel;
 use delaunay::prelude::pachner::{
     BistellarFlipKind, EdgeKey, EdgeKeyError, FacetHandle, FlipDirection, FlipError, PachnerMove,
-    PachnerMoveFeasibility, PachnerMoveResult, PachnerMoves, SimplexKey, VertexKey,
+    PachnerMoveFeasibility, PachnerMoveResult, PachnerMoves, PachnerProposal, RidgeHandle,
+    SimplexKey, TopologyOwner, TriangleHandle, VertexKey,
 };
-#[cfg(feature = "slow-tests")]
-use delaunay::prelude::pachner::{RidgeHandle, TriangleHandle};
 use uuid::Uuid;
 
 type Dt4 = DelaunayTriangulation<RobustKernel<f64>, (), (), 4>;
@@ -53,6 +52,13 @@ const STABLE_POINTS_4D: &[[f64; 4]] = &[
 struct TopologySnapshot {
     vertex_uuids: Vec<Uuid>,
     simplex_vertex_uuids: Vec<Vec<Uuid>>,
+}
+
+fn attempt_pachner_move<const D: usize>(
+    dt: &mut Dt<D>,
+    pachner_move: PachnerMove<(), D>,
+) -> Result<PachnerMoveResult<D>, FlipError> {
+    dt.propose_pachner(pachner_move)?.attempt_on(dt)
 }
 
 fn topology_and_delaunay_valid<const D: usize>(
@@ -115,6 +121,52 @@ fn stale_k1_remove_request_fails_without_mutating_topology() {
 }
 
 #[test]
+fn pachner_proposal_rejects_different_topology_owner_without_mutating() {
+    let dt = build_minimal_simplex_dt::<2>();
+    let simplex_key = first_simplex_generic(&dt);
+    let vertex: Vertex<(), 2> = vertex!(simplex_centroid_generic(&dt, simplex_key))
+        .expect("simplex centroid should be valid");
+    let proposal = dt
+        .propose_pachner(PachnerMove::K1Insert {
+            simplex_key,
+            vertex,
+        })
+        .expect("source proposal should be valid");
+
+    let mut target = build_minimal_simplex_dt::<2>();
+    let before = snapshot_topology_2d(&target);
+    let expected_owner = target.topology_owner_id();
+    let found_owner = proposal.owner_id().clone();
+    let feasibility = proposal
+        .can_attempt_on(&target)
+        .expect_err("independent triangulation should reject proposal from original owner");
+    assert_matches!(
+        &feasibility,
+        FlipError::WrongTopologyOwner { expected, found }
+            if expected == &expected_owner && found == &found_owner
+    );
+    assert_eq!(
+        FlipFailureKind::from(&feasibility),
+        FlipFailureKind::WrongTopologyOwner
+    );
+    assert_eq!(snapshot_topology_2d(&target), before);
+
+    let attempted = proposal
+        .attempt_on(&mut target)
+        .expect_err("independent triangulation should not mutate from original proposal");
+    assert_matches!(
+        &attempted,
+        FlipError::WrongTopologyOwner { expected, found }
+            if expected == &expected_owner && found == &found_owner
+    );
+    assert_eq!(
+        FlipFailureKind::from(&attempted),
+        FlipFailureKind::WrongTopologyOwner
+    );
+    assert_eq!(snapshot_topology_2d(&target), before);
+}
+
+#[test]
 #[cfg(feature = "slow-tests")]
 fn stale_k2_request_fails_without_mutating_topology() {
     let base = build_stable_dt_4d();
@@ -150,12 +202,14 @@ fn stale_pachner_error_propagates_through_delaunay_result() {
     let vertex: Vertex<(), 4> =
         vertex!(vertex_coords).expect("centroid of a stable simplex should be a valid vertex");
     let vertex_uuid = vertex.uuid();
-    let inserted = dt
-        .attempt_pachner(PachnerMove::K1Insert {
+    let inserted = attempt_pachner_move(
+        &mut dt,
+        PachnerMove::K1Insert {
             simplex_key: stale_simplex,
             vertex,
-        })
-        .expect("initial k=1 insert should make the simplex key stale");
+        },
+    )
+    .expect("initial k=1 insert should make the simplex key stale");
     let inserted_vertex = dt
         .tds()
         .vertex_key_from_uuid(&vertex_uuid)
@@ -203,8 +257,7 @@ fn edge_to_facet_query_tracks_2d_k2_mutation_freshness() {
             .is_some()
     );
 
-    let info = dt
-        .attempt_pachner(PachnerMove::K2 { facet })
+    let info = attempt_pachner_move(&mut dt, PachnerMove::K2 { facet })
         .expect("2D k=2 flip should succeed on selected fixture facet");
     assert_eq!(info.inserted_face_vertices.len(), 2);
 
@@ -243,8 +296,11 @@ fn pachner_feasibility_agrees_with_successful_2d_k2_attempt() {
     let facet = flippable_k2_facet_2d(&dt);
     let pachner_move = PachnerMove::K2 { facet };
 
-    let feasibility = dt
-        .can_attempt_pachner(&pachner_move)
+    let proposal = dt
+        .propose_pachner(pachner_move)
+        .expect("2D k=2 proposal parsing should accept selected fixture facet");
+    let feasibility = proposal
+        .can_attempt_on(&dt)
         .expect("2D k=2 feasibility should accept selected fixture facet");
     assert_pachner_feasibility_contract(
         &feasibility,
@@ -253,8 +309,8 @@ fn pachner_feasibility_agrees_with_successful_2d_k2_attempt() {
     );
 
     let mut trial = dt;
-    let result = trial
-        .attempt_pachner(pachner_move)
+    let result = proposal
+        .attempt_on(&mut trial)
         .expect("2D k=2 attempt should agree with feasibility");
     assert_eq!(feasibility.kind, result.kind);
     assert_eq!(feasibility.direction, result.direction);
@@ -270,6 +326,26 @@ fn pachner_feasibility_agrees_with_successful_2d_k2_attempt() {
 }
 
 #[test]
+fn pachner_feasibility_rejects_unsupported_2d_k2_inverse_without_mutating() {
+    let mut dt = build_flippable_dt_2d();
+    let facet = flippable_k2_facet_2d(&dt);
+    let forward = attempt_pachner_move(&mut dt, PachnerMove::K2 { facet })
+        .expect("2D k=2 attempt should create an inverse edge candidate");
+    let edge = inserted_edge_2d(&dt, &forward.inserted_face_vertices);
+    let pachner_move = PachnerMove::K2Inverse { edge };
+    let before = snapshot_topology_2d(&dt);
+
+    assert_matches!(
+        dt.can_flip_k2_inverse_from_edge(edge),
+        Err(FlipError::UnsupportedDimension { dimension: 2 })
+    );
+    assert_eq!(snapshot_topology_2d(&dt), before);
+    assert_pachner_rejection_preserves_topology(dt, pachner_move, |err| {
+        assert_matches!(err, FlipError::UnsupportedDimension { dimension: 2 });
+    });
+}
+
+#[test]
 fn pachner_feasibility_rejects_boundary_facet_like_attempt_2d() {
     let dt = build_single_triangle_dt_2d();
     let (simplex_key, _) = dt
@@ -280,11 +356,11 @@ fn pachner_feasibility_rejects_boundary_facet_like_attempt_2d() {
         .expect("single-triangle boundary facet should be a live handle");
     let pachner_move = PachnerMove::K2 { facet };
 
-    let feasibility = dt.can_attempt_pachner(&pachner_move);
+    let feasibility = dt.propose_pachner(pachner_move);
     assert_matches!(feasibility, Err(FlipError::BoundaryFacet { .. }));
 
-    let mut trial = dt;
-    let attempted = trial.attempt_pachner(pachner_move);
+    let trial = dt;
+    let attempted = trial.propose_pachner(pachner_move);
     assert_matches!(attempted, Err(FlipError::BoundaryFacet { .. }));
     assert_topology_and_delaunay_valid(&trial, "failed boundary feasibility agreement");
 }
@@ -293,20 +369,19 @@ fn pachner_feasibility_rejects_boundary_facet_like_attempt_2d() {
 fn pachner_feasibility_rejects_stale_facet_like_attempt_2d() {
     let mut dt = build_flippable_dt_2d();
     let facet = flippable_k2_facet_2d(&dt);
-    let first_flip = dt
-        .attempt_pachner(PachnerMove::K2 { facet })
+    let first_flip = attempt_pachner_move(&mut dt, PachnerMove::K2 { facet })
         .expect("first k=2 attempt should stale the original facet");
     assert!(!first_flip.new_simplices.is_empty());
     let stale_move = PachnerMove::K2 { facet };
 
-    let feasibility = dt.can_attempt_pachner(&stale_move);
+    let feasibility = dt.propose_pachner(stale_move);
     assert_matches!(
         feasibility,
         Err(FlipError::MissingSimplex { simplex_key }) if simplex_key == facet.simplex_key()
     );
 
     let before_failed_attempt = snapshot_topology_2d(&dt);
-    let attempted = dt.attempt_pachner(stale_move);
+    let attempted = dt.propose_pachner(stale_move);
     assert_matches!(
         attempted,
         Err(FlipError::MissingSimplex { simplex_key }) if simplex_key == facet.simplex_key()
@@ -326,8 +401,11 @@ fn pachner_feasibility_agrees_with_toroidal_2d_k1_insert() {
         vertex,
     };
 
-    let feasibility = dt
-        .can_attempt_pachner(&pachner_move)
+    let proposal = dt
+        .propose_pachner(pachner_move)
+        .expect("toroidal k=1 proposal parsing should accept a simplex centroid");
+    let feasibility = proposal
+        .can_attempt_on(&dt)
         .expect("toroidal k=1 feasibility should accept a simplex centroid");
     assert_pachner_feasibility_contract(
         &feasibility,
@@ -337,8 +415,8 @@ fn pachner_feasibility_agrees_with_toroidal_2d_k1_insert() {
     assert!(feasibility.inserted_face_vertices.is_none());
 
     let mut trial = dt;
-    let result = trial
-        .attempt_pachner(pachner_move)
+    let result = proposal
+        .attempt_on(&mut trial)
         .expect("toroidal k=1 attempt should agree with feasibility");
     let inserted_vertex = trial
         .tds()
@@ -347,6 +425,10 @@ fn pachner_feasibility_agrees_with_toroidal_2d_k1_insert() {
     assert_eq!(result.kind, feasibility.kind);
     assert_eq!(result.direction, feasibility.direction);
     assert_eq!(result.removed_simplices, feasibility.removed_simplices);
+    assert_eq!(
+        result.removed_face_vertices,
+        feasibility.removed_face_vertices
+    );
     assert_eq!(result.inserted_face_vertices.as_slice(), &[inserted_vertex]);
     trial
         .as_triangulation()
@@ -370,12 +452,96 @@ fn pachner_feasibility_rejects_duplicate_k1_insert_uuid_without_mutating() {
         vertex: duplicate_vertex,
     };
 
-    assert_duplicate_vertex_uuid_error(dt.can_attempt_pachner(&pachner_move), duplicate_uuid);
+    assert_duplicate_vertex_uuid_error(dt.propose_pachner(pachner_move), duplicate_uuid);
 
-    let mut trial = dt;
+    let trial = dt;
     let before_failed_attempt = snapshot_topology_2d(&trial);
-    assert_duplicate_vertex_uuid_error(trial.attempt_pachner(pachner_move), duplicate_uuid);
+    assert_duplicate_vertex_uuid_error(trial.propose_pachner(pachner_move), duplicate_uuid);
     assert_eq!(snapshot_topology_2d(&trial), before_failed_attempt);
+}
+
+#[test]
+fn pachner_feasibility_rejects_invalid_3d_inverse_k2_without_mutating() {
+    let dt = build_minimal_simplex_dt::<3>();
+    let simplex = dt
+        .simplices()
+        .next()
+        .map(|(_, simplex)| simplex)
+        .expect("minimal 3D fixture should contain one simplex");
+    let [a, b, ..] = simplex.vertices() else {
+        panic!("3D simplex should contain at least two vertices");
+    };
+    let edge = EdgeKey::try_new(dt.tds(), *a, *b).expect("simplex vertices should form an edge");
+    let pachner_move = PachnerMove::K2Inverse { edge };
+
+    assert_pachner_rejection_preserves_topology(dt, pachner_move, |err| {
+        assert_matches!(
+            err,
+            FlipError::InvalidEdgeMultiplicity {
+                found: 1,
+                expected: 3
+            }
+        );
+    });
+}
+
+#[test]
+fn pachner_feasibility_rejects_invalid_3d_k3_without_mutating() {
+    let dt = build_minimal_simplex_dt::<3>();
+    let simplex_key = first_simplex_generic(&dt);
+    let ridge = RidgeHandle::try_new(dt.tds(), simplex_key, 0, 1)
+        .expect("minimal 3D fixture should expose a ridge handle");
+    let pachner_move = PachnerMove::K3 { ridge };
+
+    assert_pachner_rejection_preserves_topology(dt, pachner_move, |err| {
+        assert_matches!(err, FlipError::InvalidRidgeMultiplicity { found: 1 });
+    });
+}
+
+#[test]
+fn pachner_feasibility_rejects_invalid_4d_k3_inverse_without_mutating() {
+    let dt = build_minimal_simplex_dt::<4>();
+    let simplex = dt
+        .simplices()
+        .next()
+        .map(|(_, simplex)| simplex)
+        .expect("minimal 4D fixture should contain one simplex");
+    let [a, b, c, ..] = simplex.vertices() else {
+        panic!("4D simplex should contain at least three vertices");
+    };
+    let triangle =
+        TriangleHandle::try_new(*a, *b, *c).expect("simplex vertices should form a triangle");
+    let pachner_move = PachnerMove::K3Inverse { triangle };
+
+    assert_pachner_rejection_preserves_topology(dt, pachner_move, |err| {
+        assert_matches!(
+            err,
+            FlipError::InvalidTriangleMultiplicity {
+                found: 1,
+                expected: 3
+            }
+        );
+    });
+}
+
+#[test]
+fn pachner_feasibility_rejects_unsupported_3d_k3_inverse_without_mutating() {
+    let dt = build_minimal_simplex_dt::<3>();
+    let simplex = dt
+        .simplices()
+        .next()
+        .map(|(_, simplex)| simplex)
+        .expect("minimal 3D fixture should contain one simplex");
+    let [a, b, c, ..] = simplex.vertices() else {
+        panic!("3D simplex should contain at least three vertices");
+    };
+    let triangle =
+        TriangleHandle::try_new(*a, *b, *c).expect("simplex vertices should form a triangle");
+    let pachner_move = PachnerMove::K3Inverse { triangle };
+
+    assert_pachner_rejection_preserves_topology(dt, pachner_move, |err| {
+        assert_matches!(err, FlipError::UnsupportedDimension { dimension: 3 });
+    });
 }
 
 #[test]
@@ -394,10 +560,13 @@ fn try_stale_k1_insert(
 ) -> DelaunayResult<()> {
     let vertex: Vertex<(), 4> = vertex!(vertex_coords)?;
     let vertex_uuid = vertex.uuid();
-    let inserted = dt.attempt_pachner(PachnerMove::K1Insert {
-        simplex_key: stale_simplex,
-        vertex,
-    })?;
+    let inserted = attempt_pachner_move(
+        dt,
+        PachnerMove::K1Insert {
+            simplex_key: stale_simplex,
+            vertex,
+        },
+    )?;
     let inserted_vertex = dt
         .tds()
         .vertex_key_from_uuid(&vertex_uuid)
@@ -525,7 +694,7 @@ fn flippable_k2_facet_2d(dt: &Dt2) -> FacetHandle {
             )
             .expect("interior 2D facet index should be valid");
             let mut trial = dt.clone();
-            if trial.attempt_pachner(PachnerMove::K2 { facet }).is_ok()
+            if attempt_pachner_move(&mut trial, PachnerMove::K2 { facet }).is_ok()
                 && topology_and_delaunay_valid(&trial)
             {
                 return facet;
@@ -537,6 +706,29 @@ fn flippable_k2_facet_2d(dt: &Dt2) -> FacetHandle {
 
 /// Captures 2D topology by stable UUIDs so failed attempts can prove non-mutation.
 fn snapshot_topology_2d(dt: &Dt2) -> TopologySnapshot {
+    snapshot_topology_generic(dt)
+}
+
+/// Verifies the primitive flip feasibility and unified Pachner report agree.
+fn assert_flip_and_pachner_feasibility_match<const D: usize>(
+    primitive: &FlipFeasibility<D>,
+    pachner: &PachnerMoveFeasibility<D>,
+) {
+    assert_eq!(primitive.kind, pachner.kind);
+    assert_eq!(primitive.direction, pachner.direction);
+    assert_eq!(primitive.removed_simplices, pachner.removed_simplices);
+    assert_eq!(
+        primitive.removed_face_vertices,
+        pachner.removed_face_vertices
+    );
+    assert_eq!(
+        primitive.inserted_face_vertices,
+        pachner.inserted_face_vertices
+    );
+}
+
+/// Captures topology by stable UUIDs for any deterministic test fixture.
+fn snapshot_topology_generic<const D: usize>(dt: &Dt<D>) -> TopologySnapshot {
     let tds = dt.tds();
     let mut vertex_uuids = tds
         .vertices()
@@ -566,6 +758,27 @@ fn snapshot_topology_2d(dt: &Dt2) -> TopologySnapshot {
         vertex_uuids,
         simplex_vertex_uuids,
     }
+}
+
+/// Verifies an invalid raw Pachner request reports the same error without mutation.
+fn assert_pachner_rejection_preserves_topology<const D: usize>(
+    dt: Dt<D>,
+    pachner_move: PachnerMove<(), D>,
+    assert_error: impl Fn(&FlipError),
+) {
+    let before = snapshot_topology_generic(&dt);
+    let feasibility = dt
+        .propose_pachner(pachner_move)
+        .expect_err("Pachner proposal parsing should reject invalid request");
+    assert_error(&feasibility);
+    assert_eq!(snapshot_topology_generic(&dt), before);
+
+    let trial = dt;
+    let attempted = trial
+        .propose_pachner(pachner_move)
+        .expect_err("Pachner proposal parsing should reject invalid request");
+    assert_error(&attempted);
+    assert_eq!(snapshot_topology_generic(&trial), before);
 }
 
 /// Verifies the generic Pachner feasibility arities implied by the reported move kind.
@@ -612,8 +825,11 @@ fn assert_public_k1_insert_feasibility_smoke<const D: usize>() {
         vertex,
     };
 
-    let feasibility = dt
-        .can_attempt_pachner(&pachner_move)
+    let proposal = dt
+        .propose_pachner(pachner_move)
+        .unwrap_or_else(|err| panic!("{D}D public k=1 proposal should succeed: {err:?}"));
+    let feasibility = proposal
+        .can_attempt_on(&dt)
         .unwrap_or_else(|err| panic!("{D}D public k=1 feasibility should succeed: {err:?}"));
     assert_pachner_feasibility_contract(
         &feasibility,
@@ -623,8 +839,8 @@ fn assert_public_k1_insert_feasibility_smoke<const D: usize>() {
     assert!(feasibility.inserted_face_vertices.is_none());
 
     let mut trial = dt;
-    let result = trial
-        .attempt_pachner(pachner_move)
+    let result = proposal
+        .attempt_on(&mut trial)
         .unwrap_or_else(|err| panic!("{D}D public k=1 mutation should succeed: {err:?}"));
     let inserted_vertex = trial
         .tds()
@@ -638,14 +854,35 @@ fn assert_public_k1_insert_feasibility_smoke<const D: usize>() {
         result.removed_face_vertices
     );
     assert_eq!(result.inserted_face_vertices.as_slice(), &[inserted_vertex]);
-    trial
-        .as_triangulation()
-        .validate()
-        .unwrap_or_else(|err| panic!("{D}D k=1 mutation should preserve topology: {err}"));
-    trial
-        .as_triangulation()
-        .is_valid_embedding()
-        .unwrap_or_else(|err| panic!("{D}D k=1 mutation should preserve embedding: {err}"));
+
+    let remove_move = PachnerMove::K1Remove {
+        vertex_key: inserted_vertex,
+    };
+    let primitive_remove_feasibility = trial
+        .can_flip_k1_remove(inserted_vertex)
+        .unwrap_or_else(|err| panic!("{D}D public k=1 remove feasibility should succeed: {err:?}"));
+    let remove_proposal = trial.propose_pachner(remove_move).unwrap_or_else(|err| {
+        panic!("{D}D public Pachner k=1 remove proposal should succeed: {err:?}")
+    });
+    let remove_feasibility = remove_proposal
+        .can_attempt_on(&trial)
+        .unwrap_or_else(|err| panic!("{D}D public Pachner k=1 remove should succeed: {err:?}"));
+    assert_flip_and_pachner_feasibility_match(&primitive_remove_feasibility, &remove_feasibility);
+    assert_pachner_feasibility_contract(
+        &remove_feasibility,
+        BistellarFlipKind::k1(D).inverse(),
+        FlipDirection::Inverse,
+    );
+
+    let removed = remove_proposal
+        .attempt_on(&mut trial)
+        .unwrap_or_else(|err| panic!("{D}D public k=1 remove mutation should succeed: {err:?}"));
+    assert_pachner_result_contract(
+        &removed,
+        BistellarFlipKind::k1(D).inverse(),
+        FlipDirection::Inverse,
+    );
+    assert_topology_and_delaunay_valid(&trial, &format!("{D}D k=1 mutation"));
 }
 
 /// Returns any live simplex key from a generic D-dimensional fixture.
@@ -710,21 +947,52 @@ fn inserted_edge_2d(dt: &Dt2, vertices: &[VertexKey]) -> EdgeKey {
     EdgeKey::try_new(dt.tds(), *a, *b).expect("reported inserted vertices should form a live edge")
 }
 
-/// Checks that a rejected detached move leaves the live topology byte-for-byte equivalent.
+/// Checks that a rejected detached proposal leaves the live topology byte-for-byte equivalent.
 fn assert_failed_attempt_preserves_topology(
     dt: &mut Dt4,
-    pachner_move: PachnerMove<(), 4>,
-    assert_error: impl FnOnce(&FlipError),
+    proposal: PachnerProposal<(), 4>,
+    assert_error: impl Fn(&FlipError),
 ) {
     let before = snapshot_topology(dt);
-    let err = dt
-        .attempt_pachner(pachner_move)
-        .expect_err("stale Pachner move should fail");
+    let proposal_generation = proposal.topology_generation();
+    let current_generation = dt.tds().generation();
+
+    let feasibility_err = proposal
+        .can_attempt_on(dt)
+        .expect_err("stale Pachner proposal feasibility should fail");
+    assert_error(&feasibility_err);
+    assert_stale_proposal_generation(&feasibility_err, proposal_generation, current_generation);
+    assert_eq!(snapshot_topology(dt), before);
+
+    let err = proposal
+        .attempt_on(dt)
+        .expect_err("stale Pachner proposal should fail");
     assert_error(&err);
+    assert_stale_proposal_generation(&err, proposal_generation, current_generation);
     dt.tds()
         .is_valid()
         .expect("failed Pachner attempt should preserve TDS validity");
     assert_eq!(snapshot_topology(dt), before);
+}
+
+/// Verifies stale proposal diagnostics report both the parsed and current generations.
+fn assert_stale_proposal_generation(
+    err: &FlipError,
+    proposal_generation: u64,
+    current_generation: u64,
+) {
+    assert_matches!(
+        err,
+        FlipError::StaleTopologyProposal {
+            proposal_generation: reported_proposal_generation,
+            current_generation: reported_current_generation,
+        } if *reported_proposal_generation == proposal_generation
+            && *reported_current_generation == current_generation
+    );
+    assert_eq!(
+        FlipFailureKind::from(err),
+        FlipFailureKind::StaleTopologyProposal
+    );
 }
 
 /// Verifies the extra k=1 insert contract: the inserted face is exactly the new vertex.
@@ -753,33 +1021,28 @@ fn assert_stale_k1_insert_preserves_topology(mut dt: Dt4) {
     let vertex_coords = simplex_centroid(&dt, stale_simplex);
     let vertex: Vertex<(), 4> = vertex!(vertex_coords).unwrap();
     let vertex_uuid = vertex.uuid();
-    let inserted = dt
-        .attempt_pachner(PachnerMove::K1Insert {
+    let stale_proposal = dt
+        .propose_pachner(PachnerMove::K1Insert {
             simplex_key: stale_simplex,
             vertex,
         })
-        .expect("initial k=1 insert should make the simplex key stale");
+        .expect("initial k=1 insert proposal should be valid");
+    let inserted = stale_proposal
+        .clone()
+        .attempt_on(&mut dt)
+        .expect("initial k=1 insert should make the proposal stale");
     let inserted_vertex = dt
         .tds()
         .vertex_key_from_uuid(&vertex_uuid)
         .expect("initial k=1 insert should create the requested vertex");
     assert_k1_insert_result(&inserted, inserted_vertex);
-    let stale_attempt_vertex: Vertex<(), 4> = vertex!(vertex_coords).unwrap();
-
-    assert_failed_attempt_preserves_topology(
-        &mut dt,
-        PachnerMove::K1Insert {
-            simplex_key: stale_simplex,
-            vertex: stale_attempt_vertex,
-        },
-        |err| {
-            assert_matches!(
-                err,
-                FlipError::MissingSimplex { simplex_key } if *simplex_key == stale_simplex,
-                "unexpected stale k=1 insert error: {err:?}"
-            );
-        },
-    );
+    assert_failed_attempt_preserves_topology(&mut dt, stale_proposal, |err| {
+        assert_matches!(
+            err,
+            FlipError::StaleTopologyProposal { .. },
+            "unexpected stale k=1 insert error: {err:?}"
+        );
+    });
 }
 
 /// Makes a k=1 remove proposal stale, then proves retrying it is failure-atomic.
@@ -787,50 +1050,56 @@ fn assert_stale_k1_remove_preserves_topology(mut dt: Dt4) {
     let simplex_key = first_simplex(&dt);
     let vertex: Vertex<(), 4> = vertex!(simplex_centroid(&dt, simplex_key)).unwrap();
     let vertex_uuid = vertex.uuid();
-    let inserted = dt
-        .attempt_pachner(PachnerMove::K1Insert {
+    let insert_proposal = dt
+        .propose_pachner(PachnerMove::K1Insert {
             simplex_key,
             vertex,
         })
+        .expect("k=1 insert proposal should be valid");
+    let inserted = insert_proposal
+        .attempt_on(&mut dt)
         .expect("k=1 insert should create a removable vertex");
     let vertex_key = dt
         .tds()
         .vertex_key_from_uuid(&vertex_uuid)
         .expect("inserted k=1 vertex should be present");
     assert_k1_insert_result(&inserted, vertex_key);
-    let removed = dt
-        .attempt_pachner(PachnerMove::K1Remove { vertex_key })
-        .expect("k=1 remove should make the vertex key stale");
+    let stale_proposal = dt
+        .propose_pachner(PachnerMove::K1Remove { vertex_key })
+        .expect("k=1 remove proposal should be valid");
+    let removed = stale_proposal
+        .clone()
+        .attempt_on(&mut dt)
+        .expect("k=1 remove should make the proposal stale");
     assert!(!removed.removed_simplices.is_empty());
 
-    assert_failed_attempt_preserves_topology(
-        &mut dt,
-        PachnerMove::K1Remove { vertex_key },
-        |err| {
-            assert_matches!(
-                err,
-                FlipError::MissingVertex { vertex_key: missing } if *missing == vertex_key,
-                "unexpected stale k=1 remove error: {err:?}"
-            );
-        },
-    );
+    assert_failed_attempt_preserves_topology(&mut dt, stale_proposal, |err| {
+        assert_matches!(
+            err,
+            FlipError::StaleTopologyProposal { .. },
+            "unexpected stale k=1 remove error: {err:?}"
+        );
+    });
 }
 
 /// Makes a k=2 facet proposal stale, then proves retrying it is failure-atomic.
 #[cfg(feature = "slow-tests")]
 fn assert_stale_k2_preserves_topology(mut dt: Dt4) {
     let facet = flippable_k2_facet(&dt);
-    let flipped = dt
-        .attempt_pachner(PachnerMove::K2 { facet })
-        .expect("k=2 flip should make its source facet stale");
+    let stale_proposal = dt
+        .propose_pachner(PachnerMove::K2 { facet })
+        .expect("k=2 proposal should be valid");
+    let flipped = stale_proposal
+        .clone()
+        .attempt_on(&mut dt)
+        .expect("k=2 flip should make its proposal stale");
     assert_eq!(flipped.inserted_face_vertices.len(), 2);
     assert!(!flipped.new_simplices.is_empty());
-    let stale_simplex = facet.simplex_key();
 
-    assert_failed_attempt_preserves_topology(&mut dt, PachnerMove::K2 { facet }, |err| {
+    assert_failed_attempt_preserves_topology(&mut dt, stale_proposal, |err| {
         assert_matches!(
             err,
-            FlipError::MissingSimplex { simplex_key } if *simplex_key == stale_simplex,
+            FlipError::StaleTopologyProposal { .. },
             "unexpected stale k=2 error: {err:?}"
         );
     });
@@ -840,22 +1109,22 @@ fn assert_stale_k2_preserves_topology(mut dt: Dt4) {
 #[cfg(feature = "slow-tests")]
 fn assert_stale_k2_inverse_preserves_topology(mut dt: Dt4) {
     let facet = flippable_k2_facet(&dt);
-    let info = dt
-        .attempt_pachner(PachnerMove::K2 { facet })
+    let info = attempt_pachner_move(&mut dt, PachnerMove::K2 { facet })
         .expect("k=2 flip should create an inverse edge");
     let edge = inserted_edge(&dt, &info.inserted_face_vertices);
-    let inverse = dt
-        .attempt_pachner(PachnerMove::K2Inverse { edge })
-        .expect("k=2 inverse should make its edge stale");
+    let stale_proposal = dt
+        .propose_pachner(PachnerMove::K2Inverse { edge })
+        .expect("k=2 inverse proposal should be valid");
+    let inverse = stale_proposal
+        .clone()
+        .attempt_on(&mut dt)
+        .expect("k=2 inverse should make its proposal stale");
     assert!(!inverse.removed_simplices.is_empty());
 
-    assert_failed_attempt_preserves_topology(&mut dt, PachnerMove::K2Inverse { edge }, |err| {
+    assert_failed_attempt_preserves_topology(&mut dt, stale_proposal, |err| {
         assert_matches!(
             err,
-            FlipError::InvalidEdgeMultiplicity {
-                found: 0,
-                expected: 4
-            },
+            FlipError::StaleTopologyProposal { .. },
             "unexpected stale inverse k=2 error: {err:?}"
         );
     });
@@ -865,17 +1134,20 @@ fn assert_stale_k2_inverse_preserves_topology(mut dt: Dt4) {
 #[cfg(feature = "slow-tests")]
 fn assert_stale_k3_preserves_topology(mut dt: Dt4) {
     let ridge = flippable_k3_ridge(&dt);
-    let flipped = dt
-        .attempt_pachner(PachnerMove::K3 { ridge })
-        .expect("k=3 flip should make its source ridge stale");
+    let stale_proposal = dt
+        .propose_pachner(PachnerMove::K3 { ridge })
+        .expect("k=3 proposal should be valid");
+    let flipped = stale_proposal
+        .clone()
+        .attempt_on(&mut dt)
+        .expect("k=3 flip should make its proposal stale");
     assert_eq!(flipped.inserted_face_vertices.len(), 3);
     assert!(!flipped.new_simplices.is_empty());
-    let stale_simplex = ridge.simplex_key();
 
-    assert_failed_attempt_preserves_topology(&mut dt, PachnerMove::K3 { ridge }, |err| {
+    assert_failed_attempt_preserves_topology(&mut dt, stale_proposal, |err| {
         assert_matches!(
             err,
-            FlipError::MissingSimplex { simplex_key } if *simplex_key == stale_simplex,
+            FlipError::StaleTopologyProposal { .. },
             "unexpected stale k=3 error: {err:?}"
         );
     });
@@ -885,22 +1157,22 @@ fn assert_stale_k3_preserves_topology(mut dt: Dt4) {
 #[cfg(feature = "slow-tests")]
 fn assert_stale_k3_inverse_preserves_topology(mut dt: Dt4) {
     let ridge = flippable_k3_ridge(&dt);
-    let info = dt
-        .attempt_pachner(PachnerMove::K3 { ridge })
+    let info = attempt_pachner_move(&mut dt, PachnerMove::K3 { ridge })
         .expect("k=3 flip should create an inverse triangle");
     let triangle = inserted_triangle(&info.inserted_face_vertices);
-    let inverse = dt
-        .attempt_pachner(PachnerMove::K3Inverse { triangle })
-        .expect("k=3 inverse should make its triangle stale");
+    let stale_proposal = dt
+        .propose_pachner(PachnerMove::K3Inverse { triangle })
+        .expect("k=3 inverse proposal should be valid");
+    let inverse = stale_proposal
+        .clone()
+        .attempt_on(&mut dt)
+        .expect("k=3 inverse should make its proposal stale");
     assert!(!inverse.removed_simplices.is_empty());
 
-    assert_failed_attempt_preserves_topology(&mut dt, PachnerMove::K3Inverse { triangle }, |err| {
+    assert_failed_attempt_preserves_topology(&mut dt, stale_proposal, |err| {
         assert_matches!(
             err,
-            FlipError::InvalidTriangleMultiplicity {
-                found: 0,
-                expected: 3
-            },
+            FlipError::StaleTopologyProposal { .. },
             "unexpected stale inverse k=3 error: {err:?}"
         );
     });
@@ -908,35 +1180,7 @@ fn assert_stale_k3_inverse_preserves_topology(mut dt: Dt4) {
 
 /// Captures topology by stable UUIDs so slotmap key reuse cannot hide mutations.
 fn snapshot_topology(dt: &Dt4) -> TopologySnapshot {
-    let tds = dt.tds();
-    let mut vertex_uuids = tds
-        .vertices()
-        .map(|(_, vertex)| vertex.uuid())
-        .collect::<Vec<_>>();
-    vertex_uuids.sort();
-
-    let mut simplex_vertex_uuids = tds
-        .simplices()
-        .map(|(_, simplex)| {
-            let mut uuids = simplex
-                .vertices()
-                .iter()
-                .map(|&vkey| {
-                    tds.vertex(vkey)
-                        .expect("simplex vertex key should exist")
-                        .uuid()
-                })
-                .collect::<Vec<_>>();
-            uuids.sort();
-            uuids
-        })
-        .collect::<Vec<_>>();
-    simplex_vertex_uuids.sort();
-
-    TopologySnapshot {
-        vertex_uuids,
-        simplex_vertex_uuids,
-    }
+    snapshot_topology_generic(dt)
 }
 
 /// Returns a simplex from the stable fixture for tests that only need any live simplex.
@@ -976,23 +1220,27 @@ fn roundtrip_k1(dt: &mut Dt4) {
     let simplex_key = first_simplex(dt);
     let new_vertex: Vertex<(), 4> = vertex!(simplex_centroid(dt, simplex_key)).unwrap();
     let new_uuid = new_vertex.uuid();
-    let inserted = dt
-        .attempt_pachner(PachnerMove::K1Insert {
+    let inserted = attempt_pachner_move(
+        dt,
+        PachnerMove::K1Insert {
             simplex_key,
             vertex: new_vertex,
-        })
-        .expect("k=1 insert should succeed on stable 4D fixture");
+        },
+    )
+    .expect("k=1 insert should succeed on stable 4D fixture");
     assert_eq!(inserted.inserted_face_vertices.len(), 1);
 
     let inserted_key = dt
         .tds()
         .vertex_key_from_uuid(&new_uuid)
         .expect("inserted k=1 vertex should be present");
-    let removed = dt
-        .attempt_pachner(PachnerMove::K1Remove {
+    let removed = attempt_pachner_move(
+        dt,
+        PachnerMove::K1Remove {
             vertex_key: inserted_key,
-        })
-        .expect("k=1 remove should invert insert");
+        },
+    )
+    .expect("k=1 remove should invert insert");
     assert_pachner_result_contract(
         &removed,
         BistellarFlipKind::k1(4).inverse(),
@@ -1018,13 +1266,11 @@ fn flippable_k2_facet(dt: &Dt4) -> FacetHandle {
             )
             .expect("interior facet index should be valid");
             let mut trial = dt.clone();
-            let Ok(info) = trial.attempt_pachner(PachnerMove::K2 { facet }) else {
+            let Ok(info) = attempt_pachner_move(&mut trial, PachnerMove::K2 { facet }) else {
                 continue;
             };
             let edge = inserted_edge(&trial, &info.inserted_face_vertices);
-            if trial
-                .attempt_pachner(PachnerMove::K2Inverse { edge })
-                .is_ok()
+            if attempt_pachner_move(&mut trial, PachnerMove::K2Inverse { edge }).is_ok()
                 && topology_and_delaunay_valid(&trial)
             {
                 return facet;
@@ -1037,13 +1283,11 @@ fn flippable_k2_facet(dt: &Dt4) -> FacetHandle {
 /// Applies a k=2 forward/inverse pair and checks both move reports.
 #[cfg(feature = "slow-tests")]
 fn roundtrip_k2(dt: &mut Dt4, facet: FacetHandle) {
-    let info: PachnerMoveResult<4> = dt
-        .attempt_pachner(PachnerMove::K2 { facet })
+    let info: PachnerMoveResult<4> = attempt_pachner_move(dt, PachnerMove::K2 { facet })
         .expect("k=2 flip should succeed on selected stable 4D facet");
     assert_pachner_result_contract(&info, BistellarFlipKind::k2(4), FlipDirection::Forward);
     let edge = inserted_edge(dt, &info.inserted_face_vertices);
-    let inverse = dt
-        .attempt_pachner(PachnerMove::K2Inverse { edge })
+    let inverse = attempt_pachner_move(dt, PachnerMove::K2Inverse { edge })
         .expect("k=2 inverse should succeed after k=2 flip");
     assert_pachner_result_contract(
         &inverse,
@@ -1078,13 +1322,11 @@ fn flippable_k3_ridge(dt: &Dt4) -> RidgeHandle {
                 )
                 .expect("ridge indices should be valid");
                 let mut trial = dt.clone();
-                let Ok(info) = trial.attempt_pachner(PachnerMove::K3 { ridge }) else {
+                let Ok(info) = attempt_pachner_move(&mut trial, PachnerMove::K3 { ridge }) else {
                     continue;
                 };
                 let triangle = inserted_triangle(&info.inserted_face_vertices);
-                if trial
-                    .attempt_pachner(PachnerMove::K3Inverse { triangle })
-                    .is_ok()
+                if attempt_pachner_move(&mut trial, PachnerMove::K3Inverse { triangle }).is_ok()
                     && topology_and_delaunay_valid(&trial)
                 {
                     return ridge;
@@ -1098,15 +1340,16 @@ fn flippable_k3_ridge(dt: &Dt4) -> RidgeHandle {
 /// Applies a k=3 forward/inverse pair and checks both move reports.
 #[cfg(feature = "slow-tests")]
 fn roundtrip_k3(dt: &mut Dt4, ridge: RidgeHandle) {
-    let info: PachnerMoveResult<4> = dt
-        .attempt_pachner(PachnerMove::K3 { ridge })
+    let info: PachnerMoveResult<4> = attempt_pachner_move(dt, PachnerMove::K3 { ridge })
         .expect("k=3 flip should succeed on selected stable 4D ridge");
     assert_pachner_result_contract(&info, BistellarFlipKind::k3(4), FlipDirection::Forward);
-    let inverse = dt
-        .attempt_pachner(PachnerMove::K3Inverse {
+    let inverse = attempt_pachner_move(
+        dt,
+        PachnerMove::K3Inverse {
             triangle: inserted_triangle(&info.inserted_face_vertices),
-        })
-        .expect("k=3 inverse should succeed after k=3 flip");
+        },
+    )
+    .expect("k=3 inverse should succeed after k=3 flip");
     assert_pachner_result_contract(
         &inverse,
         BistellarFlipKind::k3(4).inverse(),

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -123,8 +123,8 @@ use delaunay::prelude::pachner::{
     BistellarFlipKind as PachnerBistellarFlipKind, EdgeKey as PachnerEdgeKey,
     EdgeKeyError as PachnerEdgeKeyError, FacetError as PachnerFacetError,
     FacetHandle as PachnerFacetHandle, FlipDirection as PachnerFlipDirection,
-    FlipError as PachnerFlipError, PachnerMove, PachnerMoveResult, PachnerMoves,
-    RidgeHandle as PachnerRidgeHandle, SimplexKey as PachnerSimplexKey,
+    FlipError as PachnerFlipError, PachnerMove, PachnerMoveFeasibility, PachnerMoveResult,
+    PachnerMoves, RidgeHandle as PachnerRidgeHandle, SimplexKey as PachnerSimplexKey,
     TriangleHandle as PachnerTriangleHandle, TriangleHandleError as PachnerTriangleHandleError,
     Vertex as PachnerVertex, VertexKey as PachnerVertexKey, vertex as pachner_vertex,
 };
@@ -308,6 +308,8 @@ enum PreludeExportTestError {
     #[error(transparent)]
     Edge(#[from] EdgeKeyError),
     #[error(transparent)]
+    PachnerFlip(#[from] PachnerFlipError),
+    #[error(transparent)]
     RidgeCandidate(#[from] RidgeCandidateError),
     #[error(transparent)]
     ToroidalDomain(#[from] ToroidalDomainError),
@@ -348,6 +350,7 @@ const fn assert_pachner_prelude_type_exports(dt: &impl PachnerMoves<3, VertexDat
     let _pachner_direction_size = size_of::<PachnerFlipDirection>();
     let _pachner_error_size = size_of::<PachnerFlipError>();
     let _pachner_move_size = size_of::<PachnerMove<(), 3>>();
+    let _pachner_move_feasibility_size = size_of::<PachnerMoveFeasibility<3>>();
     let _pachner_result_size = size_of::<PachnerMoveResult<3>>();
     let _pachner_edge_size = size_of::<PachnerEdgeKey>();
     let _pachner_edge_error_size = size_of::<PachnerEdgeKeyError>();
@@ -375,6 +378,9 @@ fn assert_pachner_prelude_exports(
         pachner_move,
         PachnerMove::K1Insert { simplex_key: key, .. } if key == simplex_key
     );
+    let feasibility = dt.can_attempt_pachner(&pachner_move)?;
+    assert_eq!(feasibility.kind, PachnerBistellarFlipKind::k1(3));
+    assert!(feasibility.inserted_face_vertices.is_none());
     Ok(())
 }
 

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -124,9 +124,11 @@ use delaunay::prelude::pachner::{
     EdgeKeyError as PachnerEdgeKeyError, FacetError as PachnerFacetError,
     FacetHandle as PachnerFacetHandle, FlipDirection as PachnerFlipDirection,
     FlipError as PachnerFlipError, PachnerMove, PachnerMoveFeasibility, PachnerMoveResult,
-    PachnerMoves, RidgeHandle as PachnerRidgeHandle, SimplexKey as PachnerSimplexKey,
-    TriangleHandle as PachnerTriangleHandle, TriangleHandleError as PachnerTriangleHandleError,
-    Vertex as PachnerVertex, VertexKey as PachnerVertexKey, vertex as pachner_vertex,
+    PachnerMoves, PachnerProposal, RidgeHandle as PachnerRidgeHandle,
+    SimplexKey as PachnerSimplexKey, TopologyOwner as PachnerTopologyOwner,
+    TopologyOwnerId as PachnerTopologyOwnerId, TriangleHandle as PachnerTriangleHandle,
+    TriangleHandleError as PachnerTriangleHandleError, Vertex as PachnerVertex,
+    VertexKey as PachnerVertexKey, vertex as pachner_vertex,
 };
 use delaunay::prelude::query::{
     AllFacetsIter as QueryAllFacetsIter, BoundaryFacetsIter as QueryBoundaryFacetsIter, ConvexHull,
@@ -154,7 +156,7 @@ use delaunay::prelude::tds::{
     EdgeKeyError, EdgeView, FacetError, FacetHandle, FacetIncidenceView as TdsFacetIncidenceView,
     FacetView, InvariantError, NeighborSlot, OneSidedFacetsIter as TdsOneSidedFacetsIter,
     SimplexFacetsIter as TdsSimplexFacetsIter, SimplexKey, Tds, TdsConstructionError, TdsError,
-    VertexKey,
+    TopologyOwner as TdsTopologyOwner, TopologyOwnerId as TdsTopologyOwnerId, VertexKey,
 };
 use delaunay::prelude::topology::spaces::{
     GlobalTopology, GlobalTopologyModelError, LiftedLinkEdge, LiftedVertexId, TopologyKind,
@@ -337,8 +339,14 @@ const fn assert_root_pachner_moves(_: &impl DirectPachnerMoves<3, VertexData = (
 /// Proves unified Pachner dispatch inherits the kernel-free explicit flip contract.
 const fn assert_pachner_moves_without_kernel<T: PachnerMoves<2, VertexData = ()>>() {}
 
-/// Proves unified Pachner dispatch is available through unsized flip trait objects.
-const fn assert_pachner_moves_for_unsized_flip_trait_objects<
+/// Proves the focused Pachner prelude exposes topology-owner provenance.
+const fn assert_pachner_topology_owner(_: &impl PachnerTopologyOwner) {}
+
+/// Proves the focused TDS prelude exposes topology-owner provenance.
+const fn assert_tds_topology_owner(_: &impl TdsTopologyOwner) {}
+
+/// Proves unified Pachner dispatch remains object-safe with owner provenance.
+const fn assert_pachner_moves_for_unsized_trait_objects<
     T: PachnerMoves<2, VertexData = ()> + ?Sized,
 >() {
 }
@@ -346,12 +354,15 @@ const fn assert_pachner_moves_for_unsized_flip_trait_objects<
 const fn assert_pachner_prelude_type_exports(dt: &impl PachnerMoves<3, VertexData = ()>) {
     assert_pachner_moves(dt);
     assert_root_pachner_moves(dt);
+    assert_pachner_topology_owner(dt);
     let _pachner_kind_size = size_of::<PachnerBistellarFlipKind>();
     let _pachner_direction_size = size_of::<PachnerFlipDirection>();
     let _pachner_error_size = size_of::<PachnerFlipError>();
     let _pachner_move_size = size_of::<PachnerMove<(), 3>>();
+    let _pachner_proposal_size = size_of::<PachnerProposal<(), 3>>();
     let _pachner_move_feasibility_size = size_of::<PachnerMoveFeasibility<3>>();
     let _pachner_result_size = size_of::<PachnerMoveResult<3>>();
+    let _pachner_owner_size = size_of::<PachnerTopologyOwnerId>();
     let _pachner_edge_size = size_of::<PachnerEdgeKey>();
     let _pachner_edge_error_size = size_of::<PachnerEdgeKeyError>();
     let _pachner_facet_error_size = size_of::<PachnerFacetError>();
@@ -378,7 +389,9 @@ fn assert_pachner_prelude_exports(
         pachner_move,
         PachnerMove::K1Insert { simplex_key: key, .. } if key == simplex_key
     );
-    let feasibility = dt.can_attempt_pachner(&pachner_move)?;
+    let proposal = dt.propose_pachner(pachner_move)?;
+    assert_eq!(proposal.owner_id(), &dt.topology_owner_id());
+    let feasibility = proposal.can_attempt_on(dt)?;
     assert_eq!(feasibility.kind, PachnerBistellarFlipKind::k1(3));
     assert!(feasibility.inserted_face_vertices.is_none());
     Ok(())
@@ -841,7 +854,7 @@ fn root_exports_cover_flattened_public_api() -> Result<(), RootApiExportTestErro
 fn flip_exports_cover_orientation_check_stage() {
     assert_bistellar_flips_without_kernel::<GenericTriangulation<NonKernelMarker, (), (), 2>>();
     assert_pachner_moves_without_kernel::<GenericTriangulation<NonKernelMarker, (), (), 2>>();
-    assert_pachner_moves_for_unsized_flip_trait_objects::<dyn BistellarFlips<2, VertexData = ()>>();
+    assert_pachner_moves_for_unsized_trait_objects::<dyn PachnerMoves<2, VertexData = ()>>();
     assert_matches!(
         DirectFlipOrientationCheckStage::BeforeMutation,
         DirectFlipOrientationCheckStage::BeforeMutation
@@ -1047,8 +1060,12 @@ fn preludes_cover_bench_apis() -> Result<(), PreludeExportTestError> {
         .try_fold(0_usize, |count, facet| facet.map(|_| count + 1))?;
     assert_eq!(hull_facet_view_count, boundary_facet_count);
     dt.validate().unwrap();
+    assert_tds_topology_owner(dt.tds());
     assert_bistellar_flips(&dt);
     assert_pachner_prelude_exports(&dt, simplex_key)?;
+    assert_send_sync_unpin::<PachnerProposal<(), 3>>();
+    assert_send_sync_unpin::<PachnerTopologyOwnerId>();
+    assert_send_sync_unpin::<TdsTopologyOwnerId>();
 
     assert_insertion_prelude_empty_tds_exports()?;
     assert_send_sync_unpin::<TdsMutationError>();


### PR DESCRIPTION
- Add immutable flip and Pachner feasibility reports for dry-run workflows.
- Route Pachner feasibility through the shared bistellar preflight used by mutating flips.
- Export Pachner feasibility from the focused Pachner prelude.

BREAKING CHANGE: External BistellarFlips implementors must add the new can_flip_* feasibility methods.

Closes #419