### PR TITLE
refactor(errors)!: name public error variant fields

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -91,6 +91,13 @@ test(=geometry::util::simplex_lp::tests::optimized_intersection_agrees_with_lega
 '''
 slow-timeout = { period = "60s", terminate-after = 1 }
 
+[[profile.debug.overrides]]
+# The optimized 5D intersection agreement check also reaches the 10-second
+# boundary on macOS ARM runners. Keep the exception limited to that test.
+platform = 'cfg(all(target_os = "macos", target_arch = "aarch64"))'
+filter = 'test(=geometry::util::simplex_lp::tests::optimized_intersection_agrees_with_legacy_random_5d)'
+slow-timeout = { period = "60s", terminate-after = 1 }
+
 [profile.coverage]
 # Coverage runs execute LLVM-instrumented binaries in parallel, so exact
 # predicate regressions need more headroom than the normal CI profile while

--- a/.github/workflows/release-benchmarks.yml
+++ b/.github/workflows/release-benchmarks.yml
@@ -82,6 +82,7 @@ jobs:
             --run-benchmarks \
             --strict \
             --profile perf \
+            --bench-timeout 3600 \
             --output release-benchmark-artifacts/PERFORMANCE_RESULTS.md
           cargo bench --profile perf --bench cold_path_predicates
           cargo bench --profile perf --bench topology_guarantee_construction

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ type: software
 title: "delaunay: A d-dimensional Delaunay triangulation library"
 version: 0.8.0
 doi: 10.5281/zenodo.16931097
-date-released: 2026-07-27
+date-released: 2026-07-28
 url: "https://github.com/acgetchell/delaunay"
 repository-code: "https://github.com/acgetchell/delaunay"
 authors:

--- a/docs/dev/commands.md
+++ b/docs/dev/commands.md
@@ -296,7 +296,9 @@ tests in both debug and release profiles so debug assertions and default
 overflow checks remain covered. The nextest `debug` profile preserves the
 default 10-second watchdog, with 60-second overrides for the two periodic
 builder cases whose debug exact-geometry cost is platform-sensitive and, on
-Windows only, two randomized 5D agreement checks at the timeout boundary.
+Windows, two randomized 5D agreement checks at the timeout boundary. The
+optimized 5D intersection agreement check has the same focused override on
+macOS ARM runners.
 `test-integration` runs a focused release-profile nextest bucket. Selected 4D
 property families retain that default coverage with a Windows-only 60-second
 override because their release runtimes sit at the 10-second boundary on

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -387,8 +387,9 @@ The periodic T^2 builder smoke test and its matching-explicit-topology variant
 have a 60-second override because debug exact-geometry cost varies materially
 by platform. They remain in the normal suite because they cover distinct public
 builder contracts and are fast in release builds. Two randomized 5D agreement
-checks also receive 60 seconds on Windows only because they sit at the
-10-second boundary there.
+checks also receive 60 seconds on Windows because they sit at the 10-second
+boundary there. The optimized 5D intersection agreement check receives the
+same focused override on macOS ARM runners.
 
 The release integration profile similarly grants 60 seconds on Windows only
 to the promoted 4D property families that sit at the 10-second boundary there.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -472,8 +472,9 @@ fn main() -> DelaunayResult<()> {
 
 When automatic repair fails after the mutation, `delete_vertex` reports
 `DeleteVertexError::InvariantViolation { source:
-Box::new(InvariantError::Delaunay(DelaunayTriangulationValidationError::RepairOperationFailed {
-operation: DelaunayRepairOperation::VertexRemoval, source })) }`, preserving the underlying
+Box::new(InvariantError::Delaunay { source:
+DelaunayTriangulationValidationError::RepairOperationFailed {
+operation: DelaunayRepairOperation::VertexRemoval, source } }) }`, preserving the underlying
 `DelaunayRepairError` for callers that need to inspect the exact repair failure.
 Successful deletions invalidate internal locate hints so stale simplex handles
 are not reused. The spatial index is retained, but the deleted vertex entry is

--- a/justfile
+++ b/justfile
@@ -1113,6 +1113,9 @@ semgrep-test: _ensure-uv
     }
     trap cleanup EXIT
 
+    uv run --locked python scripts/semgrep_fixture_config.py \
+        --check-coverage tests/semgrep "$PWD/semgrep.yaml"
+
     # Semgrep directory test mode maps fixture paths to config paths, so mirror
     # each fixture to the shared config while keeping semgrep.yaml authoritative.
     # Run one fixture/config pair per Semgrep process so Windows does not race

--- a/papers/ARTIFACT.md
+++ b/papers/ARTIFACT.md
@@ -5,31 +5,33 @@ artifact. It indexes the immutable release, reproduction commands, validation
 evidence, generated figures, benchmark evidence, and known limits. The linked
 documents remain the source of truth for their respective contracts.
 
-> **Release status:** v0.8.0 is not an immutable artifact until the annotated
-> `v0.8.0` tag, crates.io package, GitHub release, and Zenodo version record are
-> published by [the final release audit][release-audit]. Before that event,
-> this guide describes the release target and must not be cited as a published
-> v0.8.0 archive.
+> **Release status:** v0.8.0 was published on 2026-07-28 as an annotated tag, a
+> crates.io package, a [GitHub release][github-release], and a
+> [versioned Zenodo record][zenodo-version]. The GitHub release does not contain
+> the planned Criterion baseline asset because its release-benchmark workflow
+> failed; see [Known benchmark exception](#known-benchmark-exception).
 
 ## Artifact identity
 
 | Field | v0.8.0 identity | Check |
 |---|---|---|
 | Source tag | [`v0.8.0`][source-tag] | The annotated release tag, not `main` |
-| Commit | The commit peeled from `v0.8.0` | `git rev-list -n 1 v0.8.0` |
+| Commit | `ee0b1992071552ecf8669418ea74444a699343a9` | `git rev-list -n 1 v0.8.0` |
 | GitHub archive | [`delaunay` at `v0.8.0`][source-tag] | Tag and commit must agree |
+| GitHub release | [`v0.8.0`][github-release] | Published 2026-07-28 from the annotated tag |
 | Crate | [`delaunay` 0.8.0 on crates.io][crate-release] | Package version must be `0.8.0` |
 | Rust | 1.97.1 | `rustc --version` and [`rust-toolchain.toml`](../rust-toolchain.toml) |
 | Zenodo collection | [`10.5281/zenodo.16931097`][zenodo-concept] | Stable software concept DOI |
-| Zenodo v0.8.0 record | Published by [the final release audit][release-audit] | Version DOI, tag, and commit must match this release |
+| Zenodo v0.8.0 record | [`10.5281/zenodo.21635965`][zenodo-version] | `acgetchell/delaunay-v0.8.0.zip`; MD5 `6274e49bb1ef91e1e3023225131199d7` |
 
-The commit is intentionally resolved from the annotated tag rather than
-hard-coded into a file contained by that commit. In a Git checkout, verify the
-exact commit with:
+The published commit is recorded explicitly above and must also resolve from
+the annotated tag. In a Git checkout, verify both identities with:
 
 ```bash
 TAG=v0.8.0
-test "$(git rev-parse HEAD)" = "$(git rev-list -n 1 "$TAG")"
+RELEASE_COMMIT=ee0b1992071552ecf8669418ea74444a699343a9
+test "$(git rev-list -n 1 "$TAG")" = "$RELEASE_COMMIT"
+test "$(git rev-parse HEAD)" = "$RELEASE_COMMIT"
 git show -s --format='tag=%D%ncommit=%H%ncommit-date=%cI' "$TAG^{commit}"
 rustc --version
 ```
@@ -38,10 +40,11 @@ GitHub and Zenodo source archives do not contain `.git` metadata. For an
 archive, verify its published checksum and confirm that the release metadata
 records the same tag and peeled commit before running the reproduction paths.
 
-The release-specific Zenodo DOI does not exist until the archive is published.
-The release audit must record it in the Zenodo metadata and, when the citation
-policy calls for a version DOI, in [`CITATION.cff`](../CITATION.cff). The stable
-concept DOI above identifies the software collection across releases.
+The release-specific Zenodo DOI is
+[`10.5281/zenodo.21635965`][zenodo-version].
+[`CITATION.cff`](../CITATION.cff) intentionally uses the stable concept DOI
+[`10.5281/zenodo.16931097`][zenodo-concept] to identify the software collection
+across releases; cite the version DOI when referring specifically to v0.8.0.
 
 ### Which download to use
 
@@ -165,14 +168,24 @@ cost and observability only after those invariants pass.
 | Compare two durable GitHub release assets | `just perf-github-assets "$TAG" "$PREVIOUS_TAG"` | `target/bench-reports/github-assets-performance.md` |
 | Coarse 2D–5D large-scale guard | `just perf-large-scale-smoke` | Per-dimension pass/fail wall-clock diagnostics |
 
-The release audit regenerates the public summary after the v0.8.0 version bump.
-Before publication, its version, commit, Rust version, benchmark profile,
-operating system, CPU, and memory metadata must describe the run that produced
-the numbers. Absolute timings are not portable across machines. Use
-same-machine comparisons for regression claims and the stored GitHub release
-assets for runner-to-runner release comparisons. See
+Absolute timings are not portable across machines. Use same-machine comparisons
+for regression claims and stored GitHub release assets for runner-to-runner
+release comparisons when both releases provide them. See
 [`benches/README.md`](../benches/README.md) for the benchmark contract and
 [`docs/dev/perf-tuning.md`](../docs/dev/perf-tuning.md) for evidence rules.
+
+#### Known benchmark exception
+
+The v0.8.0 GitHub release has no
+`delaunay-v0.8.0-criterion-baseline.tar.gz` asset. The
+[release-benchmark run][release-benchmark-run] failed when
+`ci_performance_suite` exceeded its 900-second command timeout, before packaging
+or upload. The checked-in v0.8.0 performance summary also identifies commit
+`1f15b9352456aca9eade44d116cd8d15d3d1ac20`, not the peeled release commit.
+Consequently, do not use that summary or `perf-github-assets` as durable v0.8.0
+release-comparison evidence. Run `just perf-local` for a same-machine comparison,
+or regenerate measurements from the exact release checkout and record the
+environment metadata alongside the results.
 
 ## Five-level claim map
 
@@ -332,28 +345,19 @@ source snapshot, not a claim that the manuscript is submission-complete.
 Substantive author-owned manuscript completion and submission packaging are
 tracked separately in [issue #522][manuscript].
 
-## Release-finalization checks
+## Published release record
 
-The v0.8.0 release audit must complete these mechanical checks before this guide
-describes a published artifact:
-
-1. Bump Cargo, lockfile, Python utility, citation, README, and active
-   documentation version references to 0.8.0; run `just docs-version-check`.
-2. Run `just ci-slow`, `just papers`, and `just publish-check` from the release
-   commit.
-3. Run `just bench-perf-summary` after the version bump and verify the checked-in
-   summary records v0.8.0, the release commit, Rust 1.97.1, and hardware metadata.
-4. Inspect `cargo package --list` and confirm the documented crates.io packaging
-   decision remains true.
-5. Create the annotated `v0.8.0` tag from the release commit, then publish the
-   crates.io package and GitHub release from that tag.
-6. Publish the Zenodo v0.8.0 software record, record its version DOI and archive
-   checksum, and verify its metadata identifies the same tag and peeled commit.
-7. Confirm the GitHub release carries the durable v0.8.0 Criterion baseline
-   asset described in [`docs/RELEASING.md`](../docs/RELEASING.md).
+The annotated tag, crates.io package, GitHub release, and Zenodo record were
+published on 2026-07-28. The source identity is the peeled commit recorded above.
+The Zenodo archive supplies the immutable version DOI and checksum for reviewer
+verification. The missing GitHub Criterion asset is the sole incomplete release
+artifact identified by this guide and is documented as a benchmark limitation,
+not as evidence that the source release is unpublished.
 
 [crate-release]: https://crates.io/crates/delaunay/0.8.0
+[github-release]: https://github.com/acgetchell/delaunay/releases/tag/v0.8.0
 [manuscript]: https://github.com/acgetchell/delaunay/issues/522
-[release-audit]: https://github.com/acgetchell/delaunay/issues/506
+[release-benchmark-run]: https://github.com/acgetchell/delaunay/actions/runs/30325806574
 [source-tag]: https://github.com/acgetchell/delaunay/tree/v0.8.0
 [zenodo-concept]: https://doi.org/10.5281/zenodo.16931097
+[zenodo-version]: https://doi.org/10.5281/zenodo.21635965

--- a/papers/ARTIFACT.md
+++ b/papers/ARTIFACT.md
@@ -22,7 +22,7 @@ documents remain the source of truth for their respective contracts.
 | Crate | [`delaunay` 0.8.0 on crates.io][crate-release] | Package version must be `0.8.0` |
 | Rust | 1.97.1 | `rustc --version` and [`rust-toolchain.toml`](../rust-toolchain.toml) |
 | Zenodo collection | [`10.5281/zenodo.16931097`][zenodo-concept] | Stable software concept DOI |
-| Zenodo v0.8.0 record | [`10.5281/zenodo.21635965`][zenodo-version] | `acgetchell/delaunay-v0.8.0.zip`; MD5 `6274e49bb1ef91e1e3023225131199d7` |
+| Zenodo v0.8.0 record | [`10.5281/zenodo.21635965`][zenodo-version] | SHA-256 `7ec456da83d105f807ac40737d38e102b30f5963467d410354925cf197cb45a7` |
 
 The published commit is recorded explicitly above and must also resolve from
 the annotated tag. In a Git checkout, verify both identities with:
@@ -39,6 +39,12 @@ rustc --version
 GitHub and Zenodo source archives do not contain `.git` metadata. For an
 archive, verify its published checksum and confirm that the release metadata
 records the same tag and peeled commit before running the reproduction paths.
+The Zenodo file is `acgetchell/delaunay-v0.8.0.zip`; the record also reports
+MD5 `6274e49bb1ef91e1e3023225131199d7`. Verify the stronger checksum with:
+
+```bash
+printf '%s\n' '7ec456da83d105f807ac40737d38e102b30f5963467d410354925cf197cb45a7  acgetchell/delaunay-v0.8.0.zip' | sha256sum --check
+```
 
 The release-specific Zenodo DOI is
 [`10.5281/zenodo.21635965`][zenodo-version].

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -868,8 +868,8 @@ class PerformanceSummaryGenerator:
         self,
         output_path: Path | None = None,
         run_benchmarks: bool = False,
-        generator_name: str | None = None,
         cargo_profile: str | None = None,
+        bench_timeout: int = 1800,
         strict: bool = False,
     ) -> bool:
         """
@@ -878,11 +878,11 @@ class PerformanceSummaryGenerator:
         Args:
             output_path: Output file path (defaults to benches/PERFORMANCE_RESULTS.md)
             run_benchmarks: Whether to run fresh public API and circumsphere benchmarks
-            generator_name: Name of the tool generating the summary (for attribution)
             cargo_profile: Optional Cargo profile for fresh benchmark runs.  When
                 ``run_benchmarks`` is True and no profile is specified, defaults
                 to :data:`BENCHMARK_BUILD_FLAVOR` so fresh runs match baseline
                 and comparison measurements.
+            bench_timeout: Timeout for the public API benchmark command in seconds.
             strict: Fail instead of rendering from existing or fallback data
                 when fresh benchmark execution is requested and any benchmark
                 command fails.
@@ -903,7 +903,10 @@ class PerformanceSummaryGenerator:
                 # comparable with baseline/compare output.
                 if cargo_profile is None:
                     cargo_profile = BENCHMARK_BUILD_FLAVOR
-                ci_success = self._run_ci_performance_suite(cargo_profile=cargo_profile)
+                ci_success = self._run_ci_performance_suite(
+                    cargo_profile=cargo_profile,
+                    bench_timeout=bench_timeout,
+                )
                 circumsphere_success, accuracy_data = self._run_circumsphere_benchmarks(cargo_profile=cargo_profile)
                 if circumsphere_success:
                     self.numerical_accuracy_data = accuracy_data
@@ -914,7 +917,7 @@ class PerformanceSummaryGenerator:
                     print("⚠️ Benchmark run failed, using existing/fallback data")
 
             # Generate markdown content
-            content = self._generate_markdown_content(generator_name)
+            content = self._generate_markdown_content()
             if strict and self._contains_fallback_summary_data(content):
                 print("❌ Strict summary mode detected fallback benchmark data", file=sys.stderr)
                 return False
@@ -1137,7 +1140,13 @@ class PerformanceSummaryGenerator:
             print(f"❌ Error running circumsphere benchmarks: {e}")
             return False, None
 
-    def _run_ci_performance_suite(self, cargo_profile: str | None = None, *, use_dev_mode: bool = False) -> bool:
+    def _run_ci_performance_suite(
+        self,
+        cargo_profile: str | None = None,
+        *,
+        use_dev_mode: bool = False,
+        bench_timeout: int = 1800,
+    ) -> bool:
         """
         Run the public API CI performance suite to generate fresh Criterion data.
 
@@ -1148,6 +1157,7 @@ class PerformanceSummaryGenerator:
             use_dev_mode: When true, pass reduced Criterion sampling arguments
                 for local development feedback. Full sampling is used by
                 default.
+            bench_timeout: Maximum runtime for the Cargo benchmark command in seconds.
 
         Returns:
             True if the benchmark completed successfully, False otherwise.
@@ -1163,7 +1173,7 @@ class PerformanceSummaryGenerator:
             result = run_cargo_command(
                 cargo_args,
                 cwd=self.project_root,
-                timeout=900,
+                timeout=bench_timeout,
                 capture_output=True,
                 check=False,
             )
@@ -5788,6 +5798,7 @@ def _add_performance_summary_subcommands(subparsers: argparse._SubParsersAction[
         action="store_true",
         help="Fail instead of rendering from existing or fallback data when fresh benchmark execution fails",
     )
+    _add_bench_timeout_arg(perf_summary_parser)
 
 
 def _add_release_performance_subcommands(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -6223,8 +6234,8 @@ def _cmd_generate_summary(args: argparse.Namespace, project_root: Path) -> None:
     success = generator.generate_summary(
         output_path=args.output,
         run_benchmarks=args.run_benchmarks,
-        generator_name="benchmark_utils.py",
         cargo_profile=args.profile,
+        bench_timeout=args.bench_timeout,
         strict=args.strict,
     )
     sys.exit(0 if success else 1)

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -890,6 +890,7 @@ class PerformanceSummaryGenerator:
         Returns:
             True if successful, False otherwise
         """
+        _require_positive_int_field("bench_timeout", bench_timeout)
         try:
             if output_path is None:
                 output_path = self.project_root / "benches" / "PERFORMANCE_RESULTS.md"
@@ -1162,6 +1163,7 @@ class PerformanceSummaryGenerator:
         Returns:
             True if the benchmark completed successfully, False otherwise.
         """
+        _require_positive_int_field("bench_timeout", bench_timeout)
         try:
             print("🔄 Running ci_performance_suite benchmarks...")
 

--- a/scripts/semgrep_fixture_config.py
+++ b/scripts/semgrep_fixture_config.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 UTF8 = "utf-8"
-RULE_ANNOTATION_RE = re.compile(r"(?:ruleid|ok):\s*([^\n]+)")
+RULE_ANNOTATION_RE = re.compile(r"(?<![A-Za-z0-9_])(?:ruleid|ok):\s*([^\n]+)")
 RULE_VIOLATION_ANNOTATION_RE = re.compile(r"(?<![A-Za-z0-9_])ruleid:\s*([^\n]+)")
 RULE_SPLIT_RE = re.compile(r"(?m)^  - id: ")
 

--- a/scripts/semgrep_fixture_config.py
+++ b/scripts/semgrep_fixture_config.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 UTF8 = "utf-8"
 RULE_ANNOTATION_RE = re.compile(r"(?:ruleid|ok):\s*([^\n]+)")
+RULE_VIOLATION_ANNOTATION_RE = re.compile(r"(?<![A-Za-z0-9_])ruleid:\s*([^\n]+)")
 RULE_SPLIT_RE = re.compile(r"(?m)^  - id: ")
 
 
@@ -19,6 +20,17 @@ def annotated_rule_ids(fixture_text: str) -> list[str]:
     """Return unique repository Semgrep rule IDs referenced by one fixture."""
     rule_ids: list[str] = []
     for match in RULE_ANNOTATION_RE.finditer(fixture_text):
+        for raw_rule_id in match.group(1).split(","):
+            rule_id = raw_rule_id.strip()
+            if rule_id.startswith("delaunay.") and rule_id not in rule_ids:
+                rule_ids.append(rule_id)
+    return rule_ids
+
+
+def violation_rule_ids(fixture_text: str) -> list[str]:
+    """Return unique rule IDs with an expected Semgrep finding."""
+    rule_ids: list[str] = []
+    for match in RULE_VIOLATION_ANNOTATION_RE.finditer(fixture_text):
         for raw_rule_id in match.group(1).split(","):
             rule_id = raw_rule_id.strip()
             if rule_id.startswith("delaunay.") and rule_id not in rule_ids:
@@ -36,6 +48,29 @@ def config_rule_chunks(config_text: str) -> dict[str, str]:
         rule_id = lines[0].strip()
         chunks[rule_id] = f"  - id: {chunk}"
     return chunks
+
+
+def fixture_paths(fixture_root: Path) -> list[Path]:
+    """Return fixture files covered by the repository Semgrep test harness."""
+    if fixture_root.is_file():
+        return [fixture_root]
+    return sorted(path for path in fixture_root.rglob("*") if path.is_file() and not path.name.endswith(".fixed"))
+
+
+def unannotated_rule_ids(fixture_root: Path, source_config_path: Path) -> list[str]:
+    """Return config rule IDs without a positive ``ruleid`` fixture."""
+    annotated_ids = {rule_id for fixture_path in fixture_paths(fixture_root) for rule_id in violation_rule_ids(fixture_path.read_text(encoding=UTF8))}
+    rule_chunks = config_rule_chunks(source_config_path.read_text(encoding=UTF8))
+    return [rule_id for rule_id in rule_chunks if rule_id not in annotated_ids]
+
+
+def validate_rule_coverage(fixture_root: Path, source_config_path: Path) -> None:
+    """Require every repository Semgrep rule to have a positive fixture."""
+    missing_rule_ids = unannotated_rule_ids(fixture_root, source_config_path)
+    if missing_rule_ids:
+        missing_rules = ", ".join(missing_rule_ids)
+        msg = f"Semgrep rules without ruleid fixtures under {fixture_root}: {missing_rules}"
+        raise ValueError(msg)
 
 
 def build_fixture_config(fixture_path: Path, source_config_path: Path) -> str:
@@ -61,9 +96,14 @@ def write_fixture_config(fixture_path: Path, source_config_path: Path, output_co
 def parse_args(argv: Sequence[str]) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__, suggest_on_error=True, color=False)
+    parser.add_argument(
+        "--check-coverage",
+        action="store_true",
+        help="Require every rule in source_config to have a ruleid fixture",
+    )
     parser.add_argument("fixture", type=Path)
     parser.add_argument("source_config", type=Path)
-    parser.add_argument("output_config", type=Path)
+    parser.add_argument("output_config", type=Path, nargs="?")
     return parser.parse_args(argv)
 
 
@@ -71,7 +111,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     """Run the fixture-config generator."""
     args = parse_args(sys.argv[1:] if argv is None else argv)
     try:
-        write_fixture_config(args.fixture, args.source_config, args.output_config)
+        if args.check_coverage:
+            if args.output_config is not None:
+                msg = "output_config is not accepted with --check-coverage"
+                raise ValueError(msg)
+            validate_rule_coverage(args.fixture, args.source_config)
+        else:
+            if args.output_config is None:
+                msg = "output_config is required unless --check-coverage is used"
+                raise ValueError(msg)
+            write_fixture_config(args.fixture, args.source_config, args.output_config)
     except ValueError as exc:
         print(exc, file=sys.stderr)
         return 1

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -3338,11 +3338,20 @@ class TestTimeoutHandling:
     def test_parser_accepts_strict_summary_generation(self) -> None:
         """Test that release workflows can fail summary generation on fallback."""
         parser = create_argument_parser()
-        args = parser.parse_args(["generate-summary", "--run-benchmarks", "--strict"])
+        args = parser.parse_args(
+            [
+                "generate-summary",
+                "--run-benchmarks",
+                "--strict",
+                "--bench-timeout",
+                "3600",
+            ],
+        )
 
         assert args.command == "generate-summary"
         assert args.run_benchmarks
         assert args.strict
+        assert args.bench_timeout == 3600
 
     def test_parser_accepts_release_performance_commands(self) -> None:
         """Test that release-performance commands expose the documented options."""
@@ -3447,8 +3456,8 @@ class TestTimeoutHandling:
         mock_generator.generate_summary.assert_called_once_with(
             output_path=Path("summary.md"),
             run_benchmarks=True,
-            generator_name="benchmark_utils.py",
             cargo_profile="release",
+            bench_timeout=1800,
             strict=True,
         )
 
@@ -3621,6 +3630,7 @@ class TestPerformanceSummaryGenerator:
         args = parser.parse_args(["generate-summary", "--run-benchmarks"])
 
         assert args.profile == BENCHMARK_BUILD_FLAVOR
+        assert args.bench_timeout == 1800
 
     @patch("benchmark_utils.run_git_command")
     def test_get_current_version_prefers_cargo_package_version(self, mock_git_command) -> None:
@@ -4121,6 +4131,7 @@ Benchmark completed.""",
                 "ci_performance_suite",
             ]
             assert "--" not in args
+            assert mock_cargo.call_args.kwargs["timeout"] == 1800
             manifest_path = project_root / "target" / "criterion" / _CI_PERFORMANCE_SUITE_MANIFEST_IDS_FILE
             assert manifest_path.read_text(encoding="utf-8") == "boundary_facets/boundary_facets_3d/50\n"
             metrics_path = project_root / "target" / "criterion" / _CI_PERFORMANCE_SUITE_METRICS_FILE
@@ -4150,6 +4161,19 @@ Benchmark completed.""",
             args = mock_cargo.call_args.args[0]
             assert args[:5] == ["bench", "--profile", requested_profile, "--bench", "ci_performance_suite"]
             assert "--" not in args
+
+    @patch("benchmark_utils.run_cargo_command")
+    def test_run_ci_performance_suite_uses_requested_timeout(self, mock_cargo) -> None:
+        """Test that release callers can extend the public API benchmark budget."""
+        mock_cargo.return_value = completed_process(CI_MANIFEST_STDOUT)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            generator = PerformanceSummaryGenerator(Path(temp_dir))
+
+            success = generator._run_ci_performance_suite(bench_timeout=3600)
+
+            assert success is True
+            assert mock_cargo.call_args.kwargs["timeout"] == 3600
 
     @patch("benchmark_utils.run_cargo_command")
     def test_run_ci_performance_suite_dev_mode_uses_reduced_sampling(self, mock_cargo) -> None:
@@ -4281,7 +4305,10 @@ Benchmark completed.""",
             assert success is True
             # When run_benchmarks=True without an explicit profile, generate_summary
             # must default to BENCHMARK_BUILD_FLAVOR.
-            mock_run_ci_suite.assert_called_once_with(cargo_profile=BENCHMARK_BUILD_FLAVOR)
+            mock_run_ci_suite.assert_called_once_with(
+                cargo_profile=BENCHMARK_BUILD_FLAVOR,
+                bench_timeout=1800,
+            )
             mock_run_benchmarks.assert_called_once_with(cargo_profile=BENCHMARK_BUILD_FLAVOR)
             assert output_file.exists()
 
@@ -4302,7 +4329,10 @@ Benchmark completed.""",
             success = generator.generate_summary(output_path=output_file, run_benchmarks=True, cargo_profile=requested_profile)
 
             assert success is True
-            mock_run_ci_suite.assert_called_once_with(cargo_profile=requested_profile)
+            mock_run_ci_suite.assert_called_once_with(
+                cargo_profile=requested_profile,
+                bench_timeout=1800,
+            )
             mock_run_benchmarks.assert_called_once_with(cargo_profile=requested_profile)
             assert output_file.exists()
 

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -3436,6 +3436,8 @@ class TestTimeoutHandling:
                 "generate-summary",
                 "--run-benchmarks",
                 "--strict",
+                "--bench-timeout",
+                "3600",
                 "--profile",
                 "release",
                 "--output",
@@ -3457,7 +3459,7 @@ class TestTimeoutHandling:
             output_path=Path("summary.md"),
             run_benchmarks=True,
             cargo_profile="release",
-            bench_timeout=1800,
+            bench_timeout=3600,
             strict=True,
         )
 
@@ -4175,6 +4177,20 @@ Benchmark completed.""",
             assert success is True
             assert mock_cargo.call_args.kwargs["timeout"] == 3600
 
+    @pytest.mark.parametrize("bench_timeout", [0, -1])
+    def test_run_ci_performance_suite_rejects_non_positive_timeout(self, bench_timeout: int) -> None:
+        """Defensive suite calls must reject invalid benchmark budgets."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            generator = PerformanceSummaryGenerator(Path(temp_dir))
+
+            with (
+                patch("benchmark_utils.run_cargo_command") as mock_cargo,
+                pytest.raises(ValueError, match="bench_timeout must be a positive integer"),
+            ):
+                generator._run_ci_performance_suite(bench_timeout=bench_timeout)
+
+            mock_cargo.assert_not_called()
+
     @patch("benchmark_utils.run_cargo_command")
     def test_run_ci_performance_suite_dev_mode_uses_reduced_sampling(self, mock_cargo) -> None:
         """Test dev mode appends reduced Criterion sampling args explicitly."""
@@ -4286,6 +4302,15 @@ Benchmark completed.""",
             # Check success message was printed
             captured = capsys.readouterr()
             assert "Generated performance summary" in captured.out
+
+    @pytest.mark.parametrize("bench_timeout", [0, -1])
+    def test_generate_summary_rejects_non_positive_timeout(self, bench_timeout: int) -> None:
+        """Direct summary calls must reject invalid benchmark budgets."""
+        with tempfile.TemporaryDirectory() as temp_dir:
+            generator = PerformanceSummaryGenerator(Path(temp_dir))
+
+            with pytest.raises(ValueError, match="bench_timeout must be a positive integer"):
+                generator.generate_summary(bench_timeout=bench_timeout)
 
     @patch("benchmark_utils.PerformanceSummaryGenerator._run_circumsphere_benchmarks")
     @patch("benchmark_utils.PerformanceSummaryGenerator._run_ci_performance_suite")

--- a/scripts/tests/test_semgrep_fixture_config.py
+++ b/scripts/tests/test_semgrep_fixture_config.py
@@ -3,7 +3,13 @@
 
 from typing import TYPE_CHECKING
 
-from semgrep_fixture_config import annotated_rule_ids, main, write_fixture_config
+from semgrep_fixture_config import (
+    annotated_rule_ids,
+    main,
+    unannotated_rule_ids,
+    violation_rule_ids,
+    write_fixture_config,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -87,3 +93,82 @@ def test_main_reports_missing_annotated_rule(tmp_path: Path, capsys: pytest.Capt
     assert exit_code == 1
     assert "missing Semgrep rules" in capsys.readouterr().err
     assert not output_config.exists()
+
+
+def test_unannotated_rule_ids_reports_rules_without_fixture_coverage(tmp_path: Path) -> None:
+    """Coverage checks should compare config rules back to all live fixtures."""
+    fixture_root = tmp_path / "fixtures"
+    fixture_root.mkdir()
+    (fixture_root / "fixture.rs").write_text(
+        "// ruleid: delaunay.rust.covered-rule\n",
+        encoding="utf-8",
+    )
+    (fixture_root / "ignored.fixed").write_text(
+        "// ruleid: delaunay.rust.uncovered-rule\n",
+        encoding="utf-8",
+    )
+    source_config = tmp_path / "semgrep.yaml"
+    source_config.write_text(
+        """rules:
+  - id: delaunay.rust.covered-rule
+    pattern: covered()
+  - id: delaunay.rust.uncovered-rule
+    pattern: uncovered()
+""",
+        encoding="utf-8",
+    )
+
+    assert unannotated_rule_ids(fixture_root, source_config) == [
+        "delaunay.rust.uncovered-rule",
+    ]
+
+
+def test_ok_annotation_does_not_count_as_positive_rule_coverage(tmp_path: Path) -> None:
+    """A non-match fixture must not substitute for an expected finding."""
+    fixture_root = tmp_path / "fixtures"
+    fixture_root.mkdir()
+    (fixture_root / "fixture.rs").write_text(
+        "// ok: delaunay.rust.ok-only-rule\n",
+        encoding="utf-8",
+    )
+    source_config = tmp_path / "semgrep.yaml"
+    source_config.write_text(
+        """rules:
+  - id: delaunay.rust.ok-only-rule
+    pattern: covered()
+""",
+        encoding="utf-8",
+    )
+
+    assert violation_rule_ids("// ok: delaunay.rust.ok-only-rule\n") == []
+    assert unannotated_rule_ids(fixture_root, source_config) == [
+        "delaunay.rust.ok-only-rule",
+    ]
+
+
+def test_main_reports_rules_without_fixture_coverage(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The harness coverage mode should fail before any Semgrep process starts."""
+    fixture_root = tmp_path / "fixtures"
+    fixture_root.mkdir()
+    source_config = tmp_path / "semgrep.yaml"
+    source_config.write_text(
+        """rules:
+  - id: delaunay.rust.uncovered-rule
+    pattern: uncovered()
+""",
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            "--check-coverage",
+            str(fixture_root),
+            str(source_config),
+        ],
+    )
+
+    assert exit_code == 1
+    assert "rules without ruleid fixtures" in capsys.readouterr().err

--- a/scripts/tests/test_semgrep_fixture_config.py
+++ b/scripts/tests/test_semgrep_fixture_config.py
@@ -31,6 +31,17 @@ def test_annotated_rule_ids_preserves_unique_project_rule_order() -> None:
     ]
 
 
+def test_annotated_rule_ids_requires_annotation_prefix_boundary() -> None:
+    """Embedded annotation names must not select fixture rules."""
+    assert annotated_rule_ids("// notruleid: delaunay.rust.covered-rule\n") == []
+    assert annotated_rule_ids("// notok: delaunay.rust.covered-rule\n") == []
+
+
+def test_violation_rule_ids_requires_annotation_prefix_boundary() -> None:
+    """Embedded rule identifiers must not count as violation annotations."""
+    assert violation_rule_ids("// notruleid: delaunay.rust.covered-rule\n") == []
+
+
 def test_write_fixture_config_extracts_only_annotated_rules(tmp_path: Path) -> None:
     """Generated configs should stay minimal and preserve annotation order."""
     fixture = tmp_path / "fixture.rs"

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -741,6 +741,7 @@ rules:
       include:
         - "/src/delaunay/construction.rs"
         - "/src/geometry/algorithms/convex_hull.rs"
+        - "/tests/semgrep/src/project_rules/**/*.rs"
     pattern-either:
       - pattern-regex: >-
           (?s)\bimpl[^{}]*\bDelaunayTriangulation\b[^{}]*\{(?:(?!^\}).)*?^\s*pub\s+(?:const\s+)?fn\s+(?:new|new_with_(?:construction_statistics|options(?:_and_construction_statistics)?|topology_guarantee)|with_(?:kernel|topology_guarantee(?:_and_options)?|options_and_statistics))\s*\(
@@ -1301,6 +1302,47 @@ rules:
         - "/tests/semgrep/**"
     pattern-regex: '(?m)(?<!#\[non_exhaustive\]\n)^\s*pub\s+enum\s+[A-Za-z0-9_]*Error\b'
 
+  - id: delaunay.rust.public-error-variants-use-named-fields
+    languages:
+      - generic
+    severity: WARNING
+    message: >-
+      Use a struct variant with a semantically named field instead of a
+      positional tuple carrier in public error enums.
+    metadata:
+      category: maintainability
+      tracking_issue: "https://github.com/acgetchell/delaunay/issues/566"
+      rationale: >-
+        Named fields document typed error payloads at the declaration and keep
+        downstream construction and matching syntax independent of tuple order.
+    paths:
+      include:
+        - "/src/**/*.rs"
+        - "/tests/semgrep/src/project_rules/**/*.rs"
+      exclude:
+        - "/tests/semgrep/**"
+    pattern-either:
+      - pattern-regex: |-
+          (?msx)
+          ^\#\[derive\(
+          (?:(?!\)\]).)*\b(?:thiserror::)?Error\b(?:(?!\)\]).)*\)\]\s*
+          (?:^\#\[(?!non_exhaustive\])[^\n]+\]\s*)*
+          ^\#\[non_exhaustive\]\s*
+          (?:^\#\[[^\n]+\]\s*)*
+          ^pub\s+enum\s+[A-Za-z_][A-Za-z0-9_]*
+          (?:\s*<(?:(?!\{).)*?>)?\s*\{
+          (?:(?!^\}).)*?^[ \t]+[A-Z][A-Za-z0-9_]*[ \t]*\(
+      - pattern-regex: |-
+          (?msx)
+          ^\#\[non_exhaustive\]\s*
+          (?:^\#\[(?!derive\()[^\n]+\]\s*)*
+          ^\#\[derive\(
+          (?:(?!\)\]).)*\b(?:thiserror::)?Error\b(?:(?!\)\]).)*\)\]\s*
+          (?:^\#\[[^\n]+\]\s*)*
+          ^pub\s+enum\s+[A-Za-z_][A-Za-z0-9_]*
+          (?:\s*<(?:(?!\{).)*?>)?\s*\{
+          (?:(?!^\}).)*?^[ \t]+[A-Z][A-Za-z0-9_]*[ \t]*\(
+
   - id: delaunay.rust.no-stringly-generator-error-payloads
     languages:
       - generic
@@ -1410,21 +1452,22 @@ rules:
       - generic
     severity: WARNING
     message: >-
-      Mark boxed nested FlipError fields with #[source] so callers can traverse
-      the typed error chain.
+      Mark boxed nested FlipError fields with #[source] or #[from] so callers
+      can traverse the typed error chain.
     metadata:
       category: maintainability
       tracking_issue: "https://github.com/acgetchell/delaunay/issues/406"
       rationale: >-
         Boxed nested flip errors should remain visible through the standard
-        Error::source chain instead of becoming display-only diagnostics.
+        Error::source chain instead of becoming display-only diagnostics;
+        thiserror's #[from] also establishes that source relationship.
     paths:
       include:
         - "/src/core/algorithms/flips/**"
         - "/tests/semgrep/src/project_rules/**/*.rs"
     # yamllint disable rule:line-length
     pattern-regex: >-
-      (?m)(?<!    #\[source\]\n)(?<!        #\[source\]\n)(?<!            #\[source\]\n)^\s*(?:reason|source):\s*Box<(?:Flip[A-Za-z0-9_]+Error|SimplexValidationError)>\s*,
+      (?m)(?<!    #\[source\]\n)(?<!    #\[from\]\n)(?<!        #\[source\]\n)(?<!        #\[from\]\n)(?<!            #\[source\]\n)(?<!            #\[from\]\n)^\s*(?:reason|source):\s*Box<(?:Flip[A-Za-z0-9_]+Error|SimplexValidationError)>\s*,
     # yamllint enable rule:line-length
 
   - id: delaunay.rust.no-public-unchecked-apis
@@ -1497,6 +1540,7 @@ rules:
       include:
         - "/README.md"
         - "/docs/**/*.md"
+        - "/tests/semgrep/docs/**/*.md"
       exclude:
         - "/docs/archive/**"
     pattern-regex: '\.(?:unwrap(?:_[A-Za-z0-9_]+)?|expect)\s*\('

--- a/semgrep.yaml
+++ b/semgrep.yaml
@@ -1330,7 +1330,8 @@ rules:
           ^\#\[non_exhaustive\]\s*
           (?:^\#\[[^\n]+\]\s*)*
           ^pub\s+enum\s+[A-Za-z_][A-Za-z0-9_]*
-          (?:\s*<(?:(?!\{).)*?>)?\s*\{
+          (?:\s*<(?:(?!\{).)*?>)?
+          (?:\s+where\b(?:(?!\{).)*)?\s*\{
           (?:(?!^\}).)*?^[ \t]+[A-Z][A-Za-z0-9_]*[ \t]*\(
       - pattern-regex: |-
           (?msx)
@@ -1340,7 +1341,8 @@ rules:
           (?:(?!\)\]).)*\b(?:thiserror::)?Error\b(?:(?!\)\]).)*\)\]\s*
           (?:^\#\[[^\n]+\]\s*)*
           ^pub\s+enum\s+[A-Za-z_][A-Za-z0-9_]*
-          (?:\s*<(?:(?!\{).)*?>)?\s*\{
+          (?:\s*<(?:(?!\{).)*?>)?
+          (?:\s+where\b(?:(?!\{).)*)?\s*\{
           (?:(?!^\}).)*?^[ \t]+[A-Z][A-Za-z0-9_]*[ \t]*\(
 
   - id: delaunay.rust.no-stringly-generator-error-payloads

--- a/src/config.rs
+++ b/src/config.rs
@@ -871,7 +871,7 @@ fn is_uuid_at(bytes: &[u8], start: usize) -> bool {
 fn demo_vertices(coordinates: &[[f64; 2]]) -> Result<Vec<Vertex<(), 2>>, CliError> {
     coordinates
         .iter()
-        .map(|coords| vertex!(*coords).map_err(CliError::CoordinateConversion))
+        .map(|coords| vertex!(*coords).map_err(|source| CliError::CoordinateConversion { source }))
         .collect()
 }
 
@@ -945,25 +945,53 @@ pub enum CliError {
     },
     /// I/O failed while writing an artifact.
     #[error(transparent)]
-    Io(#[from] io::Error),
+    Io {
+        /// Typed I/O source error.
+        #[from]
+        source: io::Error,
+    },
     /// JSON serialization failed while writing an artifact.
     #[error(transparent)]
-    Json(#[from] serde_json::Error),
+    Json {
+        /// Typed serialization source error.
+        #[from]
+        source: serde_json::Error,
+    },
     /// Coordinate range construction failed.
     #[error(transparent)]
-    CoordinateRange(#[from] CoordinateRangeError<f64>),
+    CoordinateRange {
+        /// Typed coordinate-range source error.
+        #[from]
+        source: CoordinateRangeError<f64>,
+    },
     /// Random point generation failed.
     #[error(transparent)]
-    PointGeneration(#[from] RandomPointGenerationError),
+    PointGeneration {
+        /// Typed point-generation source error.
+        #[from]
+        source: RandomPointGenerationError,
+    },
     /// Point-to-vertex conversion failed.
     #[error(transparent)]
-    CoordinateConversion(#[from] CoordinateConversionError),
+    CoordinateConversion {
+        /// Typed coordinate-conversion source error.
+        #[from]
+        source: CoordinateConversionError,
+    },
     /// Delaunay construction failed.
     #[error(transparent)]
-    Construction(#[from] DelaunayTriangulationConstructionError),
+    Construction {
+        /// Typed Delaunay-construction source error.
+        #[from]
+        source: DelaunayTriangulationConstructionError,
+    },
     /// Spherical Delaunay construction failed.
     #[error(transparent)]
-    SphericalConstruction(#[from] SphericalDelaunayConstructionError),
+    SphericalConstruction {
+        /// Typed spherical-construction source error.
+        #[from]
+        source: SphericalDelaunayConstructionError,
+    },
     /// The spherical hero count cannot be represented exactly by its plotting generator.
     #[error("spherical hero vertex count is too large: {value}")]
     SphericalHeroVertexCount {
@@ -972,13 +1000,24 @@ pub enum CliError {
     },
     /// Generic visualization export failed.
     #[error(transparent)]
-    Visualization(#[from] VisualizationExportError),
+    Visualization {
+        /// Typed visualization-export source error.
+        #[from]
+        source: VisualizationExportError,
+    },
     /// Convex hull extraction failed.
     #[error(transparent)]
-    ConvexHull(Box<ConvexHullConstructionError>),
+    ConvexHull {
+        /// Boxed convex-hull source error.
+        source: Box<ConvexHullConstructionError>,
+    },
     /// Facet-view extraction failed.
     #[error(transparent)]
-    Facet(#[from] FacetError),
+    Facet {
+        /// Typed facet source error.
+        #[from]
+        source: FacetError,
+    },
     /// A generated validation-demo case no longer fails at the intended boundary.
     #[error("validation demo case {case} is inconsistent: {message}")]
     ValidationDemoInvariant {
@@ -989,18 +1028,25 @@ pub enum CliError {
     },
     /// Pachner stress failed.
     #[error(transparent)]
-    PachnerStress(Box<PachnerStressError>),
+    PachnerStress {
+        /// Boxed Pachner-stress source error.
+        source: Box<PachnerStressError>,
+    },
 }
 
 impl From<ConvexHullConstructionError> for CliError {
     fn from(source: ConvexHullConstructionError) -> Self {
-        Self::ConvexHull(Box::new(source))
+        Self::ConvexHull {
+            source: Box::new(source),
+        }
     }
 }
 
 impl From<PachnerStressError> for CliError {
     fn from(source: PachnerStressError) -> Self {
-        Self::PachnerStress(Box::new(source))
+        Self::PachnerStress {
+            source: Box::new(source),
+        }
     }
 }
 

--- a/src/core/algorithms/flips/errors.rs
+++ b/src/core/algorithms/flips/errors.rs
@@ -592,8 +592,8 @@ impl From<&HullExtensionReason> for FlipNeighborHullExtensionFailureKind {
                 Self::MultipleBoundaryEdgeSplitFacets
             }
             HullExtensionReason::DisconnectedVisiblePatch { .. } => Self::DisconnectedVisiblePatch,
-            HullExtensionReason::PredicateFailed(_) => Self::PredicateFailed,
-            HullExtensionReason::Tds(_) => Self::Tds,
+            HullExtensionReason::PredicateFailed { source: _ } => Self::PredicateFailed,
+            HullExtensionReason::Tds { source: _ } => Self::Tds,
         }
     }
 }
@@ -628,9 +628,11 @@ pub enum FlipNeighborDelaunayValidationFailureKind {
 impl From<&DelaunayTriangulationValidationError> for FlipNeighborDelaunayValidationFailureKind {
     fn from(source: &DelaunayTriangulationValidationError) -> Self {
         match source {
-            DelaunayTriangulationValidationError::Tds(_) => Self::Tds,
-            DelaunayTriangulationValidationError::Triangulation(_) => Self::Triangulation,
-            DelaunayTriangulationValidationError::Realization(_) => Self::Realization,
+            DelaunayTriangulationValidationError::Tds { source: _ } => Self::Tds,
+            DelaunayTriangulationValidationError::Triangulation { source: _ } => {
+                Self::Triangulation
+            }
+            DelaunayTriangulationValidationError::Realization { source: _ } => Self::Realization,
             DelaunayTriangulationValidationError::VerificationFailed { .. } => {
                 Self::VerificationFailed
             }
@@ -898,11 +900,11 @@ impl From<InsertionError> for FlipNeighborWiringError {
                 facet_hash,
                 simplex_count,
             },
-            InsertionError::TopologyValidation(source) => Self::TopologyValidation {
+            InsertionError::TopologyValidation { source } => Self::TopologyValidation {
                 source: source.into(),
             },
-            InsertionError::ConflictRegion(source) => Self::ConflictRegion { source },
-            InsertionError::Location(source) => Self::Location { source },
+            InsertionError::ConflictRegion { source } => Self::ConflictRegion { source },
+            InsertionError::Location { source } => Self::Location { source },
             InsertionError::CavityFilling { reason } => Self::CavityFilling {
                 reason: reason.into(),
             },
@@ -1385,7 +1387,11 @@ pub enum FlipError {
     },
     /// Simplex creation failed.
     #[error(transparent)]
-    SimplexCreation(#[from] Box<SimplexValidationError>),
+    SimplexCreation {
+        /// Boxed simplex-validation source error.
+        #[from]
+        source: Box<SimplexValidationError>,
+    },
     /// Flip transaction could not repair post-mutation orientation invariants.
     #[error("Flip postcondition orientation repair failed: {source}")]
     PostconditionRepair {
@@ -1458,7 +1464,9 @@ impl From<FlipVertexAdjacencyError> for FlipError {
 
 impl From<SimplexValidationError> for FlipError {
     fn from(source: SimplexValidationError) -> Self {
-        Self::SimplexCreation(Box::new(source))
+        Self::SimplexCreation {
+            source: Box::new(source),
+        }
     }
 }
 
@@ -1518,7 +1526,7 @@ impl From<&FlipError> for FlipFailureKind {
             FlipError::NonManifoldFacet => Self::NonManifoldFacet,
             FlipError::InsertedSimplexAlreadyExists { .. } => Self::InsertedSimplexAlreadyExists,
             FlipError::FacetIteration { .. } => Self::FacetIteration,
-            FlipError::SimplexCreation(_) => Self::SimplexCreation,
+            FlipError::SimplexCreation { source: _ } => Self::SimplexCreation,
             FlipError::PostconditionRepair { .. } => Self::PostconditionRepair,
             FlipError::RealizationValidation { .. } => Self::RealizationValidation,
             FlipError::NeighborWiring { reason } => match reason.as_ref() {
@@ -2004,8 +2012,8 @@ impl From<&DelaunayRepairHeuristicRebuildFailure> for DelaunayRepairHeuristicReb
 
 pub(super) const fn insertion_error_kind(source: &InsertionError) -> InsertionErrorKind {
     match source {
-        InsertionError::ConflictRegion(_) => InsertionErrorKind::ConflictRegion,
-        InsertionError::Location(_) => InsertionErrorKind::Location,
+        InsertionError::ConflictRegion { source: _ } => InsertionErrorKind::ConflictRegion,
+        InsertionError::Location { source: _ } => InsertionErrorKind::Location,
         InsertionError::CavityFilling { .. } => InsertionErrorKind::CavityFilling,
         InsertionError::NeighborWiring { .. } => InsertionErrorKind::NeighborWiring,
         InsertionError::NonManifoldTopology { .. } => InsertionErrorKind::NonManifoldTopology,
@@ -2019,7 +2027,7 @@ pub(super) const fn insertion_error_kind(source: &InsertionError) -> InsertionEr
         InsertionError::DelaunayRepairFailed { .. } => InsertionErrorKind::DelaunayRepairFailed,
         InsertionError::DuplicateCoordinates { .. } => InsertionErrorKind::DuplicateCoordinates,
         InsertionError::DuplicateUuid { .. } => InsertionErrorKind::DuplicateUuid,
-        InsertionError::TopologyValidation(_) => InsertionErrorKind::TopologyValidation,
+        InsertionError::TopologyValidation { source: _ } => InsertionErrorKind::TopologyValidation,
         InsertionError::TopologyValidationFailed { .. } => {
             InsertionErrorKind::TopologyValidationFailed
         }

--- a/src/core/algorithms/flips/errors.rs
+++ b/src/core/algorithms/flips/errors.rs
@@ -2203,9 +2203,11 @@ mod tests {
     use crate::core::algorithms::locate::LocateResult;
     use crate::core::collections::{SimplexVertexKeyBuffer, SimplexVertexUuidBuffer, Uuid};
     use crate::core::realization::TriangulationRealizationSimplexDetail;
+    use crate::core::tds::TdsError;
     use crate::core::validation::TopologyGuarantee;
     use crate::geometry::traits::coordinate::CoordinateConversionValue;
     use crate::repair::DelaunayRepairOperation;
+    use crate::topology::traits::topological_space::TopologyKind;
     use slotmap::KeyData;
     use std::assert_matches;
     use std::{
@@ -2333,6 +2335,12 @@ mod tests {
             FlipFailureKind::from(&dangling_vertex_incidence),
             FlipFailureKind::DanglingVertexIncidence
         );
+
+        let simplex_creation = FlipError::from(SimplexValidationError::DuplicateVertices);
+        assert_eq!(
+            FlipFailureKind::from(&simplex_creation),
+            FlipFailureKind::SimplexCreation
+        );
     }
 
     fn assert_hull_extension_failure_kind(
@@ -2376,8 +2384,34 @@ mod tests {
             FlipNeighborHullExtensionFailureKind::DisconnectedVisiblePatch,
             "disconnected visible patch",
         );
+
+        assert_hull_extension_failure_kind(
+            &HullExtensionReason::PredicateFailed {
+                source: CoordinateConversionError::InvalidSimplexPointCount {
+                    actual: 2,
+                    expected: 3,
+                    dimension: 2,
+                },
+            },
+            FlipNeighborHullExtensionFailureKind::PredicateFailed,
+            "predicate failed",
+        );
+
+        assert_hull_extension_failure_kind(
+            &HullExtensionReason::Tds {
+                source: TdsError::InconsistentDataStructure {
+                    message: "missing boundary facet".to_string(),
+                },
+            },
+            FlipNeighborHullExtensionFailureKind::Tds,
+            "TDS",
+        );
     }
 
+    #[expect(
+        clippy::too_many_lines,
+        reason = "test keeps the insertion suberror conversion matrix together"
+    )]
     #[test]
     fn test_flip_neighbor_conversion_kinds_cover_insertion_suberrors() {
         let cavity_kind = FlipNeighborCavityFailureKind::from(
@@ -2418,6 +2452,38 @@ mod tests {
             FlipNeighborDelaunayValidationFailureKind::RepairOperationFailed
         );
         assert_eq!(validation_kind.to_string(), "repair operation failed");
+
+        let validation_cases = [
+            (
+                DelaunayTriangulationValidationError::from(TdsError::InconsistentDataStructure {
+                    message: "dangling simplex".to_string(),
+                }),
+                FlipNeighborDelaunayValidationFailureKind::Tds,
+            ),
+            (
+                DelaunayTriangulationValidationError::from(
+                    TriangulationValidationError::Disconnected { simplex_count: 2 },
+                ),
+                FlipNeighborDelaunayValidationFailureKind::Triangulation,
+            ),
+            (
+                DelaunayTriangulationValidationError::Realization {
+                    source: Box::new(
+                        TriangulationRealizationValidationError::UnsupportedTopology {
+                            topology: TopologyKind::Hyperbolic,
+                            dimension: 2,
+                        },
+                    ),
+                },
+                FlipNeighborDelaunayValidationFailureKind::Realization,
+            ),
+        ];
+        for (source, expected) in validation_cases {
+            assert_eq!(
+                FlipNeighborDelaunayValidationFailureKind::from(&source),
+                expected
+            );
+        }
 
         let repair_wiring = FlipNeighborWiringError::from(InsertionError::DelaunayRepairFailed {
             source: Box::new(DelaunayRepairError::InvalidTopology {
@@ -2468,6 +2534,58 @@ mod tests {
                 reason: SpatialIndexConstructionFailure::NonPositiveCellSize {
                     value: CoordinateConversionValue::from_f64(0.0),
                 },
+            }
+        );
+    }
+
+    #[test]
+    fn flip_neighbor_wiring_classifies_and_preserves_boundary_sources() {
+        let topology_error = InsertionError::TopologyValidation {
+            source: TdsError::InconsistentDataStructure {
+                message: "broken topology".to_string(),
+            },
+        };
+        assert_eq!(
+            insertion_error_kind(&topology_error),
+            InsertionErrorKind::TopologyValidation
+        );
+        assert_eq!(
+            FlipNeighborWiringError::from(topology_error),
+            FlipNeighborWiringError::TopologyValidation {
+                source: TdsValidationFailure::InconsistentDataStructure {
+                    message: "broken topology".to_string(),
+                },
+            }
+        );
+
+        let simplex_key = SimplexKey::from(KeyData::from_ffi(9_001));
+        let conflict_source = ConflictError::InvalidStartSimplex { simplex_key };
+        let conflict_error = InsertionError::ConflictRegion {
+            source: conflict_source.clone(),
+        };
+        assert_eq!(
+            insertion_error_kind(&conflict_error),
+            InsertionErrorKind::ConflictRegion
+        );
+        assert_eq!(
+            FlipNeighborWiringError::from(conflict_error),
+            FlipNeighborWiringError::ConflictRegion {
+                source: conflict_source,
+            }
+        );
+
+        let location_source = LocateError::InvalidSimplex { simplex_key };
+        let location_error = InsertionError::Location {
+            source: location_source.clone(),
+        };
+        assert_eq!(
+            insertion_error_kind(&location_error),
+            InsertionErrorKind::Location
+        );
+        assert_eq!(
+            FlipNeighborWiringError::from(location_error),
+            FlipNeighborWiringError::Location {
+                source: location_source,
             }
         );
     }

--- a/src/core/algorithms/flips/repair.rs
+++ b/src/core/algorithms/flips/repair.rs
@@ -771,7 +771,7 @@ where
                 | FlipError::DuplicateSimplex
                 | FlipError::NonManifoldFacet
                 | FlipError::InsertedSimplexAlreadyExists { .. }
-                | FlipError::SimplexCreation(_)),
+                | FlipError::SimplexCreation { source: _ }),
             ) => {
                 if env::var_os("DELAUNAY_REPAIR_DEBUG_FACETS").is_some() {
                     tracing::debug!(

--- a/src/core/algorithms/flips/repair_queue.rs
+++ b/src/core/algorithms/flips/repair_queue.rs
@@ -1000,7 +1000,7 @@ where
             | FlipError::NegativeOrientation { .. }
             | FlipError::DuplicateSimplex
             | FlipError::NonManifoldFacet
-            | FlipError::SimplexCreation(_)),
+            | FlipError::SimplexCreation { source: _ }),
         ) => {
             log_apply_skip(&err);
             return Ok(true);
@@ -1193,7 +1193,7 @@ where
             | FlipError::NegativeOrientation { .. }
             | FlipError::DuplicateSimplex
             | FlipError::NonManifoldFacet
-            | FlipError::SimplexCreation(_)),
+            | FlipError::SimplexCreation { source: _ }),
         ) => {
             log_apply_skip(&err);
             return Ok(true);
@@ -1377,7 +1377,7 @@ where
             | FlipError::NegativeOrientation { .. }
             | FlipError::DuplicateSimplex
             | FlipError::NonManifoldFacet
-            | FlipError::SimplexCreation(_)),
+            | FlipError::SimplexCreation { source: _ }),
         ) => {
             log_apply_skip(&err);
             return Ok(true);
@@ -1566,7 +1566,7 @@ where
             | FlipError::NegativeOrientation { .. }
             | FlipError::DuplicateSimplex
             | FlipError::NonManifoldFacet
-            | FlipError::SimplexCreation(_)),
+            | FlipError::SimplexCreation { source: _ }),
         ) => {
             log_apply_skip(&err);
             return Ok(true);

--- a/src/core/algorithms/incremental_insertion.rs
+++ b/src/core/algorithms/incremental_insertion.rs
@@ -118,14 +118,22 @@ pub enum HullExtensionReason {
     ///
     /// Preserves the structured [`CoordinateConversionError`] from the kernel or
     /// robust-predicate evaluation rather than collapsing it into a string.
-    #[error("Geometric predicate failed: {0}")]
-    PredicateFailed(#[source] CoordinateConversionError),
+    #[error("Geometric predicate failed: {source}")]
+    PredicateFailed {
+        /// Typed coordinate-conversion source error.
+        #[source]
+        source: CoordinateConversionError,
+    },
     /// Lower-layer TDS error encountered during hull extension.
     ///
     /// Preserves the structured [`TdsError`] (e.g. from boundary-facet retrieval)
     /// rather than collapsing it into a string.
-    #[error("TDS error: {0}")]
-    Tds(#[source] TdsError),
+    #[error("TDS error: {source}")]
+    Tds {
+        /// Typed TDS source error.
+        #[source]
+        source: TdsError,
+    },
 }
 
 /// Fixed context for a Level 3 topology validation failure during insertion.
@@ -566,8 +574,8 @@ impl From<TdsError> for TdsValidationFailure {
             TdsError::InconsistentDataStructure { message } => {
                 Self::InconsistentDataStructure { message }
             }
-            TdsError::Geometric(source) => Self::Geometric { source },
-            TdsError::FacetError(source) => Self::Facet { source },
+            TdsError::Geometric { source } => Self::Geometric { source },
+            TdsError::FacetError { source } => Self::Facet { source },
             TdsError::DuplicateCoordinatesInSimplex {
                 simplex_id,
                 message,
@@ -604,7 +612,7 @@ pub enum TdsConstructionFailure {
 impl From<TdsConstructionError> for TdsConstructionFailure {
     fn from(source: TdsConstructionError) -> Self {
         match source {
-            TdsConstructionError::ValidationError(source) => Self::Validation {
+            TdsConstructionError::ValidationError { source } => Self::Validation {
                 reason: source.into(),
             },
             TdsConstructionError::DuplicateUuid { entity, uuid } => {
@@ -865,7 +873,7 @@ pub enum InitialSimplexConstructionError {
 impl From<TdsConstructionError> for InitialSimplexConstructionError {
     fn from(source: TdsConstructionError) -> Self {
         match source {
-            TdsConstructionError::ValidationError(source) => Self::TdsValidation {
+            TdsConstructionError::ValidationError { source } => Self::TdsValidation {
                 source: source.into(),
             },
             TdsConstructionError::DuplicateUuid { entity, uuid } => {
@@ -882,7 +890,7 @@ impl From<TriangulationConstructionError> for InitialSimplexConstructionError {
     )]
     fn from(source: TriangulationConstructionError) -> Self {
         match source {
-            TriangulationConstructionError::Tds(source) => source.into(),
+            TriangulationConstructionError::Tds { source } => source.into(),
             TriangulationConstructionError::FailedToCreateSimplex { message } => {
                 Self::FailedToCreateSimplex { message }
             }
@@ -1656,12 +1664,20 @@ impl From<HashGridIndexError> for SpatialIndexConstructionFailure {
 #[non_exhaustive]
 pub enum InsertionError {
     /// Conflict region finding failed
-    #[error("Conflict region error: {0}")]
-    ConflictRegion(#[from] ConflictError),
+    #[error("Conflict region error: {source}")]
+    ConflictRegion {
+        /// Typed conflict-region source error.
+        #[from]
+        source: ConflictError,
+    },
 
     /// Point location failed
-    #[error("Location error: {0}")]
-    Location(#[from] LocateError),
+    #[error("Location error: {source}")]
+    Location {
+        /// Typed point-location source error.
+        #[from]
+        source: LocateError,
+    },
 
     /// Cavity filling failed.
     #[error("Cavity filling failed: {reason}")]
@@ -1758,8 +1774,12 @@ pub enum InsertionError {
     },
 
     /// Topology validation or repair failed.
-    #[error("Topology validation error: {0}")]
-    TopologyValidation(#[from] TdsError),
+    #[error("Topology validation error: {source}")]
+    TopologyValidation {
+        /// Typed TDS validation source error.
+        #[from]
+        source: TdsError,
+    },
 
     /// Level 3 topology validation failed (Triangulation layer).
     ///
@@ -1834,7 +1854,7 @@ impl From<TdsConstructionError> for CavityFillingError {
 impl From<TdsConstructionError> for InsertionError {
     fn from(source: TdsConstructionError) -> Self {
         match source {
-            TdsConstructionError::ValidationError(source) => Self::TopologyValidation(source),
+            TdsConstructionError::ValidationError { source } => Self::TopologyValidation { source },
             TdsConstructionError::DuplicateUuid { entity, uuid } => {
                 Self::DuplicateUuid { entity, uuid }
             }
@@ -1859,7 +1879,7 @@ impl From<InsertionError> for NeighborRebuildError {
                 facet_hash,
                 simplex_count,
             },
-            InsertionError::TopologyValidation(source) => Self::TopologyValidation {
+            InsertionError::TopologyValidation { source } => Self::TopologyValidation {
                 reason: source.into(),
             },
             other => Self::Unexpected {
@@ -1921,16 +1941,16 @@ impl InsertionError {
             // TDS-level topology errors: perturbation-retryable sub-variants are
             // geometric, orientation, or facet-multiplicity degeneracies.
             // Structural errors (missing simplices, broken invariants) won't be fixed by perturbation.
-            Self::TopologyValidation(tds_err) => Self::is_tds_error_retryable(tds_err),
+            Self::TopologyValidation { source } => Self::is_tds_error_retryable(source),
             // Conflict region errors: only geometry-degeneracy variants are retryable.
             // Structural variants (InvalidStartSimplex, PredicateError, SimplexDataAccessFailed,
             // InvalidSimplexArity, MissingSimplexVertex, InternalInconsistency — regardless of which typed
             // `InternalInconsistencySite` carries the failure context) represent caller
             // or implementation errors that perturbation cannot fix, and so fall
             // through to non-retryable by omission.
-            Self::ConflictRegion(ce) => {
+            Self::ConflictRegion { source } => {
                 matches!(
-                    ce,
+                    source,
                     ConflictError::NonManifoldFacet { .. }
                         | ConflictError::RidgeFan { .. }
                         | ConflictError::DisconnectedBoundary { .. }
@@ -1960,7 +1980,7 @@ impl InsertionError {
             // overflow, etc.). Non-manifold topology detection uses the dedicated
             // `NonManifoldTopology` variant.
             Self::NeighborWiring { .. }
-            | Self::Location(_)
+            | Self::Location { .. }
             | Self::RealizationValidationFailed { .. }
             | Self::DelaunayValidationFailed { .. }
             | Self::DelaunayRepairFailed { .. }
@@ -1981,7 +2001,7 @@ impl InsertionError {
     const fn is_tds_error_retryable(tds_err: &TdsError) -> bool {
         matches!(
             tds_err,
-            TdsError::Geometric(_)
+            TdsError::Geometric { source: _ }
                 | TdsError::OrientationViolation { .. }
                 | TdsError::FacetSharingViolation { .. }
         )
@@ -2094,13 +2114,13 @@ impl InsertionError {
     /// Check whether a final validation error is perturbation-retryable.
     fn is_invariant_error_retryable(err: &InvariantError) -> bool {
         match err {
-            InvariantError::Tds(source) => matches!(
+            InvariantError::Tds { source } => matches!(
                 TdsErrorKind::from(source),
                 TdsErrorKind::Geometric
                     | TdsErrorKind::OrientationViolation
                     | TdsErrorKind::FacetSharingViolation
             ),
-            InvariantError::Triangulation(source) => matches!(
+            InvariantError::Triangulation { source } => matches!(
                 TriangulationValidationErrorKind::from(source),
                 TriangulationValidationErrorKind::ManifoldFacetMultiplicity
                     | TriangulationValidationErrorKind::BoundaryRidgeMultiplicity
@@ -2109,7 +2129,9 @@ impl InsertionError {
                     | TriangulationValidationErrorKind::OrientationPromotionNonConvergence
                     | TriangulationValidationErrorKind::IsolatedVertex
             ),
-            InvariantError::Realization(_) | InvariantError::Delaunay(_) => false,
+            InvariantError::Realization { source: _ } | InvariantError::Delaunay { source: _ } => {
+                false
+            }
         }
     }
 
@@ -3665,7 +3687,7 @@ where
         let total_boundary = tds
             .one_sided_facets()
             .map_err(|e| InsertionError::HullExtension {
-                reason: HullExtensionReason::Tds(e),
+                reason: HullExtensionReason::Tds { source: e },
             })
             .and_then(|mut facets| {
                 facets
@@ -3773,7 +3795,7 @@ where
     conflict_simplices.push(edge_facet.simplex_key());
 
     let mut boundary_facets = extract_cavity_boundary(tds, &conflict_simplices)
-        .map_err(InsertionError::ConflictRegion)?;
+        .map_err(|source| InsertionError::ConflictRegion { source })?;
     boundary_facets.retain(|facet| {
         facet.simplex_key() != edge_facet.simplex_key()
             || facet.facet_index() != edge_facet.facet_index()
@@ -3791,14 +3813,18 @@ where
         Some(&conflict_simplices),
     )?;
     tds.remove_simplices_by_keys(&conflict_simplices)
-        .map_err(|e| InsertionError::TopologyValidation(e.into_inner()))?;
+        .map_err(|e| InsertionError::TopologyValidation {
+            source: e.into_inner(),
+        })?;
 
     Ok(new_simplices)
 }
 
 fn hull_extension_tds_error(source: impl Into<TdsError>) -> InsertionError {
     InsertionError::HullExtension {
-        reason: HullExtensionReason::Tds(source.into()),
+        reason: HullExtensionReason::Tds {
+            source: source.into(),
+        },
     }
 }
 
@@ -3896,7 +3922,7 @@ fn find_boundary_edge_split_facet<U, V, const D: usize>(
     let boundary_facets = tds
         .one_sided_facets()
         .map_err(|e| InsertionError::HullExtension {
-            reason: HullExtensionReason::Tds(e),
+            reason: HullExtensionReason::Tds { source: e },
         })?;
 
     for facet_view in boundary_facets {
@@ -4032,7 +4058,7 @@ fn boundary_edge_split_facet_matches<U, V, const D: usize>(
     // property we need here: is the opposite simplex truly degenerate?
     let opposite_degenerate = matches!(
         robust_orientation(&simplex_points).map_err(|e| InsertionError::HullExtension {
-            reason: HullExtensionReason::PredicateFailed(e),
+            reason: HullExtensionReason::PredicateFailed { source: e },
         })?,
         Orientation::DEGENERATE
     );
@@ -4050,7 +4076,7 @@ fn boundary_edge_split_facet_matches<U, V, const D: usize>(
     // property we need here: is the point truly on the line through the edge?
     let is_collinear = matches!(
         robust_orientation(&edge_line).map_err(|e| InsertionError::HullExtension {
-            reason: HullExtensionReason::PredicateFailed(e),
+            reason: HullExtensionReason::PredicateFailed { source: e },
         })?,
         Orientation::DEGENERATE
     );
@@ -4135,7 +4161,7 @@ where
     let boundary_facets = tds
         .one_sided_facets()
         .map_err(|e| InsertionError::HullExtension {
-            reason: HullExtensionReason::Tds(e),
+            reason: HullExtensionReason::Tds { source: e },
         })?;
 
     // Test each boundary facet for visibility
@@ -4181,7 +4207,7 @@ where
             kernel
                 .orientation(&simplex_points)
                 .map_err(|e| InsertionError::HullExtension {
-                    reason: HullExtensionReason::PredicateFailed(e),
+                    reason: HullExtensionReason::PredicateFailed { source: e },
                 })?;
 
         // Replace opposite vertex with query point (last entry in canonical order).
@@ -4191,7 +4217,7 @@ where
             kernel
                 .orientation(&simplex_points)
                 .map_err(|e| InsertionError::HullExtension {
-                    reason: HullExtensionReason::PredicateFailed(e),
+                    reason: HullExtensionReason::PredicateFailed { source: e },
                 })?;
 
         #[cfg(debug_assertions)]
@@ -4737,7 +4763,9 @@ mod tests {
             expected: 3,
             dimension: 2,
         };
-        let predicate_reason = HullExtensionReason::PredicateFailed(predicate_source.clone());
+        let predicate_reason = HullExtensionReason::PredicateFailed {
+            source: predicate_source.clone(),
+        };
         let predicate_error = std::error::Error::source(&predicate_reason)
             .and_then(|source| source.downcast_ref::<CoordinateConversionError>());
         assert_eq!(predicate_error, Some(&predicate_source));
@@ -4745,7 +4773,9 @@ mod tests {
         let tds_source = TdsError::InconsistentDataStructure {
             message: "missing boundary facet".to_string(),
         };
-        let tds_reason = HullExtensionReason::Tds(tds_source.clone());
+        let tds_reason = HullExtensionReason::Tds {
+            source: tds_source.clone(),
+        };
         let tds_error = std::error::Error::source(&tds_reason)
             .and_then(|source| source.downcast_ref::<TdsError>());
         assert_eq!(tds_error, Some(&tds_source));
@@ -4753,7 +4783,10 @@ mod tests {
         let insertion_error = InsertionError::HullExtension { reason: tds_reason };
         let insertion_source = std::error::Error::source(&insertion_error)
             .and_then(|source| source.downcast_ref::<HullExtensionReason>());
-        assert_matches!(insertion_source, Some(HullExtensionReason::Tds(_)));
+        assert_matches!(
+            insertion_source,
+            Some(HullExtensionReason::Tds { source: _ })
+        );
     }
 
     /// Macro to generate cavity replacement filling tests for different dimensions.
@@ -5556,14 +5589,18 @@ mod tests {
 
     #[test]
     fn test_insertion_retryability_covers_tds_source_kinds() {
-        let geometric = InsertionError::TopologyValidation(TdsError::Geometric(
-            GeometricError::DegenerateOrientation {
-                message: "det=0".to_string(),
+        let geometric = InsertionError::TopologyValidation {
+            source: TdsError::Geometric {
+                source: GeometricError::DegenerateOrientation {
+                    message: "det=0".to_string(),
+                },
             },
-        ));
-        let structural = InsertionError::TopologyValidation(TdsError::InconsistentDataStructure {
-            message: "dangling neighbor".to_string(),
-        });
+        };
+        let structural = InsertionError::TopologyValidation {
+            source: TdsError::InconsistentDataStructure {
+                message: "dangling neighbor".to_string(),
+            },
+        };
 
         assert!(geometric.is_retryable());
         assert!(!structural.is_retryable());
@@ -5834,52 +5871,62 @@ mod tests {
         );
         // InconsistentDataStructure is now non-retryable (structural bug, not geometry).
         assert!(
-            !InsertionError::TopologyValidation(TdsError::InconsistentDataStructure {
-                message: "test".to_string()
-            })
+            !InsertionError::TopologyValidation {
+                source: TdsError::InconsistentDataStructure {
+                    message: "test".to_string()
+                }
+            }
             .is_retryable()
         );
         // Geometry-related variants are still retryable.
         assert!(
-            InsertionError::TopologyValidation(TdsError::Geometric(
-                GeometricError::DegenerateOrientation {
-                    message: "test".to_string()
+            InsertionError::TopologyValidation {
+                source: TdsError::Geometric {
+                    source: GeometricError::DegenerateOrientation {
+                        message: "test".to_string()
+                    }
                 }
-            ))
+            }
             .is_retryable()
         );
         assert!(
-            InsertionError::TopologyValidation(TdsError::Geometric(
-                GeometricError::NegativeOrientation {
-                    message: "test".to_string()
+            InsertionError::TopologyValidation {
+                source: TdsError::Geometric {
+                    source: GeometricError::NegativeOrientation {
+                        message: "test".to_string()
+                    }
                 }
-            ))
+            }
             .is_retryable()
         );
         assert!(
-            InsertionError::TopologyValidation(TdsError::OrientationViolation {
-                simplex1_key: SimplexKey::from(KeyData::from_ffi(1)),
-                simplex1_uuid: uuid::Uuid::nil(),
-                simplex2_key: SimplexKey::from(KeyData::from_ffi(2)),
-                simplex2_uuid: uuid::Uuid::nil(),
-                simplex1_facet_index: 0,
-                simplex2_facet_index: 1,
-                facet_vertices: vec![],
-                simplex2_facet_vertices: vec![],
-                observed_odd_permutation: true,
-                expected_odd_permutation: false,
-            })
+            InsertionError::TopologyValidation {
+                source: TdsError::OrientationViolation {
+                    simplex1_key: SimplexKey::from(KeyData::from_ffi(1)),
+                    simplex1_uuid: uuid::Uuid::nil(),
+                    simplex2_key: SimplexKey::from(KeyData::from_ffi(2)),
+                    simplex2_uuid: uuid::Uuid::nil(),
+                    simplex1_facet_index: 0,
+                    simplex2_facet_index: 1,
+                    facet_vertices: vec![],
+                    simplex2_facet_vertices: vec![],
+                    observed_odd_permutation: true,
+                    expected_odd_permutation: false,
+                }
+            }
             .is_retryable()
         );
         assert!(
-            InsertionError::TopologyValidation(TdsError::FacetSharingViolation {
-                facet_key: 0x1234,
-                existing_incident_count: 2,
-                attempted_incident_count: 3,
-                max_incident_count: 2,
-                candidate_simplex_uuid: uuid::Uuid::nil(),
-                candidate_facet_index: 1,
-            })
+            InsertionError::TopologyValidation {
+                source: TdsError::FacetSharingViolation {
+                    facet_key: 0x1234,
+                    existing_incident_count: 2,
+                    attempted_incident_count: 3,
+                    max_incident_count: 2,
+                    candidate_simplex_uuid: uuid::Uuid::nil(),
+                    candidate_facet_index: 1,
+                }
+            }
             .is_retryable()
         );
         // IsolatedVertex is retryable: during insertion, a geometrically-sensitive
@@ -5990,115 +6037,141 @@ mod tests {
 
         // Conflict-region errors
         assert!(
-            InsertionError::ConflictRegion(ConflictError::NonManifoldFacet {
-                facet_hash: 0x12345_u64,
-                simplex_count: 3,
-            })
+            InsertionError::ConflictRegion {
+                source: ConflictError::NonManifoldFacet {
+                    facet_hash: 0x12345_u64,
+                    simplex_count: 3,
+                }
+            }
             .is_retryable()
         );
         assert!(
-            InsertionError::ConflictRegion(ConflictError::RidgeFan {
-                facet_count: 3,
-                ridge_vertex_count: 2,
-                extra_simplices: vec![],
-            })
+            InsertionError::ConflictRegion {
+                source: ConflictError::RidgeFan {
+                    facet_count: 3,
+                    ridge_vertex_count: 2,
+                    extra_simplices: vec![],
+                }
+            }
             .is_retryable()
         );
         // extra_simplices contents do not affect retryability — a non-empty vec is also retryable.
         assert!(
-            InsertionError::ConflictRegion(ConflictError::RidgeFan {
-                facet_count: 3,
-                ridge_vertex_count: 2,
-                extra_simplices: vec![SimplexKey::from(KeyData::from_ffi(1))],
-            })
+            InsertionError::ConflictRegion {
+                source: ConflictError::RidgeFan {
+                    facet_count: 3,
+                    ridge_vertex_count: 2,
+                    extra_simplices: vec![SimplexKey::from(KeyData::from_ffi(1))],
+                }
+            }
             .is_retryable()
         );
         assert!(
-            !InsertionError::ConflictRegion(ConflictError::InvalidStartSimplex {
-                simplex_key: SimplexKey::from(KeyData::from_ffi(u64::MAX)),
-            })
+            !InsertionError::ConflictRegion {
+                source: ConflictError::InvalidStartSimplex {
+                    simplex_key: SimplexKey::from(KeyData::from_ffi(u64::MAX)),
+                }
+            }
             .is_retryable()
         );
         assert!(
-            !InsertionError::ConflictRegion(ConflictError::PredicateError {
-                source: CoordinateConversionError::ConversionFailed {
-                    coordinate_index: 0,
-                    coordinate_value: CoordinateConversionValue::Other("test".to_string()),
-                    from_type: "f64",
-                    to_type: "f64",
-                },
-            })
+            !InsertionError::ConflictRegion {
+                source: ConflictError::PredicateError {
+                    source: CoordinateConversionError::ConversionFailed {
+                        coordinate_index: 0,
+                        coordinate_value: CoordinateConversionValue::Other("test".to_string()),
+                        from_type: "f64",
+                        to_type: "f64",
+                    },
+                }
+            }
             .is_retryable()
         );
         assert!(
-            !InsertionError::ConflictRegion(ConflictError::SimplexDataAccessFailed {
-                simplex_key: SimplexKey::from(KeyData::from_ffi(1)),
-                message: "test".to_string(),
-            })
+            !InsertionError::ConflictRegion {
+                source: ConflictError::SimplexDataAccessFailed {
+                    simplex_key: SimplexKey::from(KeyData::from_ffi(1)),
+                    message: "test".to_string(),
+                }
+            }
             .is_retryable()
         );
         assert!(
-            !InsertionError::ConflictRegion(ConflictError::InvalidSimplexArity {
-                simplex_key: SimplexKey::from(KeyData::from_ffi(1)),
-                expected: 3,
-                found: 2,
-            })
+            !InsertionError::ConflictRegion {
+                source: ConflictError::InvalidSimplexArity {
+                    simplex_key: SimplexKey::from(KeyData::from_ffi(1)),
+                    expected: 3,
+                    found: 2,
+                }
+            }
             .is_retryable()
         );
         assert!(
-            !InsertionError::ConflictRegion(ConflictError::MissingSimplexVertex {
-                simplex_key: SimplexKey::from(KeyData::from_ffi(1)),
-                vertex_key: VertexKey::from(KeyData::from_ffi(999)),
-            })
+            !InsertionError::ConflictRegion {
+                source: ConflictError::MissingSimplexVertex {
+                    simplex_key: SimplexKey::from(KeyData::from_ffi(1)),
+                    vertex_key: VertexKey::from(KeyData::from_ffi(999)),
+                }
+            }
             .is_retryable()
         );
         // InternalInconsistency is not retryable regardless of the typed site:
         // perturbation cannot fix logic errors.
         assert!(
-            !InsertionError::ConflictRegion(ConflictError::InternalInconsistency {
-                site: InternalInconsistencySite::RidgeFanExtraFacetOutOfBounds {
-                    index: 7,
-                    boundary_facets_len: 5,
-                    extra_facets_len: 3,
-                },
-            })
+            !InsertionError::ConflictRegion {
+                source: ConflictError::InternalInconsistency {
+                    site: InternalInconsistencySite::RidgeFanExtraFacetOutOfBounds {
+                        index: 7,
+                        boundary_facets_len: 5,
+                        extra_facets_len: 3,
+                    },
+                }
+            }
             .is_retryable()
         );
         assert!(
-            !InsertionError::ConflictRegion(ConflictError::InternalInconsistency {
-                site: InternalInconsistencySite::OpenBoundaryMissingFirstFacet {
-                    first_facet: 4,
-                    boundary_facets_len: 2,
+            !InsertionError::ConflictRegion {
+                source: ConflictError::InternalInconsistency {
+                    site: InternalInconsistencySite::OpenBoundaryMissingFirstFacet {
+                        first_facet: 4,
+                        boundary_facets_len: 2,
+                        facet_count: 1,
+                        ridge_vertex_count: 2,
+                    },
+                }
+            }
+            .is_retryable()
+        );
+        assert!(
+            !InsertionError::ConflictRegion {
+                source: ConflictError::InternalInconsistency {
+                    site: InternalInconsistencySite::RidgeInfoMissingSecondFacet {
+                        first_facet: 0,
+                        boundary_facets_len: 2,
+                        ridge_vertex_count: 2,
+                    },
+                }
+            }
+            .is_retryable()
+        );
+        assert!(
+            InsertionError::ConflictRegion {
+                source: ConflictError::DisconnectedBoundary {
+                    visited: 1,
+                    total: 3,
+                    disconnected_simplices: vec![],
+                }
+            }
+            .is_retryable()
+        );
+        assert!(
+            InsertionError::ConflictRegion {
+                source: ConflictError::OpenBoundary {
                     facet_count: 1,
                     ridge_vertex_count: 2,
-                },
-            })
-            .is_retryable()
-        );
-        assert!(
-            !InsertionError::ConflictRegion(ConflictError::InternalInconsistency {
-                site: InternalInconsistencySite::RidgeInfoMissingSecondFacet {
-                    first_facet: 0,
-                    boundary_facets_len: 2,
-                    ridge_vertex_count: 2,
-                },
-            })
-            .is_retryable()
-        );
-        assert!(
-            InsertionError::ConflictRegion(ConflictError::DisconnectedBoundary {
-                visited: 1,
-                total: 3,
-                disconnected_simplices: vec![],
-            })
-            .is_retryable()
-        );
-        assert!(
-            InsertionError::ConflictRegion(ConflictError::OpenBoundary {
-                facet_count: 1,
-                ridge_vertex_count: 2,
-                open_simplex: SimplexKey::from(KeyData::from_ffi(1)),
-            })
+                    open_simplex: SimplexKey::from(KeyData::from_ffi(1)),
+                }
+            }
             .is_retryable()
         );
 
@@ -6175,23 +6248,25 @@ mod tests {
 
         assert!(
             !InsertionError::HullExtension {
-                reason: HullExtensionReason::PredicateFailed(
-                    CoordinateConversionError::ConversionFailed {
+                reason: HullExtensionReason::PredicateFailed {
+                    source: CoordinateConversionError::ConversionFailed {
                         coordinate_index: 0,
                         coordinate_value: CoordinateConversionValue::Other("test".to_string()),
                         from_type: "f64",
                         to_type: "f64",
                     }
-                )
+                }
             }
             .is_retryable()
         );
 
         assert!(
             !InsertionError::HullExtension {
-                reason: HullExtensionReason::Tds(TdsError::InconsistentDataStructure {
-                    message: "test".to_string(),
-                })
+                reason: HullExtensionReason::Tds {
+                    source: TdsError::InconsistentDataStructure {
+                        message: "test".to_string(),
+                    }
+                }
             }
             .is_retryable()
         );
@@ -6205,20 +6280,20 @@ mod tests {
         assert_matches!(
             missing_boundary_simplex(simplex_key, "facet lookup"),
             InsertionError::HullExtension {
-                reason: HullExtensionReason::Tds(TdsError::SimplexNotFound {
+                reason: HullExtensionReason::Tds { source: TdsError::SimplexNotFound {
                     simplex_key: found_simplex_key,
                     context,
-                }),
+                } },
             } if found_simplex_key == simplex_key && context == "facet lookup"
         );
 
         assert_matches!(
             missing_boundary_vertex(vertex_key, simplex_key, "visible boundary facet"),
             InsertionError::HullExtension {
-                reason: HullExtensionReason::Tds(TdsError::VertexNotFound {
+                reason: HullExtensionReason::Tds { source: TdsError::VertexNotFound {
                     vertex_key: found_vertex_key,
                     context,
-                }),
+                } },
             } if found_vertex_key == vertex_key
                 && context.starts_with("visible boundary facet")
                 && context.contains(&format!("{simplex_key:?}"))
@@ -6227,21 +6302,25 @@ mod tests {
         assert_matches!(
             invalid_boundary_facet_index(3, 2),
             InsertionError::HullExtension {
-                reason: HullExtensionReason::Tds(TdsError::FacetError(
-                    FacetError::InvalidFacetIndex {
-                        index: 3,
-                        facet_count: 2,
+                reason: HullExtensionReason::Tds {
+                    source: TdsError::FacetError {
+                        source: FacetError::InvalidFacetIndex {
+                            index: 3,
+                            facet_count: 2,
+                        }
                     }
-                )),
+                },
             }
         );
 
         assert_matches!(
             boundary_facet_iteration_error(FacetError::InsideVertexNotFound),
             InsertionError::HullExtension {
-                reason: HullExtensionReason::Tds(TdsError::FacetError(
-                    FacetError::InsideVertexNotFound
-                )),
+                reason: HullExtensionReason::Tds {
+                    source: TdsError::FacetError {
+                        source: FacetError::InsideVertexNotFound
+                    }
+                },
             }
         );
     }

--- a/src/core/algorithms/pl_manifold_repair.rs
+++ b/src/core/algorithms/pl_manifold_repair.rs
@@ -237,7 +237,11 @@ impl<U, V, const D: usize> Default for PlManifoldRepairStats<U, V, D> {
 pub enum PlManifoldRepairError {
     /// The underlying TDS is structurally inconsistent.
     #[error(transparent)]
-    Tds(#[from] TdsError),
+    Tds {
+        /// Typed TDS source error.
+        #[from]
+        source: TdsError,
+    },
 
     /// Iteration budget exhausted before the facet-degree invariant was satisfied.
     #[error(
@@ -437,9 +441,11 @@ where
         // Remove the batch. `remove_simplices_by_keys` handles local neighbor
         // back-reference clearing and incident-simplex repair. Full neighbor
         // rebuild is deferred to after the loop to avoid O(simplices²) work.
-        let removed = tds
-            .remove_simplices_by_keys(&keys)
-            .map_err(|e| PlManifoldRepairError::Tds(e.into_inner()))?;
+        let removed =
+            tds.remove_simplices_by_keys(&keys)
+                .map_err(|e| PlManifoldRepairError::Tds {
+                    source: e.into_inner(),
+                })?;
         stats.simplices_removed += removed;
 
         // Remove orphaned vertices (required for PL-manifold validity).
@@ -905,16 +911,18 @@ where
     if let Some(simplex) = tds.simplex(simplex_key) {
         stats.removed_simplices.push(simplex.clone());
     }
-    let removed = tds
-        .remove_simplices_by_keys(&[simplex_key])
-        .map_err(|e| PlManifoldRepairError::Tds(e.into_inner()))?;
+    let removed =
+        tds.remove_simplices_by_keys(&[simplex_key])
+            .map_err(|e| PlManifoldRepairError::Tds {
+                source: e.into_inner(),
+            })?;
     if removed == 0 {
         return Ok(0);
     }
     stats.simplices_removed += removed;
     remove_orphaned_vertices(tds, stats)?;
     tds.assign_incident_simplices()
-        .map_err(|e| PlManifoldRepairError::Tds(e.into()))?;
+        .map_err(|e| PlManifoldRepairError::Tds { source: e.into() })?;
     Ok(removed)
 }
 
@@ -931,9 +939,10 @@ where
 fn rebuild_success_topology<U, V, const D: usize>(
     tds: &mut Tds<U, V, D>,
 ) -> Result<(), PlManifoldRepairError> {
-    tds.assign_neighbors().map_err(PlManifoldRepairError::Tds)?;
+    tds.assign_neighbors()
+        .map_err(|source| PlManifoldRepairError::Tds { source })?;
     tds.assign_incident_simplices()
-        .map_err(|e| PlManifoldRepairError::Tds(e.into()))
+        .map_err(|e| PlManifoldRepairError::Tds { source: e.into() })
 }
 
 /// Best-effort topology metadata repair before returning a non-convergence error.
@@ -1127,7 +1136,9 @@ where
             stats.removed_vertices.push(vertex.clone());
         }
         tds.remove_isolated_vertex(vk)
-            .map_err(|e| PlManifoldRepairError::Tds(e.into_inner()))?;
+            .map_err(|e| PlManifoldRepairError::Tds {
+                source: e.into_inner(),
+            })?;
     }
 
     Ok(())
@@ -1629,11 +1640,11 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(ManifoldError::Tds(TdsError::IndexOutOfBounds {
+            Err(ManifoldError::Tds { source: TdsError::IndexOutOfBounds {
                 index,
                 bound: 4,
                 ..
-            })) if index == <usize as From<u8>>::from(u8::MAX)
+            } }) if index == <usize as From<u8>>::from(u8::MAX)
         );
         assert!(facet_vertices.is_empty());
     }

--- a/src/core/construction.rs
+++ b/src/core/construction.rs
@@ -180,7 +180,11 @@ impl From<PeriodicFacetKeyDerivationError> for PeriodicQuotientFacetKeyDerivatio
 pub enum TriangulationConstructionError {
     /// Lower-layer construction error in the TDS.
     #[error(transparent)]
-    Tds(#[from] TdsConstructionError),
+    Tds {
+        /// Typed TDS-construction source error.
+        #[from]
+        source: TdsConstructionError,
+    },
 
     /// Failed to create a simplex during triangulation construction.
     #[error("Failed to create simplex during construction: {message}")]
@@ -661,14 +665,16 @@ where
         }
 
         for vertex in vertices {
-            vertex.is_valid().map_err(|source| {
-                TriangulationConstructionError::Tds(TdsConstructionError::ValidationError(
-                    TdsError::InvalidVertex {
-                        vertex_id: vertex.uuid(),
-                        source,
+            vertex
+                .is_valid()
+                .map_err(|source| TriangulationConstructionError::Tds {
+                    source: TdsConstructionError::ValidationError {
+                        source: TdsError::InvalidVertex {
+                            vertex_id: vertex.uuid(),
+                            source,
+                        },
                     },
-                ))
-            })?;
+                })?;
         }
 
         let points: SmallBuffer<Point<D>, MAX_PRACTICAL_DIMENSION_SIZE> =
@@ -733,9 +739,9 @@ where
         let _simplex_key = tds.insert_simplex_with_mapping(simplex)?;
 
         tds.assign_neighbors()
-            .map_err(TdsConstructionError::ValidationError)?;
+            .map_err(|source| TdsConstructionError::ValidationError { source })?;
         tds.assign_incident_simplices()
-            .map_err(|e| TdsConstructionError::ValidationError(e.into()))?;
+            .map_err(|e| TdsConstructionError::ValidationError { source: e.into() })?;
 
         Ok(tds)
     }
@@ -798,13 +804,15 @@ mod tests {
 
     #[test]
     fn insertion_hull_extension_exposes_typed_source() {
-        let reason = HullExtensionReason::Tds(TdsError::InconsistentDataStructure {
-            message: "missing boundary facet".to_string(),
-        });
+        let reason = HullExtensionReason::Tds {
+            source: TdsError::InconsistentDataStructure {
+                message: "missing boundary facet".to_string(),
+            },
+        };
         let error = TriangulationConstructionError::InsertionHullExtension { reason };
         let source = std::error::Error::source(&error)
             .and_then(|source| source.downcast_ref::<HullExtensionReason>());
-        assert_matches!(source, Some(HullExtensionReason::Tds(_)));
+        assert_matches!(source, Some(HullExtensionReason::Tds { source: _ }));
     }
 
     #[test]

--- a/src/core/facet_incidence.rs
+++ b/src/core/facet_incidence.rs
@@ -646,10 +646,12 @@ mod tests {
         // We test this by confirming the error structure exists and can be created.
 
         // Test that the error can be created and has correct structure
-        let error = TdsError::FacetError(FacetError::InvalidFacetIndex {
-            index: 42,
-            facet_count: 4,
-        });
+        let error = TdsError::FacetError {
+            source: FacetError::InvalidFacetIndex {
+                index: 42,
+                facet_count: 4,
+            },
+        };
 
         // Verify error display includes useful information
         let error_string = format!("{error}");
@@ -675,7 +677,9 @@ mod tests {
         // We test the error structure.
 
         // Test that the error can be created
-        let error = TdsError::FacetError(FacetError::SimplexNotFoundInTriangulation);
+        let error = TdsError::FacetError {
+            source: FacetError::SimplexNotFoundInTriangulation,
+        };
 
         // Verify error display is meaningful
         let error_string = format!("{error}");
@@ -812,7 +816,9 @@ mod tests {
 
         assert_matches!(
             err,
-            TdsError::FacetError(FacetError::FacetOwnerMismatch { .. })
+            TdsError::FacetError {
+                source: FacetError::FacetOwnerMismatch { .. }
+            }
         );
     }
 
@@ -839,7 +845,9 @@ mod tests {
 
         assert_matches!(
             err,
-            TdsError::FacetError(FacetError::FacetIndexOwnerMismatch)
+            TdsError::FacetError {
+                source: FacetError::FacetIndexOwnerMismatch
+            }
         );
     }
 
@@ -861,10 +869,12 @@ mod tests {
 
         assert_matches!(
             err,
-            TdsError::FacetError(FacetError::InvalidFacetMultiplicity {
-                facet_key: 0xCAFE,
-                found: 3
-            })
+            TdsError::FacetError {
+                source: FacetError::InvalidFacetMultiplicity {
+                    facet_key: 0xCAFE,
+                    found: 3
+                }
+            }
         );
     }
 
@@ -995,10 +1005,12 @@ mod tests {
 
         for &(multiplicity, description) in &test_cases {
             let facet_key = 0x1234_5678_9ABC_DEF0_u64; // Example facet key
-            let error = TdsError::FacetError(FacetError::InvalidFacetMultiplicity {
-                facet_key,
-                found: multiplicity,
-            });
+            let error = TdsError::FacetError {
+                source: FacetError::InvalidFacetMultiplicity {
+                    facet_key,
+                    found: multiplicity,
+                },
+            };
 
             // Verify error display includes all necessary information
             let error_string = format!("{error}");

--- a/src/core/insertion.rs
+++ b/src/core/insertion.rs
@@ -103,34 +103,46 @@ fn cavity_reduction_trace_enabled() -> bool {
 /// conflict region.
 fn retryable_conflict_trace_detail(error: &InsertionError) -> Option<String> {
     match error {
-        InsertionError::ConflictRegion(ConflictError::NonManifoldFacet {
-            facet_hash,
-            simplex_count,
-        }) => Some(format!(
+        InsertionError::ConflictRegion {
+            source:
+                ConflictError::NonManifoldFacet {
+                    facet_hash,
+                    simplex_count,
+                },
+        } => Some(format!(
             "kind=non_manifold_facet facet_hash={facet_hash:#x} simplex_count={simplex_count}"
         )),
-        InsertionError::ConflictRegion(ConflictError::RidgeFan {
-            facet_count,
-            ridge_vertex_count,
-            extra_simplices,
-        }) => Some(format!(
+        InsertionError::ConflictRegion {
+            source:
+                ConflictError::RidgeFan {
+                    facet_count,
+                    ridge_vertex_count,
+                    extra_simplices,
+                },
+        } => Some(format!(
             "kind=ridge_fan facet_count={facet_count} ridge_vertex_count={ridge_vertex_count} \
              extra_simplices={}",
             extra_simplices.len()
         )),
-        InsertionError::ConflictRegion(ConflictError::DisconnectedBoundary {
-            visited,
-            total,
-            disconnected_simplices,
-        }) => Some(format!(
+        InsertionError::ConflictRegion {
+            source:
+                ConflictError::DisconnectedBoundary {
+                    visited,
+                    total,
+                    disconnected_simplices,
+                },
+        } => Some(format!(
             "kind=disconnected_boundary visited={visited} total={total} disconnected_simplices={}",
             disconnected_simplices.len()
         )),
-        InsertionError::ConflictRegion(ConflictError::OpenBoundary {
-            facet_count,
-            ridge_vertex_count,
-            ..
-        }) => Some(format!(
+        InsertionError::ConflictRegion {
+            source:
+                ConflictError::OpenBoundary {
+                    facet_count,
+                    ridge_vertex_count,
+                    ..
+                },
+        } => Some(format!(
             "kind=open_boundary facet_count={facet_count} ridge_vertex_count={ridge_vertex_count}"
         )),
         _ => None,
@@ -793,11 +805,11 @@ where
             }
         }
 
-        Err(InsertionError::TopologyValidation(
-            TdsError::InconsistentDataStructure {
+        Err(InsertionError::TopologyValidation {
+            source: TdsError::InconsistentDataStructure {
                 message: "insertion retry loop exhausted without producing an outcome".to_string(),
             },
-        ))
+        })
     }
 
     fn select_locate_hint_from_hash_grid(
@@ -1801,7 +1813,9 @@ where
         let _removed_count = self
             .tds
             .remove_simplices_by_keys(&conflict_simplices)
-            .map_err(|e| InsertionError::TopologyValidation(e.into_inner()))?;
+            .map_err(|e| InsertionError::TopologyValidation {
+                source: e.into_inner(),
+            })?;
 
         // Iteratively repair non-manifold topology until facet sharing is valid
         let mut total_removed = 0;
@@ -1852,14 +1866,14 @@ where
                         "No simplices removed in iteration {} - repair cannot make progress",
                         iteration + 1
                     );
-                    return Err(InsertionError::TopologyValidation(
-                        TdsError::InconsistentDataStructure {
+                    return Err(InsertionError::TopologyValidation {
+                        source: TdsError::InconsistentDataStructure {
                             message: format!(
                                 "Repair stalled: {} over-shared facets remain but no simplices could be removed",
                                 issues.len()
                             ),
                         },
-                    ));
+                    });
                 }
 
                 total_removed += removed;
@@ -2152,12 +2166,14 @@ where
         let inserted_uuid = vertex.uuid();
         let point = *vertex.point();
 
-        vertex.is_valid().map_err(|source| {
-            InsertionError::TopologyValidation(TdsError::InvalidVertex {
-                vertex_id: inserted_uuid,
-                source,
-            })
-        })?;
+        vertex
+            .is_valid()
+            .map_err(|source| InsertionError::TopologyValidation {
+                source: TdsError::InvalidVertex {
+                    vertex_id: inserted_uuid,
+                    source,
+                },
+            })?;
 
         // 1. Insert vertex into Tds
         let mut v_key = self
@@ -2472,12 +2488,12 @@ where
                             // is already heavily mutated and hull extension on that state is unsound.
                             let should_fallback = matches!(
                                 &err,
-                                InsertionError::ConflictRegion(
-                                    ConflictError::NonManifoldFacet { .. }
+                                InsertionError::ConflictRegion {
+                                    source: ConflictError::NonManifoldFacet { .. }
                                         | ConflictError::RidgeFan { .. }
                                         | ConflictError::DisconnectedBoundary { .. }
                                         | ConflictError::OpenBoundary { .. }
-                                )
+                                }
                             );
 
                             if should_fallback {
@@ -2717,14 +2733,14 @@ where
                                 "No simplices removed in iteration {} - repair cannot make progress",
                                 iteration + 1
                             );
-                            return Err(InsertionError::TopologyValidation(
-                                TdsError::InconsistentDataStructure {
+                            return Err(InsertionError::TopologyValidation {
+                                source: TdsError::InconsistentDataStructure {
                                     message: format!(
                                         "Hull extension repair stalled: {} over-shared facets remain but no simplices could be removed",
                                         issues.len()
                                     ),
                                 },
-                            ));
+                            });
                         }
 
                         total_removed += removed;
@@ -3014,40 +3030,48 @@ mod tests {
         let disconnected_simplex = SimplexKey::from(KeyData::from_ffi(11));
         let open_simplex = SimplexKey::from(KeyData::from_ffi(12));
 
-        let non_manifold = InsertionError::ConflictRegion(ConflictError::NonManifoldFacet {
-            facet_hash: 0xABCD,
-            simplex_count: 3,
-        });
+        let non_manifold = InsertionError::ConflictRegion {
+            source: ConflictError::NonManifoldFacet {
+                facet_hash: 0xABCD,
+                simplex_count: 3,
+            },
+        };
         assert_eq!(
             retryable_conflict_trace_detail(&non_manifold).as_deref(),
             Some("kind=non_manifold_facet facet_hash=0xabcd simplex_count=3")
         );
 
-        let ridge_fan = InsertionError::ConflictRegion(ConflictError::RidgeFan {
-            facet_count: 4,
-            ridge_vertex_count: 2,
-            extra_simplices: vec![extra_simplex],
-        });
+        let ridge_fan = InsertionError::ConflictRegion {
+            source: ConflictError::RidgeFan {
+                facet_count: 4,
+                ridge_vertex_count: 2,
+                extra_simplices: vec![extra_simplex],
+            },
+        };
         assert_eq!(
             retryable_conflict_trace_detail(&ridge_fan).as_deref(),
             Some("kind=ridge_fan facet_count=4 ridge_vertex_count=2 extra_simplices=1")
         );
 
-        let disconnected = InsertionError::ConflictRegion(ConflictError::DisconnectedBoundary {
-            visited: 2,
-            total: 5,
-            disconnected_simplices: vec![disconnected_simplex],
-        });
+        let disconnected = InsertionError::ConflictRegion {
+            source: ConflictError::DisconnectedBoundary {
+                visited: 2,
+                total: 5,
+                disconnected_simplices: vec![disconnected_simplex],
+            },
+        };
         assert_eq!(
             retryable_conflict_trace_detail(&disconnected).as_deref(),
             Some("kind=disconnected_boundary visited=2 total=5 disconnected_simplices=1")
         );
 
-        let open = InsertionError::ConflictRegion(ConflictError::OpenBoundary {
-            facet_count: 1,
-            ridge_vertex_count: 2,
-            open_simplex,
-        });
+        let open = InsertionError::ConflictRegion {
+            source: ConflictError::OpenBoundary {
+                facet_count: 1,
+                ridge_vertex_count: 2,
+                open_simplex,
+            },
+        };
         assert_eq!(
             retryable_conflict_trace_detail(&open).as_deref(),
             Some("kind=open_boundary facet_count=1 ridge_vertex_count=2")

--- a/src/core/orientation.rs
+++ b/src/core/orientation.rs
@@ -155,12 +155,14 @@ where
                     "negative geometric orientation detected during validation",
                 );
 
-                return Err(TdsError::Geometric(GeometricError::NegativeOrientation {
-                    message: format!(
-                        "Simplex {:?} (key {simplex_key:?}, vertices {vertex_keys:?}) has negative geometric orientation; expected positive canonical orientation",
-                        simplex.uuid(),
-                    ),
-                }));
+                return Err(TdsError::Geometric {
+                    source: GeometricError::NegativeOrientation {
+                        message: format!(
+                            "Simplex {:?} (key {simplex_key:?}, vertices {vertex_keys:?}) has negative geometric orientation; expected positive canonical orientation",
+                            simplex.uuid(),
+                        ),
+                    },
+                });
             }
         }
 
@@ -197,12 +199,14 @@ where
                     "negative geometric orientation detected during local validation",
                 );
 
-                return Err(TdsError::Geometric(GeometricError::NegativeOrientation {
-                    message: format!(
-                        "Simplex {:?} (key {simplex_key:?}, vertices {vertex_keys:?}) has negative geometric orientation; expected positive canonical orientation",
-                        simplex.uuid(),
-                    ),
-                }));
+                return Err(TdsError::Geometric {
+                    source: GeometricError::NegativeOrientation {
+                        message: format!(
+                            "Simplex {:?} (key {simplex_key:?}, vertices {vertex_keys:?}) has negative geometric orientation; expected positive canonical orientation",
+                            simplex.uuid(),
+                        ),
+                    },
+                });
             }
         }
 
@@ -550,13 +554,15 @@ where
                 "Orientation predicate failed for simplex",
             )?;
             if orientation == 0 {
-                return Err(TdsError::Geometric(GeometricError::DegenerateOrientation {
-                    message: format!(
-                        "Simplex {:?} (key {simplex_key:?}) is geometrically degenerate \
+                return Err(TdsError::Geometric {
+                    source: GeometricError::DegenerateOrientation {
+                        message: format!(
+                            "Simplex {:?} (key {simplex_key:?}) is geometrically degenerate \
                          (zero-volume simplex from collinear/coplanar vertices)",
-                        simplex.uuid(),
-                    ),
-                }));
+                            simplex.uuid(),
+                        ),
+                    },
+                });
             }
         }
         Ok(())
@@ -643,7 +649,7 @@ mod tests {
         let err = tri.validate_geometric_simplex_orientation().unwrap_err();
         assert_matches!(
             &err,
-            TdsError::Geometric(GeometricError::NegativeOrientation { message })
+            TdsError::Geometric { source: GeometricError::NegativeOrientation { message } }
                 if message.contains("negative geometric orientation")
                     && message.contains("vertices"),
             "Error should contain vertex keys: {err}"
@@ -778,7 +784,7 @@ mod tests {
         let err = tri.validate_geometric_simplex_orientation().unwrap_err();
         assert_matches!(
             err,
-            TdsError::Geometric(GeometricError::NegativeOrientation { message })
+            TdsError::Geometric { source: GeometricError::NegativeOrientation { message } }
                 if message.contains("negative geometric orientation")
         );
     }

--- a/src/core/query.rs
+++ b/src/core/query.rs
@@ -128,7 +128,7 @@ impl From<TdsError> for QueryError {
 impl From<ManifoldError> for QueryError {
     fn from(source: ManifoldError) -> Self {
         match source {
-            ManifoldError::Tds(source) => Self::from(source),
+            ManifoldError::Tds { source } => Self::from(source),
             source => Self::TopologyInvalid {
                 source: Box::new(source),
             },
@@ -2379,7 +2379,7 @@ mod tests {
         };
 
         assert_matches!(
-            QueryError::from(ManifoldError::Tds(source)),
+            QueryError::from(ManifoldError::Tds { source }),
             QueryError::TriangulationCorrupted { source }
                 if matches!(
                     source.as_ref(),

--- a/src/core/realization.rs
+++ b/src/core/realization.rs
@@ -127,11 +127,17 @@ impl From<PeriodicSimplexSpanError> for PeriodicDomainPeriodError {
 pub enum TriangulationRealizationValidationError {
     /// Lower-layer element or TDS structural validation failed (Levels 1-2).
     #[error(transparent)]
-    Tds(Box<TdsError>),
+    Tds {
+        /// Boxed TDS source error.
+        source: Box<TdsError>,
+    },
 
     /// Lower-layer topology validation failed (Level 3).
     #[error(transparent)]
-    Triangulation(Box<TriangulationValidationError>),
+    Triangulation {
+        /// Boxed topology-validation source error.
+        source: Box<TriangulationValidationError>,
+    },
 
     /// Realized-overlap validation is not yet defined for this topology model.
     #[error(
@@ -352,13 +358,17 @@ pub enum TriangulationRealizationValidationError {
 
 impl From<TdsError> for TriangulationRealizationValidationError {
     fn from(source: TdsError) -> Self {
-        Self::Tds(Box::new(source))
+        Self::Tds {
+            source: Box::new(source),
+        }
     }
 }
 
 impl From<TriangulationValidationError> for TriangulationRealizationValidationError {
     fn from(source: TriangulationValidationError) -> Self {
-        Self::Triangulation(Box::new(source))
+        Self::Triangulation {
+            source: Box::new(source),
+        }
     }
 }
 
@@ -403,8 +413,10 @@ impl From<&TriangulationRealizationValidationError>
 {
     fn from(source: &TriangulationRealizationValidationError) -> Self {
         match source {
-            TriangulationRealizationValidationError::Tds(_) => Self::Tds,
-            TriangulationRealizationValidationError::Triangulation(_) => Self::Triangulation,
+            TriangulationRealizationValidationError::Tds { source: _ } => Self::Tds,
+            TriangulationRealizationValidationError::Triangulation { source: _ } => {
+                Self::Triangulation
+            }
             TriangulationRealizationValidationError::UnsupportedTopology { .. } => {
                 Self::UnsupportedTopology
             }
@@ -1126,10 +1138,10 @@ impl<K, U, V, const D: usize> Triangulation<K, U, V, D> {
         V: DataType,
     {
         self.validate().map_err(|error| match error {
-            InvariantError::Tds(source) => source.into(),
-            InvariantError::Triangulation(source) => source.into(),
-            InvariantError::Realization(source) => source,
-            source @ InvariantError::Delaunay(_) => {
+            InvariantError::Tds { source } => source.into(),
+            InvariantError::Triangulation { source } => source.into(),
+            InvariantError::Realization { source } => source,
+            source @ InvariantError::Delaunay { source: _ } => {
                 TriangulationRealizationValidationError::UnexpectedValidationLayer {
                     kind: InvariantKind::DelaunayProperty,
                     source: Box::new(source),
@@ -2463,7 +2475,7 @@ mod tests {
         let err = realized.point_for_identity(missing_identity).unwrap_err();
         assert_matches!(
             err,
-            TriangulationRealizationValidationError::Tds(source)
+            TriangulationRealizationValidationError::Tds { source }
                 if matches!(
                     *source,
                     TdsError::VertexNotFound { vertex_key, ref context }
@@ -2545,17 +2557,17 @@ mod tests {
     #[test]
     fn realization_error_kind_covers_wrapped_and_topology_variants() {
         assert_realization_error_kind(
-            &TriangulationRealizationValidationError::Tds(Box::new(
-                TdsError::InconsistentDataStructure {
+            &TriangulationRealizationValidationError::Tds {
+                source: Box::new(TdsError::InconsistentDataStructure {
                     message: "synthetic TDS failure".to_string(),
-                },
-            )),
+                }),
+            },
             TriangulationRealizationValidationErrorKind::Tds,
         );
         assert_realization_error_kind(
-            &TriangulationRealizationValidationError::Triangulation(Box::new(
-                TriangulationValidationError::Disconnected { simplex_count: 2 },
-            )),
+            &TriangulationRealizationValidationError::Triangulation {
+                source: Box::new(TriangulationValidationError::Disconnected { simplex_count: 2 }),
+            },
             TriangulationRealizationValidationErrorKind::Triangulation,
         );
         assert_realization_error_kind(
@@ -2700,8 +2712,8 @@ mod tests {
         assert_realization_error_kind(
             &TriangulationRealizationValidationError::UnexpectedValidationLayer {
                 kind: InvariantKind::DelaunayProperty,
-                source: Box::new(InvariantError::Delaunay(
-                    DelaunayTriangulationValidationError::VerificationFailed {
+                source: Box::new(InvariantError::Delaunay {
+                    source: DelaunayTriangulationValidationError::VerificationFailed {
                         source: Box::new(DelaunayVerificationError::from(
                             DelaunayValidationError::TriangulationState {
                                 source: TdsError::InconsistentDataStructure {
@@ -2710,7 +2722,7 @@ mod tests {
                             },
                         )),
                     },
-                )),
+                }),
             },
             TriangulationRealizationValidationErrorKind::UnexpectedValidationLayer,
         );

--- a/src/core/realization.rs
+++ b/src/core/realization.rs
@@ -126,16 +126,18 @@ impl From<PeriodicSimplexSpanError> for PeriodicDomainPeriodError {
 #[non_exhaustive]
 pub enum TriangulationRealizationValidationError {
     /// Lower-layer element or TDS structural validation failed (Levels 1-2).
-    #[error(transparent)]
+    #[error("{source}")]
     Tds {
         /// Boxed TDS source error.
+        #[source]
         source: Box<TdsError>,
     },
 
     /// Lower-layer topology validation failed (Level 3).
-    #[error(transparent)]
+    #[error("{source}")]
     Triangulation {
         /// Boxed topology-validation source error.
+        #[source]
         source: Box<TriangulationValidationError>,
     },
 
@@ -2482,6 +2484,36 @@ mod tests {
                         if vertex_key == missing_identity.key
                             && context.contains(&format!("offset {:?}", missing_identity.offset))
                 )
+        );
+    }
+
+    #[test]
+    fn lower_layer_realization_errors_preserve_typed_sources() {
+        let expected_tds_source = TdsError::InconsistentDataStructure {
+            message: "invalid TDS".to_string(),
+        };
+        let tds_error = TriangulationRealizationValidationError::Tds {
+            source: Box::new(expected_tds_source.clone()),
+        };
+        let tds_source = std::error::Error::source(&tds_error)
+            .expect("TDS realization error should preserve its source");
+        assert_eq!(
+            tds_source.downcast_ref::<Box<TdsError>>().map(Box::as_ref),
+            Some(&expected_tds_source),
+        );
+
+        let expected_triangulation_source =
+            TriangulationValidationError::Disconnected { simplex_count: 2 };
+        let triangulation_error = TriangulationRealizationValidationError::Triangulation {
+            source: Box::new(expected_triangulation_source.clone()),
+        };
+        let triangulation_source = std::error::Error::source(&triangulation_error)
+            .expect("triangulation realization error should preserve its source");
+        assert_eq!(
+            triangulation_source
+                .downcast_ref::<Box<TriangulationValidationError>>()
+                .map(Box::as_ref),
+            Some(&expected_triangulation_source),
         );
     }
 

--- a/src/core/repair.rs
+++ b/src/core/repair.rs
@@ -513,7 +513,9 @@ where
                 let mut simplices_removed = tri
                     .tds
                     .remove_simplices_by_keys(simplices_to_remove)
-                    .map_err(|e| InvariantError::Tds(e.into_inner()))?;
+                    .map_err(|e| InvariantError::Tds {
+                    source: e.into_inner(),
+                })?;
                 let max_repair_simplices_removed = simplices_to_remove.len();
                 let mut post_repair_frontier = SimplexKeyBuffer::new();
 
@@ -526,7 +528,9 @@ where
 
                 tri.tds
                     .remove_vertex(vertex_key)
-                    .map_err(|e| InvariantError::Tds(e.into_inner()))?;
+                    .map_err(|e| InvariantError::Tds {
+                        source: e.into_inner(),
+                    })?;
 
                 let surviving_new_simplices = tri.live_simplices_from(&new_simplices);
                 let validation_scope = tri.vertex_removal_validation_scope(
@@ -643,7 +647,7 @@ where
                 })?;
             self.tds
                 .normalize_coherent_orientation()
-                .map_err(InvariantError::Tds)?;
+                .map_err(|source| InvariantError::Tds { source })?;
             if self
                 .validate_geometric_simplex_orientation_for_simplices(validation_scope)
                 .is_ok()
@@ -696,12 +700,12 @@ where
                 let Some(vertex) = self.tds.vertex(vertex_key) else {
                     continue;
                 };
-                return Err(InvariantError::Triangulation(
-                    TriangulationValidationError::IsolatedVertex {
+                return Err(InvariantError::Triangulation {
+                    source: TriangulationValidationError::IsolatedVertex {
                         vertex_key,
                         vertex_uuid: vertex.uuid(),
                     },
-                ));
+                });
             };
 
             if let Some(vertex) = self.tds.vertex_mut(vertex_key) {
@@ -726,11 +730,15 @@ where
         let result = {
             let tri = transaction.triangulation_mut();
             (|| -> Result<usize, InvariantError> {
-                let simplices_removed = tri
-                    .tds
-                    .remove_vertex(vertex_key)
-                    .map_err(|e| InvariantError::Tds(e.into_inner()))?;
-                tri.tds.is_valid().map_err(InvariantError::Tds)?;
+                let simplices_removed =
+                    tri.tds
+                        .remove_vertex(vertex_key)
+                        .map_err(|e| InvariantError::Tds {
+                            source: e.into_inner(),
+                        })?;
+                tri.tds
+                    .is_valid()
+                    .map_err(|source| InvariantError::Tds { source })?;
                 tri.is_valid_topology()?;
                 Ok(simplices_removed)
             })()
@@ -757,12 +765,15 @@ where
         let mut affected_vertices =
             fast_hash_set_with_capacity(simplices_to_remove.len().saturating_mul(D));
         for &simplex_key in simplices_to_remove {
-            let simplex = self.tds.simplex(simplex_key).ok_or_else(|| {
-                InvariantError::Tds(TdsError::SimplexNotFound {
-                    simplex_key,
-                    context: "collecting affected vertices for vertex removal".to_string(),
-                })
-            })?;
+            let simplex = self
+                .tds
+                .simplex(simplex_key)
+                .ok_or_else(|| InvariantError::Tds {
+                    source: TdsError::SimplexNotFound {
+                        simplex_key,
+                        context: "collecting affected vertices for vertex removal".to_string(),
+                    },
+                })?;
             for &vertex_key in simplex.vertices() {
                 if vertex_key != removed_vertex {
                     affected_vertices.insert(vertex_key);
@@ -828,18 +839,22 @@ where
         validation_scope: &SimplexKeyBuffer,
     ) -> Result<(), InvariantError> {
         if self.tds.contains_vertex_key(removed_vertex) {
-            return Err(InvariantError::Tds(TdsError::InconsistentDataStructure {
-                message: format!(
-                    "Removed vertex {removed_vertex:?} still exists after vertex-removal finalization"
-                ),
-            }));
+            return Err(InvariantError::Tds {
+                source: TdsError::InconsistentDataStructure {
+                    message: format!(
+                        "Removed vertex {removed_vertex:?} still exists after vertex-removal finalization"
+                    ),
+                },
+            });
         }
 
         if self.tds.number_of_simplices() == 0
             || surviving_new_simplices.is_empty()
             || validation_scope.is_empty()
         {
-            self.tds.is_valid().map_err(InvariantError::Tds)?;
+            self.tds
+                .is_valid()
+                .map_err(|source| InvariantError::Tds { source })?;
             self.is_valid_topology()?;
             return Ok(());
         }
@@ -856,10 +871,12 @@ where
 
         #[cfg(debug_assertions)]
         {
-            self.tds.is_valid().map_err(InvariantError::Tds)?;
+            self.tds
+                .is_valid()
+                .map_err(|source| InvariantError::Tds { source })?;
             self.is_valid_topology()?;
             self.is_valid_realization()
-                .map_err(InvariantError::Realization)?;
+                .map_err(|source| InvariantError::Realization { source })?;
         }
 
         Ok(())
@@ -882,12 +899,12 @@ where
                 continue;
             }
 
-            return Err(InvariantError::Triangulation(
-                TriangulationValidationError::IsolatedVertex {
+            return Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::IsolatedVertex {
                     vertex_key,
                     vertex_uuid: vertex.uuid(),
                 },
-            ));
+            });
         }
         Ok(())
     }
@@ -1248,7 +1265,7 @@ where
 
         let to_remove = self
             .simplices_for_local_facet_issue_repair(issues)
-            .map_err(InsertionError::TopologyValidation)?;
+            .map_err(|source| InsertionError::TopologyValidation { source })?;
         let attempted = to_remove.len();
         if attempted > max_simplices_removed {
             return Err(InsertionError::MaxSimplicesRemovedExceeded {
@@ -1259,10 +1276,11 @@ where
         let mut affected_vertices = IncidentRepairVertexBuffer::new();
         self.extend_incident_repair_vertices_from_simplices(&to_remove, &mut affected_vertices);
         let frontier_simplices = self.collect_local_repair_frontier(issues, &to_remove);
-        let removed_count = self
-            .tds
-            .remove_simplices_by_keys(&to_remove)
-            .map_err(|e| InsertionError::TopologyValidation(e.into_inner()))?;
+        let removed_count = self.tds.remove_simplices_by_keys(&to_remove).map_err(|e| {
+            InsertionError::TopologyValidation {
+                source: e.into_inner(),
+            }
+        })?;
 
         Ok(LocalFacetRepairOutcome {
             removed_count,
@@ -1376,9 +1394,11 @@ where
                     &new_simplices,
                     &outcome.frontier_simplices,
                 )?;
-                tri.tds
-                    .assign_incident_simplices()
-                    .map_err(|error| InsertionError::TopologyValidation(error.into_inner()))?;
+                tri.tds.assign_incident_simplices().map_err(|error| {
+                    InsertionError::TopologyValidation {
+                        source: error.into_inner(),
+                    }
+                })?;
                 tri.validate()
                     .map_err(Self::invariant_error_to_insertion_error)?;
 
@@ -1884,10 +1904,10 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(InsertionError::TopologyValidation(TdsError::SimplexNotFound {
+            Err(InsertionError::TopologyValidation { source: TdsError::SimplexNotFound {
                 simplex_key,
                 ..
-            })) if simplex_key == ck
+            } }) if simplex_key == ck
         );
     }
 
@@ -1964,10 +1984,10 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(InvariantError::Tds(TdsError::SimplexNotFound {
+            Err(InvariantError::Tds { source: TdsError::SimplexNotFound {
                 simplex_key,
                 ..
-            })) if simplex_key == missing_simplex
+            } }) if simplex_key == missing_simplex
         );
     }
 
@@ -2098,12 +2118,12 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(InvariantError::Triangulation(
+            Err(InvariantError::Triangulation { source:
                 TriangulationValidationError::IsolatedVertex {
                     vertex_key,
                     ..
                 },
-            )) if vertex_key == isolated_survivor
+             }) if vertex_key == isolated_survivor
         );
         assert_eq!(tri.tds.number_of_vertices(), vertex_count);
         assert_eq!(tri.tds.number_of_simplices(), simplex_count);
@@ -2163,9 +2183,9 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(InvariantError::Triangulation(
+            Err(InvariantError::Triangulation { source:
                 TriangulationValidationError::IsolatedVertex { vertex_key, .. }
-            )) if vertex_key == v3
+             }) if vertex_key == v3
         );
     }
 
@@ -2187,9 +2207,9 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(InvariantError::Tds(
-                TdsError::InconsistentDataStructure { .. }
-            ))
+            Err(InvariantError::Tds {
+                source: TdsError::InconsistentDataStructure { .. }
+            })
         );
     }
 
@@ -2310,9 +2330,9 @@ mod tests {
                     ref source
                 } if matches!(
                     source.as_ref(),
-                    InvariantError::Triangulation(
+                    InvariantError::Triangulation { source:
                         TriangulationValidationError::IsolatedVertex { .. }
-                    )
+                     }
                 )
             ),
             "expected isolated-vertex invariant failure, got {error:?}"
@@ -2382,7 +2402,9 @@ mod tests {
                 tri.validate()
                     .expect("successful public repair should leave valid topology");
             }
-            Err(InsertionError::TopologyValidation(TdsError::DuplicateSimplices { .. })) => {
+            Err(InsertionError::TopologyValidation {
+                source: TdsError::DuplicateSimplices { .. },
+            }) => {
                 assert_eq!(tri.tds.number_of_simplices(), original_simplex_count);
             }
             Err(error) => panic!("unexpected duplicate-simplex repair error: {error:?}"),
@@ -2523,7 +2545,7 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(InvariantError::Tds(TdsError::InconsistentDataStructure { ref message }))
+            Err(InvariantError::Tds { source: TdsError::InconsistentDataStructure { ref message } })
                 if message.contains("Local facet repair after vertex removal failed")
                     && message.contains("Local facet repair removal budget exceeded")
         );

--- a/src/core/tds/errors.rs
+++ b/src/core/tds/errors.rs
@@ -1574,6 +1574,17 @@ mod tests {
                 DelaunayValidationErrorKind::Triangulation,
             ),
             (
+                DelaunayTriangulationValidationError::Realization {
+                    source: Box::new(
+                        TriangulationRealizationValidationError::UnsupportedTopology {
+                            topology: TopologyKind::Hyperbolic,
+                            dimension: 2,
+                        },
+                    ),
+                },
+                DelaunayValidationErrorKind::Realization,
+            ),
+            (
                 synthetic_delaunay_verification_error("non-Delaunay facet"),
                 DelaunayValidationErrorKind::VerificationFailed,
             ),

--- a/src/core/tds/errors.rs
+++ b/src/core/tds/errors.rs
@@ -71,8 +71,12 @@ impl Default for TriangulationConstructionState {
 #[non_exhaustive]
 pub enum TdsConstructionError {
     /// Validation error during construction.
-    #[error("Validation error during construction: {0}")]
-    ValidationError(#[from] TdsError),
+    #[error("Validation error during construction: {source}")]
+    ValidationError {
+        /// Typed TDS validation source error.
+        #[from]
+        source: TdsError,
+    },
     /// Attempted to insert an entity with a UUID that already exists.
     #[error("Duplicate UUID: {entity:?} with UUID {uuid} already exists")]
     DuplicateUuid {
@@ -784,11 +788,19 @@ pub enum TdsError {
     /// This wraps a [`GeometricError`] and indicates a floating-point or geometric
     /// degeneracy issue rather than an internal data structure bug.
     #[error(transparent)]
-    Geometric(#[from] GeometricError),
+    Geometric {
+        /// Typed geometric source error.
+        #[from]
+        source: GeometricError,
+    },
 
     /// Facet operation failed during validation.
-    #[error("Facet operation failed: {0}")]
-    FacetError(#[from] FacetError),
+    #[error("Facet operation failed: {source}")]
+    FacetError {
+        /// Typed facet source error.
+        #[from]
+        source: FacetError,
+    },
     /// A simplex contains two or more vertices with identical coordinates.
     ///
     /// This is distinct from [`SimplexValidationError::DuplicateVertices`] which checks
@@ -873,8 +885,8 @@ impl From<&TdsError> for TdsErrorKind {
             TdsError::RemovedSimplexStillIncident { .. } => Self::RemovedSimplexStillIncident,
             TdsError::VertexIncidenceMismatch { .. } => Self::VertexIncidenceMismatch,
             TdsError::InconsistentDataStructure { .. } => Self::InconsistentDataStructure,
-            TdsError::Geometric(_) => Self::Geometric,
-            TdsError::FacetError(_) => Self::FacetError,
+            TdsError::Geometric { source: _ } => Self::Geometric,
+            TdsError::FacetError { source: _ } => Self::FacetError,
             TdsError::DuplicateCoordinatesInSimplex { .. } => Self::DuplicateCoordinatesInSimplex,
         }
     }
@@ -1000,10 +1012,12 @@ pub enum InvariantKind {
 /// ```
 /// use delaunay::prelude::tds::{InvariantError, TdsError};
 ///
-/// let err = InvariantError::Tds(TdsError::InconsistentDataStructure {
-///     message: "bad neighbors".to_string(),
-/// });
-/// std::assert_matches!(err, InvariantError::Tds(_));
+/// let err = InvariantError::Tds {
+///     source: TdsError::InconsistentDataStructure {
+///         message: "bad neighbors".to_string(),
+///     },
+/// };
+/// std::assert_matches!(err, InvariantError::Tds { .. });
 /// ```
 ///
 /// This is used by [`TriangulationValidationReport`] so that diagnostic reporting can
@@ -1014,19 +1028,35 @@ pub enum InvariantKind {
 pub enum InvariantError {
     /// Level 1–2 (elements + TDS structure).
     #[error(transparent)]
-    Tds(#[from] TdsError),
+    Tds {
+        /// Typed TDS source error.
+        #[from]
+        source: TdsError,
+    },
 
     /// Level 3 (topology).
     #[error(transparent)]
-    Triangulation(#[from] TriangulationValidationError),
+    Triangulation {
+        /// Typed topology-validation source error.
+        #[from]
+        source: TriangulationValidationError,
+    },
 
     /// Level 4 (realized geometry).
     #[error(transparent)]
-    Realization(#[from] TriangulationRealizationValidationError),
+    Realization {
+        /// Typed realization-validation source error.
+        #[from]
+        source: TriangulationRealizationValidationError,
+    },
 
     /// Level 5 (Delaunay property).
     #[error(transparent)]
-    Delaunay(#[from] DelaunayTriangulationValidationError),
+    Delaunay {
+        /// Typed Delaunay-validation source error.
+        #[from]
+        source: DelaunayTriangulationValidationError,
+    },
 }
 
 /// Discriminant for compact Level 3 topology-validation summaries.
@@ -1111,9 +1141,11 @@ pub enum DelaunayValidationErrorKind {
 impl From<&DelaunayTriangulationValidationError> for DelaunayValidationErrorKind {
     fn from(source: &DelaunayTriangulationValidationError) -> Self {
         match source {
-            DelaunayTriangulationValidationError::Tds(_) => Self::Tds,
-            DelaunayTriangulationValidationError::Triangulation(_) => Self::Triangulation,
-            DelaunayTriangulationValidationError::Realization(_) => Self::Realization,
+            DelaunayTriangulationValidationError::Tds { source: _ } => Self::Tds,
+            DelaunayTriangulationValidationError::Triangulation { source: _ } => {
+                Self::Triangulation
+            }
+            DelaunayTriangulationValidationError::Realization { source: _ } => Self::Realization,
             DelaunayTriangulationValidationError::VerificationFailed { .. } => {
                 Self::VerificationFailed
             }
@@ -1135,9 +1167,11 @@ impl From<&DelaunayTriangulationValidationError> for DelaunayValidationErrorKind
 ///
 /// let violation = InvariantViolation {
 ///     kind: InvariantKind::Topology,
-///     error: InvariantError::Tds(TdsError::InconsistentDataStructure {
-///         message: "bad neighbors".to_string(),
-///     }),
+///     error: InvariantError::Tds {
+///         source: TdsError::InconsistentDataStructure {
+///             message: "bad neighbors".to_string(),
+///         },
+///     },
 /// };
 /// assert_eq!(violation.kind, InvariantKind::Topology);
 /// ```
@@ -1270,16 +1304,20 @@ mod tests {
             TdsErrorKind::OrientationViolation,
         );
         assert_tds_error_kind(
-            &TdsError::Geometric(GeometricError::DegenerateOrientation {
-                message: "zero determinant".to_string(),
-            }),
+            &TdsError::Geometric {
+                source: GeometricError::DegenerateOrientation {
+                    message: "zero determinant".to_string(),
+                },
+            },
             TdsErrorKind::Geometric,
         );
         assert_tds_error_kind(
-            &TdsError::FacetError(FacetError::InvalidFacetIndex {
-                index: 4,
-                facet_count: 4,
-            }),
+            &TdsError::FacetError {
+                source: FacetError::InvalidFacetIndex {
+                    index: 4,
+                    facet_count: 4,
+                },
+            },
             TdsErrorKind::FacetError,
         );
         assert_tds_error_kind(
@@ -1613,9 +1651,14 @@ mod tests {
         let inner = GeometricError::DegenerateOrientation {
             message: "test".to_string(),
         };
-        let err = TdsError::Geometric(inner.clone());
+        let err = TdsError::Geometric {
+            source: inner.clone(),
+        };
         assert!(err.to_string().contains("test"));
-        assert_eq!(TdsError::from(inner.clone()), TdsError::Geometric(inner));
+        assert_eq!(
+            TdsError::from(inner.clone()),
+            TdsError::Geometric { source: inner }
+        );
     }
 
     #[test]
@@ -1639,7 +1682,7 @@ mod tests {
             message: "test".to_string(),
         };
         let inv = InvariantError::from(tds_err);
-        assert_matches!(inv, InvariantError::Tds(_));
+        assert_matches!(inv, InvariantError::Tds { source: _ });
 
         let tri_err = TriangulationValidationError::EulerCharacteristicMismatch {
             computed: 1,
@@ -1647,14 +1690,14 @@ mod tests {
             classification: TopologyClassification::Ball(3),
         };
         let inv = InvariantError::from(tri_err);
-        assert_matches!(inv, InvariantError::Triangulation(_));
+        assert_matches!(inv, InvariantError::Triangulation { source: _ });
     }
 
     #[test]
     fn test_invariant_error_from_delaunay_validation_error() {
         let dt_err = synthetic_delaunay_verification_error("test");
         let inv = InvariantError::from(dt_err);
-        assert_matches!(inv, InvariantError::Delaunay(_));
+        assert_matches!(inv, InvariantError::Delaunay { source: _ });
     }
 
     #[test]
@@ -1689,12 +1732,14 @@ mod tests {
     fn test_invariant_violation_stores_kind_and_error() {
         let violation = InvariantViolation {
             kind: InvariantKind::NeighborConsistency,
-            error: InvariantError::Tds(TdsError::InconsistentDataStructure {
-                message: "test".to_string(),
-            }),
+            error: InvariantError::Tds {
+                source: TdsError::InconsistentDataStructure {
+                    message: "test".to_string(),
+                },
+            },
         };
         assert_eq!(violation.kind, InvariantKind::NeighborConsistency);
-        assert_matches!(violation.error, InvariantError::Tds(_));
+        assert_matches!(violation.error, InvariantError::Tds { source: _ });
     }
 
     #[test]
@@ -1725,7 +1770,9 @@ mod tests {
         let tds_err: TdsError = geo.into();
         assert_matches!(
             tds_err,
-            TdsError::Geometric(GeometricError::NegativeOrientation { .. })
+            TdsError::Geometric {
+                source: GeometricError::NegativeOrientation { .. }
+            }
         );
         // Display propagates via #[error(transparent)].
         assert!(tds_err.to_string().contains("det<0"));

--- a/src/core/tds/mutation.rs
+++ b/src/core/tds/mutation.rs
@@ -357,7 +357,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         let vertex_key = self.vertices.insert(vertex);
         if let Err(source) = self.insert_empty_vertex_incidence(vertex_key) {
             self.vertices.remove(vertex_key);
-            return Err(TdsConstructionError::ValidationError(source));
+            return Err(TdsConstructionError::ValidationError { source });
         }
         self.uuid_to_vertex_key.insert(vertex_uuid, vertex_key);
         self.refresh_incomplete_construction_state();
@@ -439,13 +439,13 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         topology_check: SimplexInsertionTopologyCheck,
     ) -> Result<SimplexKey, TdsConstructionError> {
         if simplex.number_of_vertices() != D + 1 {
-            return Err(TdsConstructionError::ValidationError(
-                TdsError::DimensionMismatch {
+            return Err(TdsConstructionError::ValidationError {
+                source: TdsError::DimensionMismatch {
                     expected: D + 1,
                     actual: simplex.number_of_vertices(),
                     context: format!("{D}-dimensional simplex vertex count"),
                 },
-            ));
+            });
         }
 
         let simplex_uuid = simplex.uuid();
@@ -471,7 +471,7 @@ impl<U, V, const D: usize> Tds<U, V, D> {
         if let Err(source) = self.add_simplex_to_vertex_incidence(simplex_key, &simplex_vertices) {
             self.simplices.remove(simplex_key);
             self.uuid_to_simplex_key.remove(&simplex_uuid);
-            return Err(TdsConstructionError::ValidationError(source));
+            return Err(TdsConstructionError::ValidationError { source });
         }
         // Topology changed; invalidate caches.
         self.bump_generation();
@@ -599,12 +599,12 @@ impl<U, V, const D: usize> Tds<U, V, D> {
     ) -> Result<(), TdsConstructionError> {
         for &vkey in simplex.vertices() {
             if !self.vertices.contains_key(vkey) {
-                return Err(TdsConstructionError::ValidationError(
-                    TdsError::VertexNotFound {
+                return Err(TdsConstructionError::ValidationError {
+                    source: TdsError::VertexNotFound {
                         vertex_key: vkey,
                         context: "referenced by simplex being inserted".to_string(),
                     },
-                ));
+                });
             }
         }
         Ok(())
@@ -3392,7 +3392,9 @@ mod tests {
         let err = tds.insert_simplex_with_mapping(simplex).unwrap_err();
         assert_matches!(
             err,
-            TdsConstructionError::ValidationError(TdsError::VertexNotFound { .. })
+            TdsConstructionError::ValidationError {
+                source: TdsError::VertexNotFound { .. }
+            }
         );
     }
 
@@ -3413,7 +3415,9 @@ mod tests {
             .unwrap_err();
         assert_matches!(
             err,
-            TdsConstructionError::ValidationError(TdsError::VertexNotFound { .. })
+            TdsConstructionError::ValidationError {
+                source: TdsError::VertexNotFound { .. }
+            }
         );
     }
 
@@ -3462,11 +3466,13 @@ mod tests {
 
         assert_matches!(
             err,
-            TdsConstructionError::ValidationError(TdsError::DimensionMismatch {
-                expected: 3,
-                actual: 2,
-                ..
-            })
+            TdsConstructionError::ValidationError {
+                source: TdsError::DimensionMismatch {
+                    expected: 3,
+                    actual: 2,
+                    ..
+                }
+            }
         );
         assert_eq!(tds.number_of_simplices(), 0);
         assert_eq!(tds.generation(), generation_before);
@@ -3507,9 +3513,9 @@ mod tests {
 
         assert_matches!(
             err,
-            TdsConstructionError::ValidationError(TdsError::InconsistentDataStructure {
+            TdsConstructionError::ValidationError { source: TdsError::InconsistentDataStructure {
                 message
-            }) if message.contains("Failed to derive periodic facet key")
+            } } if message.contains("Failed to derive periodic facet key")
         );
         assert_eq!(tds.number_of_simplices(), 1);
         assert_eq!(tds.generation(), generation_before);
@@ -3541,7 +3547,9 @@ mod tests {
 
         assert_matches!(
             err,
-            TdsConstructionError::ValidationError(TdsError::DuplicateSimplices { .. })
+            TdsConstructionError::ValidationError {
+                source: TdsError::DuplicateSimplices { .. }
+            }
         );
         assert_eq!(tds.number_of_simplices(), 1);
         assert_eq!(tds.generation(), generation_before);
@@ -3582,14 +3590,17 @@ mod tests {
         let err = tds.insert_simplex_with_mapping(candidate).unwrap_err();
 
         match err {
-            TdsConstructionError::ValidationError(TdsError::FacetSharingViolation {
-                existing_incident_count,
-                attempted_incident_count,
-                max_incident_count,
-                candidate_simplex_uuid,
-                candidate_facet_index,
-                ..
-            }) => {
+            TdsConstructionError::ValidationError {
+                source:
+                    TdsError::FacetSharingViolation {
+                        existing_incident_count,
+                        attempted_incident_count,
+                        max_incident_count,
+                        candidate_simplex_uuid,
+                        candidate_facet_index,
+                        ..
+                    },
+            } => {
                 assert_eq!(existing_incident_count, 2);
                 assert_eq!(attempted_incident_count, 3);
                 assert_eq!(max_incident_count, 2);

--- a/src/core/tds/validation.rs
+++ b/src/core/tds/validation.rs
@@ -3993,7 +3993,9 @@ mod tests {
             .expect("validation_report should include the facet-sharing violation");
         assert_matches!(
             &facet_violation.error,
-            InvariantError::Tds(TdsError::FacetSharingViolation { .. }),
+            InvariantError::Tds {
+                source: TdsError::FacetSharingViolation { .. }
+            },
             "Expected validation_report to preserve structured facet-sharing error, got {:?}",
             facet_violation.error
         );

--- a/src/core/validation.rs
+++ b/src/core/validation.rs
@@ -146,27 +146,29 @@ use uuid::Uuid;
 /// Convert an [`InsertionError`] into the appropriate [`InvariantError`], preserving
 /// structured error information across all layers.
 ///
-/// - `TopologyValidation(source)` → `InvariantError::Tds(source)` (Level 1–2 preserved)
-/// - `TopologyValidationFailed { source }` → `InvariantError::Triangulation(source)` (Level 3 preserved)
-/// - `RealizationValidationFailed { source }` → `InvariantError::Realization(source)` (Level 4 preserved)
-/// - `DelaunayValidationFailed { source }` → `InvariantError::Delaunay(source)` (Level 5 preserved)
-/// - All other variants → `InvariantError::Tds(InconsistentDataStructure { .. })` with `context`
+/// - `TopologyValidation { source }` → `InvariantError::Tds { source }` (Level 1–2 preserved)
+/// - `TopologyValidationFailed { source }` → `InvariantError::Triangulation { source }` (Level 3 preserved)
+/// - `RealizationValidationFailed { source }` → `InvariantError::Realization { source }` (Level 4 preserved)
+/// - `DelaunayValidationFailed { source }` → `InvariantError::Delaunay { source }` (Level 5 preserved)
+/// - All other variants → `InvariantError::Tds { source: InconsistentDataStructure { .. } }` with `context`
 pub(crate) fn insertion_error_to_invariant_error(
     error: InsertionError,
     context: &str,
 ) -> InvariantError {
     match error {
-        InsertionError::TopologyValidation(source) => InvariantError::Tds(source),
+        InsertionError::TopologyValidation { source } => InvariantError::Tds { source },
         InsertionError::TopologyValidationFailed { source, .. } => {
-            InvariantError::Triangulation(source)
+            InvariantError::Triangulation { source }
         }
         InsertionError::RealizationValidationFailed { source } => {
-            InvariantError::Realization(source)
+            InvariantError::Realization { source }
         }
-        InsertionError::DelaunayValidationFailed { source } => InvariantError::Delaunay(source),
-        other => InvariantError::Tds(TdsError::InconsistentDataStructure {
-            message: format!("{context}: {other}"),
-        }),
+        InsertionError::DelaunayValidationFailed { source } => InvariantError::Delaunay { source },
+        other => InvariantError::Tds {
+            source: TdsError::InconsistentDataStructure {
+                message: format!("{context}: {other}"),
+            },
+        },
     }
 }
 
@@ -461,7 +463,7 @@ impl TryFrom<ManifoldError> for TriangulationValidationError {
 
     fn try_from(err: ManifoldError) -> Result<Self, Self::Error> {
         match err {
-            ManifoldError::Tds(source) => Err(source),
+            ManifoldError::Tds { source } => Err(source),
             ManifoldError::ManifoldFacetMultiplicity {
                 facet_key,
                 simplex_count,
@@ -544,8 +546,8 @@ impl TryFrom<ManifoldError> for TriangulationValidationError {
 impl From<ManifoldError> for InvariantError {
     fn from(err: ManifoldError) -> Self {
         match TriangulationValidationError::try_from(err) {
-            Ok(source) => Self::Triangulation(source),
-            Err(source) => Self::Tds(source),
+            Ok(source) => Self::Triangulation { source },
+            Err(source) => Self::Tds { source },
         }
     }
 }
@@ -560,8 +562,10 @@ fn invariant_error_from_topology_error(err: TopologyError) -> InvariantError {
     match err {
         TopologyError::FacetMapBuild { source }
         | TopologyError::BoundaryFacetEnumeration { source }
-        | TopologyError::BoundaryFacetCount { source } => InvariantError::Tds(source),
-        TopologyError::BoundaryFacetSimplexAccess { source } => InvariantError::Tds(source.into()),
+        | TopologyError::BoundaryFacetCount { source } => InvariantError::Tds { source },
+        TopologyError::BoundaryFacetSimplexAccess { source } => InvariantError::Tds {
+            source: source.into(),
+        },
         TopologyError::BoundaryClassification { source } => InvariantError::from(*source),
     }
 }
@@ -1775,7 +1779,7 @@ where
         if let Err(source) = self.validate_global_connectedness() {
             violations.push(InvariantViolation {
                 kind: InvariantKind::Connectedness,
-                error: InvariantError::Triangulation(source),
+                error: InvariantError::Triangulation { source },
             });
         }
 
@@ -2026,23 +2030,27 @@ where
 
     /// Convert an [`InvariantError`] into the appropriate [`InsertionError`] variant.
     ///
-    /// - `InvariantError::Tds(e)` → `InsertionError::TopologyValidation(e)`
-    /// - `InvariantError::Triangulation(e)` → `InsertionError::TopologyValidationFailed { source: e }`
-    /// - `InvariantError::Realization(e)` → `InsertionError::RealizationValidationFailed { source: e }`
-    /// - `InvariantError::Delaunay(e)` → `InsertionError::DelaunayValidationFailed { source: e }`
+    /// - `InvariantError::Tds { source }` → `InsertionError::TopologyValidation { source }`
+    /// - `InvariantError::Triangulation { source }` → `InsertionError::TopologyValidationFailed { source }`
+    /// - `InvariantError::Realization { source }` → `InsertionError::RealizationValidationFailed { source }`
+    /// - `InvariantError::Delaunay { source }` → `InsertionError::DelaunayValidationFailed { source }`
     pub(crate) fn invariant_error_to_insertion_error(err: InvariantError) -> InsertionError {
         match err {
-            InvariantError::Tds(tds_err) => InsertionError::TopologyValidation(tds_err),
-            InvariantError::Triangulation(tri_err) => InsertionError::TopologyValidationFailed {
-                context: InsertionTopologyValidationContext::InvariantConversion,
-                source: tri_err,
-            },
-            InvariantError::Realization(realization_err) => {
-                InsertionError::RealizationValidationFailed {
-                    source: realization_err,
+            InvariantError::Tds { source: tds_err } => {
+                InsertionError::TopologyValidation { source: tds_err }
+            }
+            InvariantError::Triangulation { source: tri_err } => {
+                InsertionError::TopologyValidationFailed {
+                    context: InsertionTopologyValidationContext::InvariantConversion,
+                    source: tri_err,
                 }
             }
-            InvariantError::Delaunay(dt_err) => {
+            InvariantError::Realization {
+                source: realization_err,
+            } => InsertionError::RealizationValidationFailed {
+                source: realization_err,
+            },
+            InvariantError::Delaunay { source: dt_err } => {
                 InsertionError::DelaunayValidationFailed { source: dt_err }
             }
         }
@@ -2082,7 +2090,7 @@ where
         // checks so topology diagnostics still surface first.
         let simplex_keys: SimplexKeyBuffer = self.tds.simplex_keys().collect();
         self.validate_local_realization_orientation(&simplex_keys)
-            .map_err(InvariantError::Realization)?;
+            .map_err(|source| InvariantError::Realization { source })?;
 
         Ok(())
     }
@@ -2110,24 +2118,25 @@ where
         }
 
         if new_set.is_empty() {
-            return Err(InsertionError::TopologyValidation(
+            return Err(InsertionError::TopologyValidation {
+                source:
                 TdsError::InconsistentDataStructure {
                     message: "Disconnected triangulation detected after insertion: no surviving new simplices"
                         .to_string(),
                 },
-            ));
+             });
         }
 
         let expected_new_simplices = new_set.len();
 
         let Some(&start) = new_set.iter().next() else {
-            return Err(InsertionError::TopologyValidation(
-                TdsError::InconsistentDataStructure {
+            return Err(InsertionError::TopologyValidation {
+                source: TdsError::InconsistentDataStructure {
                     message:
                         "new_set unexpectedly empty after non-empty check in validate_connectedness"
                             .to_string(),
                 },
-            ));
+            });
         };
 
         let mut touches_existing_simplices = false;
@@ -2156,25 +2165,25 @@ where
         );
 
         if visited.len() != expected_new_simplices {
-            return Err(InsertionError::TopologyValidation(
-                TdsError::InconsistentDataStructure {
+            return Err(InsertionError::TopologyValidation {
+                source: TdsError::InconsistentDataStructure {
                     message: format!(
                         "Disconnected triangulation detected after insertion: new-simplex subgraph visited {} of {} simplices",
                         visited.len(),
                         expected_new_simplices
                     ),
                 },
-            ));
+            });
         }
 
         if total_simplices > expected_new_simplices && !touches_existing_simplices {
-            return Err(InsertionError::TopologyValidation(
-                TdsError::InconsistentDataStructure {
+            return Err(InsertionError::TopologyValidation {
+                source: TdsError::InconsistentDataStructure {
                     message: format!(
                         "Disconnected triangulation detected after insertion: new-simplex component ({expected_new_simplices} simplices) is not connected to existing simplices (total_simplices={total_simplices})"
                     ),
                 },
-            ));
+            });
         }
 
         Ok(())
@@ -2215,7 +2224,7 @@ where
         }
 
         self.validate_local_realization_orientation(simplices)
-            .map_err(InvariantError::Realization)?;
+            .map_err(|source| InvariantError::Realization { source })?;
 
         Ok(())
     }
@@ -2263,7 +2272,7 @@ where
                     Some([]) | None => self.is_valid_realization(),
                     Some(simplices) => self.validate_realization_for_simplices(simplices),
                 }
-                .map_err(InvariantError::Realization)
+                .map_err(|source| InvariantError::Realization { source })
             }
             InsertionValidationWork::RequiredTopologyLinks => local_simplices.map_or_else(
                 || self.validate_required_topology_links(),
@@ -2858,12 +2867,16 @@ mod tests {
         };
 
         assert_eq!(
-            TriangulationValidationError::try_from(ManifoldError::Tds(tds_err.clone())),
+            TriangulationValidationError::try_from(ManifoldError::Tds {
+                source: tds_err.clone()
+            }),
             Err(tds_err.clone())
         );
         assert_eq!(
-            InvariantError::from(ManifoldError::Tds(tds_err.clone())),
-            InvariantError::Tds(tds_err)
+            InvariantError::from(ManifoldError::Tds {
+                source: tds_err.clone()
+            }),
+            InvariantError::Tds { source: tds_err }
         );
 
         assert_matches!(
@@ -3001,7 +3014,9 @@ mod tests {
             invariant_error_from_topology_error(TopologyError::FacetMapBuild {
                 source: facet_map_err.clone()
             }),
-            InvariantError::Tds(facet_map_err)
+            InvariantError::Tds {
+                source: facet_map_err
+            }
         );
 
         let boundary_enumeration_err = TdsError::InconsistentDataStructure {
@@ -3011,7 +3026,9 @@ mod tests {
             invariant_error_from_topology_error(TopologyError::BoundaryFacetEnumeration {
                 source: boundary_enumeration_err.clone()
             }),
-            InvariantError::Tds(boundary_enumeration_err)
+            InvariantError::Tds {
+                source: boundary_enumeration_err
+            }
         );
 
         let boundary_count_err = TdsError::InconsistentDataStructure {
@@ -3021,16 +3038,20 @@ mod tests {
             invariant_error_from_topology_error(TopologyError::BoundaryFacetCount {
                 source: boundary_count_err.clone()
             }),
-            InvariantError::Tds(boundary_count_err)
+            InvariantError::Tds {
+                source: boundary_count_err
+            }
         );
 
         assert_eq!(
             invariant_error_from_topology_error(TopologyError::BoundaryFacetSimplexAccess {
                 source: FacetError::SimplexNotFoundInTriangulation
             }),
-            InvariantError::Tds(TdsError::FacetError(
-                FacetError::SimplexNotFoundInTriangulation
-            ))
+            InvariantError::Tds {
+                source: TdsError::FacetError {
+                    source: FacetError::SimplexNotFoundInTriangulation
+                }
+            }
         );
 
         let simplex_key = SimplexKey::from(KeyData::from_ffi(13));
@@ -3045,7 +3066,7 @@ mod tests {
                     facet_index: 3
                 })
             }),
-            InvariantError::Triangulation(
+            InvariantError::Triangulation { source:
                 TriangulationValidationError::BoundaryFacetInClosedTopology {
                     topology: TopologyKind::Toroidal,
                     facet_key: 0x1234_5678,
@@ -3053,7 +3074,7 @@ mod tests {
                     simplex_uuid: observed_simplex_uuid,
                     facet_index: 3
                 }
-            ) if observed_simplex_key == simplex_key && observed_simplex_uuid == simplex_uuid
+             } if observed_simplex_key == simplex_key && observed_simplex_uuid == simplex_uuid
         );
     }
 
@@ -3075,12 +3096,12 @@ mod tests {
 
         assert_matches!(
             err,
-            InvariantError::Triangulation(
-                TriangulationValidationError::BoundaryFacetInClosedTopology {
+            InvariantError::Triangulation {
+                source: TriangulationValidationError::BoundaryFacetInClosedTopology {
                     topology: TopologyKind::Spherical,
                     ..
                 }
-            )
+            }
         );
         assert_eq!(tri.global_topology(), GlobalTopology::Euclidean);
         assert!(tri.is_valid_topology().is_ok());
@@ -3282,9 +3303,9 @@ mod tests {
                         tri.set_topology_guarantee(TopologyGuarantee::PLManifold);
 
                         match tri.validate_at_completion() {
-                            Err(InvariantError::Triangulation(
+                            Err(InvariantError::Triangulation { source:
                                 TriangulationValidationError::VertexLinkNotManifold { vertex_key, .. },
-                            )) => assert_eq!(vertex_key, expected_vertex_key),
+                             }) => assert_eq!(vertex_key, expected_vertex_key),
                             other => panic!("Expected VertexLinkNotManifold, got {other:?}"),
                         }
                     }
@@ -3297,9 +3318,9 @@ mod tests {
 
                         assert_matches!(
                             tri.validate_at_completion(),
-                            Err(InvariantError::Triangulation(
+                            Err(InvariantError::Triangulation { source:
                                 TriangulationValidationError::VertexLinkNotManifold { .. }
-                            ))
+                             })
                         );
                         assert_eq!(tri.validation_policy(), ValidationPolicy::ExplicitOnly);
                         assert_eq!(
@@ -3371,9 +3392,9 @@ mod tests {
         tri.set_validation_policy(ValidationPolicy::Always);
 
         match tri.validate_after_insertion_with_scope(SuspicionFlags::default(), None) {
-            Err(InvariantError::Triangulation(TriangulationValidationError::Disconnected {
-                ..
-            })) => {}
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::Disconnected { .. },
+            }) => {}
             other => panic!("Expected Disconnected error, got {other:?}"),
         }
     }
@@ -3386,8 +3407,12 @@ mod tests {
         tri.set_validation_policy(ValidationPolicy::Always);
 
         match tri.validate_after_insertion_with_scope(SuspicionFlags::default(), None) {
-            Err(InvariantError::Tds(TdsError::MappingInconsistency { .. })) => {}
-            other => panic!("Expected InvariantError::Tds(MappingInconsistency), got {other:?}"),
+            Err(InvariantError::Tds {
+                source: TdsError::MappingInconsistency { .. },
+            }) => {}
+            other => panic!(
+                "Expected InvariantError::Tds with MappingInconsistency source, got {other:?}"
+            ),
         }
     }
 
@@ -3419,13 +3444,17 @@ mod tests {
 
     #[test]
     fn insertion_error_to_invariant_error_maps_all_arms() {
-        let source = TdsError::Geometric(GeometricError::DegenerateOrientation {
-            message: "det=0".to_string(),
-        });
-        let error = InsertionError::TopologyValidation(source.clone());
+        let source = TdsError::Geometric {
+            source: GeometricError::DegenerateOrientation {
+                message: "det=0".to_string(),
+            },
+        };
+        let error = InsertionError::TopologyValidation {
+            source: source.clone(),
+        };
         assert_eq!(
             insertion_error_to_invariant_error(error, "ctx"),
-            InvariantError::Tds(source)
+            InvariantError::Tds { source }
         );
 
         let inner = TriangulationValidationError::IsolatedVertex {
@@ -3438,7 +3467,7 @@ mod tests {
         };
         assert_eq!(
             insertion_error_to_invariant_error(error, "ctx"),
-            InvariantError::Triangulation(inner)
+            InvariantError::Triangulation { source: inner }
         );
 
         let realization_source = synthetic_realization_error();
@@ -3447,7 +3476,9 @@ mod tests {
         };
         assert_eq!(
             insertion_error_to_invariant_error(error, "ctx"),
-            InvariantError::Realization(realization_source)
+            InvariantError::Realization {
+                source: realization_source
+            }
         );
 
         let delaunay_source = synthetic_delaunay_verification_error("delaunay");
@@ -3456,7 +3487,9 @@ mod tests {
         };
         assert_eq!(
             insertion_error_to_invariant_error(error, "ctx"),
-            InvariantError::Delaunay(delaunay_source)
+            InvariantError::Delaunay {
+                source: delaunay_source
+            }
         );
 
         let error = InsertionError::CavityFilling {
@@ -3466,7 +3499,7 @@ mod tests {
         assert!(
             matches!(
                 result,
-                InvariantError::Tds(TdsError::InconsistentDataStructure { ref message })
+                InvariantError::Tds { source: TdsError::InconsistentDataStructure { ref message } }
                     if message.contains("ctx") && message.contains("fan triangulation produced no simplices")
             ),
             "CavityFilling should wrap to InconsistentDataStructure: {result:?}"
@@ -3475,27 +3508,35 @@ mod tests {
 
     #[test]
     fn invariant_error_to_insertion_error_maps_all_arms() {
-        let inv = InvariantError::Tds(TdsError::InconsistentDataStructure {
-            message: "test".to_string(),
-        });
+        let inv = InvariantError::Tds {
+            source: TdsError::InconsistentDataStructure {
+                message: "test".to_string(),
+            },
+        };
         let ins =
             Triangulation::<FastKernel<f64>, (), (), 3>::invariant_error_to_insertion_error(inv);
-        assert_matches!(ins, InsertionError::TopologyValidation(_));
+        assert_matches!(ins, InsertionError::TopologyValidation { source: _ });
 
-        let inv = InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex {
-            vertex_key: VertexKey::from(KeyData::from_ffi(1)),
-            vertex_uuid: Uuid::nil(),
-        });
+        let inv = InvariantError::Triangulation {
+            source: TriangulationValidationError::IsolatedVertex {
+                vertex_key: VertexKey::from(KeyData::from_ffi(1)),
+                vertex_uuid: Uuid::nil(),
+            },
+        };
         let ins =
             Triangulation::<FastKernel<f64>, (), (), 3>::invariant_error_to_insertion_error(inv);
         assert_matches!(ins, InsertionError::TopologyValidationFailed { .. });
 
-        let inv = InvariantError::Realization(synthetic_realization_error());
+        let inv = InvariantError::Realization {
+            source: synthetic_realization_error(),
+        };
         let ins =
             Triangulation::<FastKernel<f64>, (), (), 3>::invariant_error_to_insertion_error(inv);
         assert_matches!(ins, InsertionError::RealizationValidationFailed { .. });
 
-        let inv = InvariantError::Delaunay(synthetic_delaunay_verification_error("test"));
+        let inv = InvariantError::Delaunay {
+            source: synthetic_delaunay_verification_error("test"),
+        };
         let ins =
             Triangulation::<FastKernel<f64>, (), (), 3>::invariant_error_to_insertion_error(inv);
         assert_matches!(ins, InsertionError::DelaunayValidationFailed { .. });
@@ -3506,10 +3547,12 @@ mod tests {
         let tds_err = TdsError::InconsistentDataStructure {
             message: "underlying TDS issue".to_string(),
         };
-        let manifold_err = ManifoldError::Tds(tds_err.clone());
+        let manifold_err = ManifoldError::Tds {
+            source: tds_err.clone(),
+        };
         assert_eq!(
             InvariantError::from(manifold_err),
-            InvariantError::Tds(tds_err)
+            InvariantError::Tds { source: tds_err }
         );
 
         let err = ManifoldError::ManifoldFacetMultiplicity {
@@ -3519,12 +3562,12 @@ mod tests {
         let inv = InvariantError::from(err);
         assert_matches!(
             inv,
-            InvariantError::Triangulation(
-                TriangulationValidationError::ManifoldFacetMultiplicity {
+            InvariantError::Triangulation {
+                source: TriangulationValidationError::ManifoldFacetMultiplicity {
                     facet_key: 999,
                     simplex_count: 5
                 }
-            )
+            }
         );
 
         let ridge_vertex = VertexKey::from(KeyData::from_ffi(42));
@@ -3533,9 +3576,9 @@ mod tests {
         });
         assert_matches!(
             inv,
-            InvariantError::Triangulation(TriangulationValidationError::RidgeNotFound {
+            InvariantError::Triangulation { source: TriangulationValidationError::RidgeNotFound {
                 ridge_vertices
-            }) if ridge_vertices.as_slice() == [ridge_vertex]
+            } } if ridge_vertices.as_slice() == [ridge_vertex]
         );
     }
 
@@ -3559,12 +3602,13 @@ mod tests {
             .unwrap();
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex {
-                vertex_key,
-                ..
-            })) => assert_eq!(vertex_key, iso),
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::IsolatedVertex { vertex_key, .. },
+            }) => assert_eq!(vertex_key, iso),
             other => {
-                panic!("Expected InvariantError::Triangulation(IsolatedVertex), got {other:?}")
+                panic!(
+                    "Expected InvariantError::Triangulation with IsolatedVertex source, got {other:?}"
+                )
             }
         }
     }
@@ -3575,11 +3619,13 @@ mod tests {
         let tri = Triangulation::<FastKernel<f64>, (), (), 2>::new_with_tds(FastKernel::new(), tds);
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(TriangulationValidationError::Disconnected {
-                simplex_count,
-            })) => assert_eq!(simplex_count, 2),
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::Disconnected { simplex_count },
+            }) => assert_eq!(simplex_count, 2),
             other => {
-                panic!("Expected InvariantError::Triangulation(Disconnected), got {other:?}")
+                panic!(
+                    "Expected InvariantError::Triangulation with Disconnected source, got {other:?}"
+                )
             }
         }
     }
@@ -3591,8 +3637,12 @@ mod tests {
         tri.tds.uuid_to_vertex_key.remove(&uuid);
 
         match tri.validate() {
-            Err(InvariantError::Tds(TdsError::MappingInconsistency { .. })) => {}
-            other => panic!("Expected InvariantError::Tds(MappingInconsistency), got {other:?}"),
+            Err(InvariantError::Tds {
+                source: TdsError::MappingInconsistency { .. },
+            }) => {}
+            other => panic!(
+                "Expected InvariantError::Tds with MappingInconsistency source, got {other:?}"
+            ),
         }
     }
 
@@ -3605,11 +3655,13 @@ mod tests {
             .unwrap();
 
         match tri.validate() {
-            Err(InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex {
-                ..
-            })) => {}
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::IsolatedVertex { .. },
+            }) => {}
             other => {
-                panic!("Expected InvariantError::Triangulation(IsolatedVertex), got {other:?}")
+                panic!(
+                    "Expected InvariantError::Triangulation with IsolatedVertex source, got {other:?}"
+                )
             }
         }
     }
@@ -3733,7 +3785,7 @@ mod tests {
         );
         assert_matches!(
             non_orientable.orientation_witness(),
-            Err(InvariantError::Triangulation(
+            Err(InvariantError::Triangulation { source:
                 TriangulationValidationError::NonOrientable {
                     simplex1_key,
                     simplex1_uuid,
@@ -3742,7 +3794,7 @@ mod tests {
                     simplex2_uuid,
                     simplex2_facet_index,
                 }
-            )) if non_orientable.tds.simplex(simplex1_key).map(Simplex::uuid)
+             }) if non_orientable.tds.simplex(simplex1_key).map(Simplex::uuid)
                 == Some(simplex1_uuid)
                 && non_orientable.tds.simplex(simplex2_key).map(Simplex::uuid)
                     == Some(simplex2_uuid)
@@ -3756,9 +3808,9 @@ mod tests {
         non_orientable.set_topology_guarantee(TopologyGuarantee::PLManifold);
         assert_matches!(
             non_orientable.is_valid_topology(),
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::NonOrientable { .. }
-            ))
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::NonOrientable { .. }
+            })
         );
 
         // A local reversal violates Level 2 while the intrinsic witness remains available.
@@ -3807,9 +3859,9 @@ mod tests {
 
         assert_matches!(
             tri.orientation_witness(),
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::NonOrientable { .. }
-            ))
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::NonOrientable { .. }
+            })
         );
     }
 
@@ -3845,9 +3897,9 @@ mod tests {
         );
         assert_matches!(
             tri_3d.orientation_witness(),
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::NonOrientable { .. }
-            ))
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::NonOrientable { .. }
+            })
         );
     }
 
@@ -3948,21 +4000,22 @@ mod tests {
 
         assert_matches!(
             tri.is_valid_topology(),
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::Disconnected { .. }
-            ))
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::Disconnected { .. }
+            })
         );
 
         tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::VertexLinkNotManifold { vertex_key, .. },
-            )) => assert_eq!(vertex_key, v0),
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::RidgeLinkNotManifold { .. }
-                | TriangulationValidationError::Disconnected { .. },
-            )) => {}
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::VertexLinkNotManifold { vertex_key, .. },
+            }) => assert_eq!(vertex_key, v0),
+            Err(InvariantError::Triangulation {
+                source:
+                    TriangulationValidationError::RidgeLinkNotManifold { .. }
+                    | TriangulationValidationError::Disconnected { .. },
+            }) => {}
             other => panic!(
                 "Expected RidgeLinkNotManifold, VertexLinkNotManifold, or Disconnected, got {other:?}"
             ),
@@ -4028,14 +4081,15 @@ mod tests {
         tri.set_topology_guarantee(TopologyGuarantee::PLManifoldStrict);
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::VertexLinkNotManifold {
-                    vertex_key,
-                    connected,
-                    interior_vertex,
-                    ..
-                },
-            )) => {
+            Err(InvariantError::Triangulation {
+                source:
+                    TriangulationValidationError::VertexLinkNotManifold {
+                        vertex_key,
+                        connected,
+                        interior_vertex,
+                        ..
+                    },
+            }) => {
                 assert_eq!(vertex_key, apex);
                 assert!(connected);
                 assert!(interior_vertex);
@@ -4089,9 +4143,9 @@ mod tests {
         let tri = Triangulation::<FastKernel<f64>, (), (), 3>::new_with_tds(FastKernel::new(), tds);
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(TriangulationValidationError::Disconnected {
-                simplex_count,
-            })) => assert_eq!(simplex_count, 2),
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::Disconnected { simplex_count },
+            }) => assert_eq!(simplex_count, 2),
             other => panic!("Expected Disconnected, got {other:?}"),
         }
     }
@@ -4120,10 +4174,13 @@ mod tests {
         let expected_vk = tri.tds.insert_vertex_with_mapping(vertex).unwrap();
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex {
-                vertex_key,
-                vertex_uuid,
-            })) => {
+            Err(InvariantError::Triangulation {
+                source:
+                    TriangulationValidationError::IsolatedVertex {
+                        vertex_key,
+                        vertex_uuid,
+                    },
+            }) => {
                 assert_eq!(vertex_key, expected_vk);
                 assert_eq!(vertex_uuid, expected_uuid);
             }
@@ -4153,9 +4210,9 @@ mod tests {
 
         assert_matches!(
             tri.is_valid_topology(),
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::IsolatedVertex { .. }
-            ))
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::IsolatedVertex { .. }
+            })
         );
     }
 
@@ -4217,9 +4274,9 @@ mod tests {
         assert_eq!(topology.chi, 1);
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(TriangulationValidationError::Disconnected {
-                simplex_count,
-            })) => assert_eq!(simplex_count, 5),
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::Disconnected { simplex_count },
+            }) => assert_eq!(simplex_count, 5),
             other => panic!("Expected Disconnected, got {other:?}"),
         }
     }
@@ -4352,12 +4409,13 @@ mod tests {
         let tri = Triangulation::<FastKernel<f64>, (), (), 3>::new_with_tds(FastKernel::new(), tds);
 
         match tri.is_valid_topology() {
-            Err(InvariantError::Triangulation(TriangulationValidationError::Disconnected {
-                ..
-            })) => {}
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::ManifoldFacetMultiplicity { simplex_count, .. },
-            )) => assert_eq!(simplex_count, 3),
+            Err(InvariantError::Triangulation {
+                source: TriangulationValidationError::Disconnected { .. },
+            }) => {}
+            Err(InvariantError::Triangulation {
+                source:
+                    TriangulationValidationError::ManifoldFacetMultiplicity { simplex_count, .. },
+            }) => assert_eq!(simplex_count, 3),
             other => panic!("Expected Disconnected or ManifoldFacetMultiplicity, got {other:?}"),
         }
     }
@@ -4451,9 +4509,10 @@ mod tests {
         tri.set_topology_guarantee(TopologyGuarantee::Pseudomanifold);
 
         match tri.validate_after_insertion_with_scope(SuspicionFlags::default(), None) {
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::ManifoldFacetMultiplicity { simplex_count, .. },
-            )) => assert_eq!(simplex_count, 3),
+            Err(InvariantError::Triangulation {
+                source:
+                    TriangulationValidationError::ManifoldFacetMultiplicity { simplex_count, .. },
+            }) => assert_eq!(simplex_count, 3),
             other => panic!("Expected ManifoldFacetMultiplicity, got {other:?}"),
         }
     }
@@ -4469,9 +4528,10 @@ mod tests {
         tri.set_topology_guarantee(TopologyGuarantee::PLManifold);
 
         match tri.validate_after_insertion_with_scope(SuspicionFlags::default(), Some(&scope)) {
-            Err(InvariantError::Triangulation(
-                TriangulationValidationError::ManifoldFacetMultiplicity { simplex_count, .. },
-            )) => assert_eq!(simplex_count, 3),
+            Err(InvariantError::Triangulation {
+                source:
+                    TriangulationValidationError::ManifoldFacetMultiplicity { simplex_count, .. },
+            }) => assert_eq!(simplex_count, 3),
             other => panic!("Expected ManifoldFacetMultiplicity, got {other:?}"),
         }
     }
@@ -4492,15 +4552,15 @@ mod tests {
                         tri.topology_guarantee = TopologyGuarantee::PLManifoldStrict;
 
                         match tri.validate_after_insertion_with_scope(SuspicionFlags::default(), Some(&scope)) {
-                            Err(InvariantError::Triangulation(
+                            Err(InvariantError::Triangulation { source:
                                 TriangulationValidationError::RidgeLinkNotManifold {
                                     connected: false,
                                     ..
                                 },
-                            )) if $dim == 2 => {}
-                            Err(InvariantError::Triangulation(
+                             }) if $dim == 2 => {}
+                            Err(InvariantError::Triangulation { source:
                                 TriangulationValidationError::VertexLinkNotManifold { vertex_key, .. },
-                            )) => assert_eq!(vertex_key, expected_vertex_key),
+                             }) => assert_eq!(vertex_key, expected_vertex_key),
                             other => panic!("Expected VertexLinkNotManifold, got {other:?}"),
                         }
                     }
@@ -4579,7 +4639,7 @@ mod tests {
 
         let empty: SimplexKeyBuffer = SimplexKeyBuffer::new();
         let err = tri.validate_connectedness(&empty).unwrap_err();
-        assert_matches!(err, InsertionError::TopologyValidation(_));
+        assert_matches!(err, InsertionError::TopologyValidation { source: _ });
     }
 
     #[test]
@@ -4625,13 +4685,13 @@ mod tests {
 
         assert_matches!(
             err,
-            InvariantError::Realization(
+            InvariantError::Realization { source:
                 TriangulationRealizationValidationError::DegenerateSimplex {
                     simplex_key,
                     dimension: 3,
                     ..
                 }
-            ) if simplex_key == ck
+             } if simplex_key == ck
         );
     }
 
@@ -4648,13 +4708,13 @@ mod tests {
 
         assert_matches!(
             err,
-            InvariantError::Realization(
+            InvariantError::Realization { source:
                 TriangulationRealizationValidationError::DegenerateSimplex {
                     simplex_key,
                     dimension: 3,
                     ..
                 }
-            ) if simplex_key == ck
+             } if simplex_key == ck
         );
     }
 
@@ -4674,9 +4734,10 @@ mod tests {
 
         assert_matches!(
             err,
-            InvariantError::Realization(
-                TriangulationRealizationValidationError::SimplexIntersectionOutsideSharedFace { .. }
-            )
+            InvariantError::Realization {
+                source:
+                    TriangulationRealizationValidationError::SimplexIntersectionOutsideSharedFace { .. }
+            }
         );
     }
 
@@ -4698,7 +4759,12 @@ mod tests {
             .validate_after_insertion_with_scope(SuspicionFlags::default(), Some(&empty_scope))
             .unwrap_err();
 
-        assert_eq!(err, InvariantError::Realization(expected_realization_error));
+        assert_eq!(
+            err,
+            InvariantError::Realization {
+                source: expected_realization_error
+            }
+        );
     }
 
     #[test]
@@ -4722,9 +4788,10 @@ mod tests {
 
         assert_matches!(
             err,
-            InvariantError::Realization(
-                TriangulationRealizationValidationError::SimplexIntersectionOutsideSharedFace { .. }
-            )
+            InvariantError::Realization {
+                source:
+                    TriangulationRealizationValidationError::SimplexIntersectionOutsideSharedFace { .. }
+            }
         );
     }
 

--- a/src/delaunay/builder.rs
+++ b/src/delaunay/builder.rs
@@ -707,7 +707,11 @@ fn search_closed_2d_selection(
 fn periodic_quotient_tds_mutation_error(
     source: TdsMutationError,
 ) -> TriangulationConstructionError {
-    TriangulationConstructionError::Tds(TdsConstructionError::ValidationError(source.into()))
+    TriangulationConstructionError::Tds {
+        source: TdsConstructionError::ValidationError {
+            source: source.into(),
+        },
+    }
 }
 
 // =============================================================================
@@ -1545,9 +1549,9 @@ where
         M: GlobalTopologyModel<D>,
     {
         model.validate_configuration().map_err(|source| {
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::TopologyModelConfiguration { source },
-            )
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::TopologyModelConfiguration { source },
+            }
         })
     }
 
@@ -1625,22 +1629,22 @@ where
             let mut canonicalized_coords = *v.point().coords();
             model
                 .canonicalize_point_in_place(&mut canonicalized_coords)
-                .map_err(|source| {
-                    DelaunayTriangulationConstructionError::Triangulation(
-                        DelaunayConstructionFailure::VertexCanonicalization {
+                .map_err(
+                    |source| DelaunayTriangulationConstructionError::Triangulation {
+                        source: DelaunayConstructionFailure::VertexCanonicalization {
                             vertex_index: idx,
                             source,
                         },
-                    )
-                })?;
+                    },
+                )?;
 
             let new_point = Point::try_new(canonicalized_coords).map_err(|error| {
-                DelaunayTriangulationConstructionError::Triangulation(
-                    DelaunayConstructionFailure::CanonicalizedPointValidation {
+                DelaunayTriangulationConstructionError::Triangulation {
+                    source: DelaunayConstructionFailure::CanonicalizedPointValidation {
                         vertex_index: idx,
                         source: error,
                     },
-                )
+                }
             })?;
             let new_vertex = Vertex::from_validated_point_with_uuid(new_point, v.uuid(), v.data);
 
@@ -2095,13 +2099,13 @@ where
             match seen.entry(identity) {
                 Entry::Occupied(entry) => {
                     let existing_index = *entry.get();
-                    return Err(TdsConstructionError::ValidationError(
-                        TdsError::DuplicateExplicitSimplices {
+                    return Err(TdsConstructionError::ValidationError {
+                        source: TdsError::DuplicateExplicitSimplices {
                             existing_simplex_index: existing_index,
                             duplicate_simplex_index: simplex_index,
                             vertex_indices: Self::explicit_simplex_input_indices(simplex_spec),
                         },
-                    ));
+                    });
                 }
                 Entry::Vacant(entry) => {
                     entry.insert(simplex_index);
@@ -2131,8 +2135,8 @@ where
                     Entry::Occupied(mut entry) => {
                         let incident_count = *entry.get();
                         if incident_count >= 2 {
-                            return Err(TdsConstructionError::ValidationError(
-                                TdsError::ExplicitFacetSharingViolation {
+                            return Err(TdsConstructionError::ValidationError {
+                                source: TdsError::ExplicitFacetSharingViolation {
                                     facet_key: facet_key_from_vertices(entry.key().as_slice()),
                                     facet_vertex_indices: Self::explicit_facet_input_indices(
                                         simplex_spec,
@@ -2144,7 +2148,7 @@ where
                                     candidate_simplex_index: simplex_index,
                                     candidate_facet_index: facet_index,
                                 },
-                            ));
+                            });
                         }
                         *entry.get_mut() += 1;
                     }
@@ -2305,7 +2309,9 @@ where
         // --- Assign incident simplices ---
         tds.assign_incident_simplices().map_err(|source| {
             ExplicitConstructionError::TdsAssembly {
-                source: Box::new(TdsConstructionError::ValidationError(source.into())),
+                source: Box::new(TdsConstructionError::ValidationError {
+                    source: source.into(),
+                }),
             }
         })?;
 
@@ -2458,11 +2464,11 @@ where
             return Ok(());
         }
 
-        Err(DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::EuclideanUnsupportedGlobalTopology {
+        Err(DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::EuclideanUnsupportedGlobalTopology {
                 topology: global_topology.kind(),
             },
-        ))
+        })
     }
 
     /// Rejects explicit metadata that conflicts with derived periodic topology.
@@ -2483,8 +2489,8 @@ where
             return Ok(());
         }
 
-        Err(DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::PeriodicImageConflictingGlobalTopology {
+        Err(DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::PeriodicImageConflictingGlobalTopology {
                 requested_topology: requested_global_topology.kind(),
                 requested_mode: Self::toroidal_mode(requested_global_topology),
                 requested_periods: Self::toroidal_periods(requested_global_topology),
@@ -2492,7 +2498,7 @@ where
                 expected_periods: Self::toroidal_periods(derived_global_topology)
                     .unwrap_or_default(),
             },
-        ))
+        })
     }
 
     /// Extracts toroidal construction mode from topology metadata for diagnostics.
@@ -3252,7 +3258,7 @@ where
                 })?;
             let ck = tds_mut
                 .insert_simplex_with_mapping_trusted_vertices(simplex)
-                .map_err(TriangulationConstructionError::Tds)?;
+                .map_err(|source| TriangulationConstructionError::Tds { source })?;
             inserted_simplex_keys.push(ck);
             rep_lifted_by_key.insert(ck, lifted_vertices.clone());
         }
@@ -3379,7 +3385,7 @@ where
         if let Err(e) = tds_mut.is_valid() {
             return Err(TriangulationConstructionError::FinalTopologyValidation {
                 context: FinalTopologyValidationContext::PeriodicQuotientTopology,
-                source: Box::new(InvariantError::Tds(e)),
+                source: Box::new(InvariantError::Tds { source: e }),
             }
             .into());
         }
@@ -3393,7 +3399,7 @@ where
         let proof = candidate.validate_tds_structure().map_err(|source| {
             TriangulationConstructionError::FinalTopologyValidation {
                 context: FinalTopologyValidationContext::PeriodicQuotientTopology,
-                source: Box::new(InvariantError::Tds(source)),
+                source: Box::new(InvariantError::Tds { source }),
             }
         })?;
         Ok(candidate.into_structurally_valid_delaunay(proof))
@@ -3661,11 +3667,11 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::EuclideanUnsupportedGlobalTopology {
+            Err(DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::EuclideanUnsupportedGlobalTopology {
                     topology: TopologyKind::Spherical,
                 }
-            ))
+            })
         );
     }
 
@@ -3683,11 +3689,11 @@ mod tests {
 
         assert_matches!(
             err.error,
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::EuclideanUnsupportedGlobalTopology {
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::EuclideanUnsupportedGlobalTopology {
                     topology: TopologyKind::Spherical,
                 }
-            )
+            }
         );
         assert_eq!(err.statistics.inserted, 0);
         assert_eq!(err.statistics.skipped_duplicate, 0);
@@ -3780,13 +3786,13 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::UnsupportedPeriodicDimension {
+            Err(DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::UnsupportedPeriodicDimension {
                     dimension: 4,
                     max_validated_dimension: 3,
                     tracking_issue: 416,
                 }
-            ))
+            })
         );
     }
 
@@ -3801,7 +3807,7 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(DelaunayTriangulationConstructionError::Triangulation(
+            Err(DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::PeriodicImageConflictingGlobalTopology {
                     requested_topology: TopologyKind::Spherical,
                     requested_mode: None,
@@ -3809,7 +3815,7 @@ mod tests {
                     expected_mode: ToroidalConstructionMode::PeriodicImagePoint,
                     expected_periods,
                 }
-            )) if expected_periods.as_slice() == [1.0, 1.0]
+             }) if expected_periods.as_slice() == [1.0, 1.0]
         );
     }
 
@@ -3824,7 +3830,7 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(DelaunayTriangulationConstructionError::Triangulation(
+            Err(DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::PeriodicImageConflictingGlobalTopology {
                     requested_topology: TopologyKind::Euclidean,
                     requested_mode: None,
@@ -3832,7 +3838,7 @@ mod tests {
                     expected_mode: ToroidalConstructionMode::PeriodicImagePoint,
                     expected_periods,
                 }
-            )) if expected_periods.as_slice() == [1.0, 1.0]
+             }) if expected_periods.as_slice() == [1.0, 1.0]
         );
     }
 
@@ -3849,7 +3855,7 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(DelaunayTriangulationConstructionError::Triangulation(
+            Err(DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::PeriodicImageConflictingGlobalTopology {
                     requested_topology: TopologyKind::Toroidal,
                     requested_mode: Some(ToroidalConstructionMode::Explicit),
@@ -3857,7 +3863,7 @@ mod tests {
                     expected_mode: ToroidalConstructionMode::PeriodicImagePoint,
                     expected_periods,
                 }
-            )) if requested_periods.as_slice() == [1.0, 1.0]
+             }) if requested_periods.as_slice() == [1.0, 1.0]
                 && expected_periods.as_slice() == [1.0, 1.0]
         );
     }
@@ -3876,7 +3882,7 @@ mod tests {
 
         assert_matches!(
             result,
-            Err(DelaunayTriangulationConstructionError::Triangulation(
+            Err(DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::PeriodicImageConflictingGlobalTopology {
                     requested_topology: TopologyKind::Toroidal,
                     requested_mode: Some(ToroidalConstructionMode::PeriodicImagePoint),
@@ -3884,7 +3890,7 @@ mod tests {
                     expected_mode: ToroidalConstructionMode::PeriodicImagePoint,
                     expected_periods,
                 }
-            )) if requested_periods.as_slice() == [2.0, 1.0]
+             }) if requested_periods.as_slice() == [2.0, 1.0]
                 && expected_periods.as_slice() == [1.0, 1.0]
         );
     }
@@ -3979,12 +3985,13 @@ mod tests {
         let err =
             DelaunayTriangulationBuilder::<(), 2>::derive_periodic_facet_key(&lifted_ordered, 1)
                 .unwrap_err();
-        let DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::PeriodicQuotientFacetKeyDerivation {
-                facet_index,
-                reason,
-            },
-        ) = err
+        let DelaunayTriangulationConstructionError::Triangulation {
+            source:
+                DelaunayConstructionFailure::PeriodicQuotientFacetKeyDerivation {
+                    facet_index,
+                    reason,
+                },
+        } = err
         else {
             panic!("expected PeriodicQuotientFacetKeyDerivation mapping, got: {err:?}");
         };
@@ -4211,7 +4218,7 @@ mod tests {
 
         assert_matches!(
             &err,
-            TriangulationConstructionError::Tds(TdsConstructionError::ValidationError(tds_source))
+            TriangulationConstructionError::Tds { source: TdsConstructionError::ValidationError { source: tds_source } }
                 if tds_source == &source
         );
 
@@ -4240,14 +4247,14 @@ mod tests {
         let err = result.expect_err("non-period validation failure should be mapped");
         assert_matches!(
             err,
-            DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::TopologyModelConfiguration {
                     source: GlobalTopologyModelError::NonFiniteCoordinate {
                         axis: 0,
                         value,
                     },
                 },
-            ) if value.is_nan()
+             } if value.is_nan()
         );
     }
 
@@ -4321,7 +4328,7 @@ mod tests {
         let err = result.expect_err("canonicalization failure should be reported");
         assert_matches!(
             err,
-            DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::VertexCanonicalization {
                     vertex_index: 0,
                     source: GlobalTopologyModelError::NonFiniteCoordinate {
@@ -4329,7 +4336,7 @@ mod tests {
                         value,
                     },
                 },
-            ) if value.is_nan()
+             } if value.is_nan()
         );
     }
 
@@ -4353,11 +4360,11 @@ mod tests {
         let err = result.expect_err("missing periodic domain must fail");
         assert_matches!(
             err,
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::PeriodicImageMissingDomain {
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::PeriodicImageMissingDomain {
                     topology: TopologyKind::Toroidal,
                 }
-            )
+            }
         );
     }
 

--- a/src/delaunay/construction.rs
+++ b/src/delaunay/construction.rs
@@ -630,16 +630,25 @@ pub type DelaunayResult<T> = Result<T, DelaunayError>;
 pub enum DelaunayTriangulationConstructionError {
     /// Lower-layer construction failure summarized for Delaunay construction.
     #[error(transparent)]
-    Triangulation(DelaunayConstructionFailure),
+    Triangulation {
+        /// Typed lower-layer construction failure.
+        source: DelaunayConstructionFailure,
+    },
 
     /// Input validation error from explicit combinatorial construction.
     #[error(transparent)]
-    ExplicitConstruction(#[from] ExplicitConstructionError),
+    ExplicitConstruction {
+        /// Typed explicit-construction source error.
+        #[from]
+        source: ExplicitConstructionError,
+    },
 }
 
 impl From<TriangulationConstructionError> for DelaunayTriangulationConstructionError {
     fn from(source: TriangulationConstructionError) -> Self {
-        Self::Triangulation(source.into())
+        Self::Triangulation {
+            source: source.into(),
+        }
     }
 }
 
@@ -681,11 +690,11 @@ impl fmt::Display for DelaunayConstructionRepairPhase {
 /// };
 ///
 /// let source = DelaunayConstructionRetryFailure::Construction {
-///     source: Box::new(DelaunayTriangulationConstructionError::Triangulation(
-///         DelaunayConstructionFailure::GeometricDegeneracy {
+///     source: Box::new(DelaunayTriangulationConstructionError::Triangulation {
+///         source: DelaunayConstructionFailure::GeometricDegeneracy {
 ///             message: String::from("collinear input"),
 ///         },
-///     )),
+///     }),
 /// };
 ///
 /// std::assert_matches!(
@@ -1215,7 +1224,7 @@ impl From<TriangulationConstructionError> for DelaunayConstructionFailure {
     )]
     fn from(source: TriangulationConstructionError) -> Self {
         match source {
-            TriangulationConstructionError::Tds(source) => Self::Tds {
+            TriangulationConstructionError::Tds { source } => Self::Tds {
                 reason: source.into(),
             },
             TriangulationConstructionError::FailedToCreateSimplex { message } => {
@@ -1447,7 +1456,7 @@ fn is_geometric_flip_error(error: &FlipError) -> bool {
         | FlipError::DegenerateSimplex
         | FlipError::K1InsertionOutsideSimplex { .. }
         | FlipError::NegativeOrientation { .. } => true,
-        FlipError::SimplexCreation(source) => matches!(
+        FlipError::SimplexCreation { source } => matches!(
             source.as_ref(),
             SimplexValidationError::DegenerateSimplex
                 | SimplexValidationError::CoordinateConversion { .. }
@@ -3555,12 +3564,12 @@ where
 
         // Treat persistent construction failures or Delaunay violations as hard construction
         // errors so callers can deterministically reject.
-        Err(DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::ShuffledRetryExhausted {
+        Err(DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::ShuffledRetryExhausted {
                 attempt_count: attempts.get().saturating_add(1),
                 source: Box::new(last_failure),
             },
-        ))
+        })
     }
 
     /// Mirrors shuffled retry construction while preserving per-attempt
@@ -3866,12 +3875,12 @@ where
         // Treat persistent construction failures or Delaunay violations as hard construction
         // errors so callers can deterministically reject.
         Err(DelaunayTriangulationConstructionErrorWithStatistics {
-            error: DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::ShuffledRetryExhausted {
+            error: DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::ShuffledRetryExhausted {
                     attempt_count: attempts.get().saturating_add(1),
                     source: Box::new(last_failure),
                 },
-            ),
+            },
             statistics: aggregate_stats,
         })
     }
@@ -3909,12 +3918,12 @@ where
                 "post-construction: Delaunay validation (build) completed"
             );
             delaunay_result.map_err(|source| {
-                DelaunayTriangulationConstructionError::Triangulation(
-                    DelaunayConstructionFailure::FinalDelaunayValidation {
+                DelaunayTriangulationConstructionError::Triangulation {
+                    source: DelaunayConstructionFailure::FinalDelaunayValidation {
                         context: FinalDelaunayValidationContext::ConstructionFinalize,
                         source,
                     },
-                )
+                }
             })?;
         }
 
@@ -3966,12 +3975,12 @@ where
             );
             if let Err(err) = delaunay_result {
                 return Err(DelaunayTriangulationConstructionErrorWithStatistics {
-                    error: DelaunayTriangulationConstructionError::Triangulation(
-                        DelaunayConstructionFailure::FinalDelaunayValidation {
+                    error: DelaunayTriangulationConstructionError::Triangulation {
+                        source: DelaunayConstructionFailure::FinalDelaunayValidation {
                             context: FinalDelaunayValidationContext::ConstructionFinalize,
                             source: err,
                         },
-                    ),
+                    },
                     statistics: stats,
                 });
             }
@@ -5444,8 +5453,8 @@ where
     ) -> bool {
         matches!(
             err,
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::Tds {
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::Tds {
                     reason: TdsConstructionFailure::DuplicateUuid { .. }
                         | TdsConstructionFailure::Validation { .. },
                 } | DelaunayConstructionFailure::InternalInconsistency { .. }
@@ -5461,13 +5470,13 @@ where
                     | DelaunayConstructionFailure::ShuffledRetryExhausted { .. }
                     | DelaunayConstructionFailure::FinalTopologyValidation { .. }
                     | DelaunayConstructionFailure::FinalDelaunayValidation { .. },
-            )
+            }
         ) || matches!(
             err,
-            DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::DelaunayRepair { source, .. }
                     | DelaunayConstructionFailure::InsertionDelaunayRepair { source, .. },
-            ) if is_non_retryable_repair_error(source.as_ref())
+             } if is_non_retryable_repair_error(source.as_ref())
         )
     }
 
@@ -5488,36 +5497,36 @@ where
         index: usize,
         repair_err: DelaunayRepairError,
     ) -> DelaunayTriangulationConstructionError {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::DelaunayRepair {
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::DelaunayRepair {
                 phase: DelaunayConstructionRepairPhase::BatchLocal { index },
                 source: Box::new(repair_err),
             },
-        )
+        }
     }
 
     pub(crate) fn map_completion_repair_error(
         repair_error: DelaunayRepairError,
     ) -> DelaunayTriangulationConstructionError {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::DelaunayRepair {
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::DelaunayRepair {
                 phase: DelaunayConstructionRepairPhase::Completion,
                 source: Box::new(repair_error),
             },
-        )
+        }
     }
 
     pub(crate) fn map_final_delaunay_repair_error(
         repair_error: DelaunayRepairError,
     ) -> DelaunayTriangulationConstructionError {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::FinalDelaunayValidation {
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::FinalDelaunayValidation {
                 context: FinalDelaunayValidationContext::ConstructionFinalize,
                 source: DelaunayTriangulationValidationError::VerificationFailed {
                     source: Box::new(DelaunayVerificationError::from(repair_error)),
                 },
             },
-        )
+        }
     }
 
     /// Map an [`InsertionError`] from post-construction orientation canonicalization
@@ -5538,9 +5547,11 @@ where
         match error {
             // Geometric orientation errors (degenerate or negative) are
             // geometry problems, not internal bugs.
-            source @ (InsertionError::TopologyValidation(TdsError::Geometric(_))
-            | InsertionError::ConflictRegion(_)
-            | InsertionError::Location(_)
+            source @ (InsertionError::TopologyValidation {
+                source: TdsError::Geometric { source: _ },
+            }
+            | InsertionError::ConflictRegion { source: _ }
+            | InsertionError::Location { source: _ }
             | InsertionError::NonManifoldTopology { .. }
             | InsertionError::HullExtension { .. }
             | InsertionError::RealizationValidationFailed { .. }
@@ -5560,7 +5571,7 @@ where
             // normalization algorithm failed its post-condition — an internal bug, not
             // bad input geometry. DegenerateOrientation / NegativeOrientation capture
             // the actual FP-related geometry failures.
-            source @ (InsertionError::TopologyValidation(_)
+            source @ (InsertionError::TopologyValidation { source: _ }
             | InsertionError::TopologyValidationFailed { .. }
             | InsertionError::CavityFilling { .. }
             | InsertionError::NeighborWiring { .. }
@@ -5601,8 +5612,10 @@ where
             InsertionError::NeighborWiring { reason } => {
                 TriangulationConstructionError::InsertionNeighborWiring { source: reason }
             }
-            InsertionError::TopologyValidation(source) => {
-                TriangulationConstructionError::from(TdsConstructionError::ValidationError(source))
+            InsertionError::TopologyValidation { source } => {
+                TriangulationConstructionError::from(TdsConstructionError::ValidationError {
+                    source,
+                })
             }
             InsertionError::DuplicateUuid { entity, uuid } => {
                 TriangulationConstructionError::from(TdsConstructionError::DuplicateUuid {
@@ -5617,10 +5630,10 @@ where
                 TriangulationConstructionError::InsertionDelaunayRepair { context, source }
             }
 
-            InsertionError::ConflictRegion(source) => {
+            InsertionError::ConflictRegion { source } => {
                 TriangulationConstructionError::InsertionConflictRegion { source }
             }
-            InsertionError::Location(source) => {
+            InsertionError::Location { source } => {
                 TriangulationConstructionError::InsertionLocation { source }
             }
             InsertionError::NonManifoldTopology {
@@ -5981,17 +5994,17 @@ mod tests {
                 max: 1.0,
             },
         };
-        let err = DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::RandomPointGeneration {
+        let err = DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::RandomPointGeneration {
                 source: source.clone(),
             },
-        );
+        };
 
         assert!(!matches!(
             &err,
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::GeometricDegeneracy { .. }
-            )
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::GeometricDegeneracy { .. }
+            }
         ));
 
         let mut current_source = std::error::Error::source(&err);
@@ -6024,7 +6037,7 @@ mod tests {
                 source,
             } if matches!(
                 source.as_ref(),
-                DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayTriangulationConstructionError::Triangulation { source:
                     DelaunayConstructionFailure::InsufficientVertices {
                         dimension: 2,
                         source: SimplexValidationError::InsufficientVertices {
@@ -6033,7 +6046,7 @@ mod tests {
                             dimension: 2,
                         },
                     },
-                )
+                 }
             )
         );
     }
@@ -6103,9 +6116,9 @@ mod tests {
 
         assert_matches!(
             err,
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::FinalTopologyValidation { .. }
-            )
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::FinalTopologyValidation { .. }
+            }
         );
     }
 
@@ -6350,9 +6363,9 @@ mod tests {
             DelaunayTriangulationBuilder::new(&vertices).build();
 
         match result.unwrap_err() {
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::InsufficientVertices { dimension, .. },
-            ) => assert_eq!(dimension, 2),
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::InsufficientVertices { dimension, .. },
+            } => assert_eq!(dimension, 2),
             other => panic!("Expected InsufficientVertices error, got {other:?}"),
         }
     }
@@ -6370,9 +6383,9 @@ mod tests {
             DelaunayTriangulationBuilder::new(&vertices).build();
 
         match result.unwrap_err() {
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::InsufficientVertices { dimension, .. },
-            ) => assert_eq!(dimension, 3),
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::InsufficientVertices { dimension, .. },
+            } => assert_eq!(dimension, 3),
             other => panic!("Expected InsufficientVertices error, got {other:?}"),
         }
     }
@@ -6400,11 +6413,12 @@ mod tests {
             DelaunayTriangulationBuilder::new(&vertices).build();
 
         match result.unwrap_err() {
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::Tds {
-                    reason: TdsConstructionFailure::DuplicateUuid { entity: _, uuid },
-                },
-            ) => assert_eq!(uuid, dup_uuid),
+            DelaunayTriangulationConstructionError::Triangulation {
+                source:
+                    DelaunayConstructionFailure::Tds {
+                        reason: TdsConstructionFailure::DuplicateUuid { entity: _, uuid },
+                    },
+            } => assert_eq!(uuid, dup_uuid),
             other => panic!("Expected DuplicateUuid error, got {other:?}"),
         }
     }
@@ -6999,11 +7013,11 @@ mod tests {
 
         assert_matches!(
             error,
-            DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::SpatialIndexConstruction {
                     reason: SpatialIndexConstructionFailure::NonPositiveCellSize { value }
                 }
-            ) if value == CoordinateConversionValue::from_f64(0.0)
+             } if value == CoordinateConversionValue::from_f64(0.0)
         );
     }
 
@@ -7632,8 +7646,8 @@ mod tests {
 
         assert_eq!(
             err.error,
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::InsufficientVertices {
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::InsufficientVertices {
                     dimension: D,
                     source: SimplexValidationError::InsufficientVertices {
                         actual: D,
@@ -7641,7 +7655,7 @@ mod tests {
                         dimension: D,
                     },
                 },
-            )
+            }
         );
         assert_eq!(err.statistics.inserted, 0);
         assert_eq!(err.statistics.total_skipped(), 0);
@@ -7866,12 +7880,12 @@ mod tests {
         assert!(
             matches!(
                 mapped_hard,
-                DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayTriangulationConstructionError::Triangulation { source:
                     DelaunayConstructionFailure::DelaunayRepair {
                         phase: DelaunayConstructionRepairPhase::BatchLocal { index: 23 },
                         ref source,
                     }
-                ) if matches!(
+                 } if matches!(
                     source.as_ref(),
                     DelaunayRepairError::Flip {
                         source: flip_source
@@ -7891,12 +7905,12 @@ mod tests {
         assert!(
             matches!(
                 &mapped_geometric,
-                DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayTriangulationConstructionError::Triangulation { source:
                     DelaunayConstructionFailure::DelaunayRepair {
                         phase: DelaunayConstructionRepairPhase::BatchLocal { index: 24 },
                         source,
                     }
-                ) if matches!(
+                 } if matches!(
                     source.as_ref(),
                     DelaunayRepairError::Flip { source }
                         if matches!(source.as_ref(), FlipError::DegenerateSimplex)
@@ -7912,12 +7926,12 @@ mod tests {
         assert!(
             matches!(
                 &mapped_simplex_creation,
-                DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayTriangulationConstructionError::Triangulation { source:
                     DelaunayConstructionFailure::DelaunayRepair {
                         phase: DelaunayConstructionRepairPhase::BatchLocal { index: 25 },
                         source,
                     }
-                ) if matches!(source.as_ref(), DelaunayRepairError::Flip { .. })
+                 } if matches!(source.as_ref(), DelaunayRepairError::Flip { .. })
                     && !TestDelaunay::<4>::is_non_retryable_construction_error(
                         &mapped_simplex_creation
                     )
@@ -7936,12 +7950,12 @@ mod tests {
         assert!(
             matches!(
                 mapped_verification,
-                DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayTriangulationConstructionError::Triangulation { source:
                     DelaunayConstructionFailure::DelaunayRepair {
                         phase: DelaunayConstructionRepairPhase::BatchLocal { index: 26 },
                         ref source,
                     }
-                ) if matches!(**source, DelaunayRepairError::VerificationFailed { .. })
+                 } if matches!(**source, DelaunayRepairError::VerificationFailed { .. })
             ),
             "verification context failures should stop shuffled retries: {mapped_verification:?}"
         );
@@ -7966,12 +7980,12 @@ mod tests {
         assert!(
             matches!(
                 &mapped_predicate,
-                DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayTriangulationConstructionError::Triangulation { source:
                     DelaunayConstructionFailure::DelaunayRepair {
                         phase: DelaunayConstructionRepairPhase::BatchLocal { index: 27 },
                         source,
                     }
-                ) if matches!(source.as_ref(), DelaunayRepairError::VerificationFailed { .. })
+                 } if matches!(source.as_ref(), DelaunayRepairError::VerificationFailed { .. })
                     && !TestDelaunay::<4>::is_non_retryable_construction_error(&mapped_predicate)
             ),
             "verification predicate failures should remain typed and retryable: {mapped_predicate:?}"
@@ -7990,7 +8004,7 @@ mod tests {
         );
         assert_matches!(
             mapped,
-            DelaunayTriangulationConstructionError::Triangulation(
+            DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::FinalDelaunayValidation {
                     context: FinalDelaunayValidationContext::ConstructionFinalize,
                     source:
@@ -7998,7 +8012,7 @@ mod tests {
                             source,
                         },
                 }
-            ) if matches!(
+             } if matches!(
                 source.as_ref(),
                 DelaunayVerificationError::FlipPredicates { source }
                     if matches!(
@@ -8015,9 +8029,11 @@ mod tests {
 
     #[test]
     fn test_map_orientation_canonicalization_error_topology_validation_is_internal() {
-        let error = InsertionError::TopologyValidation(TdsError::InconsistentDataStructure {
-            message: "missing simplex".to_string(),
-        });
+        let error = InsertionError::TopologyValidation {
+            source: TdsError::InconsistentDataStructure {
+                message: "missing simplex".to_string(),
+            },
+        };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
         assert!(
             matches!(
@@ -8035,11 +8051,13 @@ mod tests {
 
     #[test]
     fn test_map_orientation_canonicalization_error_degenerate_orientation_is_degeneracy() {
-        let error = InsertionError::TopologyValidation(TdsError::Geometric(
-            GeometricError::DegenerateOrientation {
-                message: "det=0".to_string(),
+        let error = InsertionError::TopologyValidation {
+            source: TdsError::Geometric {
+                source: GeometricError::DegenerateOrientation {
+                    message: "det=0".to_string(),
+                },
             },
-        ));
+        };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
         assert!(
             matches!(
@@ -8057,11 +8075,13 @@ mod tests {
 
     #[test]
     fn test_map_orientation_canonicalization_error_negative_orientation_is_degeneracy() {
-        let error = InsertionError::TopologyValidation(TdsError::Geometric(
-            GeometricError::NegativeOrientation {
-                message: "det<0 after canonicalization".to_string(),
+        let error = InsertionError::TopologyValidation {
+            source: TdsError::Geometric {
+                source: GeometricError::NegativeOrientation {
+                    message: "det<0 after canonicalization".to_string(),
+                },
             },
-        ));
+        };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
         assert!(
             matches!(
@@ -8174,7 +8194,9 @@ mod tests {
     #[test]
     fn test_map_orientation_canonicalization_error_geometry_variants_are_degeneracy() {
         let geometry_errors: Vec<InsertionError> = vec![
-            InsertionError::Location(LocateError::EmptyTriangulation),
+            InsertionError::Location {
+                source: LocateError::EmptyTriangulation,
+            },
             InsertionError::NonManifoldTopology {
                 facet_hash: 0,
                 simplex_count: 3,
@@ -8277,12 +8299,14 @@ mod tests {
 
     #[test]
     fn test_map_insertion_error_topology_validation() {
-        let error = InsertionError::TopologyValidation(TdsError::InconsistentDataStructure {
-            message: "broken".to_string(),
-        });
+        let error = InsertionError::TopologyValidation {
+            source: TdsError::InconsistentDataStructure {
+                message: "broken".to_string(),
+            },
+        };
         let mapped = TestDelaunay::<3>::map_insertion_error(error);
         assert!(
-            matches!(mapped, TriangulationConstructionError::Tds(_)),
+            matches!(mapped, TriangulationConstructionError::Tds { source: _ }),
             "TopologyValidation should map to Tds(ValidationError), got: {mapped:?}"
         );
     }
@@ -8295,7 +8319,7 @@ mod tests {
         };
         let mapped = TestDelaunay::<3>::map_insertion_error(error);
         assert!(
-            matches!(mapped, TriangulationConstructionError::Tds(_)),
+            matches!(mapped, TriangulationConstructionError::Tds { source: _ }),
             "DuplicateUuid should map to Tds(DuplicateUuid), got: {mapped:?}"
         );
     }
@@ -8317,11 +8341,13 @@ mod tests {
 
     #[test]
     fn test_map_insertion_error_preserves_typed_insertion_sources() {
-        let conflict = InsertionError::ConflictRegion(ConflictError::OpenBoundary {
-            facet_count: 2,
-            ridge_vertex_count: 1,
-            open_simplex: SimplexKey::from(KeyData::from_ffi(1)),
-        });
+        let conflict = InsertionError::ConflictRegion {
+            source: ConflictError::OpenBoundary {
+                facet_count: 2,
+                ridge_vertex_count: 1,
+                open_simplex: SimplexKey::from(KeyData::from_ffi(1)),
+            },
+        };
         let mapped = TestDelaunay::<3>::map_insertion_error(conflict);
         assert_matches!(
             mapped,
@@ -8330,7 +8356,9 @@ mod tests {
             }
         );
 
-        let location = InsertionError::Location(LocateError::EmptyTriangulation);
+        let location = InsertionError::Location {
+            source: LocateError::EmptyTriangulation,
+        };
         let mapped = TestDelaunay::<3>::map_insertion_error(location);
         assert_matches!(
             mapped,
@@ -8627,12 +8655,12 @@ mod tests {
         let public_error: DelaunayTriangulationConstructionError = mapped.into();
         assert_matches!(
             public_error,
-            DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::LocalRepairBudgetExceeded {
+            DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::LocalRepairBudgetExceeded {
                     max_simplices_removed: 2,
                     attempted: 3,
                 }
-            )
+            }
         );
     }
 
@@ -8655,18 +8683,20 @@ mod tests {
     #[test]
     fn test_map_orientation_canonicalization_error_orientation_violation_is_internal_inconsistency()
     {
-        let error = InsertionError::TopologyValidation(TdsError::OrientationViolation {
-            simplex1_key: SimplexKey::from(KeyData::from_ffi(1)),
-            simplex1_uuid: Uuid::nil(),
-            simplex2_key: SimplexKey::from(KeyData::from_ffi(2)),
-            simplex2_uuid: Uuid::nil(),
-            simplex1_facet_index: 0,
-            simplex2_facet_index: 1,
-            facet_vertices: vec![],
-            simplex2_facet_vertices: vec![],
-            observed_odd_permutation: true,
-            expected_odd_permutation: false,
-        });
+        let error = InsertionError::TopologyValidation {
+            source: TdsError::OrientationViolation {
+                simplex1_key: SimplexKey::from(KeyData::from_ffi(1)),
+                simplex1_uuid: Uuid::nil(),
+                simplex2_key: SimplexKey::from(KeyData::from_ffi(2)),
+                simplex2_uuid: Uuid::nil(),
+                simplex1_facet_index: 0,
+                simplex2_facet_index: 1,
+                facet_vertices: vec![],
+                simplex2_facet_vertices: vec![],
+                observed_odd_permutation: true,
+                expected_odd_permutation: false,
+            },
+        };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
         assert!(
             matches!(
@@ -8679,10 +8709,12 @@ mod tests {
 
     #[test]
     fn test_map_orientation_canonicalization_error_conflict_region_is_degeneracy() {
-        let error = InsertionError::ConflictRegion(ConflictError::NonManifoldFacet {
-            facet_hash: 0x123,
-            simplex_count: 3,
-        });
+        let error = InsertionError::ConflictRegion {
+            source: ConflictError::NonManifoldFacet {
+                facet_hash: 0x123,
+                simplex_count: 3,
+            },
+        };
         let mapped = TestDelaunay::<3>::map_orientation_canonicalization_error(error);
         assert!(
             matches!(
@@ -8695,12 +8727,13 @@ mod tests {
 
     #[test]
     fn test_is_non_retryable_construction_error_duplicate_uuid() {
-        let err: DelaunayTriangulationConstructionError =
-            TriangulationConstructionError::Tds(TdsConstructionError::DuplicateUuid {
+        let err: DelaunayTriangulationConstructionError = TriangulationConstructionError::Tds {
+            source: TdsConstructionError::DuplicateUuid {
                 entity: EntityKind::Simplex,
                 uuid: Uuid::nil(),
-            })
-            .into();
+            },
+        }
+        .into();
         assert!(
             TestDelaunay::<3>::is_non_retryable_construction_error(&err),
             "DuplicateUuid should be non-retryable"
@@ -8753,11 +8786,11 @@ mod tests {
     fn test_is_non_retryable_construction_error_internal_orientation_and_wiring() {
         let orientation_err: DelaunayTriangulationConstructionError =
             TriangulationConstructionError::OrientationCanonicalizationInternal {
-                source: Box::new(InsertionError::TopologyValidation(
-                    TdsError::InconsistentDataStructure {
+                source: Box::new(InsertionError::TopologyValidation {
+                    source: TdsError::InconsistentDataStructure {
                         message: "dangling incidence".to_string(),
                     },
-                )),
+                }),
             }
             .into();
         let wiring_err: DelaunayTriangulationConstructionError =
@@ -8780,11 +8813,13 @@ mod tests {
 
     #[test]
     fn test_is_non_retryable_construction_error_tds_validation() {
-        let err: DelaunayTriangulationConstructionError = TriangulationConstructionError::Tds(
-            TdsConstructionError::ValidationError(TdsError::InconsistentDataStructure {
-                message: "test".to_string(),
-            }),
-        )
+        let err: DelaunayTriangulationConstructionError = TriangulationConstructionError::Tds {
+            source: TdsConstructionError::ValidationError {
+                source: TdsError::InconsistentDataStructure {
+                    message: "test".to_string(),
+                },
+            },
+        }
         .into();
         assert!(
             TestDelaunay::<3>::is_non_retryable_construction_error(&err),
@@ -8807,20 +8842,20 @@ mod tests {
         let final_err: DelaunayTriangulationConstructionError =
             TriangulationConstructionError::FinalTopologyValidation {
                 context: FinalTopologyValidationContext::ConstructionFinalize,
-                source: Box::new(InvariantError::Triangulation(
-                    TriangulationValidationError::IsolatedVertex {
+                source: Box::new(InvariantError::Triangulation {
+                    source: TriangulationValidationError::IsolatedVertex {
                         vertex_key,
                         vertex_uuid: Uuid::nil(),
                     },
-                )),
+                }),
             }
             .into();
-        let final_delaunay_err = DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::FinalDelaunayValidation {
+        let final_delaunay_err = DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::FinalDelaunayValidation {
                 context: FinalDelaunayValidationContext::ConstructionFinalize,
                 source: synthetic_delaunay_verification_error(),
             },
-        );
+        };
 
         assert!(
             TestDelaunay::<3>::is_non_retryable_construction_error(&insertion_err),

--- a/src/delaunay/delaunayize.rs
+++ b/src/delaunay/delaunayize.rs
@@ -783,7 +783,7 @@ fn failed_topology_repair_stats<U, V, const D: usize>(
             simplices_removed,
             ..
         } => (*iterations, *simplices_removed),
-        PlManifoldRepairError::Tds(_)
+        PlManifoldRepairError::Tds { source: _ }
         | PlManifoldRepairError::TargetedValidation { .. }
         | PlManifoldRepairError::TargetedPostconditionValidation { .. } => (0, 0),
     };

--- a/src/delaunay/deletion.rs
+++ b/src/delaunay/deletion.rs
@@ -220,7 +220,9 @@ where
     /// };
     /// std::assert_matches!(
     ///     source.as_ref(),
-    ///     InvariantError::Triangulation(TriangulationValidationError::IsolatedVertex { .. })
+    ///     InvariantError::Triangulation {
+    ///         source: TriangulationValidationError::IsolatedVertex { .. },
+    ///     }
     /// );
     /// assert_eq!(dt.number_of_vertices(), 3);
     /// assert_eq!(dt.number_of_simplices(), 1);
@@ -266,13 +268,11 @@ where
                         repair_result
                     };
 
-                    repair_result.map_err(|source| {
-                        InvariantError::Delaunay(
-                            DelaunayTriangulationValidationError::RepairOperationFailed {
-                                operation: DelaunayRepairOperation::VertexRemoval,
-                                source: Box::new(source),
-                            },
-                        )
+                    repair_result.map_err(|source| InvariantError::Delaunay {
+                        source: DelaunayTriangulationValidationError::RepairOperationFailed {
+                            operation: DelaunayRepairOperation::VertexRemoval,
+                            source: Box::new(source),
+                        },
                     })?;
 
                     // Re-canonicalize geometric orientation (#258): flip repair may leave
@@ -289,7 +289,7 @@ where
                 } else {
                     delaunay
                         .is_valid_delaunay()
-                        .map_err(InvariantError::Delaunay)?;
+                        .map_err(|source| InvariantError::Delaunay { source })?;
                 }
             }
 
@@ -466,19 +466,22 @@ mod tests {
         let err = result.expect_err("forced repair failure should make deletion fail");
         match err {
             DeleteVertexError::InvariantViolation { source } => match source.as_ref() {
-                InvariantError::Delaunay(
-                    DelaunayTriangulationValidationError::RepairOperationFailed {
-                        operation: DelaunayRepairOperation::VertexRemoval,
-                        source,
-                    },
-                ) if matches!(
+                InvariantError::Delaunay {
+                    source:
+                        DelaunayTriangulationValidationError::RepairOperationFailed {
+                            operation: DelaunayRepairOperation::VertexRemoval,
+                            source,
+                        },
+                } if matches!(
                     source.as_ref(),
                     DelaunayRepairError::NonConvergent { max_flips: 0, .. }
                 ) => {}
-                InvariantError::Triangulation(
-                    TriangulationValidationError::OrientationPromotionNonConvergence { .. },
-                )
-                | InvariantError::Tds(TdsError::FacetSharingViolation { .. }) => {}
+                InvariantError::Triangulation {
+                    source: TriangulationValidationError::OrientationPromotionNonConvergence { .. },
+                }
+                | InvariantError::Tds {
+                    source: TdsError::FacetSharingViolation { .. },
+                } => {}
                 other => panic!(
                     "expected vertex-deletion rollback error from forced repair path, got {other:?}"
                 ),
@@ -796,9 +799,9 @@ mod tests {
         };
         assert_matches!(
             source.as_ref(),
-            InvariantError::Delaunay(
-                DelaunayTriangulationValidationError::VerificationFailed { .. }
-            )
+            InvariantError::Delaunay {
+                source: DelaunayTriangulationValidationError::VerificationFailed { .. }
+            }
         );
         assert_eq!(dt.number_of_vertices(), vertex_count_before);
         assert_eq!(dt.number_of_simplices(), simplex_count_before);

--- a/src/delaunay/flips.rs
+++ b/src/delaunay/flips.rs
@@ -989,7 +989,7 @@ mod tests {
         assert_matches!(
             err,
             FlipError::RealizationValidation { source }
-                if matches!(*source, TriangulationRealizationValidationError::Triangulation(_))
+                if matches!(*source, TriangulationRealizationValidationError::Triangulation { source: _ })
         );
         assert_eq!(tri.tds.number_of_vertices(), before_vertices);
         assert_eq!(tri.tds.number_of_simplices(), before_simplices);

--- a/src/delaunay/insertion.rs
+++ b/src/delaunay/insertion.rs
@@ -40,7 +40,7 @@ fn ridge_link_repair_validation_error(err: ManifoldError) -> InsertionError {
             context: InsertionTopologyValidationContext::DelaunayRepair,
             source,
         },
-        Err(source) => InsertionError::TopologyValidation(source),
+        Err(source) => InsertionError::TopologyValidation { source },
     }
 }
 
@@ -527,7 +527,7 @@ where
         self.tri.normalize_and_promote_positive_orientation()?;
         self.tri
             .validate_geometric_simplex_orientation()
-            .map_err(InsertionError::TopologyValidation)?;
+            .map_err(|source| InsertionError::TopologyValidation { source })?;
         Ok(())
     }
 
@@ -705,8 +705,10 @@ mod tests {
             message: "unit test".to_string(),
         };
 
-        match ridge_link_repair_validation_error(ManifoldError::Tds(tds_err.clone())) {
-            InsertionError::TopologyValidation(source) => assert_eq!(source, tds_err),
+        match ridge_link_repair_validation_error(ManifoldError::Tds {
+            source: tds_err.clone(),
+        }) {
+            InsertionError::TopologyValidation { source } => assert_eq!(source, tds_err),
             other => panic!("expected TopologyValidation, got {other:?}"),
         }
     }

--- a/src/delaunay/query.rs
+++ b/src/delaunay/query.rs
@@ -1728,10 +1728,10 @@ impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
                 }
                 Ok(())
             }
-            Err(InvariantError::Tds(err)) => Err(err.into()),
-            Err(InvariantError::Triangulation(err)) => Err(err.into()),
-            Err(InvariantError::Realization(err)) => Err(err.into()),
-            Err(InvariantError::Delaunay(err)) => Err(err),
+            Err(InvariantError::Tds { source: err }) => Err(err.into()),
+            Err(InvariantError::Triangulation { source: err }) => Err(err.into()),
+            Err(InvariantError::Realization { source: err }) => Err(err.into()),
+            Err(InvariantError::Delaunay { source: err }) => Err(err),
         }
     }
 
@@ -3263,7 +3263,7 @@ mod tests {
 
         assert_matches!(
             err,
-            DelaunayTriangulationValidationError::Triangulation(source)
+            DelaunayTriangulationValidationError::Triangulation { source }
                 if matches!(
                     &*source,
                     TriangulationValidationError::BoundaryFacetInClosedTopology {

--- a/src/delaunay/spherical.rs
+++ b/src/delaunay/spherical.rs
@@ -1983,6 +1983,56 @@ mod tests {
     }
 
     #[test]
+    fn intrinsic_topology_adapters_preserve_typed_tds_sources() {
+        let direct = intrinsic_tds_error(TdsError::InconsistentDataStructure {
+            message: "invalid synthetic adjacency".to_string(),
+        });
+        assert_matches!(
+            direct,
+            SphericalDelaunayValidationError::IntrinsicTopology { source }
+                if matches!(
+                    source.as_ref(),
+                    InvariantError::Tds {
+                        source: TdsError::InconsistentDataStructure { message }
+                    } if message == "invalid synthetic adjacency"
+                )
+        );
+
+        let boundary_count = intrinsic_topology_support_error(TopologyError::BoundaryFacetCount {
+            source: TdsError::InconsistentDataStructure {
+                message: "invalid boundary count".to_string(),
+            },
+        });
+        assert_matches!(
+            boundary_count,
+            SphericalDelaunayValidationError::IntrinsicTopology { source }
+                if matches!(
+                    source.as_ref(),
+                    InvariantError::Tds {
+                        source: TdsError::InconsistentDataStructure { message }
+                    } if message == "invalid boundary count"
+                )
+        );
+
+        let facet_access =
+            intrinsic_topology_support_error(TopologyError::BoundaryFacetSimplexAccess {
+                source: FacetError::FacetNotFoundInTriangulation,
+            });
+        assert_matches!(
+            facet_access,
+            SphericalDelaunayValidationError::IntrinsicTopology { source }
+                if matches!(
+                    source.as_ref(),
+                    InvariantError::Tds {
+                        source: TdsError::FacetError {
+                            source: FacetError::FacetNotFoundInTriangulation
+                        }
+                    }
+                )
+        );
+    }
+
+    #[test]
     fn level3_rejects_empty_spherical_complex() {
         let triangulation = SphericalDelaunayTriangulation::<2> {
             points: tetrahedron_boundary_points(),

--- a/src/delaunay/spherical.rs
+++ b/src/delaunay/spherical.rs
@@ -1448,7 +1448,7 @@ fn scaled_euclidean_norm(coords: &[f64]) -> f64 {
 
 /// Wraps TDS invariant failures from the synthetic topology bridge.
 fn intrinsic_tds_error(source: TdsError) -> SphericalDelaunayValidationError {
-    intrinsic_error(InvariantError::Tds(source))
+    intrinsic_error(InvariantError::Tds { source })
 }
 
 /// Wraps manifold invariant failures from the synthetic topology bridge.
@@ -1460,7 +1460,7 @@ fn intrinsic_manifold_error(source: ManifoldError) -> SphericalDelaunayValidatio
 fn intrinsic_topology_error(
     source: TriangulationValidationError,
 ) -> SphericalDelaunayValidationError {
-    intrinsic_error(InvariantError::Triangulation(source))
+    intrinsic_error(InvariantError::Triangulation { source })
 }
 
 /// Converts topology-support helper failures into the shared invariant tree.
@@ -1468,8 +1468,10 @@ fn intrinsic_topology_support_error(source: TopologyError) -> SphericalDelaunayV
     let invariant = match source {
         TopologyError::FacetMapBuild { source }
         | TopologyError::BoundaryFacetEnumeration { source }
-        | TopologyError::BoundaryFacetCount { source } => InvariantError::Tds(source),
-        TopologyError::BoundaryFacetSimplexAccess { source } => InvariantError::Tds(source.into()),
+        | TopologyError::BoundaryFacetCount { source } => InvariantError::Tds { source },
+        TopologyError::BoundaryFacetSimplexAccess { source } => InvariantError::Tds {
+            source: source.into(),
+        },
         TopologyError::BoundaryClassification { source } => InvariantError::from(*source),
     };
     intrinsic_error(invariant)
@@ -2275,9 +2277,9 @@ mod tests {
             Err(SphericalDelaunayValidationError::IntrinsicTopology { source })
                 if matches!(
                     source.as_ref(),
-                    InvariantError::Triangulation(
+                    InvariantError::Triangulation { source:
                         TriangulationValidationError::Disconnected { simplex_count: 8 }
-                    )
+                     }
                 )
         );
     }

--- a/src/delaunay/validation.rs
+++ b/src/delaunay/validation.rs
@@ -351,15 +351,24 @@ impl From<&DelaunayVerificationError> for DelaunayVerificationErrorKind {
 pub enum DelaunayTriangulationValidationError {
     /// Lower-layer element or TDS structural validation error (Levels 1–2).
     #[error(transparent)]
-    Tds(Box<TdsError>),
+    Tds {
+        /// Boxed TDS source error.
+        source: Box<TdsError>,
+    },
 
     /// Lower-layer topology validation error (Level 3).
     #[error(transparent)]
-    Triangulation(Box<TriangulationValidationError>),
+    Triangulation {
+        /// Boxed topology-validation source error.
+        source: Box<TriangulationValidationError>,
+    },
 
     /// Lower-layer realized-geometry validation error (Level 4).
     #[error(transparent)]
-    Realization(Box<TriangulationRealizationValidationError>),
+    Realization {
+        /// Boxed realization-validation source error.
+        source: Box<TriangulationRealizationValidationError>,
+    },
 
     /// Flip-based Delaunay verification detected a violation.
     ///
@@ -398,24 +407,30 @@ pub enum DelaunayTriangulationValidationError {
 
 impl From<TdsError> for DelaunayTriangulationValidationError {
     fn from(source: TdsError) -> Self {
-        Self::Tds(Box::new(source))
+        Self::Tds {
+            source: Box::new(source),
+        }
     }
 }
 
 impl From<TriangulationValidationError> for DelaunayTriangulationValidationError {
     fn from(source: TriangulationValidationError) -> Self {
-        Self::Triangulation(Box::new(source))
+        Self::Triangulation {
+            source: Box::new(source),
+        }
     }
 }
 
 impl From<TriangulationRealizationValidationError> for DelaunayTriangulationValidationError {
     fn from(source: TriangulationRealizationValidationError) -> Self {
         match source {
-            TriangulationRealizationValidationError::Tds(source) => Self::Tds(source),
-            TriangulationRealizationValidationError::Triangulation(source) => {
-                Self::Triangulation(source)
+            TriangulationRealizationValidationError::Tds { source } => Self::Tds { source },
+            TriangulationRealizationValidationError::Triangulation { source } => {
+                Self::Triangulation { source }
             }
-            source => Self::Realization(Box::new(source)),
+            source => Self::Realization {
+                source: Box::new(source),
+            },
         }
     }
 }
@@ -648,24 +663,24 @@ where
                         .into_iter()
                         .map(|detail| InvariantViolation {
                             kind: InvariantKind::DelaunayProperty,
-                            error: InvariantError::Delaunay(
-                                DelaunayTriangulationValidationError::VerificationFailed {
+                            error: InvariantError::Delaunay {
+                                source: DelaunayTriangulationValidationError::VerificationFailed {
                                     source: Box::new(DelaunayVerificationError::from(
                                         DelaunayValidationError::from(detail),
                                     )),
                                 },
-                            ),
+                            },
                         })
                         .collect(),
                 }),
                 Err(source) => Err(TriangulationValidationReport {
                     violations: vec![InvariantViolation {
                         kind: InvariantKind::DelaunayProperty,
-                        error: InvariantError::Delaunay(
-                            DelaunayTriangulationValidationError::VerificationFailed {
+                        error: InvariantError::Delaunay {
+                            source: DelaunayTriangulationValidationError::VerificationFailed {
                                 source: Box::new(DelaunayVerificationError::from(source)),
                             },
-                        ),
+                        },
                     }],
                 }),
             };
@@ -675,7 +690,7 @@ where
             .map_err(|error| TriangulationValidationReport {
                 violations: vec![InvariantViolation {
                     kind: InvariantKind::DelaunayProperty,
-                    error: InvariantError::Delaunay(error),
+                    error: InvariantError::Delaunay { source: error },
                 }],
             })
     }
@@ -931,14 +946,14 @@ where
                             .extend(realization_report.violations.into_iter().map(|error| {
                                 InvariantViolation {
                                     kind: InvariantKind::Realization,
-                                    error: InvariantError::Realization(error),
+                                    error: InvariantError::Realization { source: error },
                                 }
                             }));
                     }
                     Err(source) => {
                         report.violations.push(InvariantViolation {
                             kind: InvariantKind::Realization,
-                            error: InvariantError::Realization(source),
+                            error: InvariantError::Realization { source },
                         });
                     }
                 }
@@ -1615,7 +1630,7 @@ mod tests {
             .expect_err("checked TDS reconstruction must reject broken UUID mappings");
         assert_matches!(
             err,
-            DelaunayTriangulationValidationError::Tds(source)
+            DelaunayTriangulationValidationError::Tds { source }
                 if matches!(source.as_ref(), TdsError::MappingInconsistency { .. })
         );
     }
@@ -1641,7 +1656,7 @@ mod tests {
             .expect_err("checked TDS reconstruction must reject isolated vertices");
         assert_matches!(
             err,
-            DelaunayTriangulationValidationError::Triangulation(source)
+            DelaunayTriangulationValidationError::Triangulation { source }
                 if matches!(
                     source.as_ref(),
                     TriangulationValidationError::IsolatedVertex { .. }
@@ -1774,10 +1789,10 @@ mod tests {
         dt.tds_mut_for_repair().uuid_to_vertex_key.remove(&uuid);
 
         match dt.validate() {
-            Err(DelaunayTriangulationValidationError::Tds(source))
+            Err(DelaunayTriangulationValidationError::Tds { source })
                 if matches!(source.as_ref(), TdsError::MappingInconsistency { .. }) => {}
             other => panic!(
-                "Expected DelaunayTriangulationValidationError::Tds(MappingInconsistency), got {other:?}"
+                "Expected DelaunayTriangulationValidationError::Tds with MappingInconsistency source, got {other:?}"
             ),
         }
     }
@@ -1801,13 +1816,13 @@ mod tests {
             .unwrap();
 
         match dt.validate() {
-            Err(DelaunayTriangulationValidationError::Triangulation(source))
+            Err(DelaunayTriangulationValidationError::Triangulation { source })
                 if matches!(
                     source.as_ref(),
                     TriangulationValidationError::IsolatedVertex { .. }
                 ) => {}
             other => panic!(
-                "Expected DelaunayTriangulationValidationError::Triangulation(IsolatedVertex), got {other:?}"
+                "Expected DelaunayTriangulationValidationError::Triangulation with IsolatedVertex source, got {other:?}"
             ),
         }
     }

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -205,6 +205,7 @@ pub enum ConvexHullConstructionError {
     #[error("Insufficient data for convex hull construction: {reason}")]
     InsufficientData {
         /// Typed reason that the input cannot define a convex hull.
+        #[source]
         reason: ConvexHullInsufficientDataReason,
     },
     /// Geometric degeneracy prevents convex hull construction.
@@ -3858,6 +3859,19 @@ mod tests {
         };
         let display = format!("{coord_error}");
         assert!(display.contains("Coordinate conversion error"));
+    }
+
+    #[test]
+    fn insufficient_data_error_preserves_typed_source() {
+        let reason = ConvexHullInsufficientDataReason::NoVertices;
+        let error = ConvexHullConstructionError::InsufficientData { reason };
+
+        assert_eq!(
+            error
+                .source()
+                .and_then(|source| source.downcast_ref::<ConvexHullInsufficientDataReason>()),
+            Some(&reason),
+        );
     }
 
     #[test]

--- a/src/geometry/algorithms/convex_hull.rs
+++ b/src/geometry/algorithms/convex_hull.rs
@@ -142,6 +142,21 @@ pub enum ConvexHullValidationError {
     },
 }
 
+/// Reasons that a triangulation lacks enough data to construct a convex hull.
+#[derive(Clone, Copy, Debug, Error, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ConvexHullInsufficientDataReason {
+    /// The triangulation contains no vertices.
+    #[error("triangulation contains no vertices")]
+    NoVertices,
+    /// The triangulation contains vertices but no simplices.
+    #[error("triangulation contains no simplices")]
+    NoSimplices,
+    /// The triangulation has no boundary facets, as for a closed topology.
+    #[error("triangulation contains no boundary facets")]
+    NoBoundaryFacets,
+}
+
 /// Errors that can occur during convex hull construction.
 ///
 /// # Examples
@@ -187,10 +202,10 @@ pub enum ConvexHullConstructionError {
         message: String,
     },
     /// Insufficient data to construct convex hull.
-    #[error("Insufficient data for convex hull construction: {message}")]
+    #[error("Insufficient data for convex hull construction: {reason}")]
     InsufficientData {
-        /// Description of the data insufficiency.
-        message: String,
+        /// Typed reason that the input cannot define a convex hull.
+        reason: ConvexHullInsufficientDataReason,
     },
     /// Geometric degeneracy prevents convex hull construction.
     #[error("Geometric degeneracy encountered during convex hull construction: {message}")]
@@ -205,8 +220,12 @@ pub enum ConvexHullConstructionError {
         message: String,
     },
     /// Coordinate conversion error occurred during geometric computations.
-    #[error("Coordinate conversion error: {0}")]
-    CoordinateConversion(#[from] CoordinateConversionError),
+    #[error("Coordinate conversion error: {source}")]
+    CoordinateConversion {
+        /// Typed source error from coordinate conversion.
+        #[from]
+        source: CoordinateConversionError,
+    },
     /// Coordinate validation failed during geometric computations.
     #[error("Coordinate validation error during convex hull computation: {source}")]
     CoordinateValidation {
@@ -1068,13 +1087,13 @@ where
         // Validate input triangulation
         if tds.number_of_vertices() == 0 {
             return Err(ConvexHullConstructionError::InsufficientData {
-                message: "Triangulation contains no vertices".to_string(),
+                reason: ConvexHullInsufficientDataReason::NoVertices,
             });
         }
 
         if tds.number_of_simplices() == 0 {
             return Err(ConvexHullConstructionError::InsufficientData {
-                message: "Triangulation contains no simplices".to_string(),
+                reason: ConvexHullInsufficientDataReason::NoSimplices,
             });
         }
 
@@ -1106,7 +1125,7 @@ where
         // Additional validation: ensure we have at least one boundary facet
         if hull_facets.is_empty() {
             return Err(ConvexHullConstructionError::InsufficientData {
-                message: "No boundary facets found in triangulation".to_string(),
+                reason: ConvexHullInsufficientDataReason::NoBoundaryFacets,
             });
         }
 
@@ -1498,7 +1517,7 @@ where
             }
         }
         let num_vertices = safe_usize_to_scalar(vertex_points.len())
-            .map_err(ConvexHullConstructionError::CoordinateConversion)?;
+            .map_err(|source| ConvexHullConstructionError::CoordinateConversion { source })?;
         for coord in &mut centroid_coords {
             *coord /= num_vertices;
         }
@@ -1733,7 +1752,7 @@ where
             // Calculate distance from point to facet centroid as a simple heuristic
             let mut centroid_coords = [0.0; D];
             let num_vertices = safe_usize_to_scalar(facet_points.len())
-                .map_err(ConvexHullConstructionError::CoordinateConversion)?;
+                .map_err(|source| ConvexHullConstructionError::CoordinateConversion { source })?;
 
             for vertex_point in &facet_points {
                 let coords = vertex_point.coords();
@@ -3133,10 +3152,11 @@ mod tests {
                         "Hull with {desc} coordinates should validate successfully"
                     );
                 }
-                Err(DelaunayTriangulationConstructionError::Triangulation(
-                    DelaunayConstructionFailure::GeometricDegeneracy { .. }
-                    | DelaunayConstructionFailure::InsufficientVertices { .. },
-                )) => {
+                Err(DelaunayTriangulationConstructionError::Triangulation {
+                    source:
+                        DelaunayConstructionFailure::GeometricDegeneracy { .. }
+                        | DelaunayConstructionFailure::InsufficientVertices { .. },
+                }) => {
                     // Extremely large/small/mixed coordinate sets may be rejected as
                     // numerically unstable by the robust initial simplex search, or
                     // Hilbert-sort dedup may collapse near-identical coordinates at
@@ -3520,7 +3540,7 @@ mod tests {
 
         // Test Debug trait on error types
         let error = ConvexHullConstructionError::InsufficientData {
-            message: "test".to_string(),
+            reason: ConvexHullInsufficientDataReason::NoVertices,
         };
         let debug_error = format!("{error:?}");
         assert!(debug_error.contains("InsufficientData"));
@@ -3603,19 +3623,12 @@ mod tests {
         let empty_dt = DelaunayTriangulation::<_, (), (), 3>::empty();
         let result = ConvexHull::try_from_triangulation(empty_dt.as_triangulation());
 
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            ConvexHullConstructionError::InsufficientData { message } => {
-                assert!(message.contains("no vertices"));
-            }
-            _ => panic!("Expected InsufficientData error for no vertices"),
-        }
-
-        // Also test with assert_matches! for variant diagnostics.
-        let result2 = ConvexHull::try_from_triangulation(empty_dt.as_triangulation());
         assert_matches!(
-            result2,
-            Err(ConvexHullConstructionError::InsufficientData { .. })
+            result,
+            Err(ConvexHullConstructionError::InsufficientData {
+                reason: ConvexHullInsufficientDataReason::NoVertices,
+                ..
+            })
         );
     }
 
@@ -3631,31 +3644,40 @@ mod tests {
         let tri = Triangulation::new_with_tds(AdaptiveKernel::<f64>::new(), tds);
 
         let result = ConvexHull::try_from_triangulation(&tri);
-        assert!(result.is_err());
-        match result.unwrap_err() {
-            ConvexHullConstructionError::InsufficientData { message } => {
-                assert!(message.contains("no simplices"));
-            }
-            _ => panic!("Expected InsufficientData error for no simplices"),
-        }
+        assert_matches!(
+            result,
+            Err(ConvexHullConstructionError::InsufficientData {
+                reason: ConvexHullInsufficientDataReason::NoSimplices,
+                ..
+            })
+        );
     }
 
     #[test]
     fn test_try_from_triangulation_no_boundary_facets_error() {
-        // This is harder to trigger naturally, but we can test error propagation
-        // by creating a TDS that would fail boundary facet extraction
-        // For now, just test that the error mapping works with a valid TDS
+        // A closed periodic T^2 quotient has simplices but no boundary facets.
         let vertices = vec![
-            vertex!([0.0, 0.0, 0.0]).unwrap(),
-            vertex!([1.0, 0.0, 0.0]).unwrap(),
-            vertex!([0.0, 1.0, 0.0]).unwrap(),
-            vertex!([0.0, 0.0, 1.0]).unwrap(),
+            vertex!([0.2, 0.3]).unwrap(),
+            vertex!([0.8, 0.1]).unwrap(),
+            vertex!([0.5, 0.7]).unwrap(),
+            vertex!([0.1, 0.9]).unwrap(),
+            vertex!([0.6, 0.4]).unwrap(),
+            vertex!([0.3, 0.5]).unwrap(),
+            vertex!([0.9, 0.2]).unwrap(),
         ];
-        let dt = create_triangulation(&vertices);
+        let dt = DelaunayTriangulationBuilder::new(&vertices)
+            .try_toroidal([1.0; 2])
+            .unwrap()
+            .build()
+            .unwrap();
         let result = ConvexHull::try_from_triangulation(dt.as_triangulation());
-        assert!(result.is_ok()); // This should succeed for a valid tetrahedron
-        let hull = result.unwrap();
-        assert!(!hull.hull_facets.is_empty());
+        assert_matches!(
+            result,
+            Err(ConvexHullConstructionError::InsufficientData {
+                reason: ConvexHullInsufficientDataReason::NoBoundaryFacets,
+                ..
+            })
+        );
     }
 
     #[test]
@@ -3809,19 +3831,31 @@ mod tests {
         let display = format!("{duplicate_error}");
         assert!(display.contains("duplicate vertices"));
 
-        // Test ConvexHullConstructionError display
-        let construction_error = ConvexHullConstructionError::InsufficientData {
-            message: "test message".to_string(),
-        };
-        let display = format!("{construction_error}");
-        assert!(display.contains("test message"));
+        // Lock in the intentionally concise, sentence-continuation wording.
+        for (reason, expected) in [
+            (
+                ConvexHullInsufficientDataReason::NoVertices,
+                "Insufficient data for convex hull construction: triangulation contains no vertices",
+            ),
+            (
+                ConvexHullInsufficientDataReason::NoSimplices,
+                "Insufficient data for convex hull construction: triangulation contains no simplices",
+            ),
+            (
+                ConvexHullInsufficientDataReason::NoBoundaryFacets,
+                "Insufficient data for convex hull construction: triangulation contains no boundary facets",
+            ),
+        ] {
+            let construction_error = ConvexHullConstructionError::InsufficientData { reason };
+            assert_eq!(construction_error.to_string(), expected);
+        }
 
-        let coord_error = ConvexHullConstructionError::CoordinateConversion(
-            CoordinateConversionError::NonFiniteValue {
+        let coord_error = ConvexHullConstructionError::CoordinateConversion {
+            source: CoordinateConversionError::NonFiniteValue {
                 coordinate_index: 0,
                 coordinate_value: InvalidCoordinateValue::Nan,
             },
-        );
+        };
         let display = format!("{coord_error}");
         assert!(display.contains("Coordinate conversion error"));
     }
@@ -4033,9 +4067,9 @@ mod tests {
                     ConvexHull::<(), (), 3>::fallback_visibility_test(&facet_vertices, &test_point);
                 test_debug!("  Extreme precision fallback result: {fallback_result:?}");
             }
-            Err(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::GeometricDegeneracy { .. },
-            )) => {
+            Err(DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::GeometricDegeneracy { .. },
+            }) => {
                 // On some platforms, these extreme coordinates may be judged too
                 // numerically unstable to form a reliable 3D simplex. In that
                 // case, it's acceptable for DelaunayTriangulationBuilder::build to fail with geometric
@@ -4785,12 +4819,12 @@ mod tests {
         assert!(cast_msg.contains("Numeric cast failed"));
         assert!(cast_msg.contains("Failed to convert f64 to usize"));
 
-        let coord_error = ConvexHullConstructionError::CoordinateConversion(
-            CoordinateConversionError::NonFiniteValue {
+        let coord_error = ConvexHullConstructionError::CoordinateConversion {
+            source: CoordinateConversionError::NonFiniteValue {
                 coordinate_index: 2,
                 coordinate_value: InvalidCoordinateValue::PositiveInfinity,
             },
-        );
+        };
         let coord_msg = format!("{coord_error}");
         assert!(coord_msg.contains("Coordinate conversion error"));
         assert!(coord_error.source().is_some());
@@ -4819,7 +4853,7 @@ mod tests {
         };
         let hull_error: ConvexHullConstructionError = coord_conv_error.into();
         match hull_error {
-            ConvexHullConstructionError::CoordinateConversion(_) => {
+            ConvexHullConstructionError::CoordinateConversion { source: _ } => {
                 test_debug!("    ✓ Coordinate conversion error properly wrapped");
             }
             _ => panic!("Coordinate conversion error not properly wrapped"),
@@ -4959,7 +4993,7 @@ mod tests {
                         );
                         // Verify appropriate error types for numeric issues
                         match e {
-                            ConvexHullConstructionError::CoordinateConversion(_)
+                            ConvexHullConstructionError::CoordinateConversion { source: _ }
                             | ConvexHullConstructionError::NumericCastFailed { .. }
                             | ConvexHullConstructionError::GeometricDegeneracy { .. } => {
                                 test_debug!("      ✓ Appropriate error type for numeric issues");
@@ -5140,7 +5174,7 @@ mod tests {
 
                     // Errors should only occur for coordinate conversion issues
                     match e {
-                        ConvexHullConstructionError::CoordinateConversion(_) => {
+                        ConvexHullConstructionError::CoordinateConversion { source: _ } => {
                             test_debug!("      ✓ Acceptable coordinate conversion error");
                         }
                         _ => {

--- a/src/geometry/quality.rs
+++ b/src/geometry/quality.rs
@@ -1457,9 +1457,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
                         || matches!(result, Err(QualityError::Inradius { .. }))
                 );
             }
-            Err(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::GeometricDegeneracy { .. },
-            )) => {
+            Err(DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::GeometricDegeneracy { .. },
+            }) => {
                 // For sufficiently extreme configurations, the robust initial simplex
                 // search may reject the input up-front as geometrically degenerate.
                 // This is acceptable as long as it is reported cleanly.
@@ -1495,10 +1495,11 @@ let simplex_key = dt.simplices().next().unwrap().0;
                         || matches!(result, Err(QualityError::Volume { .. }))
                 );
             }
-            Err(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::GeometricDegeneracy { .. }
-                | DelaunayConstructionFailure::InsufficientVertices { .. },
-            )) => {
+            Err(DelaunayTriangulationConstructionError::Triangulation {
+                source:
+                    DelaunayConstructionFailure::GeometricDegeneracy { .. }
+                    | DelaunayConstructionFailure::InsufficientVertices { .. },
+            }) => {
                 // Extremely flat/near-degenerate configurations may now be rejected
                 // up-front by the initial simplex search, or Hilbert-sort dedup may
                 // collapse near-identical coordinates (e.g. 1e-14 vs 0.0) at
@@ -1595,9 +1596,9 @@ let simplex_key = dt.simplices().next().unwrap().0;
                     assert_matches!(observed, CoordinateConversionValue::Scalar(_));
                 }
             }
-            Err(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::GeometricDegeneracy { .. },
-            )) => {
+            Err(DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::GeometricDegeneracy { .. },
+            }) => {
                 // In some numeric regimes, degeneracy is now detected at construction
                 // time instead of by the quality metrics. That is still acceptable
                 // as long as it is reported via the dedicated GeometricDegeneracy

--- a/src/geometry/util/triangulation_generation.rs
+++ b/src/geometry/util/triangulation_generation.rs
@@ -241,9 +241,9 @@ impl From<RandomTriangulationBuilderError> for DelaunayTriangulationConstruction
 const fn random_point_generation_error(
     source: RandomPointGenerationError<f64>,
 ) -> DelaunayTriangulationConstructionError {
-    DelaunayTriangulationConstructionError::Triangulation(
-        DelaunayConstructionFailure::RandomPointGeneration { source },
-    )
+    DelaunayTriangulationConstructionError::Triangulation {
+        source: DelaunayConstructionFailure::RandomPointGeneration { source },
+    }
 }
 
 /// Generates random points through the seeded or unseeded public generator path.
@@ -695,9 +695,11 @@ where
 /// #     return Ok(());
 /// # };
 /// let range = make_range().map_err(|source| {
-///     DelaunayTriangulationConstructionError::Triangulation(
-///         DelaunayConstructionFailure::RandomPointGeneration { source: source.into() },
-///     )
+///     DelaunayTriangulationConstructionError::Triangulation {
+///         source: DelaunayConstructionFailure::RandomPointGeneration {
+///             source: source.into(),
+///         },
+///     }
 /// })?;
 /// let dt = generate_random_triangulation_in_range::<(), (), 3>(
 ///     twelve,
@@ -777,9 +779,11 @@ where
 /// #     return Ok(());
 /// # };
 /// let range = make_range().map_err(|source| {
-///     DelaunayTriangulationConstructionError::Triangulation(
-///         DelaunayConstructionFailure::RandomPointGeneration { source: source.into() },
-///     )
+///     DelaunayTriangulationConstructionError::Triangulation {
+///         source: DelaunayConstructionFailure::RandomPointGeneration {
+///             source: source.into(),
+///         },
+///     }
 /// })?;
 /// let dt = generate_random_triangulation_in_range_with_topology_guarantee::<(), (), 3>(
 ///     twelve,
@@ -1404,9 +1408,9 @@ mod tests {
         };
         let err = DelaunayTriangulationConstructionError::from(err);
 
-        let DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::RandomPointGeneration { source },
-        ) = err
+        let DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::RandomPointGeneration { source },
+        } = err
         else {
             panic!("expected coordinate-range builder error to map to random-point generation");
         };
@@ -1528,9 +1532,9 @@ mod tests {
             None,
             Some(42),
         );
-        let Err(DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::RandomPointGeneration { source },
-        )) = result
+        let Err(DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::RandomPointGeneration { source },
+        }) = result
         else {
             panic!("expected RandomPointGeneration error");
         };
@@ -1560,13 +1564,13 @@ mod tests {
 
         assert_matches!(
             nan_bounds,
-            Err(DelaunayTriangulationConstructionError::Triangulation(
+            Err(DelaunayTriangulationConstructionError::Triangulation { source:
                 DelaunayConstructionFailure::RandomPointGeneration {
                     source: RandomPointGenerationError::InvalidCoordinateRange {
                         source: CoordinateRangeError::NonFiniteBound { bound, value }
                     }
                 }
-            )) if bound == CoordinateRangeBound::Minimum && value == InvalidCoordinateValue::Nan
+             }) if bound == CoordinateRangeBound::Minimum && value == InvalidCoordinateValue::Nan
         );
 
         let Err(RandomTriangulationBuilderError::CoordinateRange {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1312,7 +1312,8 @@ pub mod query {
     pub use crate::flips::RidgeHandle;
     pub use crate::geometry::Point;
     pub use crate::geometry::algorithms::convex_hull::{
-        ConvexHull, ConvexHullConstructionError, ConvexHullValidationError,
+        ConvexHull, ConvexHullConstructionError, ConvexHullInsufficientDataReason,
+        ConvexHullValidationError,
     };
     pub use crate::geometry::kernel::{
         AdaptiveKernel, ExactPredicates, FastKernel, Kernel, RobustKernel,
@@ -2085,7 +2086,8 @@ pub mod prelude {
         // Read-only algorithms
         pub use crate::assert_jaccard_gte;
         pub use crate::geometry::algorithms::convex_hull::{
-            ConvexHull, ConvexHullConstructionError, ConvexHullValidationError,
+            ConvexHull, ConvexHullConstructionError, ConvexHullInsufficientDataReason,
+            ConvexHullValidationError,
         };
         pub use crate::query::{
             JaccardComputationError, extract_edge_set, extract_facet_identifier_set,

--- a/src/topology/manifold.rs
+++ b/src/topology/manifold.rs
@@ -134,7 +134,11 @@ use thiserror::Error;
 pub enum ManifoldError {
     /// The underlying triangulation data structure is internally inconsistent.
     #[error(transparent)]
-    Tds(#[from] TdsError),
+    Tds {
+        /// Typed TDS source error.
+        #[from]
+        source: TdsError,
+    },
 
     /// A live ridge candidate does not occur in any D-simplex.
     #[error("Ridge candidate {ridge_vertices:?} is not present in the TDS")]
@@ -2444,10 +2448,12 @@ mod tests {
             facet_to_simplices,
             GlobalTopology::Euclidean,
         ) {
-            Err(ManifoldError::Tds(TdsError::FacetError(FacetError::InvalidFacetIndex {
-                index,
-                facet_count,
-            }))) => {
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::FacetError {
+                        source: FacetError::InvalidFacetIndex { index, facet_count },
+                    },
+            }) => {
                 assert_eq!(index, u8::MAX);
                 assert_eq!(facet_count, 4);
             }
@@ -2871,11 +2877,14 @@ mod tests {
         let tds: Tds<(), (), 2> = Tds::empty();
 
         match simplex_link_simplices_from_star(&tds, &[], &[]) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 1,
-                actual: 0,
-                ..
-            })) => {}
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 1,
+                        actual: 0,
+                        ..
+                    },
+            }) => {}
             other => panic!("Expected DimensionMismatch for empty simplex, got {other:?}"),
         }
     }
@@ -2907,11 +2916,14 @@ mod tests {
             .unwrap();
 
         match simplex_link_simplices_from_star(&tds, &[v0, v3], &[simplex_key]) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 1,
-                actual,
-                ..
-            })) => {
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 1,
+                        actual,
+                        ..
+                    },
+            }) => {
                 assert_ne!(actual, 1, "Expected actual != 1 for unrelated vertex");
             }
             other => panic!("Expected DimensionMismatch for link-size mismatch, got {other:?}"),
@@ -2968,11 +2980,14 @@ mod tests {
         }
 
         match validate_ridge_links(&tds) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 2,
-                actual,
-                ..
-            })) => {
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 2,
+                        actual,
+                        ..
+                    },
+            }) => {
                 assert_ne!(actual, 2, "Expected actual != 2 for corrupted link");
             }
             other => {
@@ -3042,10 +3057,13 @@ mod tests {
             GlobalTopology::Euclidean,
             &[simplex_key],
         ) {
-            Err(ManifoldError::Tds(TdsError::SimplexNotFound {
-                simplex_key: missing_key,
-                ..
-            })) => assert_eq!(missing_key, simplex_key),
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::SimplexNotFound {
+                        simplex_key: missing_key,
+                        ..
+                    },
+            }) => assert_eq!(missing_key, simplex_key),
             other => panic!("Expected SimplexNotFound, got {other:?}"),
         }
     }
@@ -3403,11 +3421,17 @@ mod tests {
             facet_to_simplices,
             GlobalTopology::Euclidean,
         ) {
-            Err(ManifoldError::Tds(TdsError::FacetError(FacetError::FacetHandleKeyMismatch {
-                expected_facet_key,
-                actual_facet_key,
-                ..
-            }))) => {
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::FacetError {
+                        source:
+                            FacetError::FacetHandleKeyMismatch {
+                                expected_facet_key,
+                                actual_facet_key,
+                                ..
+                            },
+                    },
+            }) => {
                 assert_eq!(expected_facet_key, 0);
                 assert_ne!(actual_facet_key, expected_facet_key);
             }
@@ -3474,11 +3498,11 @@ mod tests {
 
         assert_matches!(
             err,
-            ManifoldError::Tds(TdsError::FacetError(FacetError::FacetHandleKeyMismatch {
+            ManifoldError::Tds { source: TdsError::FacetError { source: FacetError::FacetHandleKeyMismatch {
                 expected_facet_key,
                 actual_facet_key: found_actual_facet_key,
                 handle: found_handle,
-            })) if expected_facet_key == mismatched_facet_key
+            } } } if expected_facet_key == mismatched_facet_key
                 && found_actual_facet_key == actual_facet_key
                 && found_handle == handle
         );

--- a/src/topology/ridge.rs
+++ b/src/topology/ridge.rs
@@ -1758,11 +1758,14 @@ mod tests {
         let tds: Tds<(), (), 2> = Tds::empty();
 
         match simplex_star_simplices(&tds, &[]) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 1,
-                actual: 0,
-                ..
-            })) => {}
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 1,
+                        actual: 0,
+                        ..
+                    },
+            }) => {}
             other => panic!("Expected DimensionMismatch for empty simplex, got {other:?}"),
         }
     }
@@ -1846,11 +1849,14 @@ mod tests {
             .unwrap();
 
         match ridge_link_edges_from_star(&tds, &simplex(&[v0]), &[simplex_key]) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 2,
-                actual: 1,
-                ..
-            })) => {}
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 2,
+                        actual: 1,
+                        ..
+                    },
+            }) => {}
             other => panic!("Expected DimensionMismatch(2, 1) for wrong ridge size, got {other:?}"),
         }
     }
@@ -2138,17 +2144,22 @@ mod tests {
 
         let ridge_candidate = RidgeCandidate::<2>::try_from_vertices([missing]).unwrap();
         match ridge_candidate.view(&tds) {
-            Err(ManifoldError::Tds(TdsError::VertexNotFound {
-                vertex_key,
-                context,
-            })) => {
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::VertexNotFound {
+                        vertex_key,
+                        context,
+                    },
+            }) => {
                 assert_eq!(vertex_key, missing);
                 assert!(context.contains("ridge query"));
             }
             other => panic!("Expected ridge view VertexNotFound error, got {other:?}"),
         }
         match ridge_star_simplices(&tds, &ridge_candidate) {
-            Err(ManifoldError::Tds(TdsError::VertexNotFound { vertex_key, .. })) => {
+            Err(ManifoldError::Tds {
+                source: TdsError::VertexNotFound { vertex_key, .. },
+            }) => {
                 assert_eq!(vertex_key, missing);
             }
             other => panic!("Expected VertexNotFound error, got {other:?}"),
@@ -2186,7 +2197,9 @@ mod tests {
         }
 
         match ridge_link_edges_from_star(&tds, &simplex(&[v0]), &[simplex_key]) {
-            Err(ManifoldError::Tds(TdsError::InconsistentDataStructure { message })) => {
+            Err(ManifoldError::Tds {
+                source: TdsError::InconsistentDataStructure { message },
+            }) => {
                 assert!(
                     message.contains("self-loop"),
                     "Unexpected message: {message}"
@@ -2246,11 +2259,14 @@ mod tests {
         }
 
         match build_ridge_star_map(&tds) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 3,
-                actual: 2,
-                ..
-            })) => {}
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 3,
+                        actual: 2,
+                        ..
+                    },
+            }) => {}
             other => {
                 panic!("Expected DimensionMismatch(3, 2) for corrupted simplex, got {other:?}")
             }
@@ -2294,11 +2310,14 @@ mod tests {
         }
 
         match build_ridge_star_map(&tds) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 4,
-                actual: 3,
-                ..
-            })) => {}
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 4,
+                        actual: 3,
+                        ..
+                    },
+            }) => {}
             other => panic!("Expected whole-TDS ridge map to fail, got {other:?}"),
         }
 
@@ -2457,11 +2476,14 @@ mod tests {
         }
 
         match build_ridge_star_map_for_simplices(&tds, [simplex_key]) {
-            Err(ManifoldError::Tds(TdsError::DimensionMismatch {
-                expected: 3,
-                actual: 2,
-                ..
-            })) => {}
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::DimensionMismatch {
+                        expected: 3,
+                        actual: 2,
+                        ..
+                    },
+            }) => {}
             other => {
                 panic!("Expected DimensionMismatch(3, 2) for corrupted simplex, got {other:?}")
             }
@@ -2473,10 +2495,13 @@ mod tests {
         let tds: Tds<(), (), 2> = Tds::empty();
         let stale_key = VertexKey::from(KeyData::from_ffi(0xDEAD));
         match simplex_star_simplices(&tds, &[stale_key]) {
-            Err(ManifoldError::Tds(TdsError::VertexNotFound {
-                vertex_key,
-                ref context,
-            })) => {
+            Err(ManifoldError::Tds {
+                source:
+                    TdsError::VertexNotFound {
+                        vertex_key,
+                        ref context,
+                    },
+            }) => {
                 assert_eq!(vertex_key, stale_key);
                 assert!(context.contains("simplex star"));
             }
@@ -2659,7 +2684,9 @@ mod tests {
         .collect();
 
         match periodic_aware_ridge_star(&tds, 0x42, &lifted, &bare) {
-            Err(ManifoldError::Tds(TdsError::InconsistentDataStructure { ref message })) => {
+            Err(ManifoldError::Tds {
+                source: TdsError::InconsistentDataStructure { ref message },
+            }) => {
                 assert!(
                     message.contains("empty star"),
                     "error should mention empty star: {message}"

--- a/tests/benchmark_flip_fixtures.rs
+++ b/tests/benchmark_flip_fixtures.rs
@@ -261,9 +261,9 @@ fn empty_flip_fixture_returns_construction_error() {
         FlipWorkflowError::Construction { dimension, source } => {
             assert_eq!(dimension, 2);
             match *source {
-                DelaunayTriangulationConstructionError::Triangulation(
-                    DelaunayConstructionFailure::InsufficientVertices { dimension, .. },
-                ) => assert_eq!(dimension, 2),
+                DelaunayTriangulationConstructionError::Triangulation {
+                    source: DelaunayConstructionFailure::InsufficientVertices { dimension, .. },
+                } => assert_eq!(dimension, 2),
                 other => panic!("unexpected construction source: {other}"),
             }
         }
@@ -607,21 +607,21 @@ fn assert_topology_and_delaunay_valid<const D: usize>(dt: &FlipTriangulation<D>,
 
 fn construction_error_is_degenerate(error: &DelaunayTriangulationConstructionError) -> bool {
     match error {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::GeometricDegeneracy { .. },
-        ) => true,
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::FinalDelaunayValidation { source, .. },
-        ) => validation_error_is_degenerate(source),
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::InsertionRealizationValidation { source },
-        ) => matches!(
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::GeometricDegeneracy { .. },
+        } => true,
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::FinalDelaunayValidation { source, .. },
+        } => validation_error_is_degenerate(source),
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::InsertionRealizationValidation { source },
+        } => matches!(
             source,
             TriangulationRealizationValidationError::DegenerateSimplex { .. }
         ),
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
-        ) => match source.as_ref() {
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
+        } => match source.as_ref() {
             DelaunayConstructionRetryFailure::Construction { source } => {
                 construction_error_is_degenerate(source)
             }
@@ -634,7 +634,7 @@ fn construction_error_is_degenerate(error: &DelaunayTriangulationConstructionErr
 fn validation_error_is_degenerate(error: &DelaunayTriangulationValidationError) -> bool {
     matches!(
         error,
-        DelaunayTriangulationValidationError::Realization(source)
+        DelaunayTriangulationValidationError::Realization { source }
             if matches!(
                 source.as_ref(),
                 TriangulationRealizationValidationError::DegenerateSimplex { .. }

--- a/tests/dedup_batch_construction.rs
+++ b/tests/dedup_batch_construction.rs
@@ -36,9 +36,9 @@ fn init_tracing() {
 const fn is_geometric_degeneracy_error(error: &DelaunayTriangulationConstructionError) -> bool {
     matches!(
         error,
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::GeometricDegeneracy { .. }
-        )
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::GeometricDegeneracy { .. }
+        }
     )
 }
 
@@ -47,9 +47,9 @@ fn is_geometric_degeneracy_or_retry_exhausted(
     error: &DelaunayTriangulationConstructionError,
 ) -> bool {
     match error {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
-        ) => matches!(
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
+        } => matches!(
             source.as_ref(),
             DelaunayConstructionRetryFailure::Construction { source }
                 if is_geometric_degeneracy_error(source)
@@ -193,9 +193,9 @@ macro_rules! gen_dedup_batch_tests {
                 assert!(
                     matches!(
                         result,
-                        Err(DelaunayTriangulationConstructionError::Triangulation(
+                        Err(DelaunayTriangulationConstructionError::Triangulation { source:
                             DelaunayConstructionFailure::InsufficientVertices { .. }
-                        ))
+                         })
                     ),
                     "{}D: all-duplicate input should fail with InsufficientVertices",
                     $dim

--- a/tests/delaunay_edge_cases.rs
+++ b/tests/delaunay_edge_cases.rs
@@ -53,9 +53,9 @@ fn init_tracing() {
 const fn is_geometric_degeneracy_error(error: &DelaunayTriangulationConstructionError) -> bool {
     matches!(
         error,
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::GeometricDegeneracy { .. }
-        )
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::GeometricDegeneracy { .. }
+        }
     )
 }
 
@@ -64,9 +64,9 @@ fn is_geometric_degeneracy_or_retry_exhausted(
     error: &DelaunayTriangulationConstructionError,
 ) -> bool {
     match error {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
-        ) => matches!(
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
+        } => matches!(
             source.as_ref(),
             DelaunayConstructionRetryFailure::Construction { source }
                 if is_geometric_degeneracy_error(source)
@@ -78,7 +78,7 @@ fn is_geometric_degeneracy_or_retry_exhausted(
 fn validation_error_is_degenerate_simplex(error: &DelaunayTriangulationValidationError) -> bool {
     matches!(
         error,
-        DelaunayTriangulationValidationError::Realization(source)
+        DelaunayTriangulationValidationError::Realization { source }
             if matches!(
                 source.as_ref(),
                 TriangulationRealizationValidationError::DegenerateSimplex { .. }
@@ -90,18 +90,18 @@ fn construction_error_is_degenerate_simplex(
     error: &DelaunayTriangulationConstructionError,
 ) -> bool {
     match error {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::FinalDelaunayValidation { source, .. },
-        ) => validation_error_is_degenerate_simplex(source),
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::InsertionRealizationValidation { source },
-        ) => matches!(
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::FinalDelaunayValidation { source, .. },
+        } => validation_error_is_degenerate_simplex(source),
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::InsertionRealizationValidation { source },
+        } => matches!(
             source,
             TriangulationRealizationValidationError::DegenerateSimplex { .. }
         ),
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
-        ) => match source.as_ref() {
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::ShuffledRetryExhausted { source, .. },
+        } => match source.as_ref() {
             DelaunayConstructionRetryFailure::Construction { source } => {
                 construction_error_is_degenerate_simplex(source)
             }

--- a/tests/euler_characteristic.rs
+++ b/tests/euler_characteristic.rs
@@ -314,9 +314,9 @@ fn test_t2_explicit_toroidal_construction_rejected() {
         .expect_err("explicit toroidal connectivity requires a quotient realization validator");
 
     match err {
-        DelaunayTriangulationConstructionError::ExplicitConstruction(
-            ExplicitConstructionError::UnsupportedExplicitTopology { topology },
-        ) => assert_eq!(topology, TopologyKind::Toroidal),
+        DelaunayTriangulationConstructionError::ExplicitConstruction {
+            source: ExplicitConstructionError::UnsupportedExplicitTopology { topology },
+        } => assert_eq!(topology, TopologyKind::Toroidal),
         other => panic!("expected explicit construction validation failure, got {other:?}"),
     }
 }
@@ -396,9 +396,9 @@ fn test_t3_explicit_toroidal_construction_rejected() {
         .expect_err("explicit toroidal connectivity requires a quotient realization validator");
 
     match err {
-        DelaunayTriangulationConstructionError::ExplicitConstruction(
-            ExplicitConstructionError::UnsupportedExplicitTopology { topology },
-        ) => assert_eq!(topology, TopologyKind::Toroidal),
+        DelaunayTriangulationConstructionError::ExplicitConstruction {
+            source: ExplicitConstructionError::UnsupportedExplicitTopology { topology },
+        } => assert_eq!(topology, TopologyKind::Toroidal),
         other => panic!("expected explicit construction validation failure, got {other:?}"),
     }
 }

--- a/tests/prelude_exports.rs
+++ b/tests/prelude_exports.rs
@@ -138,9 +138,10 @@ use delaunay::prelude::pachner::{
 };
 use delaunay::prelude::query::{
     AllFacetsIter as QueryAllFacetsIter, BoundaryFacetsIter as QueryBoundaryFacetsIter, ConvexHull,
-    ConvexHullConstructionError, EdgeIndex as QueryEdgeIndex, EdgeKey as QueryEdgeKey,
-    EdgeView as QueryEdgeView, FacetHandle as QueryFacetHandle,
-    FacetIncidenceAnalysis as QueryFacetIncidenceAnalysis,
+    ConvexHullConstructionError,
+    ConvexHullInsufficientDataReason as QueryConvexHullInsufficientDataReason,
+    EdgeIndex as QueryEdgeIndex, EdgeKey as QueryEdgeKey, EdgeView as QueryEdgeView,
+    FacetHandle as QueryFacetHandle, FacetIncidenceAnalysis as QueryFacetIncidenceAnalysis,
     FacetIncidenceView as QueryFacetIncidenceView, IncidenceView as QueryIncidenceView,
     OneSidedFacetsIter as QueryOneSidedFacetsIter, QueryError,
     RidgeCandidate as QueryRidgeCandidate, RidgeCandidateError as QueryRidgeCandidateError,
@@ -247,6 +248,7 @@ use delaunay::prelude::{
 };
 use delaunay::query::{
     AllFacetsIter as QueryFacadeAllFacetsIter, BoundaryFacetsIter as QueryFacadeBoundaryFacetsIter,
+    ConvexHullInsufficientDataReason as QueryFacadeConvexHullInsufficientDataReason,
     EdgeIndex as QueryFacadeEdgeIndex, FacetHandle as QueryFacadeFacetHandle,
     IncidenceView as QueryFacadeIncidenceView, OneSidedFacetsIter as QueryFacadeOneSidedFacetsIter,
     RidgeCandidate as QueryFacadeRidgeCandidate,
@@ -531,9 +533,9 @@ fn construction_prelude_exports_common_delaunay_error_aliases() {
         DelaunayError::Construction { source }
             if matches!(
                 source.as_ref(),
-                DelaunayTriangulationConstructionError::Triangulation(
+                DelaunayTriangulationConstructionError::Triangulation { source:
                     DelaunayConstructionFailure::InsufficientVertices { dimension: 2, .. }
-                )
+                 }
             )
     );
 
@@ -580,10 +582,11 @@ fn construction_prelude_exports_low_level_delaunay_error_aliases() {
             if err.as_ref() == &generic_construction
     );
 
-    let tds_construction =
-        TdsConstructionError::ValidationError(TdsError::InconsistentDataStructure {
+    let tds_construction = TdsConstructionError::ValidationError {
+        source: TdsError::InconsistentDataStructure {
             message: "prelude smoke test".to_owned(),
-        });
+        },
+    };
     assert_matches!(
         DelaunayError::from(tds_construction.clone()),
         DelaunayError::TdsConstruction { source: err } if err.as_ref() == &tds_construction
@@ -651,9 +654,9 @@ fn construction_prelude_exports_builder_statistics_terminal() -> Result<(), Prel
     let root_prelude_error: RootPreludeConstructionErrorWithStatistics = focused_error;
     assert_matches!(
         root_prelude_error.error,
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::InsufficientVertices { dimension: 2, .. }
-        )
+        DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::InsufficientVertices { dimension: 2, .. }
+        }
     );
 
     Ok(())
@@ -701,6 +704,23 @@ fn query_preludes_export_simplex_data_fill_error() -> Result<(), PreludeExportTe
     );
 
     Ok(())
+}
+
+#[test]
+fn query_preludes_export_convex_hull_insufficient_data_reason() {
+    let reason = QueryConvexHullInsufficientDataReason::NoBoundaryFacets;
+    let facade_reason: QueryFacadeConvexHullInsufficientDataReason = reason;
+    let error = ConvexHullConstructionError::InsufficientData {
+        reason: facade_reason,
+    };
+
+    assert_matches!(
+        error,
+        ConvexHullConstructionError::InsufficientData {
+            reason: QueryConvexHullInsufficientDataReason::NoBoundaryFacets,
+            ..
+        }
+    );
 }
 
 #[test]
@@ -982,11 +1002,11 @@ fn construction_prelude_covers_retry_exhaustion_source() {
     let retry_failure = DelaunayConstructionFailure::ShuffledRetryExhausted {
         attempt_count: 7,
         source: Box::new(DelaunayConstructionRetryFailure::Construction {
-            source: Box::new(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::GeometricDegeneracy {
+            source: Box::new(DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::GeometricDegeneracy {
                     message: "collinear".to_string(),
                 },
-            )),
+            }),
         }),
     };
 
@@ -1000,9 +1020,9 @@ fn construction_prelude_covers_retry_exhaustion_source() {
             DelaunayConstructionRetryFailure::Construction { source }
                 if matches!(
                     source.as_ref(),
-                    DelaunayTriangulationConstructionError::Triangulation(
+                    DelaunayTriangulationConstructionError::Triangulation { source:
                         DelaunayConstructionFailure::GeometricDegeneracy { message }
-                    ) if message == "collinear"
+                     } if message == "collinear"
                 )
         )
     );
@@ -1051,11 +1071,11 @@ fn root_exports_cover_flattened_public_api() -> Result<(), RootApiExportTestErro
     );
     assert_matches!(
         RootConstructionRetryFailure::Construction {
-            source: Box::new(DelaunayTriangulationConstructionError::Triangulation(
-                DelaunayConstructionFailure::GeometricDegeneracy {
+            source: Box::new(DelaunayTriangulationConstructionError::Triangulation {
+                source: DelaunayConstructionFailure::GeometricDegeneracy {
                     message: "synthetic".to_string(),
                 },
-            )),
+            }),
         },
         RootConstructionRetryFailure::Construction { .. }
     );
@@ -1741,15 +1761,19 @@ fn construction_prelude_covers_explicit_tds_preflight_errors() {
     .expect("explicit duplicate specs should parse")
     .build()
     .expect_err("duplicate explicit topology should fail TDS assembly");
-    let DelaunayTriangulationConstructionError::ExplicitConstruction(
-        ExplicitConstructionError::TdsAssembly {
-            source: duplicate_source,
-        },
-    ) = duplicate_error
+    let DelaunayTriangulationConstructionError::ExplicitConstruction {
+        source:
+            ExplicitConstructionError::TdsAssembly {
+                source: duplicate_source,
+            },
+    } = duplicate_error
     else {
         panic!("expected explicit TDS assembly error");
     };
-    let TdsConstructionError::ValidationError(explicit_duplicate) = *duplicate_source else {
+    let TdsConstructionError::ValidationError {
+        source: explicit_duplicate,
+    } = *duplicate_source
+    else {
         panic!("expected TDS validation source");
     };
     assert_matches!(
@@ -1777,15 +1801,19 @@ fn construction_prelude_covers_explicit_tds_preflight_errors() {
     .expect("explicit overshared-facet specs should parse")
     .build()
     .expect_err("overshared explicit topology should fail TDS assembly");
-    let DelaunayTriangulationConstructionError::ExplicitConstruction(
-        ExplicitConstructionError::TdsAssembly {
-            source: overshared_source,
-        },
-    ) = overshared_error
+    let DelaunayTriangulationConstructionError::ExplicitConstruction {
+        source:
+            ExplicitConstructionError::TdsAssembly {
+                source: overshared_source,
+            },
+    } = overshared_error
     else {
         panic!("expected explicit TDS assembly error");
     };
-    let TdsConstructionError::ValidationError(explicit_facet_sharing) = *overshared_source else {
+    let TdsConstructionError::ValidationError {
+        source: explicit_facet_sharing,
+    } = *overshared_source
+    else {
         panic!("expected TDS validation source");
     };
     assert_matches!(
@@ -1800,6 +1828,10 @@ fn construction_prelude_covers_explicit_tds_preflight_errors() {
 }
 
 #[test]
+#[expect(
+    clippy::too_many_lines,
+    reason = "test covers named-field construction and matching across the full explicit-error wrapper chain"
+)]
 fn construction_prelude_covers_typed_explicit_error_wrappers() {
     let explicit_construction = ExplicitConstructionError::StructuralValidation {
         source: Box::new(TdsError::FacetSharingViolation {
@@ -1837,57 +1869,24 @@ fn construction_prelude_covers_typed_explicit_error_wrappers() {
     );
 
     let explicit_insertion = ExplicitConstructionError::OrientationNormalization {
-        source: Box::new(InsertionError::TopologyValidation(
-            TdsError::InconsistentDataStructure {
+        source: Box::new(InsertionError::TopologyValidation {
+            source: TdsError::InconsistentDataStructure {
                 message: "topology validation failed".to_string(),
             },
-        )),
+        }),
     };
     assert_matches!(
         explicit_insertion,
         ExplicitConstructionError::OrientationNormalization { source }
             if matches!(
                 source.as_ref(),
-                InsertionError::TopologyValidation(TdsError::InconsistentDataStructure { .. })
+                InsertionError::TopologyValidation { source: TdsError::InconsistentDataStructure { .. } }
             )
     );
 
     let explicit_invariant = ExplicitConstructionError::TopologyValidation {
-        source: Box::new(InvariantError::Tds(TdsError::FacetSharingViolation {
-            facet_key: 42,
-            existing_incident_count: 2,
-            attempted_incident_count: 3,
-            max_incident_count: 2,
-            candidate_simplex_uuid: Uuid::default(),
-            candidate_facet_index: 0,
-        })),
-    };
-    assert_matches!(
-        explicit_invariant,
-        ExplicitConstructionError::TopologyValidation { source }
-            if matches!(source.as_ref(), InvariantError::Tds(TdsError::FacetSharingViolation { .. }))
-    );
-
-    let explicit_realization = ExplicitConstructionError::RealizationValidation {
-        source: Box::new(ConstructionDelaunayTriangulationValidationError::Tds(
-            Box::new(TdsError::InconsistentDataStructure {
-                message: "realization validation failed".to_string(),
-            }),
-        )),
-    };
-    assert_matches!(
-        explicit_realization,
-        ExplicitConstructionError::RealizationValidation { source }
-            if matches!(
-                source.as_ref(),
-                ConstructionDelaunayTriangulationValidationError::Tds(tds)
-                    if matches!(tds.as_ref(), TdsError::InconsistentDataStructure { .. })
-            )
-    );
-
-    let explicit_tds_construction = ExplicitConstructionError::TdsAssembly {
-        source: Box::new(TdsConstructionError::ValidationError(
-            TdsError::FacetSharingViolation {
+        source: Box::new(InvariantError::Tds {
+            source: TdsError::FacetSharingViolation {
                 facet_key: 42,
                 existing_incident_count: 2,
                 attempted_incident_count: 3,
@@ -1895,14 +1894,49 @@ fn construction_prelude_covers_typed_explicit_error_wrappers() {
                 candidate_simplex_uuid: Uuid::default(),
                 candidate_facet_index: 0,
             },
-        )),
+        }),
+    };
+    assert_matches!(
+        explicit_invariant,
+        ExplicitConstructionError::TopologyValidation { source }
+            if matches!(source.as_ref(), InvariantError::Tds { source: TdsError::FacetSharingViolation { .. } })
+    );
+
+    let explicit_realization = ExplicitConstructionError::RealizationValidation {
+        source: Box::new(ConstructionDelaunayTriangulationValidationError::Tds {
+            source: Box::new(TdsError::InconsistentDataStructure {
+                message: "realization validation failed".to_string(),
+            }),
+        }),
+    };
+    assert_matches!(
+        explicit_realization,
+        ExplicitConstructionError::RealizationValidation { source }
+            if matches!(
+                source.as_ref(),
+                ConstructionDelaunayTriangulationValidationError::Tds { source: tds }
+                    if matches!(tds.as_ref(), TdsError::InconsistentDataStructure { .. })
+            )
+    );
+
+    let explicit_tds_construction = ExplicitConstructionError::TdsAssembly {
+        source: Box::new(TdsConstructionError::ValidationError {
+            source: TdsError::FacetSharingViolation {
+                facet_key: 42,
+                existing_incident_count: 2,
+                attempted_incident_count: 3,
+                max_incident_count: 2,
+                candidate_simplex_uuid: Uuid::default(),
+                candidate_facet_index: 0,
+            },
+        }),
     };
     assert_matches!(
         explicit_tds_construction,
         ExplicitConstructionError::TdsAssembly { source }
             if matches!(
                 source.as_ref(),
-                TdsConstructionError::ValidationError(TdsError::FacetSharingViolation { .. })
+                TdsConstructionError::ValidationError { source: TdsError::FacetSharingViolation { .. } }
             )
     );
 }
@@ -2198,9 +2232,9 @@ fn assert_topology_prelude_dimension<const D: usize>() -> Result<(), PreludeExpo
     assert_cospherical_ridge_star::<D>()?;
     assert_matches!(
         DelaunayTriangulation::builder(&degenerate_prelude_vertices::<D>()?).build(),
-        Err(DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::GeometricDegeneracy { .. }
-        ))
+        Err(DelaunayTriangulationConstructionError::Triangulation {
+            source: DelaunayConstructionFailure::GeometricDegeneracy { .. }
+        })
     );
     Ok(())
 }

--- a/tests/regressions.rs
+++ b/tests/regressions.rs
@@ -355,9 +355,9 @@ fn regression_issue_447_explicit_exact_strip_default_strict_level5_fails() {
     assert!(
         matches!(
             err,
-            DelaunayTriangulationConstructionError::ExplicitConstruction(
-                ExplicitConstructionError::DelaunayValidation { .. }
-            )
+            DelaunayTriangulationConstructionError::ExplicitConstruction {
+                source: ExplicitConstructionError::DelaunayValidation { .. }
+            }
         ),
         "strict explicit construction should fail at Level 5 Delaunay validation, got: {err:?}",
     );

--- a/tests/semgrep/docs/validation_levels.md
+++ b/tests/semgrep/docs/validation_levels.md
@@ -44,3 +44,12 @@ let kernel = dt.as_triangulation().kernel();
 
 // ok: delaunay.rust.no-as-triangulation-storage-reach-through
 let generation = dt.topology_generation();
+
+// ruleid: delaunay.rust.no-unwrap-expect-in-markdown-examples
+let hull = ConvexHull::try_from_triangulation(&triangulation).unwrap();
+
+// ruleid: delaunay.rust.no-unwrap-expect-in-markdown-examples
+let hull = ConvexHull::try_from_triangulation(&triangulation).expect("valid hull");
+
+// ok: delaunay.rust.no-unwrap-expect-in-markdown-examples
+let hull = ConvexHull::try_from_triangulation(&triangulation)?;

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -1301,6 +1301,18 @@ pub enum MultilineGenericPositionalCarrierFixtureFailure<
 }
 
 // ruleid: delaunay.rust.public-error-variants-use-named-fields
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WhereClausePositionalCarrierFixtureFailure<T>
+where
+    T: std::error::Error,
+{
+    /// Positional carrier after a generic where clause.
+    #[error("where-clause source")]
+    Positional(T),
+}
+
+// ruleid: delaunay.rust.public-error-variants-use-named-fields
 #[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum ReorderedAttributePositionalCarrierFixtureFailure {

--- a/tests/semgrep/src/project_rules/rust_style.rs
+++ b/tests/semgrep/src/project_rules/rust_style.rs
@@ -482,6 +482,46 @@ where
     }
 }
 
+// ruleid: delaunay.rust.no-infallible-fallible-constructor-definitions
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
+    // ruleid: delaunay.rust.no-fallible-new-or-from-constructor-definitions
+    pub fn new(
+        _vertices: &[Vertex<U, D>],
+    ) -> Result<Self, DelaunayTriangulationConstructionError> {
+        todo!()
+    }
+}
+
+// ok: delaunay.rust.no-infallible-fallible-constructor-definitions
+impl<K, U, V, const D: usize> DelaunayTriangulation<K, U, V, D> {
+    // ok: delaunay.rust.no-fallible-new-or-from-constructor-definitions
+    pub fn try_new_for_fixture(
+        _vertices: &[Vertex<U, D>],
+    ) -> Result<Self, DelaunayTriangulationConstructionError> {
+        todo!()
+    }
+}
+
+// ruleid: delaunay.rust.no-infallible-fallible-constructor-definitions
+impl<U, V, const D: usize> ConvexHull<U, V, D> {
+    // ruleid: delaunay.rust.no-fallible-new-or-from-constructor-definitions
+    pub fn from_triangulation<T>(
+        _triangulation: &T,
+    ) -> Result<Self, ConvexHullConstructionError> {
+        todo!()
+    }
+}
+
+// ok: delaunay.rust.no-infallible-fallible-constructor-definitions
+impl<U, V, const D: usize> ConvexHull<U, V, D> {
+    // ok: delaunay.rust.no-fallible-new-or-from-constructor-definitions
+    pub fn try_from_triangulation_for_fixture<T>(
+        _triangulation: &T,
+    ) -> Result<Self, ConvexHullConstructionError> {
+        todo!()
+    }
+}
+
 pub fn triangulation_fallible_constructor_names_ok(
     vertices: &[Vertex<(), 3>],
     options: ConstructionOptions,
@@ -1228,6 +1268,71 @@ enum PrivateFixtureError {
     Invalid,
 }
 
+// ruleid: delaunay.rust.public-error-variants-use-named-fields
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PositionalCarrierFixtureFailure {
+    /// Single-line positional source carrier.
+    #[error(transparent)]
+    SingleLine(#[from] TypedSourceFixtureError),
+}
+
+// ruleid: delaunay.rust.public-error-variants-use-named-fields
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum GenericPositionalCarrierFixtureFailure<T> {
+    /// Generic multi-line positional carrier.
+    #[error("generic source")]
+    Positional(
+        #[source]
+        T,
+    ),
+}
+
+// ruleid: delaunay.rust.public-error-variants-use-named-fields
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum MultilineGenericPositionalCarrierFixtureFailure<
+    T,
+> {
+    /// Positional carrier under a multiline generic declaration.
+    #[error("multiline generic source")]
+    Positional(T),
+}
+
+// ruleid: delaunay.rust.public-error-variants-use-named-fields
+#[non_exhaustive]
+#[derive(Debug, thiserror::Error)]
+pub enum ReorderedAttributePositionalCarrierFixtureFailure {
+    /// Positional carrier with non-exhaustive before derive.
+    #[error(transparent)]
+    Positional(#[from] TypedSourceFixtureError),
+}
+
+// ruleid: delaunay.rust.public-error-variants-use-named-fields
+#[derive(Debug, thiserror::Error)]
+#[doc = "fixture with an intervening attribute"]
+#[non_exhaustive]
+pub enum InterveningAttributePositionalCarrierFixtureFailure {
+    /// Positional carrier after an intervening enum attribute.
+    #[error(transparent)]
+    Positional(#[from] TypedSourceFixtureError),
+}
+
+// ok: delaunay.rust.public-error-variants-use-named-fields
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum NamedCarrierFixtureFailure {
+    /// Named source carrier.
+    #[error("typed source: {source}")]
+    Named {
+        #[source]
+        source: TypedSourceFixtureError,
+    },
+}
+
+pub struct TypedSourceFixtureError;
+
 #[non_exhaustive]
 pub enum CoordinateRangeError<T = f64> {
     // ruleid: delaunay.rust.no-stringly-coordinate-range-error-payloads
@@ -1373,6 +1478,11 @@ pub enum FlipError {
         // ok: delaunay.rust.flip-error-boxed-payloads-are-sources
         #[source]
         reason: Box<FlipContextError>,
+    },
+    GoodBoxedContextFrom {
+        // ok: delaunay.rust.flip-error-boxed-payloads-are-sources
+        #[from]
+        source: Box<FlipContextError>,
     },
     // ok: delaunay.rust.flip-error-boxed-payloads-are-sources
     GoodBoxedSimplex(#[from] Box<SimplexValidationError>),

--- a/tests/triangulation_builder.rs
+++ b/tests/triangulation_builder.rs
@@ -498,13 +498,13 @@ macro_rules! gen_toroidal_high_dim_guardrail_test {
                     ));
 
                 match err {
-                    DelaunayTriangulationConstructionError::Triangulation(
+                    DelaunayTriangulationConstructionError::Triangulation { source:
                         DelaunayConstructionFailure::UnsupportedPeriodicDimension {
                             dimension,
                             max_validated_dimension,
                             tracking_issue,
                         },
-                    ) => {
+                     } => {
                         assert_eq!(dimension, $dim);
                         assert_eq!(max_validated_dimension, 3);
                         assert_eq!(tracking_issue, 416);
@@ -530,13 +530,14 @@ fn test_builder_toroidal_large_dimension_fails_before_expansion_math() {
         .expect_err("64D periodic quotient should fail before computing 3^D image count");
 
     match err {
-        DelaunayTriangulationConstructionError::Triangulation(
-            DelaunayConstructionFailure::UnsupportedPeriodicDimension {
-                dimension,
-                max_validated_dimension,
-                tracking_issue,
-            },
-        ) => {
+        DelaunayTriangulationConstructionError::Triangulation {
+            source:
+                DelaunayConstructionFailure::UnsupportedPeriodicDimension {
+                    dimension,
+                    max_validated_dimension,
+                    tracking_issue,
+                },
+        } => {
             assert_eq!(dimension, 64);
             assert_eq!(max_validated_dimension, 3);
             assert_eq!(tracking_issue, 416);
@@ -578,9 +579,9 @@ fn test_explicit_toroidal_heawood_torus_rejected() {
         .expect_err("explicit toroidal connectivity requires a quotient realization validator");
 
     match err {
-        DelaunayTriangulationConstructionError::ExplicitConstruction(
-            ExplicitConstructionError::UnsupportedExplicitTopology { topology },
-        ) => assert_eq!(topology, TopologyKind::Toroidal),
+        DelaunayTriangulationConstructionError::ExplicitConstruction {
+            source: ExplicitConstructionError::UnsupportedExplicitTopology { topology },
+        } => assert_eq!(topology, TopologyKind::Toroidal),
         other => panic!("expected explicit construction validation failure, got {other:?}"),
     }
 }
@@ -611,19 +612,19 @@ fn test_explicit_toroidal_torus_euler_mismatch_without_override() {
         .expect_err("explicit torus without Toroidal metadata should fail Euler validation");
 
     match err {
-        DelaunayTriangulationConstructionError::ExplicitConstruction(
-            ExplicitConstructionError::TopologyValidation { source },
-        ) => {
+        DelaunayTriangulationConstructionError::ExplicitConstruction {
+            source: ExplicitConstructionError::TopologyValidation { source },
+        } => {
             assert_matches!(
                 source.as_ref(),
-                InvariantError::Triangulation(
-                    TriangulationValidationError::EulerCharacteristicMismatch { .. }
-                )
+                InvariantError::Triangulation {
+                    source: TriangulationValidationError::EulerCharacteristicMismatch { .. }
+                }
             );
         }
-        DelaunayTriangulationConstructionError::ExplicitConstruction(
-            ExplicitConstructionError::OrientationNormalization { source },
-        ) => {
+        DelaunayTriangulationConstructionError::ExplicitConstruction {
+            source: ExplicitConstructionError::OrientationNormalization { source },
+        } => {
             assert_matches!(
                 source.as_ref(),
                 InsertionError::TopologyValidationFailed {
@@ -757,11 +758,11 @@ fn assert_relaxed_explicit_invalid_realization_fails<const D: usize>() {
         .expect_err("relaxed explicit construction should still reject invalid realizations");
 
     match err {
-        DelaunayTriangulationConstructionError::ExplicitConstruction(
-            ExplicitConstructionError::RealizationValidation { source },
-        ) => assert_matches!(
+        DelaunayTriangulationConstructionError::ExplicitConstruction {
+            source: ExplicitConstructionError::RealizationValidation { source },
+        } => assert_matches!(
             source.as_ref(),
-            DelaunayTriangulationValidationError::Realization(_)
+            DelaunayTriangulationValidationError::Realization { source: _ }
         ),
         other => panic!("expected relaxed explicit realization-validation failure, got {other:?}"),
     }
@@ -1188,9 +1189,9 @@ fn test_explicit_non_delaunay_mesh() {
     assert!(
         matches!(
             err,
-            DelaunayTriangulationConstructionError::ExplicitConstruction(
-                ExplicitConstructionError::DelaunayValidation { .. }
-            )
+            DelaunayTriangulationConstructionError::ExplicitConstruction {
+                source: ExplicitConstructionError::DelaunayValidation { .. }
+            }
         ),
         "expected explicit validation failure, got {err:?}"
     );
@@ -1287,9 +1288,9 @@ fn test_explicit_unreferenced_vertices_rejected() {
     assert!(
         matches!(
             err,
-            DelaunayTriangulationConstructionError::ExplicitConstruction(
-                ExplicitConstructionError::TopologyValidation { .. }
-            )
+            DelaunayTriangulationConstructionError::ExplicitConstruction {
+                source: ExplicitConstructionError::TopologyValidation { .. }
+            }
         ),
         "Unreferenced vertices should produce TopologyValidation, got: {err}"
     );
@@ -1353,16 +1354,16 @@ fn test_explicit_error_variant_non_manifold_facet() {
         .build()
         .unwrap_err();
 
-    let DelaunayTriangulationConstructionError::ExplicitConstruction(
-        ExplicitConstructionError::TdsAssembly { source },
-    ) = &err
+    let DelaunayTriangulationConstructionError::ExplicitConstruction {
+        source: ExplicitConstructionError::TdsAssembly { source },
+    } = &err
     else {
         panic!("Expected explicit TDS assembly failure, got: {err}");
     };
 
     assert_matches!(
         source.as_ref(),
-        TdsConstructionError::ValidationError(TdsError::ExplicitFacetSharingViolation {
+        TdsConstructionError::ValidationError { source: TdsError::ExplicitFacetSharingViolation {
             facet_vertex_indices,
             existing_incident_count: 2,
             attempted_incident_count: 3,
@@ -1370,7 +1371,7 @@ fn test_explicit_error_variant_non_manifold_facet() {
             candidate_simplex_index: 2,
             candidate_facet_index: 2,
             ..
-        }) if facet_vertex_indices == &[0, 1]
+        } } if facet_vertex_indices == &[0, 1]
     );
 }
 
@@ -1418,9 +1419,9 @@ fn test_explicit_error_variant_incompatible_topology() {
     assert!(
         matches!(
             err,
-            DelaunayTriangulationConstructionError::ExplicitConstruction(
-                ExplicitConstructionError::IncompatibleTopology
-            )
+            DelaunayTriangulationConstructionError::ExplicitConstruction {
+                source: ExplicitConstructionError::IncompatibleTopology
+            }
         ),
         "Expected IncompatibleTopology, got: {err}"
     );
@@ -1447,9 +1448,9 @@ fn test_explicit_error_variant_unsupported_construction_options() {
     assert!(
         matches!(
             err,
-            DelaunayTriangulationConstructionError::ExplicitConstruction(
-                ExplicitConstructionError::UnsupportedConstructionOptions
-            )
+            DelaunayTriangulationConstructionError::ExplicitConstruction {
+                source: ExplicitConstructionError::UnsupportedConstructionOptions
+            }
         ),
         "Expected UnsupportedConstructionOptions, got: {err}"
     );
@@ -1468,9 +1469,9 @@ fn test_explicit_error_variant_unsupported_construction_options() {
     assert!(
         matches!(
             mixed_err,
-            DelaunayTriangulationConstructionError::ExplicitConstruction(
-                ExplicitConstructionError::UnsupportedConstructionOptions
-            )
+            DelaunayTriangulationConstructionError::ExplicitConstruction {
+                source: ExplicitConstructionError::UnsupportedConstructionOptions
+            }
         ),
         "Expected mixed non-enforcing point-insertion options to be rejected, got: {mixed_err}",
     );
@@ -1491,21 +1492,21 @@ fn test_explicit_error_variant_duplicate_simplices_structural_validation() {
         .build()
         .unwrap_err();
 
-    let DelaunayTriangulationConstructionError::ExplicitConstruction(
-        ExplicitConstructionError::TdsAssembly { source },
-    ) = &err
+    let DelaunayTriangulationConstructionError::ExplicitConstruction {
+        source: ExplicitConstructionError::TdsAssembly { source },
+    } = &err
     else {
         panic!("expected explicit TDS assembly failure, got {err:?}");
     };
 
     assert_matches!(
         source.as_ref(),
-        TdsConstructionError::ValidationError(TdsError::DuplicateExplicitSimplices {
+        TdsConstructionError::ValidationError { source: TdsError::DuplicateExplicitSimplices {
             existing_simplex_index: 0,
             duplicate_simplex_index: 1,
             vertex_indices,
             ..
-        }) if vertex_indices == &[0, 1, 2]
+        } } if vertex_indices == &[0, 1, 2]
     );
 }
 
@@ -1525,9 +1526,9 @@ fn test_explicit_error_variant_geometric_nondegeneracy() {
         .unwrap_err();
 
     match err {
-        DelaunayTriangulationConstructionError::ExplicitConstruction(
-            ExplicitConstructionError::GeometricNondegeneracy { source },
-        ) => assert_matches!(source.as_ref(), TdsError::Geometric(_)),
+        DelaunayTriangulationConstructionError::ExplicitConstruction {
+            source: ExplicitConstructionError::GeometricNondegeneracy { source },
+        } => assert_matches!(source.as_ref(), TdsError::Geometric { source: _ }),
         other => panic!("expected explicit geometric nondegeneracy failure, got {other:?}"),
     }
 }
@@ -1536,8 +1537,8 @@ fn test_explicit_error_variant_geometric_nondegeneracy() {
 #[test]
 fn test_explicit_error_variant_completion_validation_summary() {
     let err = ExplicitConstructionError::CompletionValidation {
-        source: Box::new(InvariantError::Triangulation(
-            TriangulationValidationError::VertexLinkNotManifold {
+        source: Box::new(InvariantError::Triangulation {
+            source: TriangulationValidationError::VertexLinkNotManifold {
                 vertex_key: VertexKey::default(),
                 link_vertex_count: 0,
                 link_simplex_count: 0,
@@ -1546,16 +1547,16 @@ fn test_explicit_error_variant_completion_validation_summary() {
                 connected: false,
                 interior_vertex: false,
             },
-        )),
+        }),
     };
 
     match err {
         ExplicitConstructionError::CompletionValidation { source } => {
             assert_matches!(
                 source.as_ref(),
-                InvariantError::Triangulation(
-                    TriangulationValidationError::VertexLinkNotManifold { .. }
-                )
+                InvariantError::Triangulation {
+                    source: TriangulationValidationError::VertexLinkNotManifold { .. }
+                }
             );
         }
         other => panic!("expected explicit completion validation failure, got {other:?}"),
@@ -1566,19 +1567,21 @@ fn test_explicit_error_variant_completion_validation_summary() {
 #[test]
 fn test_explicit_error_variant_orientation_normalization_summary() {
     let source = ExplicitConstructionError::OrientationNormalization {
-        source: Box::new(InsertionError::TopologyValidation(
-            TdsError::InconsistentDataStructure {
+        source: Box::new(InsertionError::TopologyValidation {
+            source: TdsError::InconsistentDataStructure {
                 message: "orientation normalization could not establish coherent simplices"
                     .to_string(),
             },
-        )),
+        }),
     };
 
     match source {
         ExplicitConstructionError::OrientationNormalization { source } => {
             assert_matches!(
                 source.as_ref(),
-                InsertionError::TopologyValidation(TdsError::InconsistentDataStructure { .. })
+                InsertionError::TopologyValidation {
+                    source: TdsError::InconsistentDataStructure { .. }
+                }
             );
             assert!(source.to_string().contains("coherent simplices"));
         }


### PR DESCRIPTION
- Replace positional error payloads with named source fields and typed convex-hull insufficiency reasons.
- Enforce named public error fields and positive Semgrep rule coverage.
- Extend release benchmark timeouts and reconcile v0.8.0 artifact metadata.

BREAKING CHANGE: Public tuple-style error variants now use struct-style named fields; downstream construction and matching must use `source` or `reason` fields.

Closes #566