### PR TITLE
fix(validation): reject malformed notebook schema values

### DIFF
--- a/scripts/notebook_check.py
+++ b/scripts/notebook_check.py
@@ -177,10 +177,21 @@ def parse_execution_count(value: Any, *, path: Path, index: int) -> int | None:
     raise TypeError(msg)
 
 
+def parse_nbformat(value: Any, *, path: Path) -> int:
+    """Parse the supported notebook format version."""
+    if not isinstance(value, int) or isinstance(value, bool) or value != 4:
+        msg = f"{path}: expected nbformat to be the integer 4, got {value!r}"
+        raise ValueError(msg)
+    return value
+
+
 def parse_notebook_cell(raw_cell: Any, *, path: Path, index: int) -> NotebookCell:
     """Parse a raw nbformat cell into validated notebook metadata."""
     if not isinstance(raw_cell, dict):
         msg = f"{path}: cell {index}: expected cell to be an object"
+        raise TypeError(msg)
+    if not isinstance(raw_cell.get("metadata"), dict):
+        msg = f"{path}: cell {index}: expected metadata to be an object"
         raise TypeError(msg)
     return NotebookCell(
         index=index,
@@ -202,9 +213,7 @@ def load_notebook(path: Path) -> NotebookDocument:
     if not isinstance(notebook, dict):
         msg = f"{path}: expected notebook JSON to be an object"
         raise TypeError(msg)
-    if notebook.get("nbformat") != 4:
-        msg = f"{path}: expected nbformat 4, got {notebook.get('nbformat')!r}"
-        raise ValueError(msg)
+    nbformat = parse_nbformat(notebook.get("nbformat"), path=path)
     cells = notebook.get("cells")
     if not isinstance(cells, list):
         msg = f"{path}: expected notebook cells to be a list"
@@ -215,7 +224,7 @@ def load_notebook(path: Path) -> NotebookDocument:
         raise TypeError(msg)
     return NotebookDocument(
         path=path,
-        nbformat=4,
+        nbformat=nbformat,
         nbformat_minor=nbformat_minor,
         cells=tuple(parse_notebook_cell(cell, path=path, index=index) for index, cell in enumerate(cells, start=1)),
     )

--- a/scripts/tests/test_notebook_check.py
+++ b/scripts/tests/test_notebook_check.py
@@ -112,12 +112,16 @@ def test_load_notebook_rejects_non_object_json(tmp_path: Path) -> None:
         load_notebook(notebook)
 
 
-def test_load_notebook_rejects_wrong_nbformat(tmp_path: Path) -> None:
-    """Only nbformat v4 notebooks are supported."""
-    notebook = tmp_path / "old-format.ipynb"
-    notebook.write_text('{"cells": [], "nbformat": 3, "nbformat_minor": 0, "metadata": {}}', encoding="utf-8")
+@pytest.mark.parametrize("nbformat", [3, 4.0, True, False])
+def test_load_notebook_rejects_non_v4_integer_nbformat(tmp_path: Path, nbformat: float | bool) -> None:
+    """Only the JSON integer token 4 is a supported nbformat version."""
+    notebook = tmp_path / "bad-format.ipynb"
+    notebook.write_text(
+        json.dumps({"cells": [], "nbformat": nbformat, "nbformat_minor": 0, "metadata": {}}),
+        encoding="utf-8",
+    )
 
-    with pytest.raises(ValueError, match="expected nbformat 4"):
+    with pytest.raises(ValueError, match="expected nbformat to be the integer 4"):
         load_notebook(notebook)
 
 
@@ -154,6 +158,15 @@ def test_load_notebook_rejects_bad_outputs_shape(tmp_path: Path) -> None:
     write_notebook(notebook, [code_cell("x = 1", outputs={"output_type": "stream"})])
 
     with pytest.raises(TypeError, match="outputs must be a list"):
+        load_notebook(notebook)
+
+
+def test_load_notebook_rejects_non_object_cell_metadata(tmp_path: Path) -> None:
+    """Every notebook cell must provide a JSON metadata object."""
+    notebook = tmp_path / "bad-cell-metadata.ipynb"
+    write_notebook(notebook, [{**code_cell("x = 1"), "metadata": []}])
+
+    with pytest.raises(TypeError, match=r"cell 1: expected metadata to be an object"):
         load_notebook(notebook)
 
 


### PR DESCRIPTION
- Reject non-object cell metadata with notebook and cell context.
- Require nbformat to use the JSON integer 4 rather than numeric-equivalent values.

Closes #548