### PR TITLE
fix(tooling): harden version resolution and refresh tool pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "03:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -22,6 +25,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "04:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10
@@ -39,6 +45,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "tuesday"
+      time: "05:00"
+      timezone: "America/Los_Angeles"
     cooldown:
       default-days: 7
     open-pull-requests-limit: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,15 +69,42 @@ jobs:
         id: tool_versions
         shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          cargo_machete_version="$(resolve_version cargo_machete_version)"
+          cargo_nextest_version="$(resolve_version nextest_version)"
+          dprint_version="$(resolve_version dprint_version)"
+          rumdl_version="$(resolve_version rumdl_version)"
+          taplo_version="$(resolve_version taplo_version)"
+          typos_version="$(resolve_version typos_version)"
+          uv_version="$(resolve_version uv_version)"
+          zizmor_version="$(resolve_version zizmor_version)"
+
           {
-            echo "CARGO_MACHETE_VERSION=$(just --evaluate cargo_machete_version)"
-            echo "CARGO_NEXTEST_VERSION=$(just --evaluate nextest_version)"
-            echo "DPRINT_VERSION=$(just --evaluate dprint_version)"
-            echo "RUMDL_VERSION=$(just --evaluate rumdl_version)"
-            echo "TAPLO_VERSION=$(just --evaluate taplo_version)"
-            echo "TYPOS_VERSION=$(just --evaluate typos_version)"
-            echo "UV_VERSION=$(just --evaluate uv_version)"
-            echo "ZIZMOR_VERSION=$(just --evaluate zizmor_version)"
+            echo "CARGO_MACHETE_VERSION=$cargo_machete_version"
+            echo "CARGO_NEXTEST_VERSION=$cargo_nextest_version"
+            echo "DPRINT_VERSION=$dprint_version"
+            echo "RUMDL_VERSION=$rumdl_version"
+            echo "TAPLO_VERSION=$taplo_version"
+            echo "TYPOS_VERSION=$typos_version"
+            echo "UV_VERSION=$uv_version"
+            echo "ZIZMOR_VERSION=$zizmor_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Python

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -40,10 +40,32 @@ jobs:
 
       - name: Export coverage tool versions
         id: tool_versions
+        shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          cargo_llvm_cov_version="$(resolve_version cargo_llvm_cov_version)"
+          cargo_nextest_version="$(resolve_version nextest_version)"
+
           {
-            echo "CARGO_LLVM_COV_VERSION=$(just --evaluate cargo_llvm_cov_version)"
-            echo "CARGO_NEXTEST_VERSION=$(just --evaluate nextest_version)"
+            echo "CARGO_LLVM_COV_VERSION=$cargo_llvm_cov_version"
+            echo "CARGO_NEXTEST_VERSION=$cargo_nextest_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Install LLVM coverage tools

--- a/.github/workflows/papers.yml
+++ b/.github/workflows/papers.yml
@@ -76,11 +76,34 @@ jobs:
 
       - name: Export paper tool versions
         id: tool_versions
+        shell: bash
         run: |
+          set -euo pipefail
+
+          resolve_version() {
+            local name="$1"
+            local value
+
+            if ! value="$(just --evaluate "$name")"; then
+              echo "::error::Failed to resolve $name from justfile" >&2
+              return 1
+            fi
+            if [[ -z "$value" ]]; then
+              echo "::error::Resolved empty $name from justfile" >&2
+              return 1
+            fi
+
+            printf '%s\n' "$value"
+          }
+
+          tectonic_version="$(resolve_version tectonic_version)"
+          tex_fmt_version="$(resolve_version tex_fmt_version)"
+          uv_version="$(resolve_version uv_version)"
+
           {
-            echo "TECTONIC_VERSION=$(just --evaluate tectonic_version)"
-            echo "TEX_FMT_VERSION=$(just --evaluate tex_fmt_version)"
-            echo "UV_VERSION=$(just --evaluate uv_version)"
+            echo "TECTONIC_VERSION=$tectonic_version"
+            echo "TEX_FMT_VERSION=$tex_fmt_version"
+            echo "UV_VERSION=$uv_version"
           } >> "$GITHUB_OUTPUT"
 
       - name: Set up Python

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -33,6 +33,6 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@6fc4b006235f201fdab3722e17240ab420d580e5 # v0.6.1
+        uses: zizmorcore/zizmor-action@3dc1ecc9bcb9e94e9b2c709687979e1298497054 # v0.6.2
         with:
           inputs: .github

--- a/justfile
+++ b/justfile
@@ -21,15 +21,15 @@ dprint_version := "0.55.2"
 git_cliff_version := "2.13.1"
 just_version := "1.57.0"
 nextest_version := "0.9.140"
-rumdl_version := "0.2.47"
+rumdl_version := "0.2.48"
 samply_version := "0.13.1"
 sarif_fmt_version := "0.8.0"
 taplo_version := "0.10.0"
 tectonic_version := "0.17.0"
 tex_fmt_version := "0.5.7"
 typos_version := "1.48.0"
-uv_version := "0.12.0"
-zizmor_version := "1.28.0"
+uv_version := "0.12.1"
+zizmor_version := "1.29.0"
 
 # Common cargo-llvm-cov arguments for all coverage runs.
 # Excludes benches/examples from reports while allowing integration tests to


### PR DESCRIPTION
- Fail workflow setup when justfile pins cannot be resolved or are empty.
- Stagger weekly Dependabot updates for Actions, Cargo, and uv dependencies.
- Update rumdl, uv, zizmor, and the pinned zizmor action.