### PR TITLE
test: rebalance default and slow test coverage

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -45,6 +45,31 @@ path = "test-results/junit.xml"
 store-success-output = false
 store-failure-output = true
 
+[[profile.ci.overrides]]
+# These promoted 4D property families finish with little or no margin under
+# the 10-second budget on Windows runners. Keep the normal budget elsewhere.
+platform = 'cfg(windows)'
+filter = '''
+(
+    binary(=proptest_convex_hull)
+    | binary(=proptest_facet)
+    | binary(=proptest_orientation)
+    | binary(=proptest_simplex)
+    | binary(=proptest_tds)
+) & test(/_4d$/)
+'''
+slow-timeout = { period = "60s", terminate-after = 1 }
+
+[[profile.ci.overrides]]
+# These two 4D Delaunay properties also sit at the Windows timeout boundary;
+# other 4D properties in the same binary retain the normal 10-second budget.
+platform = 'cfg(windows)'
+filter = '''
+binary(=proptest_delaunay_triangulation)
+& test(/^(prop_duplicate_coordinates_rejected_4d|prop_insertion_order_robustness_4d)$/)
+'''
+slow-timeout = { period = "60s", terminate-after = 1 }
+
 [profile.debug]
 # Debug assertions and overflow checks make exact-geometry paths slower than
 # their release counterparts. Inherit the default 10-second budget and grant

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -47,10 +47,13 @@ store-failure-output = true
 
 [profile.debug]
 # Debug assertions and overflow checks make exact-geometry paths slower than
-# their release counterparts. Keep a finite watchdog without weakening CI's
-# release/default 10-second budget.
+# their release counterparts. Inherit the default 10-second budget and grant
+# extra headroom only to the known platform-sensitive periodic builder cases.
 inherits = "ci"
 retries = 0
+
+[[profile.debug.overrides]]
+filter = 'test(=builder::tests::test_builder_toroidal_t2_smoke) | test(=builder::tests::test_builder_toroidal_accepts_matching_explicit_global_topology)'
 slow-timeout = { period = "60s", terminate-after = 1 }
 
 [profile.coverage]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -73,12 +73,22 @@ slow-timeout = { period = "60s", terminate-after = 1 }
 [profile.debug]
 # Debug assertions and overflow checks make exact-geometry paths slower than
 # their release counterparts. Inherit the default 10-second budget and grant
-# extra headroom only to the known platform-sensitive periodic builder cases.
+# extra headroom only to named platform-sensitive cases.
 inherits = "ci"
 retries = 0
 
 [[profile.debug.overrides]]
 filter = 'test(=builder::tests::test_builder_toroidal_t2_smoke) | test(=builder::tests::test_builder_toroidal_accepts_matching_explicit_global_topology)'
+slow-timeout = { period = "60s", terminate-after = 1 }
+
+[[profile.debug.overrides]]
+# These randomized 5D agreement checks finish at the 10-second boundary on
+# Windows runners. Keep the normal budget on other platforms.
+platform = 'cfg(windows)'
+filter = '''
+test(=geometry::util::simplex_lp::tests::optimized_intersection_agrees_with_legacy_random_5d)
+| test(=validation::tests::randomized_full_report_matches_brute_force_5d)
+'''
 slow-timeout = { period = "60s", terminate-after = 1 }
 
 [profile.coverage]

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -293,10 +293,12 @@ smoke recipe for cases where a compile-only check is the desired validator; do
 not run it before `test-integration` unless you intentionally want a separate
 compile-only pass. `test-unit` runs lib unit
 tests in both debug and release profiles so debug assertions and default
-overflow checks remain covered; the nextest `debug` profile gives slower debug
-geometry paths a finite 60-second watchdog. `test-integration` runs a focused
-release-profile nextest bucket. `test-cli` owns the feature-gated CLI tests,
-and `test-rust` composes every Rust test class once.
+overflow checks remain covered. The nextest `debug` profile preserves the
+default 10-second watchdog, with a 60-second override only for the two periodic
+builder cases whose debug exact-geometry cost is platform-sensitive.
+`test-integration` runs a focused release-profile nextest bucket. `test-cli`
+owns the feature-gated CLI tests, and `test-rust` composes every Rust test class
+once.
 
 ```bash
 just ci
@@ -442,7 +444,11 @@ The routine correctness suite has two buckets:
 profile. Debug-mode exact-predicate arithmetic can make high-dimensional tests
 look like hangs, so slow correctness timing should be measured with the release
 recipe. Deterministic slow tests should use `#[cfg(feature = "slow-tests")]`,
-not `#[ignore]`.
+not `#[ignore]`. The recipe is the maintained execution path for every test
+hidden by that feature and includes feature-gated doctests after the nextest
+run. When adding or removing a gate, compare nextest discovery with and without
+`--features slow-tests` so the slow-only case is demonstrably owned by this
+lane.
 
 `just perf-no-regressions` is the fuller local PR guard. It runs
 `ci_performance_suite` with the shared dev-mode Criterion arguments against a

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -296,9 +296,11 @@ tests in both debug and release profiles so debug assertions and default
 overflow checks remain covered. The nextest `debug` profile preserves the
 default 10-second watchdog, with a 60-second override only for the two periodic
 builder cases whose debug exact-geometry cost is platform-sensitive.
-`test-integration` runs a focused release-profile nextest bucket. `test-cli`
-owns the feature-gated CLI tests, and `test-rust` composes every Rust test class
-once.
+`test-integration` runs a focused release-profile nextest bucket. Selected 4D
+property families retain that default coverage with a Windows-only 60-second
+override because their release runtimes sit at the 10-second boundary on
+Windows runners; non-Windows platforms keep the normal budget. `test-cli` owns
+the feature-gated CLI tests, and `test-rust` composes every Rust test class once.
 
 ```bash
 just ci

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -294,8 +294,9 @@ not run it before `test-integration` unless you intentionally want a separate
 compile-only pass. `test-unit` runs lib unit
 tests in both debug and release profiles so debug assertions and default
 overflow checks remain covered. The nextest `debug` profile preserves the
-default 10-second watchdog, with a 60-second override only for the two periodic
-builder cases whose debug exact-geometry cost is platform-sensitive.
+default 10-second watchdog, with 60-second overrides for the two periodic
+builder cases whose debug exact-geometry cost is platform-sensitive and, on
+Windows only, two randomized 5D agreement checks at the timeout boundary.
 `test-integration` runs a focused release-profile nextest bucket. Selected 4D
 property families retain that default coverage with a Windows-only 60-second
 override because their release runtimes sit at the 10-second boundary on

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -380,6 +380,14 @@ Default test recipes are split by target class:
 - `just test-cli` runs feature-gated CLI integration tests.
 - `just test-python` runs Python tests.
 
+The debug unit-test profile keeps the same 10-second per-test budget as the
+default and CI profiles. Timeout exceptions must be nextest overrides matching
+the smallest stable set of test names; do not raise the whole debug profile.
+The periodic T^2 builder smoke test and its matching-explicit-topology variant
+have a 60-second override because debug exact-geometry cost varies materially
+by platform. They remain in the normal suite because they cover distinct public
+builder contracts and are fast in release builds.
+
 For test-only changes, run only the matching focused recipe. If multiple test
 target classes changed, compose those focused recipes once each. Use
 `just test` when you intentionally want the full default test suite;
@@ -402,6 +410,11 @@ especially when measuring repair paths that need deliberately invalid topology.
 Those helpers should still have focused unit tests for their fixture contract.
 Known limitations should be asserted explicitly or tracked outside the routine
 test suite rather than hidden behind `#[ignore]`.
+
+`just test-slow` is the maintained execution path for every test hidden by the
+`slow-tests` feature, including feature-gated doctests. When changing a gate,
+compare nextest discovery with and without `--features slow-tests`; a test is
+not owned by the slow lane unless it appears in the feature-enabled catalog.
 
 Run all default test buckets:
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -388,6 +388,11 @@ have a 60-second override because debug exact-geometry cost varies materially
 by platform. They remain in the normal suite because they cover distinct public
 builder contracts and are fast in release builds.
 
+The release integration profile similarly grants 60 seconds on Windows only
+to the promoted 4D property families that sit at the 10-second boundary there.
+The overrides combine platform, integration-binary, and test-name filters so
+unrelated tests and non-Windows platforms retain the normal budget.
+
 For test-only changes, run only the matching focused recipe. If multiple test
 target classes changed, compose those focused recipes once each. Use
 `just test` when you intentionally want the full default test suite;

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -386,7 +386,9 @@ the smallest stable set of test names; do not raise the whole debug profile.
 The periodic T^2 builder smoke test and its matching-explicit-topology variant
 have a 60-second override because debug exact-geometry cost varies materially
 by platform. They remain in the normal suite because they cover distinct public
-builder contracts and are fast in release builds.
+builder contracts and are fast in release builds. Two randomized 5D agreement
+checks also receive 60 seconds on Windows only because they sit at the
+10-second boundary there.
 
 The release integration profile similarly grants 60 seconds on Windows only
 to the promoted 4D property families that sit at the 10-second boundary there.

--- a/justfile
+++ b/justfile
@@ -1416,7 +1416,8 @@ test-diagnostics: _ensure-nextest
 test-doc:
     cargo test --doc --release --verbose
 
-# test-integration: runs all default integration tests under the 10s per-test budget.
+# Run default integration tests in release mode under the normal 10-second budget.
+# Narrow platform-specific overrides grant headroom to boundary-running cases.
 [group('tests and coverage')]
 test-integration: _ensure-nextest
     cargo nextest run --release --profile ci --test '*'

--- a/tests/README.md
+++ b/tests/README.md
@@ -97,7 +97,7 @@ Property-based tests for Tds (Triangulation Data Structure) combinatorial/topolo
 
 **Dimensions Tested:** 2D-5D; 5D full TDS property variants over the 10-second budget run through `just test-slow`.
 
-**Run with:** `cargo test --test proptest_tds` or included in `just test`
+**Run with:** `cargo test --release --test proptest_tds` or included in `just test`
 
 #### [`proptest_orientation.rs`](./proptest_orientation.rs)
 
@@ -111,7 +111,7 @@ Property-based tests focused on coherent orientation invariants in the TDS layer
 
 **Dimensions Tested:** 2D-5D; 5D full orientation property variants over the 10-second budget run through `just test-slow`.
 
-**Run with:** `cargo test --test proptest_orientation` or included in `just test`
+**Run with:** `cargo test --release --test proptest_orientation` or included in `just test`
 
 #### [`proptest_triangulation.rs`](./proptest_triangulation.rs)
 
@@ -169,7 +169,7 @@ Property-based tests for `DelaunayTriangulation` invariants (all Delaunay-specif
 
 **Dimensions Tested:** 2D-5D; variants over the 10-second budget run through `just test-slow`.
 
-**Run with:** `cargo test --test proptest_delaunay_triangulation` or included in `just test`
+**Run with:** `cargo test --release --test proptest_delaunay_triangulation` or included in `just test`
 
 #### [`proptest_simplex.rs`](./proptest_simplex.rs)
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -95,7 +95,7 @@ Property-based tests for Tds (Triangulation Data Structure) combinatorial/topolo
 - **Vertex Count Consistency**: Vertex key count matches reported vertex count
 - **Dimension Consistency**: Reported dimension matches actual structure
 
-**Dimensions Tested:** 2D-5D; 4D/5D full TDS property variants over the 10-second budget run through `just test-slow`.
+**Dimensions Tested:** 2D-5D; 5D full TDS property variants over the 10-second budget run through `just test-slow`.
 
 **Run with:** `cargo test --test proptest_tds` or included in `just test`
 
@@ -109,7 +109,7 @@ Property-based tests focused on coherent orientation invariants in the TDS layer
 - **Tamper detection**: simplex-order tampering is detected as `OrientationViolation`
 - **Incremental coherence**: orientation remains coherent after each successful insertion
 
-**Dimensions Tested:** 2D-5D; 4D/5D full orientation property variants over the 10-second budget run through `just test-slow`.
+**Dimensions Tested:** 2D-5D; 5D full orientation property variants over the 10-second budget run through `just test-slow`.
 
 **Run with:** `cargo test --test proptest_orientation` or included in `just test`
 
@@ -165,7 +165,7 @@ Property-based tests for `DelaunayTriangulation` invariants (all Delaunay-specif
 - Inverse edge/triangle queues for 4D/5D repair
 - See `src/core/algorithms/flips.rs` for implementation
 
-**Slow variants:** 4D/5D empty-circumsphere, duplicate-coordinate, duplicate-cloud, and insertion-order robustness properties are gated by `slow-tests`.
+**Slow variants:** 5D empty-circumsphere, duplicate-coordinate, duplicate-cloud, and insertion-order robustness properties are gated by `slow-tests`.
 
 **Dimensions Tested:** 2D-5D; variants over the 10-second budget run through `just test-slow`.
 
@@ -182,7 +182,7 @@ Property-based tests for Simplex data structure verifying simplex-level invarian
 - **Facet Completeness**: All facets properly defined and accessible
 - **Vertex References**: All vertex keys are valid and consistent
 
-**Dimensions Tested:** 2D-5D; 4D/5D full simplex property variants over the 10-second budget run through `just test-slow`.
+**Dimensions Tested:** 2D-5D; 5D full simplex property variants over the 10-second budget run through `just test-slow`.
 
 **Run with:** `cargo test --release --test proptest_simplex`
 
@@ -197,7 +197,7 @@ Property-based tests for convex hull computation verifying hull properties and i
 - **Boundary Subset Property**: Hull is a subset of triangulation boundary
 - **Dimension Consistency**: Hull dimension matches point set dimension
 
-**Dimensions Tested:** 2D-5D; convex-hull property variants over the 10-second budget run through `just test-slow`.
+**Dimensions Tested:** 2D-5D; 5D convex-hull property variants over the 10-second budget run through `just test-slow`.
 
 **Run with:** `cargo test --release --test proptest_convex_hull`
 
@@ -212,7 +212,7 @@ Property-based tests for Facet operations verifying facet adjacency and orientat
 - **Orientation Alternation**: Adjacent simplices have opposite facet orientations
 - **Facet Key Validity**: All facet identifiers are valid and retrievable
 
-**Dimensions Tested:** 2D-5D; 4D/5D full facet property variants over the 10-second budget run through `just test-slow`.
+**Dimensions Tested:** 2D-5D; 5D full facet property variants over the 10-second budget run through `just test-slow`.
 
 **Run with:** `cargo test --release --test proptest_facet`
 

--- a/tests/benchmark_flip_fixtures.rs
+++ b/tests/benchmark_flip_fixtures.rs
@@ -96,7 +96,6 @@ fn flip_fixtures_cover_minimal_3d_k1_roundtrip() {
 }
 
 /// Verifies the stable 3D public k=1 fixture workflow.
-#[cfg(feature = "slow-tests")]
 #[test]
 fn flip_fixtures_cover_stable_3d_k1_roundtrip() {
     verify_3d_fixture_move(STABLE_POINTS_3D, CandidateFilter::Any, FlipMoveKind::K1);
@@ -127,7 +126,6 @@ fn flip_fixtures_cover_stable_3d_k3_forward() {
 }
 
 /// Verifies the adversarial 3D public k=1 roundtrip workflow.
-#[cfg(feature = "slow-tests")]
 #[test]
 fn flip_fixtures_cover_adversarial_3d_k1_roundtrip() {
     verify_3d_fixture_move(

--- a/tests/proptest_convex_hull.rs
+++ b/tests/proptest_convex_hull.rs
@@ -359,5 +359,5 @@ test_minimal_simplex_hull!(4);
 test_minimal_simplex_hull!(5);
 test_convex_hull_properties!(2, 4, 10);
 test_convex_hull_properties!(3, 5, 12);
-test_convex_hull_properties!(4, 6, 14, #[cfg(feature = "slow-tests")]);
+test_convex_hull_properties!(4, 6, 14);
 test_convex_hull_properties!(5, 7, 16, #[cfg(feature = "slow-tests")]);

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -920,7 +920,7 @@ macro_rules! gen_duplicate_coords_test {
 
 gen_duplicate_coords_test!(2, 3, 10);
 gen_duplicate_coords_test!(3, 4, 12);
-gen_duplicate_coords_test!(4, 5, 14, #[cfg(feature = "slow-tests")]);
+gen_duplicate_coords_test!(4, 5, 14);
 gen_duplicate_coords_test!(5, 6, 16, #[cfg(feature = "slow-tests")]);
 
 /// Allow runtime tuning for the empty-circumsphere property in higher dimensions.
@@ -1016,7 +1016,7 @@ proptest! {
 // 2D–5D coverage (keep ranges small to bound runtime)
 test_empty_circumsphere!(2, 6, 10);
 test_empty_circumsphere!(3, 6, 10);
-test_empty_circumsphere!(4, 6, 12, #[cfg(feature = "slow-tests")]);
+test_empty_circumsphere!(4, 6, 12);
 test_empty_circumsphere!(5, 7, 12, #[cfg(feature = "slow-tests")]);
 
 // =============================================================================
@@ -1896,7 +1896,7 @@ macro_rules! gen_insertion_order_robustness_high_dim {
     };
 }
 
-gen_insertion_order_robustness_high_dim!(4, 6, 12, #[cfg(feature = "slow-tests")]);
+gen_insertion_order_robustness_high_dim!(4, 6, 12);
 gen_insertion_order_robustness_high_dim!(5, 7, 12, #[cfg(feature = "slow-tests")]);
 
 // =============================================================================
@@ -2021,5 +2021,5 @@ macro_rules! gen_duplicate_cloud_test {
 
 gen_duplicate_cloud_test!(2, 2);
 gen_duplicate_cloud_test!(3, 3);
-gen_duplicate_cloud_test!(4, 4, #[cfg(feature = "slow-tests")]);
+gen_duplicate_cloud_test!(4, 4);
 gen_duplicate_cloud_test!(5, 5, #[cfg(feature = "slow-tests")]);

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -883,7 +883,8 @@ macro_rules! gen_duplicate_coords_test {
             proptest! {
                 /// Tests that duplicate coordinates are rejected during insertion.
                 ///
-                /// **Status**: Active in 2D/3D. 4D/5D remain ignored for runtime (slow in test-integration).
+                /// **Status**: Active in the default suite in 2D/3D/4D; 5D remains
+                /// gated by `slow-tests`.
                 $(#[$attr])*
                 #[test]
                 fn [<prop_duplicate_coordinates_rejected_ $dim d>](

--- a/tests/proptest_facet.rs
+++ b/tests/proptest_facet.rs
@@ -132,7 +132,7 @@ macro_rules! test_facet_properties {
 // Parameters: dimension, min_vertices, max_vertices, expected_facet_vertices (D)
 test_facet_properties!(2, 4, 10, 2);
 test_facet_properties!(3, 5, 12, 3);
-test_facet_properties!(4, 6, 14, 4, #[cfg(feature = "slow-tests")]);
+test_facet_properties!(4, 6, 14, 4);
 test_facet_properties!(5, 7, 16, 5, #[cfg(feature = "slow-tests")]);
 
 // Additional invariant: facet multiplicity (each facet should belong to 1 or 2 simplices)
@@ -171,5 +171,5 @@ macro_rules! test_facet_multiplicity {
 
 test_facet_multiplicity!(2, 4, 10);
 test_facet_multiplicity!(3, 5, 12);
-test_facet_multiplicity!(4, 6, 14, #[cfg(feature = "slow-tests")]);
+test_facet_multiplicity!(4, 6, 14);
 test_facet_multiplicity!(5, 7, 16, #[cfg(feature = "slow-tests")]);

--- a/tests/proptest_orientation.rs
+++ b/tests/proptest_orientation.rs
@@ -154,12 +154,7 @@ macro_rules! gen_orientation_incremental_props {
 
 gen_orientation_construction_and_tamper_props!(2, 4, 10);
 gen_orientation_construction_and_tamper_props!(3, 5, 12);
-gen_orientation_construction_and_tamper_props!(
-    4,
-    6,
-    14,
-    #[cfg(feature = "slow-tests")]
-);
+gen_orientation_construction_and_tamper_props!(4, 6, 14);
 gen_orientation_construction_and_tamper_props!(
     5,
     7,
@@ -169,5 +164,5 @@ gen_orientation_construction_and_tamper_props!(
 
 gen_orientation_incremental_props!(2, 4, 10);
 gen_orientation_incremental_props!(3, 5, 12);
-gen_orientation_incremental_props!(4, 6, 14, #[cfg(feature = "slow-tests")]);
+gen_orientation_incremental_props!(4, 6, 14);
 gen_orientation_incremental_props!(5, 7, 16, #[cfg(feature = "slow-tests")]);

--- a/tests/proptest_simplex.rs
+++ b/tests/proptest_simplex.rs
@@ -129,5 +129,5 @@ macro_rules! test_simplex_properties {
 // Parameters: dimension, min_vertices, max_vertices, expected_vertices (D+1), max_neighbors (D+1)
 test_simplex_properties!(2, 4, 10, 3, 3);
 test_simplex_properties!(3, 5, 12, 4, 4);
-test_simplex_properties!(4, 6, 14, 5, 5, #[cfg(feature = "slow-tests")]);
+test_simplex_properties!(4, 6, 14, 5, 5);
 test_simplex_properties!(5, 7, 16, 6, 6, #[cfg(feature = "slow-tests")]);

--- a/tests/proptest_tds.rs
+++ b/tests/proptest_tds.rs
@@ -336,7 +336,7 @@ macro_rules! gen_simplex_vertex_count {
 
 gen_tds_validity!(2);
 gen_tds_validity!(3);
-gen_tds_validity!(4, #[cfg(feature = "slow-tests")]);
+gen_tds_validity!(4);
 gen_tds_validity!(5, #[cfg(feature = "slow-tests")]);
 
 // =============================================================================
@@ -347,7 +347,7 @@ gen_neighbor_symmetry!(2);
 
 gen_neighbor_symmetry!(3);
 
-gen_neighbor_symmetry!(4, #[cfg(feature = "slow-tests")]);
+gen_neighbor_symmetry!(4);
 
 gen_neighbor_symmetry!(5, #[cfg(feature = "slow-tests")]);
 
@@ -359,7 +359,7 @@ gen_neighbor_index_semantics!(2);
 
 gen_neighbor_index_semantics!(3);
 
-gen_neighbor_index_semantics!(4, #[cfg(feature = "slow-tests")]);
+gen_neighbor_index_semantics!(4);
 
 gen_neighbor_index_semantics!(5, #[cfg(feature = "slow-tests")]);
 
@@ -371,7 +371,7 @@ gen_simplex_vertices_exist_in_tds!(2);
 
 gen_simplex_vertices_exist_in_tds!(3);
 
-gen_simplex_vertices_exist_in_tds!(4, #[cfg(feature = "slow-tests")]);
+gen_simplex_vertices_exist_in_tds!(4);
 
 gen_simplex_vertices_exist_in_tds!(5, #[cfg(feature = "slow-tests")]);
 
@@ -383,7 +383,7 @@ gen_no_duplicate_simplices!(2);
 
 gen_no_duplicate_simplices!(3);
 
-gen_no_duplicate_simplices!(4, #[cfg(feature = "slow-tests")]);
+gen_no_duplicate_simplices!(4);
 
 gen_no_duplicate_simplices!(5, #[cfg(feature = "slow-tests")]);
 
@@ -395,7 +395,7 @@ gen_dimension_consistency!(2, 3);
 
 gen_dimension_consistency!(3, 4);
 
-gen_dimension_consistency!(4, 5, #[cfg(feature = "slow-tests")]);
+gen_dimension_consistency!(4, 5);
 
 gen_dimension_consistency!(5, 6, #[cfg(feature = "slow-tests")]);
 
@@ -407,7 +407,7 @@ gen_vertex_count_consistency!(2);
 
 gen_vertex_count_consistency!(3);
 
-gen_vertex_count_consistency!(4, #[cfg(feature = "slow-tests")]);
+gen_vertex_count_consistency!(4);
 
 gen_vertex_count_consistency!(5, #[cfg(feature = "slow-tests")]);
 
@@ -419,7 +419,7 @@ gen_simplex_vertex_count!(2, 3);
 
 gen_simplex_vertex_count!(3, 4);
 
-gen_simplex_vertex_count!(4, 5, #[cfg(feature = "slow-tests")]);
+gen_simplex_vertex_count!(4, 5);
 
 gen_simplex_vertex_count!(5, 6, #[cfg(feature = "slow-tests")]);
 
@@ -457,7 +457,7 @@ gen_is_valid_topology!(2);
 
 gen_is_valid_topology!(3);
 
-gen_is_valid_topology!(4, #[cfg(feature = "slow-tests")]);
+gen_is_valid_topology!(4);
 
 gen_is_valid_topology!(5, #[cfg(feature = "slow-tests")]);
 

--- a/tests/proptest_toroidal.rs
+++ b/tests/proptest_toroidal.rs
@@ -7,12 +7,9 @@
 //! - **Periodic construction invariance**: axis reflection and input permutation
 //!   preserve Levels 1-5 validity for the validated unit-domain fixture.
 
-#[cfg(feature = "slow-tests")]
 use delaunay::prelude::construction::{DelaunayTriangulationBuilder, Vertex};
-#[cfg(feature = "slow-tests")]
 use delaunay::prelude::geometry::RobustKernel;
 use delaunay::prelude::topology::spaces::{TopologicalSpace, ToroidalSpace};
-#[cfg(feature = "slow-tests")]
 use delaunay::vertex;
 use proptest::prelude::*;
 
@@ -37,7 +34,6 @@ fn coords_2d() -> impl Strategy<Value = [f64; 2]> {
 }
 
 /// Builds a proven non-degenerate fixture after axis reflection and input reordering.
-#[cfg(feature = "slow-tests")]
 fn transformed_periodic_vertices_t2(
     reflected_axes: [bool; 2],
     priorities: [u16; 7],
@@ -103,7 +99,6 @@ proptest! {
     }
 }
 
-#[cfg(feature = "slow-tests")]
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(32))]
 

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -646,9 +646,9 @@ fn regression_issue_307_4d_bulk_repair_keeps_positive_orientation() {
 /// inserts 500/500 vertices with zero skips and passes full Level 1–4
 /// validation.
 ///
-/// Gated behind `slow-tests` because batch insertion currently takes ~4 min
-/// wall time in release mode (still well below the previous ~10 min retry
-/// exhaustion); run with:
+/// Gated behind `slow-tests` because the deterministic 500-point 4D repair
+/// workload exceeds the default-suite 10-second budget in release mode; run
+/// with:
 ///
 /// ```bash
 /// cargo test --release --test regressions --features slow-tests \

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -463,13 +463,11 @@ fn test_builder_toroidal_t3_compact_quotient_handles_adversarial_transforms() {
         assert!(dt.is_valid_structure().is_ok());
         assert!(dt.as_triangulation().validate().is_ok());
         assert!(dt.is_valid_delaunay().is_ok());
-        #[cfg(feature = "slow-tests")]
         assert!(dt.validate().is_ok());
     }
 }
 
-/// Exhaustive periodic all-translates intersection validation belongs to the slow bucket.
-#[cfg(feature = "slow-tests")]
+/// Exhaustive periodic all-translates intersection validation stays within the default budget.
 #[test]
 fn test_builder_toroidal_t3_compact_quotient_validates_levels_1_to_5() {
     let vertices = compact_toroidal_vertices_t3();


### PR DESCRIPTION
- Promote bounded 3D and 4D invariant coverage into the default suite.
- Limit debug timeout relief to two platform-sensitive periodic builder tests.
- Document catalog-based ownership for remaining slow-test cases.

Closes #500