### PR TITLE
fix(test): enforce Proptest case-count precedence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1146,9 +1146,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ include = [
     "/src/**/*.rs",
     "/tests/*.proptest-regressions",
     "/tests/*.rs",
+    "/tests/common/**/*.rs",
     "/tests/COVERAGE.md",
     "/tests/README.md",
 ]

--- a/docs/property_testing_summary.md
+++ b/docs/property_testing_summary.md
@@ -100,13 +100,21 @@ prefer the documented recipes in [`tests/README.md`](../tests/README.md).
 
 ## Configuration
 
-The repository default is defined in [`proptest.toml`](../proptest.toml):
+The 32-case repository fallback is declared in
+[`proptest.toml`](../proptest.toml) and enforced for integration properties by
+[`tests/common/proptest_config.rs`](../tests/common/proptest_config.rs):
 
-```toml
-cases = 32
+```rust
+pub const REPOSITORY_DEFAULT_CASES: u32 = 32;
 ```
 
-Override it locally with environment variables:
+Proptest does not read `proptest.toml` itself. The regression tests keep its
+declaration synchronized with the Rust constant that supplies the fallback.
+
+Expensive suites may define a smaller local fallback. `PROPTEST_CASES` takes
+precedence over both the 32-case repository fallback and suite-local fallbacks.
+
+Override the case count locally with environment variables:
 
 ```bash
 PROPTEST_CASES=128 cargo test --release --test proptest_point

--- a/justfile
+++ b/justfile
@@ -28,7 +28,7 @@ taplo_version := "0.10.0"
 tectonic_version := "0.17.0"
 tex_fmt_version := "0.5.7"
 typos_version := "1.49.0"
-uv_version := "0.12.4"
+uv_version := "0.12.5"
 zizmor_version := "1.29.0"
 
 # Common cargo-llvm-cov arguments for all coverage runs.

--- a/proptest.toml
+++ b/proptest.toml
@@ -1,15 +1,11 @@
-# Proptest configuration for delaunay
+# Repository Proptest configuration declaration
 #
-# This sets the default number of test cases for all property-based tests.
-# The default proptest value is 256, which is excessive for our complex
-# triangulation construction tests (each case builds a full 3D-5D triangulation
-# with flip-based repair).
+# Proptest does not read this file directly. Integration property tests apply
+# this fallback through `tests/common/proptest_config.rs`, and
+# `tests/proptest_config.rs` verifies that the declaration and Rust constant
+# remain synchronized.
 #
 # Override via environment variable: PROPTEST_CASES=64 cargo test
 
-# Number of test cases to run per property test
+# Number of cases for properties without a suite-specific local fallback
 cases = 32
-
-# Maximum number of shrink iterations when a test fails
-# (keep default of 1024)
-# max_shrink_iters = 1024

--- a/tests/COVERAGE.md
+++ b/tests/COVERAGE.md
@@ -56,8 +56,9 @@ harness source.
 `just coverage-ci` runs through `cargo llvm-cov nextest` with the nextest
 `coverage` profile. That single instrumented CI pass produces both
 `coverage/cobertura.xml` and Codecov test-analytics JUnit XML. Property tests
-remain part of the CI coverage run; their case budget is controlled by
-`proptest.toml`, and longer deterministic coverage belongs behind the
+remain part of the CI coverage run; their shared repository fallback is 32
+cases, suite-local fallbacks may reduce that budget, and `PROPTEST_CASES`
+overrides either fallback. Longer deterministic coverage belongs behind the
 `slow-tests` feature rather than being hidden from coverage.
 
 Doc-test coverage remains intentionally disabled because `cargo-llvm-cov` marks

--- a/tests/README.md
+++ b/tests/README.md
@@ -270,7 +270,9 @@ Property-based tests for serialization and deserialization verifying data preser
 - Property tests use randomized inputs to discover edge cases
 - Tests may take longer than unit tests due to multiple iterations
 - Failures include shrunk minimal failing cases for debugging
-- Configure test cases via `PROPTEST_CASES=N` environment variable (default: 256)
+- Integration properties default to 32 cases unless they configure a suite-specific local fallback
+- Configure test cases via `PROPTEST_CASES=N`; when set, it takes precedence over both repository and suite-specific
+  fallbacks
 - Reproduce failures using `PROPTEST_SEED=<seed>` from test output
 - For deterministic ordering when debugging, use `--test-threads=1`
 - Always prefer `--release` mode for representative performance

--- a/tests/common/proptest_config.rs
+++ b/tests/common/proptest_config.rs
@@ -1,0 +1,41 @@
+#![forbid(unsafe_code)]
+
+use proptest::test_runner::Config as ProptestConfig;
+
+/// Repository-wide fallback for property tests without a narrower local budget.
+pub const REPOSITORY_DEFAULT_CASES: u32 = 32;
+
+/// Applies the repository fallback to an otherwise unconfigured `proptest!` block.
+pub fn repository_default() -> ProptestConfig {
+    with_default_cases(REPOSITORY_DEFAULT_CASES)
+}
+
+/// Preserves a suite-specific local default while honoring `PROPTEST_CASES`.
+pub fn with_default_cases(default_cases: u32) -> ProptestConfig {
+    let config = ProptestConfig::default();
+    if std::env::var_os("PROPTEST_CASES").is_some() {
+        config
+    } else {
+        ProptestConfig {
+            cases: default_cases,
+            ..config
+        }
+    }
+}
+
+/// Gives every integration property a repository fallback while preserving
+/// explicit suite configuration and Proptest's environment overrides.
+macro_rules! repo_proptest {
+    (#![proptest_config($config:expr)] $($tokens:tt)*) => {
+        ::proptest::proptest! {
+            #![proptest_config($config)]
+            $($tokens)*
+        }
+    };
+    ($($tokens:tt)*) => {
+        ::proptest::proptest! {
+            #![proptest_config($crate::proptest_config::repository_default())]
+            $($tokens)*
+        }
+    };
+}

--- a/tests/proptest_config.rs
+++ b/tests/proptest_config.rs
@@ -1,0 +1,113 @@
+#![forbid(unsafe_code)]
+
+//! Integration tests for suite-specific Proptest case-count defaults.
+
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
+use proptest::prelude::*;
+use proptest::test_runner::Config as ProptestConfig;
+use proptest_config::{REPOSITORY_DEFAULT_CASES, repository_default, with_default_cases};
+use std::process::Command;
+
+const CHILD_EXPECTED_CASES: &str = "DELAUNAY_PROPTEST_CONFIG_CHILD_EXPECTED_CASES";
+const LOCAL_DEFAULT_CASES: u32 = 12;
+
+repo_proptest! {
+    #[test]
+    fn repository_wrapper_runs_with_shared_configuration(value in Just(42_u8)) {
+        prop_assert_eq!(value, 42);
+    }
+}
+
+/// Reads the repository declaration without adding a TOML parser dependency to
+/// the integration-test support surface.
+fn declared_repository_default_cases() -> u32 {
+    include_str!("../proptest.toml")
+        .lines()
+        .find_map(|line| line.strip_prefix("cases = "))
+        .expect("proptest.toml must declare `cases = <u32>`")
+        .parse()
+        .expect("the proptest.toml case count must be a valid u32")
+}
+
+/// Runs each precedence check in a fresh process so Proptest reads the intended
+/// environment before its default configuration is cached.
+fn assert_cases_in_isolated_process(
+    test_name: &str,
+    config: fn() -> ProptestConfig,
+    proptest_cases: Option<&str>,
+    expected_cases: u32,
+) {
+    if let Some(expected_cases) = std::env::var_os(CHILD_EXPECTED_CASES) {
+        let expected_cases = expected_cases
+            .to_string_lossy()
+            .parse::<u32>()
+            .expect("child expected case count must be a valid u32");
+        assert_eq!(config().cases, expected_cases);
+        return;
+    }
+
+    let test_executable =
+        std::env::current_exe().expect("the current integration-test executable must exist");
+    let mut command = Command::new(test_executable);
+    command
+        .arg("--exact")
+        .arg(test_name)
+        .env(CHILD_EXPECTED_CASES, expected_cases.to_string());
+    if let Some(proptest_cases) = proptest_cases {
+        command.env("PROPTEST_CASES", proptest_cases);
+    } else {
+        command.env_remove("PROPTEST_CASES");
+    }
+
+    let output = command
+        .output()
+        .expect("the isolated integration-test process must run");
+    assert!(
+        output.status.success(),
+        "isolated case-count check failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[test]
+fn repository_default_matches_toml_declaration() {
+    assert_eq!(
+        REPOSITORY_DEFAULT_CASES,
+        declared_repository_default_cases()
+    );
+}
+
+#[test]
+fn repository_default_applies_without_proptest_cases() {
+    assert_cases_in_isolated_process(
+        "repository_default_applies_without_proptest_cases",
+        repository_default,
+        None,
+        REPOSITORY_DEFAULT_CASES,
+    );
+}
+
+#[test]
+fn suite_default_applies_without_proptest_cases() {
+    assert_cases_in_isolated_process(
+        "suite_default_applies_without_proptest_cases",
+        || with_default_cases(LOCAL_DEFAULT_CASES),
+        None,
+        LOCAL_DEFAULT_CASES,
+    );
+}
+
+#[test]
+fn proptest_cases_takes_precedence_over_suite_default() {
+    const OVERRIDE_CASES: u32 = 37;
+    assert_cases_in_isolated_process(
+        "proptest_cases_takes_precedence_over_suite_default",
+        || with_default_cases(LOCAL_DEFAULT_CASES),
+        Some("37"),
+        OVERRIDE_CASES,
+    );
+}

--- a/tests/proptest_convex_hull.rs
+++ b/tests/proptest_convex_hull.rs
@@ -9,6 +9,10 @@
 //!
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::assert_jaccard_gte;
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
 use delaunay::prelude::query::*;
@@ -39,7 +43,7 @@ fn count_boundary_facets<K, U, V, const D: usize>(dt: &DelaunayTriangulation<K, 
 macro_rules! test_minimal_simplex_hull {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: Hull facet count for minimal simplex is D+1
                 $(#[$attr])*
                 #[test]
@@ -98,7 +102,7 @@ macro_rules! test_minimal_simplex_hull {
 macro_rules! test_convex_hull_properties {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: Convex hull can be constructed from valid triangulation
                 $(#[$attr])*
                 #[test]

--- a/tests/proptest_delaunay_triangulation.rs
+++ b/tests/proptest_delaunay_triangulation.rs
@@ -31,6 +31,10 @@
 //! local flip configurations (O(simplices)) instead of the naive O(simplices × vertices) brute-force.
 //! This provides ~40-100x speedup for property-based testing while remaining equally correct.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::construction::{
     ConstructionOptions, DedupPolicy, DelaunayRepairPolicy, DelaunayTriangulation,
     TopologyGuarantee, Vertex,
@@ -42,6 +46,7 @@ use delaunay::try_vertices_from_points;
 use delaunay::vertex;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestCaseError, TestRunner};
+use proptest_config::{repository_default, with_default_cases};
 use rand::{SeedableRng, seq::SliceRandom};
 use std::cell::RefCell;
 use std::collections::HashSet;
@@ -666,12 +671,9 @@ fn regression_insertion_order_3d_case_001() {
 macro_rules! gen_incremental_insertion_validity {
     ($dim:literal, $min:literal, $max:literal $(, cases = $cases:literal)? $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(
-                    #![proptest_config(Config {
-                        cases: $cases,
-                        ..Config::default()
-                    })]
+                    #![proptest_config(with_default_cases($cases))]
                 )?
                 $(#[$attr])*
                 #[test]
@@ -740,7 +742,7 @@ macro_rules! gen_incremental_insertion_validity {
 }
 
 gen_incremental_insertion_validity!(2, 3, 5);
-proptest! {
+repo_proptest! {
     #[test]
     fn prop_incremental_insertion_maintains_validity_3d(
         initial_points in prop::collection::vec(vertex_3d(), 4..=6),
@@ -811,11 +813,8 @@ proptest! {
 gen_incremental_insertion_validity!(4, 5, 7);
 gen_incremental_insertion_validity!(5, 6, 8, cases = 12);
 
-proptest! {
-    #![proptest_config(Config {
-        cases: 64,
-        ..Config::default()
-    })]
+repo_proptest! {
+    #![proptest_config(with_default_cases(64))]
 
     #[test]
     fn prop_on_suspicion_validates_cocircular_2d_sequences(
@@ -847,7 +846,7 @@ proptest! {
 macro_rules! gen_non_finite_insert_rejection_tests {
     ($($dim:literal),+ $(,)?) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(
                     #[test]
                     fn [<prop_non_finite_point_rejected_before_insert_preserves_topology_ $dim d>](
@@ -880,7 +879,7 @@ gen_non_finite_insert_rejection_tests!(2, 3, 4, 5);
 macro_rules! gen_duplicate_coords_test {
     ($dim:literal, $min:literal, $max:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Tests that duplicate coordinates are rejected during insertion.
                 ///
                 /// **Status**: Active in the default suite in 2D/3D/4D; 5D remains
@@ -968,7 +967,7 @@ macro_rules! empty_circumsphere_vertices {
 macro_rules! test_empty_circumsphere {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-proptest! {
+repo_proptest! {
                 /// Property: For every simplex, no other vertex lies strictly inside
                 /// the circumsphere defined by that simplex (Delaunay condition).
                 $(#[$attr])*
@@ -1046,9 +1045,8 @@ macro_rules! gen_high_dim_delaunay_smoke {
                 init_tracing();
 
                 let config = Config {
-                    cases: 6,
                     max_shrink_iters: 16,
-                    ..Config::default()
+                    ..with_default_cases(6)
                 };
                 let target_cases = config.cases;
                 let mut runner = TestRunner::new(config);
@@ -1247,7 +1245,7 @@ gen_high_dim_delaunay_smoke!(5, 7, 9);
 macro_rules! gen_insertion_order_robustness_test {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: Delaunay triangulations remain valid across different insertion orders.
                 ///
                 /// **Status**: Passing - validates insertion-order robustness.
@@ -1411,7 +1409,7 @@ fn prop_insertion_order_robustness_3d() {
 
     init_tracing();
 
-    let config = Config::default();
+    let config = repository_default();
     let target_cases = config.cases;
     let mut runner = TestRunner::new(config);
 
@@ -1714,7 +1712,7 @@ macro_rules! gen_insertion_order_robustness_high_dim_impl {
 
                 init_tracing();
 
-                let config = Config::default();
+                let config = repository_default();
                 let target_cases = config.cases;
                 let mut runner = TestRunner::new(config);
 
@@ -1944,7 +1942,7 @@ macro_rules! gen_duplicate_cloud_test {
                 })
             }
 
-            proptest! {
+            repo_proptest! {
                 /// Property: Random clouds with duplicates and near-duplicates
                 /// produce triangulations that are globally Delaunay for the kept subset.
                 ///

--- a/tests/proptest_euler_characteristic.rs
+++ b/tests/proptest_euler_characteristic.rs
@@ -16,6 +16,10 @@
 //!
 //! For deterministic tests with known configurations, see `euler_characteristic.rs`.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
 use delaunay::prelude::generators::try_generate_random_triangulation_with_topology_guarantee;
 use delaunay::vertex;
@@ -61,7 +65,7 @@ const fn nonzero(value: usize) -> NonZeroUsize {
 macro_rules! test_euler_properties {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: Euler characteristic matches topological classification
                 $(#[$attr])*
                 #[test]

--- a/tests/proptest_facet.rs
+++ b/tests/proptest_facet.rs
@@ -8,6 +8,10 @@
 //!
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
 use delaunay::prelude::query::*;
 use delaunay::try_vertices_from_points;
@@ -31,7 +35,7 @@ fn finite_coordinate() -> impl Strategy<Value = f64> {
 macro_rules! test_facet_properties {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal, $expected_facet_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: Each facet should have exactly D vertices (one less than simplex)
                 $(#[$attr])*
                 #[test]
@@ -139,7 +143,7 @@ test_facet_properties!(5, 7, 16, 5, #[cfg(feature = "slow-tests")]);
 macro_rules! test_facet_multiplicity {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_facet_multiplicity_ $dim d>](

--- a/tests/proptest_flips.rs
+++ b/tests/proptest_flips.rs
@@ -8,6 +8,10 @@
 //! subdivision round-trips preserve topology and Euler characteristic across
 //! dimensions 2D-5D.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use ::uuid::Uuid;
 use delaunay::flips::BistellarFlips;
 use delaunay::prelude::construction::{
@@ -303,9 +307,7 @@ macro_rules! gen_k1_roundtrip_properties {
     ($($dim:literal),* $(,)?) => {
         pastey::paste! {
             $(
-                proptest! {
-                    #![proptest_config(ProptestConfig::with_cases(32))]
-
+                repo_proptest! {
                     #[test]
                     fn [<prop_k1_flip_roundtrip_preserves_topology_and_euler_ $dim d>](
                         (origin, edge_lengths) in prop_oneof![

--- a/tests/proptest_geometry.rs
+++ b/tests/proptest_geometry.rs
@@ -10,6 +10,10 @@
 //!
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use core::array;
 
 use delaunay::prelude::geometry::*;
@@ -64,7 +68,7 @@ fn prop_assert_relative_close(actual: f64, expected: f64) -> Result<(), TestCase
 macro_rules! test_geometry_properties {
     ($dim:literal, $num_points:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: All simplex vertices are equidistant from the circumcenter
                 #[test]
                 fn [<prop_circumcenter_equidistance_ $dim d>](
@@ -243,7 +247,7 @@ test_geometry_properties!(3, 4);
 test_geometry_properties!(4, 5);
 test_geometry_properties!(5, 6);
 
-proptest! {
+repo_proptest! {
     /// Property: Low-dimensional simplex volume remains scale-aware across many orders
     /// of magnitude. This guards against fixed absolute degeneracy thresholds.
     #[test]

--- a/tests/proptest_orientation.rs
+++ b/tests/proptest_orientation.rs
@@ -10,6 +10,10 @@
 
 #![forbid(unsafe_code)]
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
 use delaunay::prelude::geometry::*;
 use delaunay::prelude::insertion::InsertionOutcome;
@@ -25,7 +29,7 @@ fn finite_coordinate() -> impl Strategy<Value = f64> {
 macro_rules! gen_orientation_construction_and_tamper_props {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: every successfully constructed triangulation is coherently oriented.
                 $(#[$attr])*
                 #[test]
@@ -119,7 +123,7 @@ macro_rules! gen_orientation_construction_and_tamper_props {
 macro_rules! gen_orientation_incremental_props {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: after each successful insertion, orientation remains coherent.
                 $(#[$attr])*
                 #[test]

--- a/tests/proptest_point.rs
+++ b/tests/proptest_point.rs
@@ -8,6 +8,10 @@
 //! - Coordinate extraction consistency
 //! - Non-finite coordinate rejection and scalar special-value determinism
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::geometry::*;
 use proptest::prelude::*;
 use rustc_hash::FxHasher;
@@ -61,7 +65,7 @@ fn hash_point<T: Hash>(point: &T) -> u64 {
 macro_rules! gen_equal_points_equal_hashes {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_equal_points_equal_hashes_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let p1 = Point::try_new(coords).expect("finite point coordinates");
@@ -77,7 +81,7 @@ macro_rules! gen_equal_points_equal_hashes {
 macro_rules! gen_equality_reflexive {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_equality_reflexive_ $dim d>](point in [<point_ $dim d>]()) {
                     prop_assert_eq!(point, point);
@@ -90,7 +94,7 @@ macro_rules! gen_equality_reflexive {
 macro_rules! gen_equality_symmetric {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_equality_symmetric_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let p1 = Point::try_new(coords).expect("finite point coordinates");
@@ -106,7 +110,7 @@ macro_rules! gen_equality_symmetric {
 macro_rules! gen_equality_transitive {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_equality_transitive_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let p1 = Point::try_new(coords).expect("finite point coordinates");
@@ -124,7 +128,7 @@ macro_rules! gen_equality_transitive {
 macro_rules! gen_hashmap_key_usage {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_hashmap_key_usage_ $dim d>](
                     point1 in [<point_ $dim d>](),
@@ -153,7 +157,7 @@ macro_rules! gen_hashmap_key_usage {
 macro_rules! gen_coordinate_roundtrip {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_coordinate_roundtrip_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let point = Point::try_new(coords).expect("finite point coordinates");
@@ -169,7 +173,7 @@ macro_rules! gen_coordinate_roundtrip {
 macro_rules! gen_into_conversion_matches_coords {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_into_conversion_matches_coords_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let point = Point::try_new(coords).expect("finite point coordinates");
@@ -187,7 +191,7 @@ macro_rules! gen_into_conversion_matches_coords {
 macro_rules! gen_get_method_consistency {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_get_method_consistency_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let point = Point::try_new(coords).expect("finite point coordinates");
@@ -205,7 +209,7 @@ macro_rules! gen_get_method_consistency {
 macro_rules! gen_finite_coordinates_validate {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_finite_coordinates_validate_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let point = Point::try_new(coords).expect("finite point coordinates");
@@ -219,7 +223,7 @@ macro_rules! gen_finite_coordinates_validate {
 macro_rules! gen_infinite_coordinates_fail_validation {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_infinite_coordinates_fail_validation_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let mut arr = coords;
@@ -251,7 +255,7 @@ macro_rules! gen_infinite_coordinates_fail_validation {
 macro_rules! gen_nan_coordinates_fail_validation {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_nan_coordinates_fail_validation_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let mut arr = coords;
@@ -273,7 +277,7 @@ macro_rules! gen_nan_coordinates_fail_validation {
 macro_rules! gen_ordering_equal_consistency {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_ordering_consistent_with_equality_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let p1 = Point::try_new(coords).expect("finite point coordinates");
@@ -290,7 +294,7 @@ macro_rules! gen_ordering_equal_consistency {
 macro_rules! gen_ordering_antisymmetric {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_ordering_antisymmetric_ $dim d>](p1 in [<point_ $dim d>](), p2 in [<point_ $dim d>]()) {
                     match (p1.partial_cmp(&p2), p2.partial_cmp(&p1)) {
@@ -308,7 +312,7 @@ macro_rules! gen_ordering_antisymmetric {
 macro_rules! gen_ordering_transitive {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_ordering_transitive_ $dim d>](p1 in [<point_ $dim d>](), p2 in [<point_ $dim d>](), p3 in [<point_ $dim d>]()) {
                     if p1.partial_cmp(&p2) == Some(Ordering::Less) && p2.partial_cmp(&p3) == Some(Ordering::Less) {
@@ -323,7 +327,7 @@ macro_rules! gen_ordering_transitive {
 macro_rules! gen_nan_handling_consistency {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_nan_handling_consistency_ $dim d>](finite_coord in finite_f64()) {
                     let mut arr = [finite_coord; $dim];

--- a/tests/proptest_predicates.rs
+++ b/tests/proptest_predicates.rs
@@ -6,6 +6,10 @@
 //! - Insphere transitivity and symmetry properties
 //! - Robustness under small perturbations
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::geometry::*;
 use proptest::prelude::*;
 
@@ -51,7 +55,7 @@ fn point_5d() -> impl Strategy<Value = Point<5>> {
 macro_rules! gen_orientation_sign_flip {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_orientation_sign_flip_ $dim d>](
                     simplex in prop::collection::vec([<point_ $dim d>](), $dim + 1)
@@ -90,7 +94,7 @@ macro_rules! gen_orientation_sign_flip {
 macro_rules! gen_orientation_cyclic_invariance {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_orientation_cyclic_invariance_ $dim d>](
                     simplex in prop::collection::vec([<point_ $dim d>](), $dim + 1)
@@ -118,7 +122,7 @@ macro_rules! gen_orientation_cyclic_invariance {
 macro_rules! gen_insphere_simplex_vertices_on_boundary {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_insphere_simplex_vertices_on_boundary_ $dim d>](
                     simplex in prop::collection::vec([<point_ $dim d>](), $dim + 1)
@@ -142,7 +146,7 @@ macro_rules! gen_insphere_simplex_vertices_on_boundary {
 macro_rules! gen_insphere_inward_scaling_inside {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_insphere_inward_scaling_makes_point_inside_ $dim d>](
                     simplex in prop::collection::vec([<point_ $dim d>](), $dim + 1)
@@ -185,7 +189,7 @@ macro_rules! gen_insphere_inward_scaling_inside {
 macro_rules! gen_insphere_distant_point_outside_by_radius {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_insphere_distant_point_is_outside_ $dim d>](
                     simplex in prop::collection::vec([<point_ $dim d>](), $dim + 1)
@@ -225,7 +229,7 @@ macro_rules! gen_insphere_distant_point_outside_by_radius {
 macro_rules! gen_insphere_scale_center_outside {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_insphere_scaling_makes_point_outside_ $dim d>](
                     simplex in prop::collection::vec([<point_ $dim d>](), $dim + 1)
@@ -278,7 +282,7 @@ gen_insphere_distant_point_outside_by_radius!(5);
 gen_insphere_scale_center_outside!(4);
 gen_insphere_scale_center_outside!(5);
 
-proptest! {
+repo_proptest! {
     /// Large translations near the f64 squared-norm overflow boundary should
     /// not change robust insphere classification when the local simplex scale
     /// remains finite.
@@ -337,7 +341,7 @@ proptest! {
 // CROSS-PREDICATE CONSISTENCY TESTS
 // =============================================================================
 
-proptest! {
+repo_proptest! {
     /// Property: If a simplex has DEGENERATE orientation, insphere tests
     /// on that simplex may fail or return inconsistent results.
     ///

--- a/tests/proptest_safe_conversions.rs
+++ b/tests/proptest_safe_conversions.rs
@@ -14,6 +14,10 @@
 //! - Round-trip conversions preserve values where possible
 //! - Non-finite values (NaN, Infinity) are properly rejected
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use approx::assert_relative_eq;
 use delaunay::prelude::geometry::*;
 use num_traits::cast;
@@ -45,7 +49,7 @@ fn safe_usize() -> impl Strategy<Value = usize> {
 // f64 input -> f64 output should match exactly
 macro_rules! gen_safe_scalar_to_f64_ok_f64 {
     () => {
-        proptest! {
+        repo_proptest! {
             #[test]
             fn prop_safe_scalar_to_f64_succeeds_for_finite_f64(value in finite_f64()) {
                 let result: Result<f64, _> = safe_scalar_to_f64(value);
@@ -59,7 +63,7 @@ macro_rules! gen_safe_scalar_to_f64_ok_f64 {
 // f64 input -> f64 output
 macro_rules! gen_safe_scalar_from_f64_ok_f64 {
     () => {
-        proptest! {
+        repo_proptest! {
             #[test]
             fn prop_safe_scalar_from_f64_succeeds_for_finite_f64(value in finite_f64()) {
                 let result: Result<f64, _> = safe_scalar_from_f64(value);
@@ -73,7 +77,7 @@ macro_rules! gen_safe_scalar_from_f64_ok_f64 {
 // Round-trip scalar tests
 macro_rules! gen_round_trip_scalar_f64_f64 {
     () => {
-        proptest! {
+        repo_proptest! {
             #[test]
             fn prop_round_trip_f64_f64(value in finite_f64()) {
                 let converted: Result<f64, _> = safe_scalar_to_f64(value);
@@ -87,7 +91,7 @@ macro_rules! gen_round_trip_scalar_f64_f64 {
 }
 
 // Non-finite rejection tests
-proptest! {
+repo_proptest! {
     /// Property: safe_scalar_to_f64 rejects non-finite values
     #[test]
     fn prop_safe_scalar_to_f64_rejects_non_finite(value in non_finite_f64()) {
@@ -117,7 +121,7 @@ gen_round_trip_scalar_f64_f64!();
 macro_rules! gen_safe_usize_to_scalar_succeeds {
     ($name:ident, $ty:ty, $strategy:ident) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<$name>](value in $strategy()) {
                     let result: Result<$ty, _> = safe_usize_to_scalar(value);
@@ -134,7 +138,7 @@ macro_rules! gen_safe_usize_to_scalar_succeeds {
 macro_rules! gen_safe_usize_exact_small_values {
     ($name:ident, $ty:ty, $upper:expr) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<$name>](value in 0..=$upper) {
                     let result: Result<$ty, _> = safe_usize_to_scalar(value);
@@ -179,7 +183,7 @@ gen_safe_usize_preserves_const!(prop_safe_usize_preserves_zero, 0_usize, 0.0_f64
 gen_safe_usize_preserves_const!(prop_safe_usize_preserves_one, 1_usize, 1.0_f64, f64, 1e-15);
 
 // Monotonicity test retained for f64
-proptest! {
+repo_proptest! {
     /// Property: safe_usize_to_scalar is monotonic for safe values
     #[test]
     fn prop_safe_usize_monotonic(value1 in safe_usize(), value2 in safe_usize()) {
@@ -213,7 +217,7 @@ proptest! {
 macro_rules! gen_safe_coords_to_f64 {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_safe_coords_to_f64_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let result = safe_coords_to_f64(&coords);
@@ -232,7 +236,7 @@ macro_rules! gen_safe_coords_to_f64 {
 macro_rules! gen_safe_coords_from_f64 {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_safe_coords_from_f64_ $dim d>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let result: Result<[f64; $dim], _> = safe_coords_from_f64(&coords);
@@ -251,7 +255,7 @@ macro_rules! gen_safe_coords_from_f64 {
 macro_rules! gen_round_trip_coords_f64_exact {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 #[test]
                 fn [<prop_round_trip_coords_ $dim d _exact>](coords in prop::array::[<uniform $dim>](finite_f64())) {
                     let to_f64 = safe_coords_to_f64(&coords);
@@ -279,7 +283,7 @@ gen_safe_coords_from_f64!(3);
 gen_round_trip_coords_f64_exact!(4);
 
 // Keep 3D rejection tests
-proptest! {
+repo_proptest! {
     /// Property: Coordinate array with one NaN is rejected
     #[test]
     fn prop_coords_reject_nan_3d(good_coord in finite_f64(), nan_index in 0..3_usize) {
@@ -318,7 +322,7 @@ fn prop_zero_coords_convert_correctly_3d() {
     }
 }
 
-proptest! {
+repo_proptest! {
 
     /// Property: Negative coordinates convert correctly
     #[test]

--- a/tests/proptest_serialization.rs
+++ b/tests/proptest_serialization.rs
@@ -8,6 +8,10 @@
 //!
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use approx::relative_eq;
 use delaunay::prelude::Tds;
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
@@ -15,6 +19,7 @@ use delaunay::prelude::geometry::AdaptiveKernel;
 use delaunay::prelude::query::*;
 use delaunay::try_vertices_from_points;
 use proptest::prelude::*;
+use proptest_config::with_default_cases;
 
 /// Type alias for the default round-trip target (`AdaptiveKernel`).
 type DefaultDt<const D: usize> = DelaunayTriangulation<AdaptiveKernel<f64>, (), (), D>;
@@ -45,12 +50,9 @@ fn finite_coordinate() -> impl Strategy<Value = f64> {
 macro_rules! test_serialization_properties {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, cases = $cases:literal)? $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(
-                    #![proptest_config(proptest::test_runner::Config {
-                        cases: $cases,
-                        ..proptest::test_runner::Config::default()
-                    })]
+                    #![proptest_config(with_default_cases($cases))]
                 )?
 
                 /// Property: Triangulation structure preserved after JSON roundtrip

--- a/tests/proptest_simplex.rs
+++ b/tests/proptest_simplex.rs
@@ -9,6 +9,10 @@
 //!
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::construction::{DelaunayTriangulation, TopologyGuarantee};
 use delaunay::prelude::query::*;
 use delaunay::try_vertices_from_points;
@@ -32,7 +36,7 @@ fn finite_coordinate() -> impl Strategy<Value = f64> {
 macro_rules! test_simplex_properties {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal, $expected_vertices:literal, $max_neighbors:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: All simplices should have unique vertices (no duplicates)
                 $(#[$attr])*
                 #[test]

--- a/tests/proptest_sos.rs
+++ b/tests/proptest_sos.rs
@@ -24,6 +24,10 @@
 
 #![forbid(unsafe_code)]
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::geometry::sos::{sos_insphere_sign, sos_orientation_sign};
 use delaunay::prelude::geometry::{CoordinateConversionError, DegenerateSimplexReason, Point};
 use proptest::prelude::*;
@@ -110,7 +114,7 @@ macro_rules! gen_sos_tests {
             // Degenerate orientation — co-hyperplanar points ($dim D)
             // =============================================================
 
-            proptest! {
+            repo_proptest! {
                 /// `SoS` orientation returns ±1 for first-order-resolvable degenerate points.
                 #[test]
                 fn [<prop_sos_orientation_nonzero_ $dim d>](
@@ -218,7 +222,7 @@ macro_rules! gen_sos_tests {
             // Co-spherical insphere — hyper-rectangle vertices ($dim D)
             // =============================================================
 
-            proptest! {
+            repo_proptest! {
                 /// `SoS` insphere returns ±1 for exactly co-spherical points.
                 #[test]
                 fn [<prop_sos_insphere_nonzero_ $dim d>](
@@ -277,7 +281,7 @@ macro_rules! gen_sos_tests {
             // Robustness — arbitrary finite inputs ($dim D)
             // =============================================================
 
-            proptest! {
+            repo_proptest! {
                 /// `SoS` orientation never panics on random inputs.
                 #[test]
                 fn [<prop_sos_orientation_robust_ $dim d>](
@@ -322,7 +326,7 @@ gen_sos_tests!(5, prop::array::uniform5);
 // ERROR HANDLING (dimension-independent)
 // =============================================================================
 
-proptest! {
+repo_proptest! {
     /// `SoS` orientation returns `Err` for wrong point count.
     #[test]
     fn prop_sos_orientation_rejects_wrong_count(

--- a/tests/proptest_tds.rs
+++ b/tests/proptest_tds.rs
@@ -22,6 +22,10 @@
 //! Tests that construct through the Delaunay owner use owner-level Level 2
 //! structural validation instead of borrowing the underlying storage.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::collections::{SimplexVertexBuffer, SimplexVertexKeyBuffer};
 use delaunay::prelude::construction::{DelaunayTriangulation, Vertex};
 use delaunay::prelude::query::*;
@@ -29,6 +33,7 @@ use delaunay::prelude::tds::{Tds, jaccard_index};
 use delaunay::try_vertices_from_points;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestCaseError, TestRunner};
+use proptest_config::with_default_cases;
 use std::cell::RefCell;
 use std::collections::HashSet;
 
@@ -112,7 +117,7 @@ fn small_vertex_set_5d() -> impl Strategy<Value = Vec<Vertex<(), 5>>> {
 macro_rules! gen_tds_validity {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_tds_from_vertices_is_valid_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -130,7 +135,7 @@ macro_rules! gen_tds_validity {
 macro_rules! gen_neighbor_symmetry {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_neighbor_symmetry_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -189,7 +194,7 @@ macro_rules! gen_neighbor_symmetry {
 macro_rules! gen_neighbor_index_semantics {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_neighbor_index_semantics_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -234,7 +239,7 @@ macro_rules! gen_neighbor_index_semantics {
 macro_rules! gen_simplex_vertices_exist_in_tds {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_simplex_vertices_exist_in_tds_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -256,7 +261,7 @@ macro_rules! gen_simplex_vertices_exist_in_tds {
 macro_rules! gen_no_duplicate_simplices {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_no_duplicate_simplices_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -278,7 +283,7 @@ macro_rules! gen_no_duplicate_simplices {
 macro_rules! gen_dimension_consistency {
     ($dim:literal, $min_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_dimension_consistency_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -296,7 +301,7 @@ macro_rules! gen_dimension_consistency {
 macro_rules! gen_vertex_count_consistency {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_vertex_count_consistency_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -314,7 +319,7 @@ macro_rules! gen_vertex_count_consistency {
 macro_rules! gen_simplex_vertex_count {
     ($dim:literal, $expected:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_simplex_vertex_count_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -433,7 +438,7 @@ gen_simplex_vertex_count!(5, 6, #[cfg(feature = "slow-tests")]);
 macro_rules! gen_is_valid_topology {
     ($dim:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 $(#[$attr])*
                 #[test]
                 fn [<prop_triangulation_is_valid_topology_ $dim d>](vertices in [<small_vertex_set_ $dim d>]()) {
@@ -482,9 +487,8 @@ macro_rules! gen_high_dim_tds_smoke {
                 }
 
                 let config = Config {
-                    cases: 6,
                     max_shrink_iters: 16,
-                    ..Config::default()
+                    ..with_default_cases(6)
                 };
                 let target_cases = config.cases;
                 let mut runner = TestRunner::new(config);

--- a/tests/proptest_toroidal.rs
+++ b/tests/proptest_toroidal.rs
@@ -7,6 +7,10 @@
 //! - **Periodic construction invariance**: axis reflection and input permutation
 //!   preserve Levels 1-5 validity for the validated unit-domain fixture.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::construction::{DelaunayTriangulationBuilder, Vertex};
 use delaunay::prelude::geometry::RobustKernel;
 use delaunay::prelude::topology::spaces::{TopologicalSpace, ToroidalSpace};
@@ -66,7 +70,7 @@ fn transformed_periodic_vertices_t2(
 // Tests
 // =============================================================================
 
-proptest! {
+repo_proptest! {
     /// Canonicalized coordinates always lie in `[0, L_i)` for every axis.
     #[test]
     fn prop_canonicalize_in_domain(domain in domain_t2(), mut coords in coords_2d()) {
@@ -99,9 +103,7 @@ proptest! {
     }
 }
 
-proptest! {
-    #![proptest_config(ProptestConfig::with_cases(32))]
-
+repo_proptest! {
     /// Periodic quotient construction remains valid under axis reflections and input permutation.
     #[test]
     fn prop_periodic_quotient_reflection_and_permutation_preserve_invariants(

--- a/tests/proptest_triangulation.rs
+++ b/tests/proptest_triangulation.rs
@@ -34,6 +34,10 @@
 //!
 //! Tests are generated for dimensions 2D-5D using macros to reduce duplication.
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use ::uuid::Uuid;
 use delaunay::prelude::construction::{
     DelaunayTriangulation, DelaunayTriangulationBuilder, TopologyGuarantee,
@@ -44,6 +48,7 @@ use delaunay::try_vertices_from_points;
 use delaunay::vertex;
 use proptest::prelude::*;
 use proptest::test_runner::{Config, TestCaseError, TestRunner};
+use proptest_config::with_default_cases;
 use std::cell::RefCell;
 use std::collections::HashMap;
 
@@ -188,7 +193,7 @@ where
 macro_rules! test_simplex_quality_properties {
     ($dim:literal, $num_points:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: Radius ratio R/r ≥ D for non-degenerate D-simplices
                 $(#[$attr])*
                 #[test]
@@ -375,7 +380,7 @@ macro_rules! test_simplex_quality_properties {
 macro_rules! test_quality_properties {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
 
                 /// Property: Radius ratio is always positive for valid simplices
                 $(#[$attr])*
@@ -702,7 +707,7 @@ test_quality_properties!(5, 7, 16, #[cfg(feature = "slow-tests")]);
 macro_rules! test_facet_topology_invariant {
     ($dim:literal, $min_vertices:literal, $max_vertices:literal $(, #[$attr:meta])*) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: All simplices in a valid triangulation have no over-shared facets
                 $(#[$attr])*
                 #[test]
@@ -823,9 +828,8 @@ macro_rules! gen_high_dim_facet_topology_smoke {
                 }
 
                 let config = Config {
-                    cases: 6,
                     max_shrink_iters: 16,
-                    ..Config::default()
+                    ..with_default_cases(6)
                 };
                 let target_cases = config.cases;
                 let mut runner = TestRunner::new(config);

--- a/tests/proptest_vertex.rs
+++ b/tests/proptest_vertex.rs
@@ -12,6 +12,10 @@
 
 #![allow(unused_imports)] // Imports used in macro expansion
 
+#[macro_use]
+#[path = "common/proptest_config.rs"]
+mod proptest_config;
+
 use delaunay::prelude::construction::{Vertex, VertexValidationError};
 use delaunay::prelude::geometry::{CoordinateConversionError, Point};
 use delaunay::prelude::tds::UuidValidationError;
@@ -53,7 +57,7 @@ fn hash_of<T: Hash>(value: &T) -> u64 {
 macro_rules! test_vertex_properties {
     ($dim:literal) => {
         pastey::paste! {
-            proptest! {
+            repo_proptest! {
                 /// Property: Vertex equality is reflexive (v == v)
                 #[test]
                 fn [<prop_vertex_equality_reflexive_ $dim d>](coords in prop::array::[<uniform $dim>](finite_coordinate())) {
@@ -259,7 +263,7 @@ test_vertex_properties!(5);
 // CROSS-DIMENSIONAL TESTS
 // =============================================================================
 
-proptest! {
+repo_proptest! {
     /// Property: Vertex constructors reject non-finite coordinates before storage.
     #[test]
     fn prop_vertex_rejects_non_finite_2d(valid_coord in finite_coordinate(), non_finite_coord in non_finite_coordinate(), non_finite_index in 0..2_usize) {


### PR DESCRIPTION
- Apply the 32-case repository fallback while preserving suite-specific budgets.
- Let PROPTEST_CASES override repository and suite fallbacks, including manual runners.
- Synchronize packaged test support, configuration declarations, and guidance.
- Refresh the locked UUID dependency and uv tool pin.

Closes #553