### PR TITLE
fix(flips): align k=1 preflight with periodic realization

### DIFF
--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -1706,8 +1706,16 @@ fn new_vertex_periodic_offset_in_frame<U, V, const D: usize>(
         .ok_or(FlipError::MissingSimplex {
             simplex_key: target_simplex_key,
         })?;
-    let target_offsets = periodic_offsets_or_zero_frame(target_simplex_key, target_simplex)?;
-    Ok(target_offsets.first().copied().unwrap_or([0_i8; D]))
+    k1_inserted_vertex_periodic_offset(target_simplex_key, target_simplex)
+}
+
+/// Selects the local lattice sheet used by both k=1 preflight and mutation planning.
+fn k1_inserted_vertex_periodic_offset<V, const D: usize>(
+    simplex_key: SimplexKey,
+    simplex: &Simplex<V, D>,
+) -> Result<[i8; D], FlipError> {
+    let offsets = periodic_offsets_or_zero_frame(simplex_key, simplex)?;
+    Ok(offsets.first().copied().unwrap_or([0_i8; D]))
 }
 
 /// Finds the target facet opposite the source facet, if the simplices share it.
@@ -2869,6 +2877,26 @@ pub enum FlipPredicateError {
         #[source]
         source: CoordinateValidationError,
     },
+    /// A topology model failed to lift a proposed k=1 vertex into the selected simplex frame.
+    #[error("failed to lift proposed k=1 vertex into simplex {simplex_key:?} frame: {source}")]
+    K1InsertedVertexLift {
+        /// Simplex whose local realization frame was requested.
+        simplex_key: SimplexKey,
+        /// Underlying topology-model error.
+        #[source]
+        source: GlobalTopologyModelError,
+    },
+    /// A lifted proposed k=1 vertex produced invalid point coordinates.
+    #[error(
+        "proposed k=1 vertex lifted into simplex {simplex_key:?} frame produced invalid coordinates: {source}"
+    )]
+    K1InsertedVertexPointValidation {
+        /// Simplex whose local realization frame was requested.
+        simplex_key: SimplexKey,
+        /// Coordinate validation failure for the lifted point.
+        #[source]
+        source: CoordinateValidationError,
+    },
 }
 
 impl FlipPredicateError {
@@ -3187,6 +3215,9 @@ pub enum FlipFailureKind {
     /// Degenerate simplex.
     #[error("degenerate simplex")]
     DegenerateSimplex,
+    /// Forward k=1 insertion point lies outside the selected simplex.
+    #[error("k=1 insertion outside simplex")]
+    K1InsertionOutsideSimplex,
     /// Negative orientation.
     #[error("negative orientation")]
     NegativeOrientation,
@@ -4099,6 +4130,18 @@ pub enum FlipError {
     /// Flip would create a degenerate simplex (zero orientation).
     #[error("Flip would create a degenerate simplex (zero orientation)")]
     DegenerateSimplex,
+    /// A forward k=1 insertion point is outside the selected simplex in its active chart.
+    #[error(
+        "Proposed k=1 vertex lies outside simplex {simplex_key:?} across facet slot {opposite_vertex_index} opposite {opposite_vertex:?}"
+    )]
+    K1InsertionOutsideSimplex {
+        /// Simplex selected for subdivision.
+        simplex_key: SimplexKey,
+        /// Vertex opposite a facet across which the proposed point lies outside.
+        opposite_vertex: VertexKey,
+        /// Vertex slot whose opposite facet the proposed point crosses.
+        opposite_vertex_index: usize,
+    },
     /// Delaunay repair would create a negative-orientation replacement simplex.
     #[error(
         "Delaunay repair would create a negative-orientation replacement simplex {simplex_vertices:?}"
@@ -4264,6 +4307,7 @@ impl From<&FlipError> for FlipFailureKind {
             FlipError::InvalidFlipContext { .. } => Self::InvalidFlipContext,
             FlipError::PredicateFailure { .. } => Self::PredicateFailure,
             FlipError::DegenerateSimplex => Self::DegenerateSimplex,
+            FlipError::K1InsertionOutsideSimplex { .. } => Self::K1InsertionOutsideSimplex,
             FlipError::NegativeOrientation { .. } => Self::NegativeOrientation,
             FlipError::DuplicateSimplex => Self::DuplicateSimplex,
             FlipError::NonManifoldFacet => Self::NonManifoldFacet,
@@ -4359,7 +4403,9 @@ pub struct FlipInfo<const D: usize> {
 /// is `None` for the same reason: the inserted vertex key does not exist until
 /// the mutation commits. Other move kinds report the already-live inserted face.
 /// Feasibility checks build only local replacement buffers and do not clone the
-/// full triangulation.
+/// full triangulation. They report deterministic failures on the inspected
+/// state; allocation failure, process termination, and other environmental
+/// failures remain outside the feasibility guarantee.
 ///
 /// # Examples
 ///
@@ -6618,14 +6664,124 @@ where
     validate_bistellar_flip::<U, V, D, 3>(tds, context)
 }
 
+/// Lifts a proposed k=1 vertex into the same simplex-local chart used by mutation planning.
+fn k1_inserted_vertex_point_in_simplex_frame<U, V, const D: usize>(
+    topology_model: &GlobalTopologyModelAdapter<D>,
+    simplex_key: SimplexKey,
+    simplex: &Simplex<V, D>,
+    vertex: &Vertex<U, D>,
+) -> Result<Point<D>, FlipError> {
+    let periodic_offset = if topology_model.supports_periodic_orientation_offsets() {
+        Some(k1_inserted_vertex_periodic_offset(simplex_key, simplex)?)
+    } else {
+        None
+    };
+    let lifted_coords = topology_model
+        .lift_for_orientation(*vertex.point().coords(), periodic_offset)
+        .map_err(|source| FlipPredicateError::K1InsertedVertexLift {
+            simplex_key,
+            source,
+        })?;
+    Point::try_new(lifted_coords).map_err(|source| {
+        FlipPredicateError::K1InsertedVertexPointValidation {
+            simplex_key,
+            source,
+        }
+        .into()
+    })
+}
+
+/// Requires the proposed k=1 point to lie strictly inside the selected realization chart.
+fn validate_k1_insertion_realization<U, V, const D: usize>(
+    tds: &Tds<U, V, D>,
+    topology_model: &GlobalTopologyModelAdapter<D>,
+    simplex_key: SimplexKey,
+    simplex: &Simplex<V, D>,
+    vertex: &Vertex<U, D>,
+) -> Result<(), FlipError>
+where
+    U: DataType,
+    V: DataType,
+{
+    let offsets = periodic_offsets_or_zero_frame(simplex_key, simplex)?;
+    let use_offsets = topology_model.supports_periodic_orientation_offsets();
+    let mut simplex_points: SmallBuffer<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE> =
+        SmallBuffer::with_capacity(simplex.number_of_vertices());
+    for (vertex_index, &vertex_key) in simplex.vertices().iter().enumerate() {
+        let periodic_offset = use_offsets.then_some(offsets[vertex_index]);
+        simplex_points.push(lift_vertex_point(
+            tds,
+            topology_model,
+            vertex_key,
+            periodic_offset,
+        )?);
+    }
+
+    let simplex_orientation = robust_orientation(&simplex_points).map_err(|source| {
+        FlipPredicateError::coordinate_conversion(
+            FlipPredicateOperation::ReplacementSimplexOrientation,
+            source,
+        )
+    })?;
+    if simplex_orientation == Orientation::DEGENERATE {
+        return Err(FlipError::DegenerateSimplex);
+    }
+
+    let inserted_point =
+        k1_inserted_vertex_point_in_simplex_frame(topology_model, simplex_key, simplex, vertex)?;
+    for (omit_index, &opposite_vertex) in simplex.vertices().iter().enumerate() {
+        let mut replacement_points: SmallBuffer<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE> =
+            SmallBuffer::with_capacity(D + 1);
+        replacement_points.push(inserted_point);
+        replacement_points.extend(
+            simplex_points
+                .iter()
+                .enumerate()
+                .filter_map(|(index, point)| (index != omit_index).then_some(*point)),
+        );
+
+        let replacement_orientation =
+            robust_orientation(&replacement_points).map_err(|source| {
+                FlipPredicateError::coordinate_conversion(
+                    FlipPredicateOperation::ReplacementSimplexOrientation,
+                    source,
+                )
+            })?;
+        if replacement_orientation == Orientation::DEGENERATE {
+            return Err(FlipError::DegenerateSimplex);
+        }
+
+        let expected_orientation = if omit_index.is_multiple_of(2) {
+            simplex_orientation
+        } else {
+            match simplex_orientation {
+                Orientation::POSITIVE => Orientation::NEGATIVE,
+                Orientation::NEGATIVE => Orientation::POSITIVE,
+                Orientation::DEGENERATE => return Err(FlipError::DegenerateSimplex),
+            }
+        };
+        if replacement_orientation != expected_orientation {
+            return Err(FlipError::K1InsertionOutsideSimplex {
+                simplex_key,
+                opposite_vertex,
+                opposite_vertex_index: omit_index,
+            });
+        }
+    }
+
+    Ok(())
+}
+
 /// Validate a forward k=1 move (simplex split) without mutating the TDS.
 ///
 /// # Errors
 ///
 /// Returns a [`FlipError`] if the simplex is missing, the vertex UUID is already
-/// present, or the replacement simplices would be degenerate.
+/// present, the replacement simplices would be degenerate, or the inserted point
+/// is outside the selected simplex in its active realization chart.
 pub(crate) fn validate_bistellar_flip_k1_insert<U, V, const D: usize>(
     tds: &Tds<U, V, D>,
+    topology_model: &GlobalTopologyModelAdapter<D>,
     simplex_key: SimplexKey,
     vertex: &Vertex<U, D>,
 ) -> Result<FlipFeasibility<D>, FlipError>
@@ -6652,13 +6808,13 @@ where
         .ok_or(FlipError::MissingSimplex { simplex_key })?;
     let removed_face_vertices: VertexKeyList = simplex.vertices().iter().copied().collect();
 
-    for &omit in &removed_face_vertices {
+    for omit_index in 0..removed_face_vertices.len() {
         let mut points: SmallBuffer<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE> =
             SmallBuffer::with_capacity(D + 1);
         points.push(*vertex.point());
-        for &vkey in &removed_face_vertices {
-            if vkey != omit {
-                points.push(vertex_point(tds, vkey)?);
+        for (vertex_index, &vertex_key) in removed_face_vertices.iter().enumerate() {
+            if vertex_index != omit_index {
+                points.push(vertex_point(tds, vertex_key)?);
             }
         }
 
@@ -6674,6 +6830,7 @@ where
             }
         }
     }
+    validate_k1_insertion_realization(tds, topology_model, simplex_key, simplex, vertex)?;
 
     Ok(FlipFeasibility {
         kind: BistellarFlipKind::k1(D),
@@ -15791,6 +15948,48 @@ mod tests {
         GlobalTopology::try_toroidal([1.0; D], ToroidalConstructionMode::PeriodicImagePoint)
             .unwrap()
             .model()
+    }
+
+    #[test]
+    fn k1_periodic_exterior_error_identifies_repeated_vertex_slot() {
+        let mut tds: Tds<(), (), 2> = Tds::empty();
+        let repeated_vertex = tds
+            .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
+            .unwrap();
+        let other_vertex = tds
+            .insert_vertex_with_mapping(vertex!([0.0, 1.0]).unwrap())
+            .unwrap();
+        let simplex = Simplex::try_new_periodic(
+            vec![repeated_vertex, other_vertex, repeated_vertex],
+            vec![[0, 0], [0, 0], [1, 0]],
+        )
+        .expect("distinct lifted identities should form a periodic simplex");
+        let simplex_key = tds.insert_simplex_with_mapping(simplex).unwrap();
+        let candidate = vertex!([0.9, 0.25]).unwrap();
+        let topology_model = toroidal_model::<2>();
+        let simplex = tds.simplex(simplex_key).unwrap();
+
+        let error = validate_k1_insertion_realization(
+            &tds,
+            &topology_model,
+            simplex_key,
+            simplex,
+            &candidate,
+        )
+        .expect_err("candidate should cross the facet opposite slot zero");
+
+        assert_eq!(
+            FlipFailureKind::from(&error),
+            FlipFailureKind::K1InsertionOutsideSimplex
+        );
+        assert_matches!(
+            error,
+            FlipError::K1InsertionOutsideSimplex {
+                simplex_key: rejected,
+                opposite_vertex,
+                opposite_vertex_index: 0,
+            } if rejected == simplex_key && opposite_vertex == repeated_vertex
+        );
     }
 
     fn insert_periodic_simplex_with_lifted_vertex<const D: usize>(

--- a/src/core/algorithms/flips.rs
+++ b/src/core/algorithms/flips.rs
@@ -6808,25 +6808,27 @@ where
         .ok_or(FlipError::MissingSimplex { simplex_key })?;
     let removed_face_vertices: VertexKeyList = simplex.vertices().iter().copied().collect();
 
-    for omit_index in 0..removed_face_vertices.len() {
-        let mut points: SmallBuffer<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE> =
-            SmallBuffer::with_capacity(D + 1);
-        points.push(*vertex.point());
-        for (vertex_index, &vertex_key) in removed_face_vertices.iter().enumerate() {
-            if vertex_index != omit_index {
-                points.push(vertex_point(tds, vertex_key)?);
+    if !topology_model.supports_periodic_orientation_offsets() {
+        for omit_index in 0..removed_face_vertices.len() {
+            let mut points: SmallBuffer<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE> =
+                SmallBuffer::with_capacity(D + 1);
+            points.push(*vertex.point());
+            for (vertex_index, &vertex_key) in removed_face_vertices.iter().enumerate() {
+                if vertex_index != omit_index {
+                    points.push(vertex_point(tds, vertex_key)?);
+                }
             }
-        }
 
-        match robust_orientation(&points) {
-            Ok(Orientation::POSITIVE | Orientation::NEGATIVE) => {}
-            Ok(Orientation::DEGENERATE) => return Err(FlipError::DegenerateSimplex),
-            Err(error) => {
-                return Err(FlipPredicateError::coordinate_conversion(
-                    FlipPredicateOperation::ReplacementSimplexOrientation,
-                    error,
-                )
-                .into());
+            match robust_orientation(&points) {
+                Ok(Orientation::POSITIVE | Orientation::NEGATIVE) => {}
+                Ok(Orientation::DEGENERATE) => return Err(FlipError::DegenerateSimplex),
+                Err(error) => {
+                    return Err(FlipPredicateError::coordinate_conversion(
+                        FlipPredicateOperation::ReplacementSimplexOrientation,
+                        error,
+                    )
+                    .into());
+                }
             }
         }
     }
@@ -15951,7 +15953,7 @@ mod tests {
     }
 
     #[test]
-    fn k1_periodic_exterior_error_identifies_repeated_vertex_slot() {
+    fn k1_periodic_preflight_uses_lifted_repeated_vertex_slots() {
         let mut tds: Tds<(), (), 2> = Tds::empty();
         let repeated_vertex = tds
             .insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
@@ -15965,16 +15967,37 @@ mod tests {
         )
         .expect("distinct lifted identities should form a periodic simplex");
         let simplex_key = tds.insert_simplex_with_mapping(simplex).unwrap();
-        let candidate = vertex!([0.9, 0.25]).unwrap();
         let topology_model = toroidal_model::<2>();
-        let simplex = tds.simplex(simplex_key).unwrap();
+        let interior_candidate = vertex!([0.25, 0.25]).unwrap();
 
-        let error = validate_k1_insertion_realization(
+        let feasibility = validate_bistellar_flip_k1_insert(
             &tds,
             &topology_model,
             simplex_key,
-            simplex,
-            &candidate,
+            &interior_candidate,
+        )
+        .expect("lifted replacement simplices should be non-degenerate");
+        assert_eq!(feasibility.kind, BistellarFlipKind::k1(2));
+
+        let boundary_candidate = vertex!([0.5, 0.0]).unwrap();
+        assert_eq!(
+            validate_bistellar_flip_k1_insert(
+                &tds,
+                &topology_model,
+                simplex_key,
+                &boundary_candidate,
+            )
+            .expect_err("candidate on a lifted facet should be degenerate"),
+            FlipError::DegenerateSimplex
+        );
+
+        let exterior_candidate = vertex!([0.9, 0.25]).unwrap();
+
+        let error = validate_bistellar_flip_k1_insert(
+            &tds,
+            &topology_model,
+            simplex_key,
+            &exterior_candidate,
         )
         .expect_err("candidate should cross the facet opposite slot zero");
 
@@ -15989,6 +16012,66 @@ mod tests {
                 opposite_vertex,
                 opposite_vertex_index: 0,
             } if rejected == simplex_key && opposite_vertex == repeated_vertex
+        );
+    }
+
+    #[test]
+    fn k1_periodic_preflight_reports_candidate_lift_overflow() {
+        let mut tds: Tds<(), (), 2> = Tds::empty();
+        let vertices = vec![
+            tds.insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
+                .unwrap(),
+            tds.insert_vertex_with_mapping(vertex!([0.0, 0.5]).unwrap())
+                .unwrap(),
+            tds.insert_vertex_with_mapping(vertex!([1.0, 0.0]).unwrap())
+                .unwrap(),
+        ];
+        let simplex = Simplex::try_new_periodic(vertices, vec![[1, 0], [0, 0], [0, 0]]).unwrap();
+        let simplex_key = tds.insert_simplex_with_mapping(simplex).unwrap();
+        let topology_model = GlobalTopology::try_toroidal(
+            [f64::MAX, 1.0],
+            ToroidalConstructionMode::PeriodicImagePoint,
+        )
+        .unwrap()
+        .model();
+        let candidate = vertex!([f64::MAX, 0.25]).unwrap();
+
+        let error =
+            validate_bistellar_flip_k1_insert(&tds, &topology_model, simplex_key, &candidate)
+                .expect_err("candidate lift should overflow its selected lattice sheet");
+        assert_matches!(
+            error,
+            FlipError::PredicateFailure { reason }
+                if matches!(
+                    reason.as_ref(),
+                    FlipPredicateError::K1InsertedVertexLift {
+                        simplex_key: rejected,
+                        source: GlobalTopologyModelError::NonFiniteCoordinate { axis: 0, value },
+                    } if *rejected == simplex_key && value.is_infinite()
+                )
+        );
+    }
+
+    #[test]
+    fn k1_periodic_preflight_rejects_degenerate_lifted_source() {
+        let mut tds: Tds<(), (), 2> = Tds::empty();
+        let vertices = vec![
+            tds.insert_vertex_with_mapping(vertex!([0.0, 0.0]).unwrap())
+                .unwrap(),
+            tds.insert_vertex_with_mapping(vertex!([0.25, 0.0]).unwrap())
+                .unwrap(),
+            tds.insert_vertex_with_mapping(vertex!([0.75, 0.0]).unwrap())
+                .unwrap(),
+        ];
+        let simplex = Simplex::try_new_periodic(vertices, vec![[0, 0]; 3]).unwrap();
+        let simplex_key = tds.insert_simplex_with_mapping(simplex).unwrap();
+        let topology_model = toroidal_model::<2>();
+        let candidate = vertex!([0.5, 0.25]).unwrap();
+
+        assert_eq!(
+            validate_bistellar_flip_k1_insert(&tds, &topology_model, simplex_key, &candidate,)
+                .expect_err("degenerate lifted source should fail preflight"),
+            FlipError::DegenerateSimplex
         );
     }
 

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -1445,6 +1445,7 @@ fn is_geometric_flip_error(error: &FlipError) -> bool {
     match error {
         FlipError::PredicateFailure { .. }
         | FlipError::DegenerateSimplex
+        | FlipError::K1InsertionOutsideSimplex { .. }
         | FlipError::NegativeOrientation { .. } => true,
         FlipError::SimplexCreation(source) => matches!(
             source.as_ref(),

--- a/src/delaunay/flips.rs
+++ b/src/delaunay/flips.rs
@@ -124,7 +124,8 @@ pub trait BistellarFlips<const D: usize> {
     /// # Errors
     ///
     /// Returns [`FlipError`] if the simplex is missing, the vertex cannot be inserted,
-    /// or the flip would create invalid topology.
+    /// the point is not strictly inside the selected simplex's active realization
+    /// chart, or the flip would create invalid topology.
     ///
     /// # Example
     ///
@@ -162,17 +163,24 @@ pub trait BistellarFlips<const D: usize> {
 
     /// Validate a forward k=1 move (simplex split) without mutating topology.
     ///
-    /// This checks the same deterministic pre-mutation conditions as
-    /// [`Self::flip_k1_insert`] on the same triangulation state, including
-    /// simplex liveness, duplicate inserted-vertex UUIDs, and exact
-    /// replacement-simplex degeneracy. The returned feasibility report omits
-    /// the inserted vertex key because that key is allocated only by the
-    /// mutating executor.
+    /// This checks the same deterministic structural, topological, and
+    /// orientation-realization conditions as [`Self::flip_k1_insert`] on the
+    /// same unchanged triangulation state. These include simplex liveness,
+    /// duplicate inserted-vertex UUIDs, exact replacement-simplex degeneracy,
+    /// and strict containment in the selected simplex's active affine chart.
+    /// Periodic containment is evaluated in the simplex's lifted local frame.
+    /// The returned feasibility report omits the inserted vertex key because
+    /// that key is allocated only by the mutating executor.
+    ///
+    /// Success predicts deterministic execution on the unchanged state; it
+    /// cannot guarantee against allocation failure, process termination, or
+    /// other environmental failures outside the triangulation contract.
     ///
     /// # Errors
     ///
     /// Returns [`FlipError`] when the corresponding mutating operation would
-    /// fail during deterministic pre-mutation validation.
+    /// fail during deterministic structural, topological, or
+    /// orientation-realization validation.
     ///
     /// # Examples
     ///
@@ -597,6 +605,7 @@ where
         simplex_key: SimplexKey,
         vertex: Vertex<U, D>,
     ) -> Result<FlipInfo<D>, FlipError> {
+        let _ = self.can_flip_k1_insert(simplex_key, &vertex)?;
         apply_realized_flip(self, |tri| {
             apply_bistellar_flip_k1_raw(&mut tri.tds, simplex_key, vertex)
         })
@@ -607,7 +616,8 @@ where
         simplex_key: SimplexKey,
         vertex: &Vertex<U, D>,
     ) -> Result<FlipFeasibility<D>, FlipError> {
-        validate_bistellar_flip_k1_insert(&self.tds, simplex_key, vertex)
+        let topology_model = self.global_topology.model();
+        validate_bistellar_flip_k1_insert(&self.tds, &topology_model, simplex_key, vertex)
     }
 
     fn flip_k1_remove(&mut self, vertex_key: VertexKey) -> Result<FlipInfo<D>, FlipError> {
@@ -827,11 +837,20 @@ mod tests {
             .unwrap();
         let mut tri = dt.into_triangulation();
         let simplex_key = tri.simplices().next().unwrap().0;
+        let candidate = vertex!([0.25, 0.25, 0.25]).unwrap();
+        let feasibility = tri
+            .can_flip_k1_insert(simplex_key, &candidate)
+            .expect("interior k=1 insertion should pass preflight");
 
-        let inserted = tri
-            .flip_k1_insert(simplex_key, vertex!([0.25, 0.25, 0.25]).unwrap())
-            .unwrap();
+        let inserted = tri.flip_k1_insert(simplex_key, candidate).unwrap();
         let inserted_vertex = inserted.inserted_face_vertices[0];
+        assert_eq!(feasibility.kind, inserted.kind);
+        assert_eq!(feasibility.direction, inserted.direction);
+        assert_eq!(feasibility.removed_simplices, inserted.removed_simplices);
+        assert_eq!(
+            feasibility.removed_face_vertices,
+            inserted.removed_face_vertices
+        );
         assert!(!inserted.new_simplices.is_empty());
         assert!(tri.validate().is_ok());
 
@@ -858,11 +877,76 @@ mod tests {
         let inserted = vertex!([0.5, 0.0]).unwrap();
         let inserted_uuid = inserted.uuid();
 
+        let preflight_err = tri.can_flip_k1_insert(simplex_key, &inserted).unwrap_err();
+        assert_matches!(preflight_err, FlipError::DegenerateSimplex);
+        assert_eq!(tri.tds.number_of_vertices(), before_vertices);
+        assert_eq!(tri.tds.number_of_simplices(), before_simplices);
+
         let err = tri.flip_k1_insert(simplex_key, inserted).unwrap_err();
 
         assert_matches!(err, FlipError::DegenerateSimplex);
         assert_eq!(tri.tds.number_of_vertices(), before_vertices);
         assert_eq!(tri.tds.number_of_simplices(), before_simplices);
+        assert!(tri.vertex_key_from_uuid(&inserted_uuid).is_none());
+        assert!(tri.validate().is_ok());
+        assert!(tri.is_valid_realization().is_ok());
+    }
+
+    #[test]
+    fn triangulation_flip_k1_insert_rejects_exterior_point_before_mutation() {
+        let vertices = vec![
+            vertex!([0.0, 0.0]).unwrap(),
+            vertex!([1.0, 0.0]).unwrap(),
+            vertex!([0.0, 1.0]).unwrap(),
+        ];
+        let dt: DelaunayTriangulation<_, (), (), 2> = DelaunayTriangulation::builder(&vertices)
+            .topology_guarantee(TopologyGuarantee::PLManifold)
+            .build()
+            .unwrap();
+        let mut tri = dt.into_triangulation();
+        let simplex_key = tri.simplices().next().unwrap().0;
+        let expected_opposite_index = tri
+            .simplex(simplex_key)
+            .unwrap()
+            .vertices()
+            .iter()
+            .position(|&vertex_key| *tri.vertex(vertex_key).unwrap().point().coords() == [0.0, 0.0])
+            .expect("fixture simplex should contain the origin");
+        let expected_opposite_vertex =
+            tri.simplex(simplex_key).unwrap().vertices()[expected_opposite_index];
+        let inserted = vertex!([0.75, 0.75]).unwrap();
+        let inserted_uuid = inserted.uuid();
+        let before = tri.tds.clone();
+
+        let preflight_err = tri.can_flip_k1_insert(simplex_key, &inserted).unwrap_err();
+        assert_eq!(
+            FlipFailureKind::from(&preflight_err),
+            FlipFailureKind::K1InsertionOutsideSimplex
+        );
+        assert_matches!(
+            preflight_err,
+            FlipError::K1InsertionOutsideSimplex {
+                simplex_key: rejected,
+                opposite_vertex,
+                opposite_vertex_index,
+            } if rejected == simplex_key
+                && opposite_vertex == expected_opposite_vertex
+                && opposite_vertex_index == expected_opposite_index
+        );
+        assert_eq!(tri.tds, before);
+
+        let commit_err = tri.flip_k1_insert(simplex_key, inserted).unwrap_err();
+        assert_matches!(
+            commit_err,
+            FlipError::K1InsertionOutsideSimplex {
+                simplex_key: rejected,
+                opposite_vertex,
+                opposite_vertex_index,
+            } if rejected == simplex_key
+                && opposite_vertex == expected_opposite_vertex
+                && opposite_vertex_index == expected_opposite_index
+        );
+        assert_eq!(tri.tds, before);
         assert!(tri.vertex_key_from_uuid(&inserted_uuid).is_none());
         assert!(tri.validate().is_ok());
         assert!(tri.is_valid_realization().is_ok());

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -4,6 +4,7 @@
 //! integration test crates, unless the case needs separate crate-level setup,
 //! feature flags, or profile isolation.
 
+use delaunay::flips::{BistellarFlips, FlipError, SimplexKey};
 use delaunay::prelude::construction::{
     ConstructionOptions, ConstructionStatistics, DelaunayRepairPolicy, DelaunayTriangulation,
     DelaunayTriangulationBuilder, DelaunayTriangulationConstructionError,
@@ -18,6 +19,7 @@ use delaunay::prelude::ordering::{
 };
 use delaunay::vertex;
 use std::num::NonZeroUsize;
+use uuid::Uuid;
 
 /// Replays a full Hilbert ordering while keeping only the prefix that first
 /// exposed issue #307, so the regression stays fast and deterministic.
@@ -532,8 +534,8 @@ fn regression_insertion_error_preserves_top_level_retryability() {
     assert!(source.is_retryable());
 }
 
-#[test]
-fn regression_periodic_neighbor_validation_uses_lifted_vertex_offsets() {
+/// Builds the deterministic periodic T² fixture shared by regressions #536 and #551.
+fn periodic_regression_fixture_t2() -> DelaunayTriangulation<RobustKernel<f64>, (), (), 2> {
     let vertices: Vec<Vertex<(), 2>> = (0..7)
         .map(|index| {
             let index_f64 = f64::from(u32::try_from(index).expect("test index fits in u32"));
@@ -546,11 +548,111 @@ fn regression_periodic_neighbor_validation_uses_lifted_vertex_offsets() {
         .collect();
     let kernel = RobustKernel::<f64>::new();
 
-    let dt = DelaunayTriangulationBuilder::new(&vertices)
+    DelaunayTriangulationBuilder::new(&vertices)
         .try_toroidal([1.0_f64; 2])
         .unwrap()
         .build_with_kernel(&kernel)
-        .expect("periodic T^2 build should succeed");
+        .expect("periodic T^2 build should succeed")
+}
+
+/// Finds a periodic simplex by exact coordinate bits and lattice offsets.
+fn periodic_simplex_key(
+    dt: &DelaunayTriangulation<RobustKernel<f64>, (), (), 2>,
+    expected: [([f64; 2], [i8; 2]); 3],
+) -> SimplexKey {
+    let mut expected: Vec<_> = expected
+        .into_iter()
+        .map(|(coords, offset)| (coords.map(f64::to_bits), offset))
+        .collect();
+    expected.sort_unstable();
+
+    dt.simplices()
+        .find_map(|(simplex_key, simplex)| {
+            let offsets = simplex.periodic_vertex_offsets()?;
+            let mut actual: Vec<_> = simplex
+                .vertices()
+                .iter()
+                .copied()
+                .zip(offsets.iter().copied())
+                .map(|(vertex_key, offset)| {
+                    let coords = *dt
+                        .vertex(vertex_key)
+                        .expect("simplex should reference a live vertex")
+                        .point()
+                        .coords();
+                    (coords.map(f64::to_bits), offset)
+                })
+                .collect();
+            actual.sort_unstable();
+            (actual == expected).then_some(simplex_key)
+        })
+        .expect("periodic fixture should contain the requested lifted simplex")
+}
+
+type PeriodicSimplexSnapshot = (Uuid, Vec<(Uuid, [i8; 2])>, Vec<Option<Uuid>>);
+
+#[derive(Debug, PartialEq, Eq)]
+struct PeriodicTopologySnapshot {
+    vertices: Vec<(Uuid, [u64; 2])>,
+    simplices: Vec<PeriodicSimplexSnapshot>,
+}
+
+/// Captures canonical periodic topology and realization state through public views.
+fn snapshot_periodic_topology(
+    dt: &DelaunayTriangulation<RobustKernel<f64>, (), (), 2>,
+) -> PeriodicTopologySnapshot {
+    let mut vertices: Vec<_> = dt
+        .vertices()
+        .map(|(_, vertex)| (vertex.uuid(), vertex.point().coords().map(f64::to_bits)))
+        .collect();
+    vertices.sort_unstable_by_key(|(uuid, _)| *uuid);
+
+    let mut simplices: Vec<_> = dt
+        .simplices()
+        .map(|(_, simplex)| {
+            let offsets = simplex
+                .periodic_vertex_offsets()
+                .expect("periodic simplex should carry lifted offsets");
+            let vertices = simplex
+                .vertices()
+                .iter()
+                .copied()
+                .zip(offsets.iter().copied())
+                .map(|(vertex_key, offset)| {
+                    let uuid = dt
+                        .vertex(vertex_key)
+                        .expect("simplex should reference a live vertex")
+                        .uuid();
+                    (uuid, offset)
+                })
+                .collect();
+            let neighbors = simplex
+                .neighbors()
+                .map(|keys| {
+                    keys.map(|neighbor_key| {
+                        neighbor_key.map(|key| {
+                            dt.simplex(key)
+                                .expect("neighbor should reference a live simplex")
+                                .uuid()
+                        })
+                    })
+                    .collect()
+                })
+                .unwrap_or_default();
+            (simplex.uuid(), vertices, neighbors)
+        })
+        .collect();
+    simplices.sort_unstable_by_key(|(uuid, _, _)| *uuid);
+
+    PeriodicTopologySnapshot {
+        vertices,
+        simplices,
+    }
+}
+
+#[test]
+fn regression_periodic_neighbor_validation_uses_lifted_vertex_offsets() {
+    let dt = periodic_regression_fixture_t2();
 
     assert!(
         dt.simplices()
@@ -561,6 +663,102 @@ fn regression_periodic_neighbor_validation_uses_lifted_vertex_offsets() {
         dt.is_valid_structure().is_ok(),
         "neighbor validation must compare lifted (offset) identities"
     );
+}
+
+#[test]
+fn regression_issue_551_periodic_k1_preflight_rejects_orientation_repair_failure() {
+    let dt = periodic_regression_fixture_t2();
+    let simplex_key = periodic_simplex_key(
+        &dt,
+        [
+            ([0.131_152_949_166_187_8, 0.113_961_030_586_907_43], [0, 0]),
+            ([0.262_461_179_900_496_8, 0.795_584_412_305_938_3], [0, -1]),
+            ([0.343_614_129_000_127_8, 0.859_545_442_942_608_2], [0, -1]),
+        ],
+    );
+    let candidate = vertex!([0.05, 0.35]).expect("finite regression point");
+    let candidate_uuid = candidate.uuid();
+    let before = snapshot_periodic_topology(&dt);
+
+    let preflight_error = dt
+        .can_flip_k1_insert(simplex_key, &candidate)
+        .expect_err("lifted-chart exterior point must fail immutable feasibility");
+    assert!(matches!(
+        preflight_error,
+        FlipError::K1InsertionOutsideSimplex {
+            simplex_key: rejected,
+            ..
+        } if rejected == simplex_key
+    ));
+    assert_eq!(
+        snapshot_periodic_topology(&dt),
+        before,
+        "immutable preflight must not alter the TDS"
+    );
+    assert!(dt.vertex_key_from_uuid(&candidate_uuid).is_none());
+
+    let mut trial = dt;
+    let before_commit = snapshot_periodic_topology(&trial);
+    let commit_error = trial
+        .flip_k1_insert(simplex_key, candidate)
+        .expect_err("commit must share the deterministic k=1 preflight");
+    assert!(matches!(
+        commit_error,
+        FlipError::K1InsertionOutsideSimplex {
+            simplex_key: rejected,
+            ..
+        } if rejected == simplex_key
+    ));
+    assert_eq!(
+        snapshot_periodic_topology(&trial),
+        before_commit,
+        "rejected commit must not mutate"
+    );
+    trial
+        .as_triangulation()
+        .validate_realization()
+        .expect("rejected insertion must preserve the original realization");
+}
+
+#[test]
+fn regression_issue_551_periodic_k1_preflight_success_matches_commit() {
+    let dt = periodic_regression_fixture_t2();
+    let simplex_key = periodic_simplex_key(
+        &dt,
+        [
+            ([0.131_152_949_166_187_8, 0.113_961_030_586_907_43], [0, 0]),
+            ([0.343_614_129_000_127_8, 0.859_545_442_942_608_2], [0, -1]),
+            ([0.606_230_589_834_825_3, 0.422_792_206_212_024_2], [0, 0]),
+        ],
+    );
+    let candidate = vertex!([0.360_332_556_000_380_3, 0.132_099_559_913_846_6])
+        .expect("finite periodic interior point");
+    let before = snapshot_periodic_topology(&dt);
+
+    let feasibility = dt
+        .can_flip_k1_insert(simplex_key, &candidate)
+        .expect("strictly interior periodic point should pass preflight");
+    assert_eq!(
+        snapshot_periodic_topology(&dt),
+        before,
+        "successful preflight must not alter the TDS"
+    );
+
+    let mut trial = dt;
+    let committed = trial
+        .flip_k1_insert(simplex_key, candidate)
+        .expect("successful periodic preflight should be executable");
+    assert_eq!(feasibility.kind, committed.kind);
+    assert_eq!(feasibility.direction, committed.direction);
+    assert_eq!(feasibility.removed_simplices, committed.removed_simplices);
+    assert_eq!(
+        feasibility.removed_face_vertices,
+        committed.removed_face_vertices
+    );
+    trial
+        .as_triangulation()
+        .validate_realization()
+        .expect("successful periodic k=1 insertion must preserve Level 4 realization");
 }
 
 /// The 35-vertex 3D seed `0xE30C78582376677C` produces a Hilbert-ordered


### PR DESCRIPTION
- Evaluate insertion containment in the simplex's lifted periodic frame.
- Share deterministic validation between feasibility checks and mutation.
- Report typed exterior-facet and slot diagnostics without mutating topology.

Closes #551