### PR TITLE
fix(tooling): harden dependency and release automation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,15 +1,19 @@
 name: Dependabot review and auto-merge
 
-on:
+"on":
   pull_request:
     types:
       - opened
       - reopened
       - ready_for_review
+      - synchronize
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
-  issues: write
   pull-requests: write
 
 jobs:
@@ -21,12 +25,42 @@ jobs:
     steps:
       - name: Request CodeRabbit review
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr comment "$PR_URL" --body "@coderabbitai review"
+          # Dependabot-triggered workflows receive Dependabot secrets.
+          GH_TOKEN: ${{ secrets.CODERABBIT_REVIEW_TOKEN }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [[ -z "$GH_TOKEN" ]]; then
+            echo "::error::CODERABBIT_REVIEW_TOKEN is not configured."
+            exit 1
+          fi
+
+          token_owner="$(gh api user --jq '.login')"
+          if [[ "$token_owner" != "acgetchell" ]]; then
+            echo "::error::CODERABBIT_REVIEW_TOKEN must belong to acgetchell."
+            exit 1
+          fi
+
+          marker="<!-- coderabbit-review-request:${PR_HEAD_SHA} -->"
+          comments="$(
+            gh api --paginate \
+              "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+              --jq '.[] | select(.user.login == "acgetchell") | .body'
+          )"
+          if grep -Fxq -- "$marker" <<< "$comments"; then
+            echo "CodeRabbit review already requested for ${PR_HEAD_SHA}."
+            exit 0
+          fi
+          body="$(printf '@coderabbitai review\n\n%s' "$marker")"
+          gh api \
+            --method POST \
+            "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            --raw-field body="$body"
 
       - name: Enable auto-merge
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+        run: gh pr merge --auto --squash --match-head-commit "$PR_HEAD_SHA" "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -58,9 +58,50 @@ jobs:
             "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
             --raw-field body="$body"
 
-      - name: Enable auto-merge
+      - name: Wait for CodeRabbit approval
+        id: coderabbit-approval
+        timeout-minutes: 60
         env:
           GH_TOKEN: ${{ github.token }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          while true; do
+            current_head_sha="$(
+              gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}" --jq '.head.sha'
+            )"
+            if [[ "$current_head_sha" != "$PR_HEAD_SHA" ]]; then
+              echo "::error::PR head changed while waiting for CodeRabbit approval."
+              exit 1
+            fi
+
+            review_state="$(
+              gh api --paginate \
+                "repos/${REPOSITORY}/pulls/${PR_NUMBER}/reviews?per_page=100" |
+                jq --raw-output --slurp --arg sha "$PR_HEAD_SHA" '[.[][] | select(
+                  .user.login == "coderabbitai[bot]" and
+                  .commit_id == $sha
+                )] | last | .state // empty'
+            )"
+            if [[ "$review_state" == "APPROVED" ]]; then
+              echo "approved_head_sha=${PR_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+              break
+            fi
+
+            sleep 15
+          done
+
+      - name: Wait for required checks
+        timeout-minutes: 60
+        env:
+          GH_TOKEN: ${{ github.token }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash --match-head-commit "$PR_HEAD_SHA" "$PR_URL"
+        run: gh pr checks --required --watch --fail-fast "$PR_URL"
+
+      - name: Squash approved PR head
+        env:
+          APPROVED_HEAD_SHA: ${{ steps.coderabbit-approval.outputs.approved_head_sha }}
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --squash --match-head-commit "$APPROVED_HEAD_SHA" "$PR_URL"

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -433,7 +433,7 @@ def create_tag(tag_version: str, *, force: bool = False) -> None:
         print(f"  1. Force-push the tag: {_BLUE}git push --force origin {tag_version}{_RESET}")
     else:
         print(f"  1. Push the tag: {_BLUE}git push origin {tag_version}{_RESET}")
-    print(f"  2. Create GitHub release: {_BLUE}gh release create {tag_version} --notes-from-tag{_RESET}")
+    print(f"  2. Create GitHub release: {_BLUE}gh release create {tag_version} --title {tag_version} --notes-from-tag{_RESET}")
     if is_truncated:
         print(f"\n{_YELLOW}Note: Tag annotation references CHANGELOG.md due to size (>125KB).{_RESET}")
 

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -129,6 +129,25 @@ class TestValidateSemver:
 
 
 class TestCreateTag:
+    def test_next_step_sets_release_title(
+        self,
+        tmp_path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        changelog = tmp_path / "CHANGELOG.md"
+        with (
+            patch("tag_release._tag_exists", return_value=False),
+            patch("tag_release.find_changelog", return_value=changelog),
+            patch(
+                "tag_release.extract_changelog_section",
+                return_value=("## v1.2.3\n\n- Fixed\n", changelog),
+            ),
+            patch("tag_release.run_git_command_with_input"),
+        ):
+            create_tag("v1.2.3")
+
+        assert "gh release create v1.2.3 --title v1.2.3 --notes-from-tag" in capsys.readouterr().out
+
     def test_truncated_message_uses_posix_source_url(
         self,
         tmp_path,


### PR DESCRIPTION
- Authenticate CodeRabbit review requests as acgetchell and deduplicate them per PR head.
- Cancel superseded runs and queue squash auto-merge only for the triggering commit.
- Include the version title in the suggested GitHub release command.