### PR TITLE
fix(api)!: report explicit topology preflight failures precisely

### DIFF
--- a/.github/workflows/papers.yml
+++ b/.github/workflows/papers.yml
@@ -87,7 +87,15 @@ jobs:
       - name: Install paper system dependencies
         run: |
           brew update
-          brew install chktex libpng pkgconf
+          brew install libpng pkgconf
+          if ! command -v tlmgr >/dev/null; then
+            brew install --cask basictex
+          fi
+          export PATH="/Library/TeX/texbin:$PATH"
+          echo "/Library/TeX/texbin" >> "$GITHUB_PATH"
+          if ! command -v chktex >/dev/null; then
+            sudo tlmgr install chktex
+          fi
 
       - name: Install just
         uses: taiki-e/cache-cargo-install-action@417450f3c33ee20393705369577571770643d4c7 # v3.0.7

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -545,8 +545,8 @@ TeX distribution or system package manager. Building Tectonic from Cargo also
 requires `pkg-config` and development headers for its native bridge libraries,
 including fontconfig, FreeType, Graphite2, HarfBuzz, ICU, libpng, and zlib.
 `just setup-tools` checks ICU locally and auto-detects common Homebrew ICU
-pkg-config directories before it asks for a manual `PKG_CONFIG_PATH`; the Linux
-paper CI job installs the full native package set explicitly.
+pkg-config directories before it asks for a manual `PKG_CONFIG_PATH`; paper CI
+installs the platform native package set explicitly.
 
 ---
 

--- a/docs/dev/tooling-alignment.md
+++ b/docs/dev/tooling-alignment.md
@@ -225,11 +225,10 @@ The useful updates ported in this pass are:
   Cargo rather than Homebrew so local setup cannot drift from CI pins. The CI
   build matrix runs `just ci` on Linux, macOS, and Windows after syncing the
   locked uv dev group and installing the pinned Cargo tools. The papers workflow
-  separately installs `chktex` from the system package manager because it is TeX
-  distribution tooling rather than a Rust CLI, and installs the Linux native
-  bridge-library headers required when compiling Tectonic from Cargo. All
-  uv-backed workflows use uv 0.11.27 to match the local Python tooling
-  bootstrap.
+  runs on macOS, installs `chktex` from the TeX distribution when the runner
+  does not already provide it, and installs the native bridge-library packages
+  required when compiling Tectonic from Cargo. All uv-backed workflows use uv
+  0.11.27 to match the local Python tooling bootstrap.
 - `.codecov.yml` now ratchets Delaunay's coverage policy above the older
   causal-triangulations baseline without copying la-stack's near-total
   threshold. Project coverage targets the current 90% line with only 1%

--- a/src/config.rs
+++ b/src/config.rs
@@ -252,13 +252,16 @@ struct GenerateConfig<const D: usize> {
 impl<const D: usize> GenerateConfig<D> {
     /// Validate dimension-dependent generation limits.
     fn try_new(args: GenerateArgs) -> Result<Self, CliError> {
-        let vertices = NonZeroUsize::new(args.vertices)
-            .filter(|vertices| vertices.get() > D)
-            .ok_or(CliError::TooFewVertices {
+        let minimum = D + 1;
+        let vertices = validated_nonzero_count(
+            args.vertices,
+            |vertices| vertices.get() >= minimum,
+            || CliError::TooFewVertices {
                 dimension: D,
                 vertices: args.vertices,
-                minimum: D + 1,
-            })?;
+                minimum,
+            },
+        )?;
 
         Ok(Self {
             kind: args.kind,
@@ -1067,13 +1070,15 @@ impl PachnerStressConfig {
     /// Build a validated stress configuration from command-line values.
     fn try_new(input: PachnerStressConfigInput) -> Result<Self, PachnerStressError> {
         let minimum_vertices = input.dimension.value() + 1;
-        let vertex_count = NonZeroUsize::new(input.vertex_count)
-            .filter(|vertex_count| vertex_count.get() >= minimum_vertices)
-            .ok_or(PachnerStressError::TooFewVertices {
+        let vertex_count = validated_nonzero_count(
+            input.vertex_count,
+            |vertex_count| vertex_count.get() >= minimum_vertices,
+            || PachnerStressError::TooFewVertices {
                 dimension: input.dimension.value(),
                 vertices: input.vertex_count,
                 minimum: minimum_vertices,
-            })?;
+            },
+        )?;
         let validate_every = input.validate_every.min(input.move_attempts);
         let growth_slack =
             (vertex_count.get() / DEFAULT_VERTEX_GROWTH_DIVISOR).max(input.dimension.value() + 1);
@@ -2213,6 +2218,21 @@ fn positive_nonzero(
     value: usize,
 ) -> Result<NonZeroUsize, PachnerStressError> {
     NonZeroUsize::new(value).ok_or(PachnerStressError::NonPositive { argument, value })
+}
+
+/// Parses a raw count once while preserving the caller's typed threshold error.
+///
+/// CLI commands use this so zero and below-minimum counts report the same
+/// domain-specific "too few vertices" diagnostic instead of leaking
+/// `NonZeroUsize` parsing as a separate user-facing error class.
+fn validated_nonzero_count<E>(
+    value: usize,
+    is_valid: impl FnOnce(NonZeroUsize) -> bool,
+    error: impl FnOnce() -> E,
+) -> Result<NonZeroUsize, E> {
+    NonZeroUsize::new(value)
+        .filter(|count| is_valid(*count))
+        .ok_or_else(error)
 }
 
 #[cfg(test)]

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -235,6 +235,20 @@ pub enum TdsValidationFailure {
         message: String,
     },
 
+    /// Explicit input contained duplicate maximal simplices.
+    #[error(
+        "duplicate explicit simplices at input indices {existing_simplex_index} and {duplicate_simplex_index} with input vertex indices {vertex_indices:?}"
+    )]
+    #[non_exhaustive]
+    DuplicateExplicitSimplices {
+        /// Index of the first simplex specification with this canonical vertex set.
+        existing_simplex_index: usize,
+        /// Index of the duplicate simplex specification.
+        duplicate_simplex_index: usize,
+        /// Canonical sorted input vertex-index identity shared by both simplex specifications.
+        vertex_indices: Vec<usize>,
+    },
+
     /// A simplex insertion or validation pass found a facet incident to too many simplices.
     ///
     /// During insertion preflight, the `candidate_*` fields identify the simplex that
@@ -256,6 +270,28 @@ pub enum TdsValidationFailure {
         /// UUID of the candidate or offending simplex.
         candidate_simplex_uuid: uuid::Uuid,
         /// Facet index on the candidate or offending simplex.
+        candidate_facet_index: usize,
+    },
+
+    /// Explicit input contained a facet incident to too many maximal simplices.
+    #[error(
+        "explicit facet {facet_key} with input vertex indices {facet_vertex_indices:?} exceeds incident-simplex limit: input simplex {candidate_simplex_index} would make {attempted_incident_count} incident simplices, max {max_incident_count}; candidate facet {candidate_facet_index}; existing incident simplices {existing_incident_count}"
+    )]
+    #[non_exhaustive]
+    ExplicitFacetSharingViolation {
+        /// Canonical key of the over-shared facet.
+        facet_key: u64,
+        /// Canonical sorted input vertex indices defining the over-shared facet.
+        facet_vertex_indices: Vec<usize>,
+        /// Number of pre-existing explicit simplices already incident to the facet.
+        existing_incident_count: usize,
+        /// Number of incident simplices that would exist after the candidate input simplex.
+        attempted_incident_count: usize,
+        /// Maximum allowed number of incident simplices for a PL-manifold facet.
+        max_incident_count: usize,
+        /// Input index of the simplex that would exceed facet multiplicity.
+        candidate_simplex_index: usize,
+        /// Facet index on the candidate input simplex.
         candidate_facet_index: usize,
     },
 
@@ -426,6 +462,15 @@ impl From<TdsError> for TdsValidationFailure {
                 expected_odd_permutation,
             },
             TdsError::DuplicateSimplices { message } => Self::DuplicateSimplices { message },
+            TdsError::DuplicateExplicitSimplices {
+                existing_simplex_index,
+                duplicate_simplex_index,
+                vertex_indices,
+            } => Self::DuplicateExplicitSimplices {
+                existing_simplex_index,
+                duplicate_simplex_index,
+                vertex_indices,
+            },
             TdsError::FacetSharingViolation {
                 facet_key,
                 existing_incident_count,
@@ -439,6 +484,23 @@ impl From<TdsError> for TdsValidationFailure {
                 attempted_incident_count,
                 max_incident_count,
                 candidate_simplex_uuid,
+                candidate_facet_index,
+            },
+            TdsError::ExplicitFacetSharingViolation {
+                facet_key,
+                facet_vertex_indices,
+                existing_incident_count,
+                attempted_incident_count,
+                max_incident_count,
+                candidate_simplex_index,
+                candidate_facet_index,
+            } => Self::ExplicitFacetSharingViolation {
+                facet_key,
+                facet_vertex_indices,
+                existing_incident_count,
+                attempted_incident_count,
+                max_incident_count,
+                candidate_simplex_index,
                 candidate_facet_index,
             },
             TdsError::FailedToCreateSimplex { message } => Self::FailedToCreateSimplex { message },
@@ -5504,6 +5566,46 @@ mod tests {
 
         assert!(geometric.is_retryable());
         assert!(!structural.is_retryable());
+    }
+
+    #[test]
+    fn test_tds_validation_failure_preserves_explicit_input_context() {
+        let duplicate = TdsValidationFailure::from(TdsError::DuplicateExplicitSimplices {
+            existing_simplex_index: 0,
+            duplicate_simplex_index: 2,
+            vertex_indices: vec![0, 1, 2],
+        });
+        assert_matches!(
+            duplicate,
+            TdsValidationFailure::DuplicateExplicitSimplices {
+                existing_simplex_index: 0,
+                duplicate_simplex_index: 2,
+                vertex_indices,
+            } if vertex_indices == [0, 1, 2]
+        );
+
+        let overshared_facet =
+            TdsValidationFailure::from(TdsError::ExplicitFacetSharingViolation {
+                facet_key: 42,
+                facet_vertex_indices: vec![0, 1],
+                existing_incident_count: 2,
+                attempted_incident_count: 3,
+                max_incident_count: 2,
+                candidate_simplex_index: 4,
+                candidate_facet_index: 2,
+            });
+        assert_matches!(
+            overshared_facet,
+            TdsValidationFailure::ExplicitFacetSharingViolation {
+                facet_key: 42,
+                facet_vertex_indices,
+                existing_incident_count: 2,
+                attempted_incident_count: 3,
+                max_incident_count: 2,
+                candidate_simplex_index: 4,
+                candidate_facet_index: 2,
+            } if facet_vertex_indices == [0, 1]
+        );
     }
 
     #[test]

--- a/src/core/tds/errors.rs
+++ b/src/core/tds/errors.rs
@@ -608,6 +608,19 @@ pub enum TdsError {
         /// Description of the duplicate simplex validation failure.
         message: String,
     },
+    /// Explicit input contains duplicate maximal simplices.
+    #[error(
+        "Duplicate explicit simplices at input indices {existing_simplex_index} and {duplicate_simplex_index} with input vertex indices {vertex_indices:?}"
+    )]
+    #[non_exhaustive]
+    DuplicateExplicitSimplices {
+        /// Index of the first simplex specification with this canonical vertex set.
+        existing_simplex_index: usize,
+        /// Index of the duplicate simplex specification.
+        duplicate_simplex_index: usize,
+        /// Canonical sorted input vertex-index identity shared by both simplex specifications.
+        vertex_indices: Vec<usize>,
+    },
     /// A simplex insertion or validation pass found a facet incident to too many simplices.
     ///
     /// During insertion preflight, the `candidate_*` fields identify the simplex that
@@ -629,6 +642,27 @@ pub enum TdsError {
         /// UUID of the candidate or offending simplex.
         candidate_simplex_uuid: Uuid,
         /// Facet index on the candidate or offending simplex.
+        candidate_facet_index: usize,
+    },
+    /// Explicit input contains a facet incident to too many maximal simplices.
+    #[error(
+        "Explicit facet {facet_key} with input vertex indices {facet_vertex_indices:?} exceeds incident-simplex limit: input simplex {candidate_simplex_index} would make {attempted_incident_count} incident simplices, max {max_incident_count}; candidate facet {candidate_facet_index}; existing incident simplices {existing_incident_count}"
+    )]
+    #[non_exhaustive]
+    ExplicitFacetSharingViolation {
+        /// Canonical key of the over-shared facet.
+        facet_key: u64,
+        /// Canonical sorted input vertex indices defining the over-shared facet.
+        facet_vertex_indices: Vec<usize>,
+        /// Number of pre-existing explicit simplices already incident to the facet.
+        existing_incident_count: usize,
+        /// Number of incident simplices that would exist after the candidate input simplex.
+        attempted_incident_count: usize,
+        /// Maximum allowed number of incident simplices for a PL-manifold facet.
+        max_incident_count: usize,
+        /// Input index of the simplex that would exceed facet multiplicity.
+        candidate_simplex_index: usize,
+        /// Facet index on the candidate input simplex.
         candidate_facet_index: usize,
     },
     /// Failed to create a simplex during triangulation.
@@ -823,8 +857,11 @@ impl From<&TdsError> for TdsErrorKind {
             TdsError::InvalidSimplex { .. } => Self::InvalidSimplex,
             TdsError::InvalidNeighbors { .. } => Self::InvalidNeighbors,
             TdsError::OrientationViolation { .. } => Self::OrientationViolation,
-            TdsError::DuplicateSimplices { .. } => Self::DuplicateSimplices,
-            TdsError::FacetSharingViolation { .. } => Self::FacetSharingViolation,
+            TdsError::DuplicateSimplices { .. } | TdsError::DuplicateExplicitSimplices { .. } => {
+                Self::DuplicateSimplices
+            }
+            TdsError::FacetSharingViolation { .. }
+            | TdsError::ExplicitFacetSharingViolation { .. } => Self::FacetSharingViolation,
             TdsError::FailedToCreateSimplex { .. } => Self::FailedToCreateSimplex,
             TdsError::NotNeighbors { .. } => Self::NotNeighbors,
             TdsError::MappingInconsistency { .. } => Self::MappingInconsistency,
@@ -1336,6 +1373,30 @@ mod tests {
                 message: "dangling neighbor".to_string(),
             },
             TdsErrorKind::InconsistentDataStructure,
+        );
+    }
+
+    #[test]
+    fn tds_error_kind_from_error_preserves_explicit_operation_variants() {
+        assert_tds_error_kind(
+            &TdsError::DuplicateExplicitSimplices {
+                existing_simplex_index: 0,
+                duplicate_simplex_index: 1,
+                vertex_indices: vec![3],
+            },
+            TdsErrorKind::DuplicateSimplices,
+        );
+        assert_tds_error_kind(
+            &TdsError::ExplicitFacetSharingViolation {
+                facet_key: 42,
+                facet_vertex_indices: vec![0, 1],
+                existing_incident_count: 2,
+                attempted_incident_count: 3,
+                max_incident_count: 2,
+                candidate_simplex_index: 2,
+                candidate_facet_index: 1,
+            },
+            TdsErrorKind::FacetSharingViolation,
         );
     }
 

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -747,6 +747,8 @@ impl<'v, U, const D: usize> DelaunayTriangulationBuilder<'v, U, D> {
         }
     }
 
+    /// Creates a default-kernel builder from explicit vertex and simplex indices.
+    ///
     /// This is not an unchecked topology wrapper. The deferred
     /// [`build`](Self::build) or [`build_with_kernel`](Self::build_with_kernel)
     /// call accepts only Euclidean explicit connectivity and validates the
@@ -1840,32 +1842,43 @@ where
             || options == ConstructionOptions::default().without_final_delaunay_enforcement()
     }
 
-    /// Proves explicit simplex topology once so insertion can use the prechecked TDS path.
-    fn validate_explicit_simplices_for_prechecked_insert(
-        simplices: &[Simplex<V, D>],
+    /// Proves explicit simplex topology once before taking the prechecked TDS insertion path.
+    ///
+    /// The public constructor has already rejected empty input, wrong arity,
+    /// out-of-bounds vertex indices, and repeated vertex indices within a
+    /// simplex. This helper checks the cross-simplex topology that only becomes
+    /// visible after raw indices are mapped to canonical [`VertexKey`] values.
+    fn validate_explicit_topology(
+        simplices: ValidatedExplicitSimplices<'_>,
+        index_to_key: &[VertexKey],
     ) -> Result<(), TdsConstructionError> {
-        Self::validate_explicit_no_duplicate_simplices(simplices)?;
-        Self::validate_explicit_facet_sharing(simplices)?;
+        let simplices = simplices.as_slice();
+        Self::reject_duplicate_explicit_simplices(simplices, index_to_key)?;
+        Self::reject_overshared_explicit_facets(simplices, index_to_key)?;
         Ok(())
     }
 
     /// Rejects duplicate explicit maximal simplices before the insertion loop.
-    fn validate_explicit_no_duplicate_simplices(
-        simplices: &[Simplex<V, D>],
+    ///
+    /// The duplicate check uses sorted [`VertexKey`] identities so callers cannot
+    /// bypass the explicit-construction invariant by permuting the same input
+    /// simplex indices.
+    fn reject_duplicate_explicit_simplices(
+        simplices: &[Vec<usize>],
+        index_to_key: &[VertexKey],
     ) -> Result<(), TdsConstructionError> {
         let mut seen: FastHashMap<SimplexVertexKeyBuffer, usize> = FastHashMap::default();
 
-        for (simplex_index, simplex) in simplices.iter().enumerate() {
-            let identity = Self::explicit_simplex_identity(simplex);
+        for (simplex_index, simplex_spec) in simplices.iter().enumerate() {
+            let identity = Self::explicit_simplex_identity(simplex_spec, index_to_key);
             match seen.entry(identity) {
                 Entry::Occupied(entry) => {
                     let existing_index = *entry.get();
-                    let identity = entry.key();
                     return Err(TdsConstructionError::ValidationError(
-                        TdsError::DuplicateSimplices {
-                            message: format!(
-                                "Found duplicate explicit simplex at input indices {existing_index} and {simplex_index} with vertex keys {identity:?}"
-                            ),
+                        TdsError::DuplicateExplicitSimplices {
+                            existing_simplex_index: existing_index,
+                            duplicate_simplex_index: simplex_index,
+                            vertex_indices: Self::explicit_simplex_input_indices(simplex_spec),
                         },
                     ));
                 }
@@ -1879,26 +1892,35 @@ where
     }
 
     /// Rejects explicit facets that would exceed PL-manifold multiplicity.
-    fn validate_explicit_facet_sharing(
-        simplices: &[Simplex<V, D>],
+    ///
+    /// This protects the public explicit-import path from committing topology
+    /// that later Level 3 validation must reject after neighbor assignment.
+    fn reject_overshared_explicit_facets(
+        simplices: &[Vec<usize>],
+        index_to_key: &[VertexKey],
     ) -> Result<(), TdsConstructionError> {
         let mut facet_incident_counts: FastHashMap<SimplexVertexKeyBuffer, usize> =
             FastHashMap::default();
 
-        for simplex in simplices {
+        for (simplex_index, simplex_spec) in simplices.iter().enumerate() {
             for facet_index in 0..=D {
-                let facet_identity = Self::explicit_facet_identity(simplex, facet_index);
+                let facet_identity =
+                    Self::explicit_facet_identity(simplex_spec, index_to_key, facet_index);
                 match facet_incident_counts.entry(facet_identity) {
                     Entry::Occupied(mut entry) => {
                         let incident_count = *entry.get();
                         if incident_count >= 2 {
                             return Err(TdsConstructionError::ValidationError(
-                                TdsError::FacetSharingViolation {
+                                TdsError::ExplicitFacetSharingViolation {
                                     facet_key: facet_key_from_vertices(entry.key().as_slice()),
+                                    facet_vertex_indices: Self::explicit_facet_input_indices(
+                                        simplex_spec,
+                                        facet_index,
+                                    ),
                                     existing_incident_count: incident_count,
                                     attempted_incident_count: incident_count + 1,
                                     max_incident_count: 2,
-                                    candidate_simplex_uuid: simplex.uuid(),
+                                    candidate_simplex_index: simplex_index,
                                     candidate_facet_index: facet_index,
                                 },
                             ));
@@ -1915,24 +1937,58 @@ where
         Ok(())
     }
 
-    /// Builds a canonical simplex identity from vertex keys for duplicate detection.
-    fn explicit_simplex_identity(simplex: &Simplex<V, D>) -> SimplexVertexKeyBuffer {
-        let mut identity: SimplexVertexKeyBuffer = simplex.vertices().iter().copied().collect();
+    /// Builds a canonical simplex identity from prevalidated explicit vertex indices.
+    fn explicit_simplex_identity(
+        simplex_spec: &[usize],
+        index_to_key: &[VertexKey],
+    ) -> SimplexVertexKeyBuffer {
+        let mut identity = Self::explicit_simplex_vertex_keys(simplex_spec, index_to_key);
         identity.as_mut_slice().sort_unstable();
         identity
     }
 
-    /// Builds a canonical facet identity for one explicit simplex facet.
+    /// Builds a canonical input-index identity from prevalidated explicit vertex indices.
+    fn explicit_simplex_input_indices(simplex_spec: &[usize]) -> Vec<usize> {
+        let mut identity = simplex_spec.to_vec();
+        identity.sort_unstable();
+        identity
+    }
+
+    /// Builds a canonical facet identity for one prevalidated explicit simplex facet.
     fn explicit_facet_identity(
-        simplex: &Simplex<V, D>,
+        simplex_spec: &[usize],
+        index_to_key: &[VertexKey],
         facet_index: usize,
     ) -> SimplexVertexKeyBuffer {
         let mut identity = SimplexVertexKeyBuffer::new();
-        identity.extend(simplex.vertices().iter().enumerate().filter_map(
-            |(vertex_index, &vertex_key)| (vertex_index != facet_index).then_some(vertex_key),
+        identity.extend(simplex_spec.iter().enumerate().filter_map(
+            |(local_vertex_index, &input_vertex_index)| {
+                (local_vertex_index != facet_index).then_some(index_to_key[input_vertex_index])
+            },
         ));
         identity.as_mut_slice().sort_unstable();
         identity
+    }
+
+    /// Builds a canonical input-index identity for one prevalidated explicit simplex facet.
+    fn explicit_facet_input_indices(simplex_spec: &[usize], facet_index: usize) -> Vec<usize> {
+        let mut identity: Vec<usize> = simplex_spec
+            .iter()
+            .enumerate()
+            .filter_map(|(local_vertex_index, &input_vertex_index)| {
+                (local_vertex_index != facet_index).then_some(input_vertex_index)
+            })
+            .collect();
+        identity.sort_unstable();
+        identity
+    }
+
+    /// Maps prevalidated explicit vertex indices into TDS keys without an intermediate `Vec`.
+    fn explicit_simplex_vertex_keys(
+        simplex_spec: &[usize],
+        index_to_key: &[VertexKey],
+    ) -> SimplexVertexKeyBuffer {
+        simplex_spec.iter().map(|&vi| index_to_key[vi]).collect()
     }
 
     /// Builds a triangulation from explicit vertex and simplex specifications.
@@ -1978,7 +2034,7 @@ where
         Self::reject_explicit_non_euclidean_topology(global_topology)?;
 
         let vertex_count = vertices.len();
-        let simplices = simplices.as_slice();
+        let simplex_specs = simplices.as_slice();
 
         // --- Build TDS ---
         let mut tds: Tds<U, V, D> = Tds::empty();
@@ -1994,29 +2050,22 @@ where
             index_to_key.push(vk);
         }
 
-        // Assemble simplices once with stack-backed vertex buffers, then prove
-        // duplicate/facet topology before using the prechecked TDS insertion path.
-        let mut explicit_simplices = Vec::with_capacity(simplices.len());
-        for (simplex_idx, simplex_spec) in simplices.iter().enumerate() {
-            let vertex_keys: SimplexVertexKeyBuffer =
-                simplex_spec.iter().map(|&vi| index_to_key[vi]).collect();
+        Self::validate_explicit_topology(simplices, &index_to_key).map_err(|source| {
+            ExplicitConstructionError::TdsAssembly {
+                source: Box::new(source),
+            }
+        })?;
+
+        // Construct each simplex only at insertion time after the topology
+        // precheck has proved duplicate and facet-sharing constraints.
+        for (simplex_idx, simplex_spec) in simplex_specs.iter().enumerate() {
+            let vertex_keys = Self::explicit_simplex_vertex_keys(simplex_spec, &index_to_key);
             let simplex = Simplex::try_new(vertex_keys).map_err(|e| {
                 ExplicitConstructionError::SimplexCreation {
                     simplex_index: simplex_idx,
                     source: e,
                 }
             })?;
-            explicit_simplices.push(simplex);
-        }
-
-        Self::validate_explicit_simplices_for_prechecked_insert(&explicit_simplices).map_err(
-            |source| ExplicitConstructionError::TdsAssembly {
-                source: Box::new(source),
-            },
-        )?;
-
-        // Insert simplices.
-        for simplex in explicit_simplices {
             tds.insert_simplex_with_mapping_prechecked_topology(simplex)
                 .map_err(|source| ExplicitConstructionError::TdsAssembly {
                     source: Box::new(source),

--- a/src/delaunay/delaunayize.rs
+++ b/src/delaunay/delaunayize.rs
@@ -89,6 +89,7 @@ use thiserror::Error;
 /// - `topology_max_iterations`: 64
 /// - `topology_max_simplices_removed`: 10,000
 /// - `fallback_rebuild`: false
+/// - `delaunay_max_flips`: `None`
 ///
 /// # Examples
 ///
@@ -748,7 +749,7 @@ where
 {
     if let Some(max_flips) = config.delaunay_max_flips {
         dt.repair_delaunay_with_flips_advanced(
-            DelaunayRepairHeuristicConfig::default().with_max_flips(max_flips),
+            DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(max_flips),
         )
         .map(|outcome| outcome.stats)
     } else {

--- a/src/delaunay/repair.rs
+++ b/src/delaunay/repair.rs
@@ -170,7 +170,7 @@ impl DelaunayRepairPolicy {
 /// let config = DelaunayRepairHeuristicConfig::default()
 ///     .with_shuffle_seed(7)
 ///     .with_perturbation_seed(11)
-///     .with_max_flips(100);
+///     .with_delaunay_max_flips(100);
 /// assert_eq!(config.shuffle_seed, Some(7));
 /// assert_eq!(config.perturbation_seed, Some(11));
 /// assert_eq!(config.max_flips, Some(100));
@@ -227,23 +227,27 @@ impl DelaunayRepairHeuristicConfig {
         self
     }
 
-    /// Sets the optional per-attempt flip budget cap.
+    /// Sets the optional per-attempt flip budget cap for Delaunay repair.
+    ///
+    /// The cap applies to each primary, robust, or heuristic Delaunay-repair
+    /// attempt. Use [`Self::without_delaunay_max_flips`] to return to the
+    /// dimension-dependent internal budget.
     ///
     /// # Examples
     ///
     /// ```rust
     /// use delaunay::prelude::repair::DelaunayRepairHeuristicConfig;
     ///
-    /// let config = DelaunayRepairHeuristicConfig::default().with_max_flips(100);
+    /// let config = DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(100);
     /// assert_eq!(config.max_flips, Some(100));
     /// ```
     #[must_use]
-    pub const fn with_max_flips(mut self, max_flips: usize) -> Self {
+    pub const fn with_delaunay_max_flips(mut self, max_flips: usize) -> Self {
         self.max_flips = Some(max_flips);
         self
     }
 
-    /// Clears the per-attempt flip budget cap.
+    /// Clears the per-attempt flip budget cap for Delaunay repair.
     ///
     /// # Examples
     ///
@@ -251,12 +255,12 @@ impl DelaunayRepairHeuristicConfig {
     /// use delaunay::prelude::repair::DelaunayRepairHeuristicConfig;
     ///
     /// let config = DelaunayRepairHeuristicConfig::default()
-    ///     .with_max_flips(100)
-    ///     .without_max_flips();
+    ///     .with_delaunay_max_flips(100)
+    ///     .without_delaunay_max_flips();
     /// assert_eq!(config.max_flips, None);
     /// ```
     #[must_use]
-    pub const fn without_max_flips(mut self) -> Self {
+    pub const fn without_delaunay_max_flips(mut self) -> Self {
         self.max_flips = None;
         self
     }
@@ -1401,7 +1405,7 @@ mod tests {
             DelaunayTriangulation::builder(&vertices).build().unwrap();
 
         // Sub-case 1: Already Delaunay — max_flips=0 should succeed (no flips needed).
-        let config = DelaunayRepairHeuristicConfig::default().with_max_flips(0);
+        let config = DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(0);
         let outcome = dt.repair_delaunay_with_flips_advanced(config).unwrap();
         assert_eq!(outcome.stats.flips_performed, 0);
         assert!(
@@ -1426,7 +1430,7 @@ mod tests {
             DelaunayTriangulation::builder(&vertices).build().unwrap();
 
         let _guard = ForceRepairNonconvergentGuard::enable();
-        let config = DelaunayRepairHeuristicConfig::default().with_max_flips(0);
+        let config = DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(0);
         // The primary repair is forced to fail; the robust fallback should succeed
         // because the triangulation is actually Delaunay.
         let outcome = dt.repair_delaunay_with_flips_advanced(config).unwrap();
@@ -1473,7 +1477,7 @@ mod tests {
         assert!(robust_dt.verify_via_flip_predicates().is_err());
 
         // max_flips=0 should fail (flips are needed but budget is zero).
-        let config_zero = DelaunayRepairHeuristicConfig::default().with_max_flips(0);
+        let config_zero = DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(0);
         // The advanced path tries primary (fails at budget=0), then robust fallback.
         // The robust fallback also respects the budget, so it should also fail at 0,
         // then the heuristic rebuild fires. The key assertion: it should not silently
@@ -1489,7 +1493,7 @@ mod tests {
         }
 
         // Now retry with a generous budget — should succeed.
-        let config_generous = DelaunayRepairHeuristicConfig::default().with_max_flips(100);
+        let config_generous = DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(100);
         // Reconstruct dt from the same raw TDS in case the previous attempt mutated it.
         let tds2 = non_delaunay_quad_tds();
         let mut dt2: DelaunayTriangulation<AdaptiveKernel<f64>, (), (), 2> =
@@ -1677,7 +1681,7 @@ mod tests {
     fn heuristic_config_resolves_missing_seeds_deterministically() {
         let config = DelaunayRepairHeuristicConfig::default()
             .with_perturbation_seed(11)
-            .with_max_flips(7);
+            .with_delaunay_max_flips(7);
 
         let seeds = config.resolve_seeds(5);
 
@@ -1690,7 +1694,7 @@ mod tests {
         let config = DelaunayRepairHeuristicConfig::default()
             .with_shuffle_seed(0)
             .with_perturbation_seed(0)
-            .without_max_flips();
+            .without_delaunay_max_flips();
 
         let seeds = config.resolve_seeds(0);
 

--- a/src/delaunay/serialization.rs
+++ b/src/delaunay/serialization.rs
@@ -160,7 +160,10 @@ mod tests {
     }
 
     #[test]
-    fn serialize_delaunay_triangulation_does_not_require_kernel_or_datatype_bounds() {
+    fn serialize_internal_delaunay_fixture_does_not_require_kernel_or_datatype_bounds() {
+        // No public constructor can express this fixture: the test intentionally
+        // uses non-`Kernel`, non-`DataType` parameters to prove the Serialize impl
+        // only depends on the serialized TDS payload bounds.
         let dt: DelaunayTriangulation<NotAKernel, SerializeOnlyPayload, SerializeOnlyPayload, 2> =
             DelaunayTriangulation {
                 tri: Triangulation {

--- a/tests/benchmark_flip_fixtures.rs
+++ b/tests/benchmark_flip_fixtures.rs
@@ -68,6 +68,13 @@ const MINIMAL_K2_ROUNDTRIP_POINTS_3D: &[[f64; 3]] = &[
     [0.20, 0.20, -0.85],
 ];
 
+const MINIMAL_K1_ROUNDTRIP_POINTS_3D: &[[f64; 3]] = &[
+    [0.0, 0.0, 0.0],
+    [1.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0],
+    [0.0, 0.0, 1.0],
+];
+
 /// Verifies the stable and adversarial 2D public flip fixture workflows.
 #[test]
 fn flip_fixtures_cover_2d_workflows() {
@@ -78,7 +85,18 @@ fn flip_fixtures_cover_2d_workflows() {
     );
 }
 
+/// Verifies a minimal 3D public k=1 fixture workflow in the default suite.
+#[test]
+fn flip_fixtures_cover_minimal_3d_k1_roundtrip() {
+    verify_3d_fixture_move(
+        MINIMAL_K1_ROUNDTRIP_POINTS_3D,
+        CandidateFilter::Any,
+        FlipMoveKind::K1,
+    );
+}
+
 /// Verifies the stable 3D public k=1 fixture workflow.
+#[cfg(feature = "slow-tests")]
 #[test]
 fn flip_fixtures_cover_stable_3d_k1_roundtrip() {
     verify_3d_fixture_move(STABLE_POINTS_3D, CandidateFilter::Any, FlipMoveKind::K1);

--- a/tests/delaunay_repair_fallback.rs
+++ b/tests/delaunay_repair_fallback.rs
@@ -81,7 +81,7 @@ fn repair_fallback_produces_valid_triangulation() {
     }
     assert!(flipped, "fixture should contain a flippable interior facet");
 
-    let config = DelaunayRepairHeuristicConfig::default().with_max_flips(0);
+    let config = DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(0);
     let outcome = dt
         .repair_delaunay_with_flips_advanced(config)
         .expect("heuristic rebuild fallback should repair the non-Delaunay fixture");

--- a/tests/large_scale_debug.rs
+++ b/tests/large_scale_debug.rs
@@ -1525,7 +1525,7 @@ where
         let t_repair = Instant::now();
         let repair_config = repair_max_flips
             .map_or_else(DelaunayRepairHeuristicConfig::default, |max_flips| {
-                DelaunayRepairHeuristicConfig::default().with_max_flips(max_flips)
+                DelaunayRepairHeuristicConfig::default().with_delaunay_max_flips(max_flips)
             });
         match dt.repair_delaunay_with_flips_advanced(repair_config) {
             Ok(outcome) => {

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -116,7 +116,7 @@ use delaunay::prelude::geometry::{
 use delaunay::prelude::insertion::{
     InitialSimplexConstructionError, InitialSimplexUnexpectedInsertionStage, InsertionError,
     InsertionErrorKind as FocusedInsertionErrorKind, InsertionTopologyValidationContext,
-    NeighborRebuildError,
+    NeighborRebuildError, TdsValidationFailure,
 };
 use delaunay::prelude::ordering::{
     HilbertBitDepth, HilbertError, HilbertQuantizedBatch, MAX_HILBERT_BITS, hilbert_index_in_range,
@@ -1296,6 +1296,7 @@ fn assert_misc_bench_prelude_exports() {
     assert_insertion_prelude_empty_tds_exports();
     assert_send_sync_unpin::<TdsMutationError>();
     assert_send_sync_unpin::<NeighborRebuildError>();
+    assert_send_sync_unpin::<TdsValidationFailure>();
     assert_send_sync_unpin::<ConstructionSkipSample>();
     assert_send_sync_unpin::<ConstructionSlowInsertionSample>();
     assert_send_sync_unpin::<DelaunayError>();
@@ -1733,7 +1734,80 @@ fn generator_prelude_covers_validated_coordinate_ranges() -> Result<(), PreludeE
 }
 
 #[test]
-fn construction_prelude_covers_typed_explicit_errors() {
+fn construction_prelude_covers_explicit_tds_preflight_errors() {
+    let duplicate_vertices = vec![
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+    ];
+    let duplicate_simplices = vec![vec![0, 1, 2], vec![0, 2, 1]];
+    let duplicate_error = DelaunayTriangulationBuilder::try_from_vertices_and_simplices(
+        &duplicate_vertices,
+        &duplicate_simplices,
+    )
+    .expect("explicit duplicate specs should parse")
+    .build()
+    .expect_err("duplicate explicit topology should fail TDS assembly");
+    let DelaunayTriangulationConstructionError::ExplicitConstruction(
+        ExplicitConstructionError::TdsAssembly {
+            source: duplicate_source,
+        },
+    ) = duplicate_error
+    else {
+        panic!("expected explicit TDS assembly error");
+    };
+    let TdsConstructionError::ValidationError(explicit_duplicate) = *duplicate_source else {
+        panic!("expected TDS validation source");
+    };
+    assert_matches!(
+        explicit_duplicate,
+        TdsError::DuplicateExplicitSimplices {
+            existing_simplex_index: 0,
+            duplicate_simplex_index: 1,
+            vertex_indices,
+            ..
+        } if vertex_indices == [0, 1, 2]
+    );
+
+    let overshared_vertices = vec![
+        vertex!([0.0_f64, 0.0]).unwrap(),
+        vertex!([1.0, 0.0]).unwrap(),
+        vertex!([0.0, 1.0]).unwrap(),
+        vertex!([1.0, 1.0]).unwrap(),
+        vertex!([0.5, -1.0]).unwrap(),
+    ];
+    let overshared_simplices = vec![vec![0, 1, 2], vec![0, 1, 3], vec![0, 1, 4]];
+    let overshared_error = DelaunayTriangulationBuilder::try_from_vertices_and_simplices(
+        &overshared_vertices,
+        &overshared_simplices,
+    )
+    .expect("explicit overshared-facet specs should parse")
+    .build()
+    .expect_err("overshared explicit topology should fail TDS assembly");
+    let DelaunayTriangulationConstructionError::ExplicitConstruction(
+        ExplicitConstructionError::TdsAssembly {
+            source: overshared_source,
+        },
+    ) = overshared_error
+    else {
+        panic!("expected explicit TDS assembly error");
+    };
+    let TdsConstructionError::ValidationError(explicit_facet_sharing) = *overshared_source else {
+        panic!("expected TDS validation source");
+    };
+    assert_matches!(
+        explicit_facet_sharing,
+        TdsError::ExplicitFacetSharingViolation {
+            facet_vertex_indices,
+            attempted_incident_count: 3,
+            candidate_simplex_index: 2,
+            ..
+        } if facet_vertex_indices == [0, 1]
+    );
+}
+
+#[test]
+fn construction_prelude_covers_typed_explicit_error_wrappers() {
     let explicit_construction = ExplicitConstructionError::StructuralValidation {
         source: Box::new(TdsError::FacetSharingViolation {
             facet_key: 42,
@@ -2365,11 +2439,14 @@ fn assert_repair_heuristic_config_fluent_setters() {
     let heuristic_config = DelaunayRepairHeuristicConfig::default()
         .with_shuffle_seed(7)
         .with_perturbation_seed(11)
-        .with_max_flips(100);
+        .with_delaunay_max_flips(100);
     assert_eq!(heuristic_config.shuffle_seed, Some(7));
     assert_eq!(heuristic_config.perturbation_seed, Some(11));
     assert_eq!(heuristic_config.max_flips, Some(100));
-    assert_eq!(heuristic_config.without_max_flips().max_flips, None);
+    assert_eq!(
+        heuristic_config.without_delaunay_max_flips().max_flips,
+        None
+    );
 }
 
 fn assert_delaunayize_config_fluent_setters() {

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -5,7 +5,6 @@
 
 #![forbid(unsafe_code)]
 
-use delaunay::vertex;
 use std::assert_matches;
 use std::collections::HashMap;
 use std::f64::consts::TAU;
@@ -21,6 +20,7 @@ use delaunay::prelude::tds::{InvariantError, TdsConstructionError, TdsError, Ver
 use delaunay::prelude::topology::spaces::{GlobalTopology, TopologyKind, ToroidalConstructionMode};
 use delaunay::prelude::topology::validation::{TopologyClassification, euler_characteristic};
 use delaunay::prelude::validation::{TriangulationValidationError, ValidationPolicy};
+use delaunay::vertex;
 
 // =============================================================================
 // Euclidean path
@@ -1380,11 +1380,15 @@ fn test_explicit_error_variant_non_manifold_facet() {
 
     assert_matches!(
         source.as_ref(),
-        TdsConstructionError::ValidationError(TdsError::FacetSharingViolation {
+        TdsConstructionError::ValidationError(TdsError::ExplicitFacetSharingViolation {
+            facet_vertex_indices,
+            existing_incident_count: 2,
             attempted_incident_count: 3,
             max_incident_count: 2,
+            candidate_simplex_index: 2,
+            candidate_facet_index: 2,
             ..
-        })
+        }) if facet_vertex_indices == &[0, 1]
     );
 }
 
@@ -1498,7 +1502,7 @@ fn test_explicit_error_variant_duplicate_simplices_structural_validation() {
         vertex!([1.0, 0.0]).unwrap(),
         vertex!([0.0, 1.0]).unwrap(),
     ];
-    let simplices = vec![vec![0, 1, 2], vec![0, 1, 2]];
+    let simplices = vec![vec![0, 1, 2], vec![0, 2, 1]];
 
     let err = DelaunayTriangulationBuilder::try_from_vertices_and_simplices(&vertices, &simplices)
         .unwrap()
@@ -1514,7 +1518,12 @@ fn test_explicit_error_variant_duplicate_simplices_structural_validation() {
 
     assert_matches!(
         source.as_ref(),
-        TdsConstructionError::ValidationError(TdsError::DuplicateSimplices { .. })
+        TdsConstructionError::ValidationError(TdsError::DuplicateExplicitSimplices {
+            existing_simplex_index: 0,
+            duplicate_simplex_index: 1,
+            vertex_indices,
+            ..
+        }) if vertex_indices == &[0, 1, 2]
     );
 }
 


### PR DESCRIPTION
- Add typed explicit-simplex duplicate and facet-sharing errors that preserve input simplex and vertex indices.
- Preflight explicit topology from validated simplex specs before constructing TDS simplices.
- Rename the Delaunay repair flip-budget fluent setters to make their repair scope explicit.
- Repair the papers workflow TeX dependency setup for macOS runners.

BREAKING CHANGE: `DelaunayRepairHeuristicConfig::with_max_flips` and `without_max_flips` were renamed to `with_delaunay_max_flips` and `without_delaunay_max_flips`.