### PR TITLE
fix(release): harden benchmark parsing and correct audit guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,11 +100,13 @@ When in doubt, favor the invariant over the convenient edit.
 ### Numerical Correctness
 
 - Geometric predicates (`insphere`, `insphere_lifted`, `orientation`) use the
-  three-stage pattern from `src/geometry/predicates.rs`:
+  filtered-exact pattern from `src/geometry/predicates.rs`:
   - Stage 1: provable f64 fast filter with a Shewchuk-style error bound.
   - Stage 2: exact sign via Bareiss in `la-stack`.
-  - Stage 3: deterministic `InSphere::BOUNDARY` /
-    `Orientation::DEGENERATE` fallback for non-finite inputs.
+- Lifted-coordinate construction rejects non-finite or unrepresentable
+  intermediates with a typed error before determinant evaluation; it must not
+  silently classify them as `InSphere::BOUNDARY` or
+  `Orientation::DEGENERATE`.
 - No f64 operation may silently lose sign information. Avoid patterns such as
   `unwrap_or(NaN)`, `unwrap_or(f64::INFINITY)`, or "return `true` on error."
 - Algorithms cite their source in `REFERENCES.md` and document conditioning

--- a/docs/dev/rust/reference.md
+++ b/docs/dev/rust/reference.md
@@ -249,9 +249,8 @@ Higher-level
 when they also mutate insertion hints, spatial indexes, or repair bookkeeping;
 the guard must restore or intentionally invalidate that auxiliary state
 alongside the TDS. Do not wrap only the TDS when owner-coupled state can change.
-Issue #364 tracks this rollback-infrastructure coverage; issue #448 remains the
-separate `remove_vertex` orientation-correctness follow-up and should not be
-folded into infrastructure-only cleanup.
+Issue #364 completed the rollback-infrastructure audit; the separate
+`remove_vertex` orientation-correctness work was resolved in #448.
 
 Detached trial/scratch workspaces are a separate pattern: they may use
 `clone_for_rollback`/`clone_from_for_rollback` directly when the canonical owner

--- a/docs/production_review_remediation_checklist.md
+++ b/docs/production_review_remediation_checklist.md
@@ -33,24 +33,27 @@ Treat partial items as still open until their acceptance notes are satisfied.
   orthogonal construction, insertion, query, repair, orientation, validation,
   and serialization modules. The remaining large-file targets are `core/algorithms/flips.rs`
   and, if future review warrants another split, the TDS validation/mutation modules.
-- [ ] **7. Replace full-TDS clone rollback with journaled or localized rollback.**
-  This remains the largest performance opportunity. Tracked for v0.8.0 in
-  #364.
+- [x] **7. Audit full-TDS clone rollback and centralize transactional mutation.**
+  Scoped rollback guards now centralize failure-atomic TDS and triangulation
+  mutation, with detached scratch workspaces retained where copy-on-success is
+  the intended algorithm. Closed in #364; valid 2D removal rollback behavior
+  was completed in #448.
 - [x] **8. Harden robust insphere against squared-norm overflow.**
   Share the relative-coordinate formulation with `AdaptiveKernel::in_sphere`
   or return a typed error for non-finite squared norms.
 - [x] **9. Strengthen `OnSuspicion` validation coverage.**
   Normal-path validation now runs pseudomanifold checks, with PL guarantees
   layering ridge and vertex-link checks as required.
-- [ ] **10. Replace nested `Option` neighbors with a typed enum.**
-  Make unassigned neighbors distinct from assigned boundary slots and hide raw
-  mutation behind accessors. Deferred beyond v0.7.8 and tracked in #387.
+- [x] **10. Replace nested `Option` neighbors with a typed enum.**
+  `NeighborSlot` distinguishes unassigned, boundary, and neighboring-simplex
+  states, while raw neighbor mutation remains behind TDS-owned accessors.
+  Closed in #387.
 - [x] **11. Gate `simplices_mut()` out of production builds.**
   The raw storage accessor was deleted; tests now use narrower mutation paths
   or exercise lower-level helpers directly.
-- [ ] **12. Confirm clone semantics for linear-algebra error variants.**
-  Verify `LaError: Clone` and keep parent error enums honestly cloneable.
-  Deferred beyond v0.7.8 and tracked in #384.
+- [x] **12. Confirm clone semantics for linear-algebra error variants.**
+  `LaError` clone behavior and the parent error enums were audited together;
+  clone bounds now reflect their payload semantics. Closed in #384.
 - [x] **13. Make strict insphere consistency test control isolated.**
   The once-init strict-insphere env snapshot is now named and documented as
   process-wide, while unit tests use a thread-local override guard instead of
@@ -72,9 +75,9 @@ Treat partial items as still open until their acceptance notes are satisfied.
   transactional rollback instead of being cloned/restored or discarded; committed
   removals prune the deleted key, and query paths continue validating grid hits
   against the live TDS.
-- [ ] **17. Add a leaner adaptive orientation fast path.**
-  Avoid paying the diagnostic plus exact predicate path when SoS is unnecessary.
-  Deferred beyond v0.7.8 and tracked in #256.
+- [x] **17. Add a leaner adaptive orientation fast path.**
+  The adaptive kernel uses the filtered orientation sign before exact/SoS
+  fallback, and the affected 2D-5D property tests are enabled. Closed in #256.
 - [x] **18. Avoid fresh UUID allocation for rollback snapshots.**
   Rollback snapshots now preserve identity with `Arc::clone`; ordinary `Clone`
   intentionally keeps fresh runtime identity.
@@ -102,19 +105,19 @@ Treat partial items as still open until their acceptance notes are satisfied.
 - [x] **23. Reconsider skipped insertions as success outcomes.**
   Make skipped duplicate and degeneracy outcomes harder for callers to ignore.
   Closed for v0.7.8 in #386.
-- [ ] **24. Make `Simplex` encapsulation consistent.**
-  Private neighbor storage plus accessors is the likely direction. Tracked for
-  v0.8.0+ in #387.
-- [ ] **25. Protect `Vertex::incident_simplex` mutation.**
-  Introduce a checked setter or newtype so invalid incident-simplex links are
-  harder to construct. Tracked for v0.8.0+ in #387.
+- [x] **24. Make `Simplex` encapsulation consistent.**
+  Neighbor storage is private and mutation is routed through the validated TDS
+  surface. Closed in #387.
+- [x] **25. Protect `Vertex::incident_simplex` mutation.**
+  The field and setter are crate-private, with public read access and TDS-owned
+  repair/assignment paths. Closed in #387.
 - [x] **26. Revisit public `core` module naming.**
   Keep `crate::core` as the internal implementation namespace, and expose the
   public low-level surface through curated modules and focused preludes such as
   `tds`, `collections`, `algorithms`, and `query`. Closed for v0.7.8 in #388.
-- [ ] **27. Normalize boxing policy in Delaunay repair error variants.**
-  Pick a consistent enum-size and payload strategy. Deferred beyond v0.7.8 and
-  tracked in #384.
+- [x] **27. Normalize boxing policy in Delaunay repair error variants.**
+  Large recursive/diagnostic payloads follow the audited boxing policy while
+  lightweight classification remains inline. Closed in #384.
 
 ## Testing Gaps
 

--- a/just/helpers.just
+++ b/just/helpers.just
@@ -147,7 +147,7 @@ _pachner-stress-dim label vertices attempts validate_every output_dir mode:
     mkdir -p "$output_dir"
 
     echo "Pachner stress ${label}/${mode}: ${vertices} vertices, ${attempts} attempted moves."
-    echo "Validation scope: topology (Levels 1-3; Level 4 embedding overlap scan deferred to #483)."
+    echo "Validation scope: topology (Levels 1-3; Level 4 realization overlap scan deferred to #482)."
     cargo run --locked --profile perf --features cli --bin delaunay -- \
         pachner-stress \
         --dimension "$label" \

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ taplo_version := "0.10.0"
 tectonic_version := "0.16.9"
 tex_fmt_version := "0.5.7"
 typos_version := "1.48.0"
-uv_version := "0.11.28"
+uv_version := "0.11.29"
 zizmor_version := "1.26.1"
 
 # Common cargo-llvm-cov arguments for all coverage runs.

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -6,6 +6,7 @@ for benchmark data processing. It provides the core data structures used
 throughout the benchmark infrastructure.
 """
 
+import math
 import re
 from dataclasses import dataclass
 
@@ -177,6 +178,11 @@ def parse_benchmark_header(line: str) -> BenchmarkData | None:
 # the regex patterns below using re.compile() for better performance.
 
 
+def _is_valid_positive_interval(values: list[float]) -> bool:
+    """Return whether values form a finite, positive low/mean/high interval."""
+    return len(values) == 3 and all(math.isfinite(value) and value > 0.0 for value in values) and values[0] <= values[1] <= values[2]
+
+
 def parse_time_data(benchmark: BenchmarkData, line: str) -> bool:
     """
     Parse time data lines to extract timing information.
@@ -189,7 +195,7 @@ def parse_time_data(benchmark: BenchmarkData, line: str) -> bool:
         True if data was parsed successfully, False otherwise
     """
     # Match pattern like "Time: [100.0, 110.0, 120.0] µs"
-    # Support scientific notation (1.2e3), negative values, and flexible whitespace
+    # Support scientific notation (1.2e3) and flexible whitespace.
     match = re.match(r"^Time:\s*\[([0-9eE+.\-,\s]+)\]\s+(.+)$", line.strip())
     if match:
         try:
@@ -198,7 +204,7 @@ def parse_time_data(benchmark: BenchmarkData, line: str) -> bool:
             unit = match.group(2)
             values = [float(x.strip()) for x in values_str.split(",")]
 
-            if len(values) == 3:
+            if _is_valid_positive_interval(values):
                 benchmark.time_low = values[0]
                 benchmark.time_mean = values[1]
                 benchmark.time_high = values[2]
@@ -230,7 +236,7 @@ def parse_throughput_data(benchmark: BenchmarkData, line: str) -> bool:
         True if data was parsed successfully, False otherwise
     """
     # Match pattern like "Throughput: [8000.0, 9090.9, 10000.0] Kelem/s"
-    # Support scientific notation (1.2e3), negative values, and flexible whitespace
+    # Support scientific notation (1.2e3) and flexible whitespace.
     match = re.match(r"^Throughput:\s*\[([0-9eE+.\-,\s]+)\]\s+(.+)$", line.strip())
     if match:
         try:
@@ -239,7 +245,7 @@ def parse_throughput_data(benchmark: BenchmarkData, line: str) -> bool:
             unit = match.group(2)
             values = [float(x.strip()) for x in values_str.split(",")]
 
-            if len(values) == 3:
+            if _is_valid_positive_interval(values):
                 benchmark.throughput_low = values[0]
                 benchmark.throughput_mean = values[1]
                 benchmark.throughput_high = values[2]

--- a/scripts/tests/test_benchmark_models.py
+++ b/scripts/tests/test_benchmark_models.py
@@ -6,8 +6,13 @@ Tests data models, parsing functions, and formatting utilities for benchmark pro
 """
 
 import re
+from dataclasses import replace
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from benchmark_models import (
     BenchmarkData,
@@ -418,12 +423,6 @@ class TestFormattingFunctions:
         assert benchmark.time_mean == 110.0
         assert benchmark.time_unit == "µs"
 
-        # Test negative values
-        benchmark2 = BenchmarkData(1000, "3D")
-        success = parse_time_data(benchmark2, "Time: [-1.0, 0.0, 1.0] µs")
-        assert success is True
-        assert benchmark2.time_mean == 0.0
-
         # Test flexible whitespace
         benchmark3 = BenchmarkData(1000, "3D")
         success = parse_time_data(benchmark3, "Time:   [ 100.0 ,  110.0,   120.0 ]   µs")
@@ -447,6 +446,30 @@ class TestFormattingFunctions:
         assert success is True
         assert benchmark2.throughput_mean == 9090.9
         assert benchmark2.throughput_unit == "Kelem/s"
+
+    @pytest.mark.parametrize(
+        ("parser", "line"),
+        [
+            (parse_time_data, "Time: [-1.0, 1.0, 2.0] µs"),
+            (parse_time_data, "Time: [0.0, 1.0, 2.0] µs"),
+            (parse_time_data, "Time: [1.0, 3.0, 2.0] µs"),
+            (parse_time_data, "Time: [1.0, 1e999, 1e999] µs"),
+            (parse_throughput_data, "Throughput: [-1.0, 1.0, 2.0] Kelem/s"),
+            (parse_throughput_data, "Throughput: [1.0, 3.0, 2.0] Kelem/s"),
+            (parse_throughput_data, "Throughput: [1.0, 1e999, 1e999] Kelem/s"),
+        ],
+    )
+    def test_parsers_reject_nonphysical_intervals(
+        self,
+        parser: Callable[[BenchmarkData, str], bool],
+        line: str,
+    ) -> None:
+        """Malformed intervals must not mutate an existing benchmark record."""
+        expected = BenchmarkData(1000, "3D").with_timing(1.0, 2.0, 3.0, "ns").with_throughput(4.0, 5.0, 6.0, "elem/s")
+        benchmark = replace(expected)
+
+        assert parser(benchmark, line) is False
+        assert benchmark == expected
 
     def test_format_benchmark_tables_dimension_sorting(self) -> None:
         """Test that dimensions are sorted numerically rather than lexically."""

--- a/src/geometry/predicates.rs
+++ b/src/geometry/predicates.rs
@@ -819,19 +819,19 @@ pub fn insphere<const D: usize>(
 /// # Robustness
 ///
 /// Both the orientation sub-predicate and the lifted insphere determinant use a
-/// three-stage evaluation (via internal helpers `insphere_from_matrix` and
-/// `orientation_from_matrix`):
+/// filtered-exact evaluation (via internal helpers
+/// `try_insphere_from_matrix` and `try_orientation_from_matrix`):
 /// 1. **f64 fast filter** with adaptive tolerance — resolves well-conditioned cases
 ///    without allocating.
 /// 2. **Exact Bareiss** via [`la_stack::Matrix::det_sign_exact`] — provably correct
 ///    sign for finite matrix entries.
-/// 3. **Indeterminate fallback** — if exact arithmetic cannot run (non-finite
-///    entries), the helpers return `BOUNDARY` / `DEGENERATE` directly.  No
-///    additional floating-point sign classification is performed.
 ///
-/// This makes `insphere_lifted` provably correct for finite inputs. For additional
-/// robustness strategies (symbolic perturbation, consistency checking), use
-/// [`crate::geometry::kernel::RobustKernel`].
+/// Relative-coordinate or lifted-norm overflow is returned as a typed
+/// coordinate-conversion error before determinant evaluation. Therefore a
+/// returned classification has a provably correct sign, while finite inputs
+/// whose lifted intermediates are not representable fail explicitly. For
+/// additional robustness strategies (symbolic perturbation, consistency
+/// checking), use [`crate::geometry::kernel::RobustKernel`].
 ///
 /// # Algorithm
 ///
@@ -2372,7 +2372,7 @@ mod tests {
     }
 
     // =======================================================================
-    // insphere_from_matrix Stage 2 & Stage 3 coverage
+    // Exact matrix evaluation and typed boundary-failure coverage
     // =======================================================================
 
     #[test]

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -11,7 +11,8 @@
 //!   better-shaped simplices. An equilateral simplex has a radius ratio close to
 //!   the dimension-dependent optimal value.
 //! - **Normalized Volume**: Volume divided by the D-th power of the average edge length.
-//!   Provides a scale-invariant measure of simplex shape quality.
+//!   Provides a scale-invariant measure of simplex shape quality above the
+//!   documented absolute degeneracy floor.
 //!
 //! # References
 //!
@@ -429,10 +430,11 @@ where
 /// Computes the normalized volume quality metric for a simplex.
 ///
 /// This metric provides a scale-invariant measure of simplex quality by dividing
-/// the volume by the D-th power of the average edge length. It avoids the numerical
-/// issues that can arise when computing inradius for very small simplices. Volume
-/// and edge-length-power degeneracy checks use the D-th power of the scale-aware
-/// length epsilon so comparisons have matching physical dimensions.
+/// the volume by the D-th power of the average edge length. Accepted simplices
+/// retain that scale invariance, while an absolute `1e-12` length floor rejects
+/// smaller scales as numerically degenerate. Volume and edge-length-power
+/// degeneracy checks use the D-th power of the scale-aware length epsilon so
+/// comparisons have matching physical dimensions.
 ///
 /// # Quality Interpretation
 ///

--- a/tests/README.md
+++ b/tests/README.md
@@ -236,7 +236,9 @@ that a valid SoS implementation must satisfy.
 
 **Test Coverage:**
 
-- **Orientation Non-Degeneracy**: SoS orientation always returns ±1 for exactly degenerate (co-hyperplanar) inputs
+- **Orientation Non-Degeneracy**: SoS orientation returns ±1 for
+  first-order-resolvable exactly degenerate (co-hyperplanar) inputs and a typed
+  `VanishingSosCofactors` error when every first-order cofactor vanishes
 - **Orientation Determinism**: same degenerate input always produces the same sign
 - **Orientation Translation Invariance**: shifting all points by a constant integer offset preserves the sign
 - **Insphere Non-Degeneracy**: SoS insphere always returns ±1 for exactly co-spherical (hyper-rectangle vertex) inputs


### PR DESCRIPTION
- Reject non-finite, non-positive, and misordered benchmark intervals.
- Align numerical and validation documentation with implemented behavior.
- Record completed remediation work and correct the Level 4 issue owner.
- Update the pinned uv version to 0.11.29.