### PR TITLE
feat(geometry): adopt la-stack 0.4.4 exact APIs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,9 +474,9 @@ dependencies = [
 
 [[package]]
 name = "la-stack"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20547b00fd054ecec5b70da9094c06e36a85c6957edc1fb029355d1a49f4c0b"
+checksum = "52fcf8450d810977da5f9b3cebdfb3ca870f58189a50ed87cb8a05d653374213"
 dependencies = [
  "num-bigint",
  "num-rational",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ rustdoc-args = [ "--cfg", "docsrs" ]
 allocation-counter = { version = "0.8.1", optional = true } # for memory profiling
 arc-swap = "1.9.2"
 clap = { version = "4.6.1", features = [ "derive" ], optional = true }
-la-stack = { version = "0.4.3", default-features = false, features = [ "exact" ] }
+la-stack = { version = "0.4.4", default-features = false, features = [ "exact" ] }
 tracing = { version = "0.1.44", default-features = false, features = [ "std" ] }
 rustc-hash = "2.1.3" # Fast non-cryptographic hashing for performance
 smallvec = { version = "1.15.2", features = [ "serde" ] } # Stack allocation for small collections

--- a/benches/README.md
+++ b/benches/README.md
@@ -102,8 +102,8 @@ allocation checks, or targeted diagnostics.
 |-----------|---------|-------|-----------------|---------|
 | `allocation_hot_paths.rs` | Construction/query/barycenter allocation contracts | Calibrated 2D-5D canary fixtures | ~1-2 min | Manual allocation checks |
 | `ci_performance_suite.rs` | Public workflow regression contract | Calibrated 2D-5D canaries | ~5-10 min | CI, baselines, `just perf-no-regressions` |
-| `circumsphere_containment.rs` | Compare circumsphere predicate methods | 2D-5D fixed, 3D random, edge cases | ~5 min | Predicate tuning, summaries |
-| `cold_path_predicates.rs` | Track hot/cold predicate paths | 2D-5D hot queries, near-boundary cases | ~2-5 min | Predicate optimization work |
+| `circumsphere_containment.rs` | Circumsphere predicates and solves | 2D-5D predicates, 3D LU/exact solves | ~5 min | Predicate/circumcenter tuning |
+| `cold_path_predicates.rs` | Track predicate paths | Hot, centered, and certified exact cases in 2D-5D | ~2-5 min | Predicate tuning |
 | `delaunay_repair.rs` | Flip-based Delaunay repair plus transaction-pressure cases | 2D-5D repair-convergent fixtures | ~2-5 min | Repair tuning |
 | `pachner_stress.rs` | Unified Pachner move API stress | Accepted 4D microcases plus forward/inverse round trips | Manual | Pachner move workflow tuning |
 | `pl_manifold_repair.rs` | Over-shared facet and targeted topology repair | 2D/3D synthetic repair fixtures | <1 min | PL-manifold repair tuning |
@@ -394,6 +394,10 @@ This suite compares three predicate paths:
 - `insphere_distance`: explicit circumcenter plus distance comparison
 - `insphere_lifted`: lifted-paraboloid determinant formulation
 
+The `circumcenter/solve_path` group separately compares a regular 3D LU solve
+with a near-coplanar fixture that LU classifies as numerically singular and the
+exact rounded solve resolves. Both fixtures are validated before timing.
+
 Fresh local perf-profile run on maintainer Apple M4 Max hardware
 (2026-05-14, Rust 1.95.0):
 
@@ -438,9 +442,13 @@ cargo bench --profile perf --bench cold_path_predicates -- --noplot
 
 `cold_path_predicates.rs` tracks the fast f64 filter path and the exact
 Bareiss fallback path used by `insphere`, `insphere_lifted`, and the orientation
-predicate they invoke. The hot group uses well-separated random queries; the
-near-boundary group deliberately pushes queries close to the circumsphere so
-Stage 2 costs remain visible.
+predicate they invoke. The hot group uses well-separated random queries. The
+historically named `near_boundary` group samples around the circumsphere center
+and remains only for saved-baseline compatibility; it does not establish exact
+fallback. The `exact_fallback` group validates known cospherical 2D-4D fixtures
+before timing them, making it the benchmark's correctness-certified Stage-2
+signal. The 5D hot group remains Stage-2-dominant because the fast determinant
+bound is unavailable at that matrix size.
 
 ## Profiling Suite
 

--- a/benches/circumsphere_containment.rs
+++ b/benches/circumsphere_containment.rs
@@ -15,7 +15,7 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use delaunay::prelude::generators::generate_random_points_in_range_seeded;
-use delaunay::prelude::geometry::{CoordinateRange, Point};
+use delaunay::prelude::geometry::{CoordinateRange, Point, circumcenter};
 use delaunay::prelude::query::*;
 use std::hint::black_box;
 
@@ -284,6 +284,31 @@ fn benchmark_edge_cases(c: &mut Criterion) {
     bench_edge_case!(c, 5, "near_boundary", simplex_5d, near_boundary_5d);
 }
 
+/// Benchmark circumcenter's regular LU path and numerical-singularity exact fallback.
+fn benchmark_circumcenter_solve_paths(c: &mut Criterion) {
+    let regular = standard_simplex::<3>();
+    let near_singular = vec![
+        finite_point([0.0, 0.0, 0.0]),
+        finite_point([1.0, 0.0, 0.0]),
+        finite_point([0.0, 1.0, 0.0]),
+        finite_point([0.5, 0.5, 1.0e-14]),
+    ];
+
+    // Validate both fixtures before timing. A successful `circumcenter` call
+    // returns a finite-by-construction `Point`.
+    let _regular_center = circumcenter(&regular).or_abort();
+    let _fallback_center = circumcenter(&near_singular).or_abort();
+
+    let mut group = c.benchmark_group("circumcenter/solve_path");
+    group.bench_function("regular_lu_3d", |b| {
+        b.iter(|| black_box(circumcenter(black_box(&regular)).or_abort()));
+    });
+    group.bench_function("near_singular_exact_fallback_3d", |b| {
+        b.iter(|| black_box(circumcenter(black_box(&near_singular)).or_abort()));
+    });
+    group.finish();
+}
+
 /// Numerical consistency test - compare results of all three methods
 fn numerical_consistency_test() {
     println!("\n=== Numerical Consistency Test ===");
@@ -386,6 +411,7 @@ fn benchmark_with_consistency_check(c: &mut Criterion) {
     benchmark_random_queries(c);
     benchmark_different_dimensions(c);
     benchmark_edge_cases(c);
+    benchmark_circumcenter_solve_paths(c);
 }
 
 criterion_group!(benches, benchmark_with_consistency_check);

--- a/benches/cold_path_predicates.rs
+++ b/benches/cold_path_predicates.rs
@@ -7,7 +7,9 @@
 //! both invoke) in 2D–4D, plus a Stage-2-dominant 5D reference. A secondary
 //! centered-query group retains its historical `near_boundary` benchmark
 //! identifier for saved-baseline compatibility, but it does not independently
-//! establish Stage-2 entry.
+//! establish Stage-2 entry. The `exact_fallback` group uses known cospherical
+//! points and validates their boundary classification before timing, so it is
+//! the correctness-certified Stage-2 signal for 2D-4D.
 //!
 //! ## Stage anatomy
 //!
@@ -39,7 +41,7 @@
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use delaunay::prelude::generators::generate_random_points_in_range_seeded;
-use delaunay::prelude::geometry::CoordinateRange;
+use delaunay::prelude::geometry::{CoordinateRange, InSphere};
 use delaunay::prelude::query::*;
 use std::hint::black_box;
 
@@ -123,6 +125,44 @@ fn run_insphere_lifted<const D: usize>(simplex: &[Point<D>], queries: &[Point<D>
         };
         black_box(result);
     }
+}
+
+/// Benchmark a known cospherical query that forces exact sign resolution.
+fn bench_exact_fallback_case<const D: usize>(
+    group: &mut criterion::BenchmarkGroup<'_, criterion::measurement::WallTime>,
+) {
+    let simplex = standard_simplex::<D>();
+    let boundary = finite_point([1.0; D]);
+
+    let insphere_result = insphere(&simplex, boundary).or_abort();
+    let lifted_result = insphere_lifted(&simplex, boundary).or_abort();
+    if insphere_result != InSphere::BOUNDARY || lifted_result != InSphere::BOUNDARY {
+        abort_benchmark(format_args!(
+            "{D}D exact-fallback fixture must be cospherical: insphere={insphere_result}, lifted={lifted_result}"
+        ));
+    }
+
+    group.bench_function(format!("insphere_{D}d"), |b| {
+        b.iter(|| {
+            let result = insphere(black_box(&simplex), black_box(boundary)).or_abort();
+            black_box(result)
+        });
+    });
+    group.bench_function(format!("insphere_lifted_{D}d"), |b| {
+        b.iter(|| {
+            let result = insphere_lifted(black_box(&simplex), black_box(boundary)).or_abort();
+            black_box(result)
+        });
+    });
+}
+
+/// Benchmark correctness-certified Stage-2 exact fallback in 2D-4D.
+fn bench_exact_fallback(c: &mut Criterion) {
+    let mut group = c.benchmark_group("predicates/exact_fallback");
+    bench_exact_fallback_case::<2>(&mut group);
+    bench_exact_fallback_case::<3>(&mut group);
+    bench_exact_fallback_case::<4>(&mut group);
+    group.finish();
 }
 
 /// Benchmark the Stage-1 hot path for `insphere` and `insphere_lifted`.
@@ -280,5 +320,10 @@ fn bench_centered_queries(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_hot_path, bench_centered_queries);
+criterion_group!(
+    benches,
+    bench_hot_path,
+    bench_centered_queries,
+    bench_exact_fallback
+);
 criterion_main!(benches);

--- a/examples/README.md
+++ b/examples/README.md
@@ -71,8 +71,9 @@ for ergonomic coordinate access.
 ### `numerical_robustness`
 
 Compares `FastKernel`, `RobustKernel`, and `AdaptiveKernel` on degenerate
-orientation and cospherical insphere queries, then builds a small triangulation
-with the default adaptive kernel.
+orientation and cospherical insphere queries, demonstrates the near-singular
+circumcenter exact-solve fallback, then builds a small triangulation with the
+default adaptive kernel.
 
 - Run: `cargo run --release --example numerical_robustness`
 - Source: [`numerical_robustness.rs`](./numerical_robustness.rs)

--- a/examples/numerical_robustness.rs
+++ b/examples/numerical_robustness.rs
@@ -13,7 +13,7 @@ use delaunay::prelude::construction::{
 };
 use delaunay::prelude::geometry::{
     AdaptiveKernel, CircumcenterError, CoordinateConversionError, CoordinateValidationError,
-    FastKernel, Kernel, Point, RobustKernel, robust_insphere, robust_orientation,
+    FastKernel, Kernel, Point, RobustKernel, circumcenter, robust_insphere, robust_orientation,
 };
 use delaunay::prelude::validation::DelaunayTriangulationValidationError;
 
@@ -39,7 +39,24 @@ fn main() -> Result<(), NumericalRobustnessExampleError> {
     println!();
     compare_insphere_boundary_handling()?;
     println!();
+    demonstrate_circumcenter_exact_fallback()?;
+    println!();
     build_with_adaptive_kernel()?;
+    Ok(())
+}
+
+/// Demonstrates the exact-solve fallback for a numerically near-singular tetrahedron.
+fn demonstrate_circumcenter_exact_fallback() -> Result<(), NumericalRobustnessExampleError> {
+    let near_coplanar = [
+        Point::try_new([0.0, 0.0, 0.0])?,
+        Point::try_new([1.0, 0.0, 0.0])?,
+        Point::try_new([0.0, 1.0, 0.0])?,
+        Point::try_new([0.5, 0.5, 1.0e-14])?,
+    ];
+    let center = circumcenter(&near_coplanar)?;
+
+    println!("Near-coplanar circumcenter:");
+    println!("  finite center from exact fallback: {:?}", center.coords());
     Ok(())
 }
 

--- a/src/geometry/matrix.rs
+++ b/src/geometry/matrix.rs
@@ -21,7 +21,7 @@
 /// exposing the rest of `la-stack` to downstream callers.
 pub use la_stack::LaError;
 use la_stack::Matrix as LaMatrix;
-pub(crate) use la_stack::{DEFAULT_SINGULAR_TOL, Vector as LaVector};
+pub(crate) use la_stack::{DEFAULT_SINGULAR_TOL, SingularityReason, Vector as LaVector};
 use thiserror::Error;
 
 /// Stack-matrix dispatch limit.
@@ -106,10 +106,10 @@ pub(crate) enum StackMatrixDispatchError {
 impl From<LaError> for StackMatrixDispatchError {
     fn from(source: LaError) -> Self {
         match source {
-            LaError::UnsupportedDimension { requested, max } => {
+            LaError::UnsupportedDimension { requested, max, .. } => {
                 Self::UnsupportedDim { k: requested, max }
             }
-            LaError::IndexOutOfBounds { row, col, dim } => Self::Matrix {
+            LaError::IndexOutOfBounds { row, col, dim, .. } => Self::Matrix {
                 source: MatrixError::OutOfBounds {
                     row,
                     column: col,
@@ -166,7 +166,7 @@ pub(crate) fn matrix_get<const D: usize>(
     row: usize,
     column: usize,
 ) -> Result<f64, StackMatrixDispatchError> {
-    m.get_checked(row, column).map_err(Into::into)
+    m.try_get(row, column).map_err(Into::into)
 }
 
 /// Write one finite entry into a stack matrix, preserving backend diagnostics.
@@ -181,38 +181,27 @@ pub(crate) fn matrix_set<const D: usize>(
     column: usize,
     value: f64,
 ) -> Result<(), StackMatrixDispatchError> {
-    m.set_checked(row, column, value).map_err(Into::into)
+    m.set(row, column, value).map_err(Into::into)
 }
 
-/// Return a finite determinant and error-bound pair when the f64 fast filter supports the matrix size.
+/// Return a determinant and its certified error bound when the f64 fast filter supports the matrix size.
 ///
 /// `Ok(None)` means the closed-form direct determinant path is unavailable or
-/// inconclusive for this matrix size, including cases where the direct
-/// determinant overflowed to a non-finite value; callers should continue to
-/// exact arithmetic when the active matrix block is finite.
+/// inconclusive for this matrix size, including arithmetic overflow or
+/// underflow-sensitive evaluation. Callers should continue to exact arithmetic;
+/// `la-stack` matrices are finite by construction in v0.4.4.
 #[inline]
 pub(crate) fn matrix_fast_filter<const D: usize>(
     m: &Matrix<D>,
 ) -> Result<Option<(f64, f64)>, StackMatrixDispatchError> {
-    match (m.det_direct(), m.det_errbound()) {
-        (Ok(Some(det)), Ok(Some(errbound))) if det.is_finite() && errbound.is_finite() => {
-            Ok(Some((det, errbound)))
-        }
-        (Ok(_), Ok(_))
-        | (Err(LaError::NonFinite { row: None, .. }), _)
-        | (_, Err(LaError::NonFinite { row: None, .. })) => Ok(None),
-        (Err(source), _) | (_, Err(source)) => Err(source.into()),
+    match m.det_direct_with_errbound() {
+        Ok(Some(estimate)) => Ok(Some((
+            estimate.determinant(),
+            estimate.absolute_error_bound(),
+        ))),
+        Ok(None) | Err(LaError::NonFinite { .. }) => Ok(None),
+        Err(source) => Err(source.into()),
     }
-}
-
-/// Return whether the direct determinant is finite when the direct formula is available.
-///
-/// Predicate code uses this to decide whether a finite direct determinant has
-/// already established that the active matrix entries are safe for exact
-/// fallback.
-#[inline]
-pub(crate) fn matrix_direct_det_is_finite<const D: usize>(m: &Matrix<D>) -> bool {
-    matches!(m.det_direct(), Ok(Some(det)) if det.is_finite())
 }
 
 /// Compute a determinant, returning `Ok(0.0)` for singular matrices.
@@ -265,11 +254,7 @@ mod tests {
 
     #[test]
     fn la_index_error_maps_to_matrix_error_with_context() {
-        let err = StackMatrixDispatchError::from(LaError::IndexOutOfBounds {
-            row: 3,
-            col: 4,
-            dim: 2,
-        });
+        let err = StackMatrixDispatchError::from(LaError::index_out_of_bounds(3, 4, 2));
 
         assert_eq!(
             err,
@@ -285,7 +270,7 @@ mod tests {
 
     #[test]
     fn stack_matrix_dispatch_error_clones_la_error_source() {
-        let source = LaError::Singular { pivot_col: 3 };
+        let source = LaError::singular_exact(3);
         let error = StackMatrixDispatchError::La { source };
 
         assert_eq!(error.clone(), error);

--- a/src/geometry/predicates.rs
+++ b/src/geometry/predicates.rs
@@ -8,8 +8,7 @@
 
 use crate::core::simplex::SimplexValidationError;
 use crate::geometry::matrix::{
-    Matrix, StackMatrixDispatchError, matrix_direct_det_is_finite, matrix_fast_filter, matrix_get,
-    matrix_set, matrix_zero_like,
+    Matrix, StackMatrixDispatchError, matrix_fast_filter, matrix_get, matrix_set, matrix_zero_like,
 };
 use crate::geometry::point::Point;
 use crate::geometry::sos::exact_det_sign;
@@ -58,25 +57,6 @@ fn validate_active_matrix_dimension<const N: usize>(
     }
 
     Err(StackMatrixDispatchError::ActiveBlockDimensionMismatch { k, dim: N })
-}
-
-/// Verifies that the active matrix block is structurally present and finite.
-fn active_matrix_block_is_finite<const N: usize>(
-    matrix: &Matrix<N>,
-    k: usize,
-) -> Result<bool, StackMatrixDispatchError> {
-    validate_active_matrix_dimension::<N>(k)?;
-
-    for i in 0..k {
-        for j in 0..k {
-            let entry = matrix_get(matrix, i, j)?;
-            if !entry.is_finite() {
-                return Ok(false);
-            }
-        }
-    }
-
-    Ok(true)
 }
 
 /// Exact determinant signs for the relative-coordinate lifted insphere matrix.
@@ -255,8 +235,9 @@ pub(crate) fn relative_insphere_determinant_sign<const D: usize>(
 /// Compute insphere classification from a pre-populated insphere matrix.
 ///
 /// Uses [`la_stack::Matrix::det_sign_exact`] for provably correct results when
-/// the matrix entries are finite.  Returns [`InSphere::BOUNDARY`] when the
-/// entries are non-finite and exact arithmetic cannot run.
+/// the matrix entries are finite. `la-stack` matrices are finite by
+/// construction, so an inconclusive or overflowed fast filter always proceeds
+/// to an exact sign.
 ///
 /// `orient_sign` encodes how to interpret a positive determinant:
 /// - `1`: positive det → INSIDE (e.g. standard insphere with POSITIVE simplex orientation)
@@ -275,12 +256,12 @@ pub(crate) fn try_insphere_from_matrix<const N: usize>(
     validate_active_matrix_dimension::<N>(k)?;
 
     // Stage 1: provable f64 fast filter for D ≤ 4.
-    // `det_errbound()` returns a Shewchuk-style error bound derived from the
-    // matrix permanent: |det_direct() − det_exact| ≤ errbound.  If the f64
+    // `det_direct_with_errbound()` returns a paired determinant and
+    // Shewchuk-style error bound derived from the matrix permanent:
+    // |det_direct() − det_exact| ≤ errbound. If the f64
     // determinant clearly exceeds the bound, the sign is guaranteed correct
     // without allocating.  For D ≥ 5, `det_errbound()` returns `None` and
     // we skip directly to exact arithmetic.
-    let direct_det_is_finite = matrix_direct_det_is_finite(matrix);
     if let Some((det, errbound)) = matrix_fast_filter(matrix)? {
         let det_norm = det * f64::from(orient_sign);
         if det_norm > errbound {
@@ -296,23 +277,18 @@ pub(crate) fn try_insphere_from_matrix<const N: usize>(
     // keep Stage 1 lean; for D ≤ 4 with well-separated inputs, the vast
     // majority of calls return before reaching this point.
     cold_path();
-    let exact_is_safe = direct_det_is_finite || active_matrix_block_is_finite(matrix, k)?;
-    if exact_is_safe && let Ok(sign) = matrix.det_sign_exact() {
-        return Ok(sign_to_insphere(sign, orient_sign));
-    }
-
-    // Stage 3: sign is unresolvable (non-finite entries prevent exact
-    // arithmetic from running).
-    cold_path();
-    Ok(InSphere::BOUNDARY)
+    Ok(sign_to_insphere(
+        matrix.det_sign_exact().as_i8(),
+        orient_sign,
+    ))
 }
 
 /// Compute orientation from a pre-populated orientation matrix.
 ///
 /// Uses [`la_stack::Matrix::det_sign_exact`] for provably correct results when
 /// the matrix entries are finite (even if the f64 determinant overflows).
-/// Returns [`Orientation::DEGENERATE`] when the entries are non-finite and
-/// exact arithmetic cannot run.
+/// `la-stack` matrices are finite by construction, so an inconclusive or
+/// overflowed fast filter always proceeds to an exact sign.
 ///
 /// `k` must equal the number of rows/columns actually used in `matrix`.
 #[inline]
@@ -324,7 +300,6 @@ pub(crate) fn try_orientation_from_matrix<const N: usize>(
 
     // Stage 1: provable f64 fast filter for D ≤ 4.
     // See `insphere_from_matrix` for detailed explanation of the error bound.
-    let direct_det_is_finite = matrix_direct_det_is_finite(matrix);
     if let Some((det, errbound)) = matrix_fast_filter(matrix)? {
         if det > errbound {
             return Ok(Orientation::POSITIVE);
@@ -338,14 +313,7 @@ pub(crate) fn try_orientation_from_matrix<const N: usize>(
     // (D ≤ 4) or always for D ≥ 5.  See `insphere_from_matrix` for why this
     // is annotated cold.
     cold_path();
-    let exact_is_safe = direct_det_is_finite || active_matrix_block_is_finite(matrix, k)?;
-    if exact_is_safe && let Ok(sign) = matrix.det_sign_exact() {
-        return Ok(sign_to_orientation(sign));
-    }
-
-    // Stage 3: sign is unresolvable (same reasoning as insphere_from_matrix).
-    cold_path();
-    Ok(Orientation::DEGENERATE)
+    Ok(sign_to_orientation(matrix.det_sign_exact().as_i8()))
 }
 
 /// Represents the position of a point relative to a circumsphere.
@@ -653,11 +621,9 @@ pub fn insphere_distance<const D: usize>(
 /// - **4D-5D**: 1.6x faster than `insphere`
 ///
 /// The performance advantage comes from `insphere_lifted`'s use of relative coordinates and
-/// la-stack v0.2.0's closed-form determinants for D=1-4. Note that `insphere_lifted` is a
-/// fast floating-point predicate that may be less robust than
-/// [`crate::geometry::robust_predicates::robust_insphere`] for nearly-degenerate
-/// configurations; for 3D+ triangulations requiring numerical robustness, use
-/// [`crate::geometry::kernel::RobustKernel`].
+/// la-stack's closed-form determinants for D=1-4. Inconclusive fast-filter
+/// results fall back to an exact determinant sign, including nearly degenerate
+/// configurations.
 ///
 /// # Algorithm
 ///
@@ -845,7 +811,7 @@ pub fn insphere<const D: usize>(
 /// The performance gains come from:
 /// 1. Using relative coordinates which reduce numerical magnitude
 /// 2. Computing smaller (D+1)×(D+1) determinants instead of (D+2)×(D+2)
-/// 3. Benefiting from la-stack v0.2.0's closed-form determinants for D=1-4
+/// 3. Benefiting from la-stack's closed-form determinants for D=1-4
 ///
 /// This method combines the numerical stability of determinant-based predicates with
 /// optimal performance, making it ideal for production use.
@@ -2303,13 +2269,10 @@ mod tests {
         let k = 4;
         with_la_stack_matrix!(k, |m| {
             let err = try_matrix_set(&mut m, 3, 3, f64::NAN).unwrap_err();
-            assert_matches!(
+            assert_eq!(
                 err,
                 StackMatrixDispatchError::La {
-                    source: LaError::NonFinite {
-                        row: Some(3),
-                        col: 3
-                    }
+                    source: LaError::non_finite_input_matrix(3, 3),
                 }
             );
         });
@@ -2414,9 +2377,9 @@ mod tests {
 
     #[test]
     fn test_insphere_from_matrix_stage2_exact_via_overflow() {
-        // Stage 2: det_direct() overflows to non-finite, but all individual
-        // entries are finite.  The entry-by-entry finite check passes,
-        // enabling exact Bareiss to resolve the sign.
+        // Stage 2: the paired fast filter reports non-finite arithmetic, but
+        // the matrix itself is finite by construction. Exact Bareiss resolves
+        // the sign without rescanning its entries.
         let k = 4;
         let big = 1e100;
         with_la_stack_matrix!(k, |m| {
@@ -2489,13 +2452,10 @@ mod tests {
         let k = 3;
         with_la_stack_matrix!(k, |m| {
             let err = try_matrix_set(&mut m, 2, 2, f64::NAN).unwrap_err();
-            assert_matches!(
+            assert_eq!(
                 err,
                 StackMatrixDispatchError::La {
-                    source: LaError::NonFinite {
-                        row: Some(2),
-                        col: 2
-                    }
+                    source: LaError::non_finite_input_matrix(2, 2),
                 }
             );
         });

--- a/src/geometry/sos.rs
+++ b/src/geometry/sos.rs
@@ -383,7 +383,7 @@ fn insphere_cofactor_det<const D: usize>(
 /// Compute the exact sign of a matrix determinant
 ///
 /// Uses the two-stage approach:
-/// 1. `det_direct()` + `det_errbound()` for D ≤ 4 (provable fast filter)
+/// 1. `det_direct_with_errbound()` for D ≤ 4 (provable fast filter)
 /// 2. `det_sign_exact()` for exact result
 ///
 /// Returns -1, 0, or +1.
@@ -400,7 +400,7 @@ pub(crate) fn exact_det_sign<const N: usize>(matrix: &Matrix<N>) -> i32 {
     }
 
     // Stage 2: exact sign via Bareiss algorithm in BigRational.
-    matrix.det_sign_exact().map_or(0, i32::from)
+    i32::from(matrix.det_sign_exact().as_i8())
 }
 
 // =============================================================================

--- a/src/geometry/traits/coordinate.rs
+++ b/src/geometry/traits/coordinate.rs
@@ -1244,10 +1244,7 @@ mod tests {
 
     #[test]
     fn coordinate_conversion_error_clones_linear_algebra_source() {
-        let source = LaError::NonFinite {
-            row: Some(1),
-            col: 2,
-        };
+        let source = LaError::non_finite_input_matrix(1, 2);
         let converted = CoordinateConversionError::LinearAlgebraFailure { source };
 
         assert_eq!(converted.clone(), converted);
@@ -1256,10 +1253,7 @@ mod tests {
 
     #[test]
     fn la_errors_map_to_public_coordinate_conversion_errors() {
-        let unsupported = CoordinateConversionError::from(LaError::UnsupportedDimension {
-            requested: 9,
-            max: 7,
-        });
+        let unsupported = CoordinateConversionError::from(LaError::unsupported_dimension(9, 7));
         assert_eq!(
             unsupported,
             CoordinateConversionError::UnsupportedMatrixDimension {
@@ -1268,11 +1262,7 @@ mod tests {
             }
         );
 
-        let index_error = CoordinateConversionError::from(LaError::IndexOutOfBounds {
-            row: 3,
-            col: 4,
-            dim: 2,
-        });
+        let index_error = CoordinateConversionError::from(LaError::index_out_of_bounds(3, 4, 2));
         assert_eq!(
             index_error,
             CoordinateConversionError::MatrixError {

--- a/src/geometry/util/circumsphere.rs
+++ b/src/geometry/util/circumsphere.rs
@@ -8,8 +8,8 @@
 use super::conversions::{ValueConversionError, safe_coords_to_f64};
 use super::norms::{hypot, squared_norm};
 use crate::geometry::matrix::{
-    DEFAULT_SINGULAR_TOL, LaError, LaVector, Matrix, MatrixError, StackMatrixDispatchError,
-    matrix_set,
+    DEFAULT_SINGULAR_TOL, LaError, LaVector, Matrix, MatrixError, SingularityReason,
+    StackMatrixDispatchError, matrix_set,
 };
 use crate::geometry::point::Point;
 use crate::geometry::traits::coordinate::{
@@ -414,7 +414,10 @@ pub fn circumcenter<const D: usize>(points: &[Point<D>]) -> Result<Point<D>, Cir
             .solve(b_vec)
             .map_err(CircumcenterError::from)?
             .into_array(),
-        Err(LaError::Singular { .. }) => {
+        Err(LaError::Singular {
+            reason: SingularityReason::Numerical { .. },
+            ..
+        }) => {
             // Exact-arithmetic fallback: LU rejected the system as
             // near-singular, so we pay for BigRational Gaussian elimination.
             // This path is cold — well-conditioned simplices return above.
@@ -1231,6 +1234,16 @@ mod tests {
             Point::try_new([0.0, 1.0, 0.0]).expect("finite point coordinates"),
             Point::try_new([0.5, 0.5, eps]).expect("finite point coordinates"), // Barely off the z=0 plane
         ];
+
+        let system = Matrix::try_from_rows([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.5, 0.5, eps]])
+            .expect("finite system matrix");
+        assert_matches!(
+            system.lu(DEFAULT_SINGULAR_TOL),
+            Err(LaError::Singular {
+                reason: SingularityReason::Numerical { .. },
+                ..
+            })
+        );
 
         let result = circumcenter(&points);
         // The exact solver should succeed where LU alone would fail or

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2143,10 +2143,7 @@ mod tests {
 
     #[test]
     fn circumcenter_error_clones_linear_algebra_source() {
-        let source = LaError::NonFinite {
-            row: Some(1),
-            col: 2,
-        };
+        let source = LaError::non_finite_input_matrix(1, 2);
         let error = CircumcenterError::LinearAlgebraFailure { source };
 
         assert_eq!(error.clone(), error);
@@ -2155,10 +2152,7 @@ mod tests {
 
     #[test]
     fn la_errors_map_to_public_circumcenter_errors() {
-        let unsupported = CircumcenterError::from(LaError::UnsupportedDimension {
-            requested: 9,
-            max: 7,
-        });
+        let unsupported = CircumcenterError::from(LaError::unsupported_dimension(9, 7));
         assert_eq!(
             unsupported,
             CircumcenterError::UnsupportedMatrixDimension {
@@ -2167,11 +2161,7 @@ mod tests {
             }
         );
 
-        let index_error = CircumcenterError::from(LaError::IndexOutOfBounds {
-            row: 3,
-            col: 4,
-            dim: 2,
-        });
+        let index_error = CircumcenterError::from(LaError::index_out_of_bounds(3, 4, 2));
         assert_eq!(
             index_error,
             CircumcenterError::MatrixError {


### PR DESCRIPTION
Closes #505

- Use paired certified determinant filters and finite-by-construction matrices.
- Preserve exact versus numerical singularity handling in circumcenter solves.
- Add exact-fallback predicate and circumcenter benchmarks with a robustness example.