### PR TITLE
fix(tooling): harden release and performance preflight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@
 *.toc
 
 # Python packaging artifacts
+/build/
 *.egg-info/
 .ruff_cache/
 .pytest_cache/

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -81,9 +81,9 @@ Update release metadata to match the crate version:
 - `pyproject.toml`: update `[project] version` for the Python utility package.
 
 Review the citation identity fields at the same time: author, ORCID,
-repository, license, and DOI. Keep the DOI policy deliberate: update it only
-when the release has a known release-specific DOI or the archival policy
-changes.
+repository, license, and DOI. Keep the Zenodo concept DOI
+`10.5281/zenodo.16931097` unchanged across releases; do not replace it with a
+version-specific DOI.
 
 Refresh both committed lockfiles after manual metadata edits:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "delaunay-scripts"
 version = "0.8.0"
 description = "Python utility scripts for the delaunay Rust library"
-readme = "README.md"
+readme = "scripts/README.md"
 requires-python = ">=3.14"
 license = "BSD-3-Clause"
 license-files = [ "LICENSE" ]

--- a/scripts/benchmark_utils.py
+++ b/scripts/benchmark_utils.py
@@ -497,6 +497,15 @@ class ReleaseReportConfig:
             raise ValueError(msg)
 
 
+@dataclass(frozen=True, slots=True)
+class ToolRunOptions:
+    """Execution controls for one repository support command."""
+
+    timeout: int = RELEASE_COMMAND_TIMEOUT_SECONDS
+    env: dict[str, str] | None = None
+    stream_output: bool = False
+
+
 @dataclass(frozen=True)
 class RevisionEvidence:
     """Source, toolchain, and command evidence for one measured revision."""
@@ -845,7 +854,7 @@ def _ci_performance_sidecar_timestamp(criterion_dir: Path) -> str | None:
 
 def is_valid_criterion_estimate(mean_ns: float, low_ns: float, high_ns: float) -> bool:
     """Return whether Criterion estimate values are finite and ordered."""
-    return all(math.isfinite(value) for value in (mean_ns, low_ns, high_ns)) and mean_ns > 0 and 0 <= low_ns <= mean_ns <= high_ns
+    return all(math.isfinite(value) and value > 0 for value in (mean_ns, low_ns, high_ns)) and low_ns <= high_ns
 
 
 def _is_object_mapping(value: object) -> TypeIs[Mapping[object, object]]:
@@ -881,8 +890,8 @@ def _parse_criterion_estimate(data: object) -> CriterionEstimate | None:
 
     try:
         mean_ns = _criterion_float(mean_data["point_estimate"])
-        low_ns = _criterion_float(confidence_interval.get("lower_bound", mean_ns))
-        high_ns = _criterion_float(confidence_interval.get("upper_bound", mean_ns))
+        low_ns = _criterion_float(confidence_interval["lower_bound"])
+        high_ns = _criterion_float(confidence_interval["upper_bound"])
     except _CRITERION_ESTIMATE_PARSE_ERRORS:
         return None
 
@@ -3542,12 +3551,25 @@ def _format_command_failure(command: list[str], exc: subprocess.CalledProcessErr
     return "\n".join(parts)
 
 
-def _run_tool(command: str, args: list[str], *, cwd: Path, timeout: int = RELEASE_COMMAND_TIMEOUT_SECONDS, env: dict[str, str] | None = None) -> None:
+def _run_tool(command: str, args: list[str], *, cwd: Path, options: ToolRunOptions | None = None) -> None:
     """Run a support command and translate subprocess failures."""
+    resolved_options = options or ToolRunOptions()
     try:
-        run_safe_command(command, args, cwd=cwd, timeout=timeout, env=env)
+        run_safe_command(
+            command,
+            args,
+            cwd=cwd,
+            timeout=resolved_options.timeout,
+            env=resolved_options.env,
+            capture_output=not resolved_options.stream_output,
+        )
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(_format_command_failure([command, *args], exc)) from exc
+
+
+def _progress(message: str) -> None:
+    """Write one immediately visible performance-workflow phase marker."""
+    print(f"[performance] {message}", file=sys.stderr, flush=True)
 
 
 def _run_git(args: list[str], *, cwd: Path, timeout: int = RELEASE_COMMAND_TIMEOUT_SECONDS) -> None:
@@ -3691,6 +3713,13 @@ def resolve_performance_request(options: PerformanceRequestOptions) -> ResolvedP
             raise ValueError(msg)
         current_tag = _current_package_tag(options.repo_root)
         latest = _latest_published_release(options.repo_root).tag
+        if current_tag == latest:
+            msg = (
+                f"current package tag and latest published release are both {latest}; "
+                "use a named local Criterion baseline for same-version experiments, "
+                "or rerun after updating the package version"
+            )
+            raise ValueError(msg)
         return ResolvedPerformanceRequest(current_tag=current_tag, baseline_tag=latest, worktree_ref=options.worktree_ref, tags_to_fetch=(latest,))
 
     if options.current_tag is None or options.baseline_tag is None:
@@ -4110,13 +4139,18 @@ def _run_saved_baseline_for_suite(
             "--save-baseline",
             baseline_tag,
         )
+        _progress(f"running baseline benchmark {target} for {baseline_tag}")
         _run_tool(
             command[0],
             list(command[1:]),
             cwd=worktree,
-            timeout=RELEASE_BENCH_TIMEOUT_SECONDS,
-            env=env,
+            options=ToolRunOptions(
+                timeout=RELEASE_BENCH_TIMEOUT_SECONDS,
+                env=env,
+                stream_output=True,
+            ),
         )
+        _progress(f"completed baseline benchmark {target} for {baseline_tag}")
         commands.append(command)
     return tuple(commands)
 
@@ -4124,18 +4158,34 @@ def _run_saved_baseline_for_suite(
 def _run_latest_for_suite(*, worktree: Path, suite: str, env: dict[str, str] | None) -> tuple[tuple[str, ...], ...]:
     """Run current benchmarks for a suite."""
     if suite == "release-signal" and (worktree / "justfile").exists():
-        _run_tool("just", ["bench-latest"], cwd=worktree, timeout=RELEASE_BENCH_TIMEOUT_SECONDS, env=env)
+        _progress("running current release-signal benchmarks")
+        _run_tool(
+            "just",
+            ["bench-latest"],
+            cwd=worktree,
+            options=ToolRunOptions(
+                timeout=RELEASE_BENCH_TIMEOUT_SECONDS,
+                env=env,
+                stream_output=True,
+            ),
+        )
+        _progress("completed current release-signal benchmarks")
         return (("just", "bench-latest"),)
     commands: list[tuple[str, ...]] = []
     for target in _bench_targets_for_suite(worktree, suite):
         command = ("cargo", "bench", "--profile", BENCHMARK_BUILD_FLAVOR, "--bench", target)
+        _progress(f"running current benchmark {target}")
         _run_tool(
             command[0],
             list(command[1:]),
             cwd=worktree,
-            timeout=RELEASE_BENCH_TIMEOUT_SECONDS,
-            env=env,
+            options=ToolRunOptions(
+                timeout=RELEASE_BENCH_TIMEOUT_SECONDS,
+                env=env,
+                stream_output=True,
+            ),
         )
+        _progress(f"completed current benchmark {target}")
         commands.append(command)
     return tuple(commands)
 
@@ -4148,6 +4198,7 @@ def _generate_local_baseline_into_worktree(
 ) -> RevisionEvidence:
     """Generate a local baseline and return its complete revision evidence."""
     baseline_worktree = tmp_dir / "baseline-worktree"
+    _progress(f"preparing baseline worktree for {config.baseline_tag}")
     _run_git(["worktree", "add", "--detach", str(baseline_worktree), config.baseline_tag], cwd=config.repo_root)
     try:
         observed_baseline_tag = _current_package_tag(baseline_worktree)
@@ -4725,6 +4776,7 @@ def _build_performance_bundle_in_temp_worktree(*, config: ReleaseReportConfig) -
         tmp_dir = Path(tmp)
         worktree = tmp_dir / "worktree"
 
+        _progress(f"preparing current worktree for {config.current_tag}")
         _run_git(["worktree", "add", "--detach", str(worktree), config.worktree_ref], cwd=config.repo_root)
         try:
             if config.apply_current_diff:
@@ -4778,6 +4830,7 @@ def _build_performance_bundle_in_temp_worktree(*, config: ReleaseReportConfig) -
                 )
                 current_acquisition_commands = ()
                 baseline_acquisition_commands = ()
+            _progress("collecting and validating performance artifacts")
             context = ArtifactContext(
                 release=ReleasePair(current=config.current_tag, baseline=config.baseline_tag),
                 statistic="median",

--- a/scripts/check_docs_version_sync.py
+++ b/scripts/check_docs_version_sync.py
@@ -6,6 +6,7 @@ import re
 import sys
 import tomllib
 from dataclasses import dataclass
+from datetime import date
 from enum import StrEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeGuard
@@ -228,7 +229,10 @@ def _uv_lock_reference(path: Path, project: PythonProjectInfo) -> VersionReferen
     return _single_package_reference(path, entries, candidate_indices, project.name, ReferenceKind.UV_LOCK)
 
 
-_CITATION_VERSION_RE = re.compile(r"^version:\s*(?P<quote>['\"]?)(?P<version>[0-9A-Za-z][0-9A-Za-z.+-]*)(?P=quote)\s*(?:#.*)?$")
+_ZENODO_CONCEPT_DOI = "10.5281/zenodo.16931097"
+_CITATION_VERSION_RE = re.compile(r"^version:[ \t]*(?P<quote>['\"]?)(?P<version>[0-9A-Za-z][0-9A-Za-z.+-]*)(?P=quote)(?:[ \t]+#.*)?[ \t]*$")
+_CITATION_DATE_RE = re.compile(r"^date-released:[ \t]*(?P<quote>['\"]?)(?P<date>\d{4}-\d{2}-\d{2})(?P=quote)(?:[ \t]+#.*)?[ \t]*$")
+_CITATION_DOI_RE = re.compile(r"^doi:[ \t]*(?P<quote>['\"]?)(?P<doi>[^\s'\"]+)(?P=quote)(?:[ \t]+#.*)?[ \t]*$")
 
 
 def _citation_reference(path: Path) -> VersionReference:
@@ -246,6 +250,98 @@ def _citation_reference(path: Path) -> VersionReference:
         msg = f"{path} must contain exactly one top-level version; found {len(references)}"
         raise TypeError(msg)
     return references[0]
+
+
+def _require_iso_date(value: str, *, path: Path, line: int, field: str) -> None:
+    """Require one calendar-valid ISO date with source context."""
+    try:
+        date.fromisoformat(value)
+    except ValueError as exc:
+        msg = f"{path}:{line}: {field} is not a valid ISO date: {value!r}"
+        raise TypeError(msg) from exc
+
+
+def _citation_release_date(path: Path) -> tuple[int, str]:
+    """Return the only top-level ``date-released`` value in CITATION.cff."""
+    matches: list[tuple[int, str]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if re.match(r"^date-released(?=\s|:|$)", line) is None:
+            continue
+        match = _CITATION_DATE_RE.fullmatch(line)
+        if match is None:
+            msg = f"{path}:{line_number}: top-level date-released must use YYYY-MM-DD"
+            raise TypeError(msg)
+        value = match.group("date")
+        _require_iso_date(value, path=path, line=line_number, field="top-level date-released")
+        matches.append((line_number, value))
+    if not matches:
+        msg = f"{path}: missing top-level date-released; expected exactly one YYYY-MM-DD value"
+        raise TypeError(msg)
+    if len(matches) != 1:
+        locations = ", ".join(f"{path}:{line}" for line, _value in matches)
+        msg = f"{locations}: duplicate top-level date-released values; expected exactly one"
+        raise TypeError(msg)
+    return matches[0]
+
+
+def _validate_citation_doi(path: Path) -> None:
+    """Require the stable Zenodo concept DOI in top-level citation metadata."""
+    matches: list[tuple[int, str]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        if re.match(r"^doi(?=\s|:|$)", line) is None:
+            continue
+        match = _CITATION_DOI_RE.fullmatch(line)
+        if match is None:
+            msg = f"{path}:{line_number}: top-level doi must be a non-empty scalar"
+            raise TypeError(msg)
+        matches.append((line_number, match.group("doi")))
+    if not matches:
+        msg = f"{path}: missing top-level doi; expected Zenodo concept DOI {_ZENODO_CONCEPT_DOI}"
+        raise TypeError(msg)
+    if len(matches) != 1:
+        locations = ", ".join(f"{path}:{line}" for line, _value in matches)
+        msg = f"{locations}: duplicate top-level doi values; expected exactly one Zenodo concept DOI"
+        raise TypeError(msg)
+    line_number, value = matches[0]
+    if value != _ZENODO_CONCEPT_DOI:
+        msg = f"{path}:{line_number}: top-level doi must remain the Zenodo concept DOI {_ZENODO_CONCEPT_DOI}; found {value!r}"
+        raise TypeError(msg)
+
+
+def _validate_release_date_sync(root: Path, package: PackageInfo) -> None:
+    """Require citation metadata and the generated release heading to agree."""
+    citation = root / "CITATION.cff"
+    citation_line, citation_date = _citation_release_date(citation)
+    changelog = root / "CHANGELOG.md"
+    if not changelog.is_file():
+        return
+
+    heading_prefix = re.compile(rf"^## \[v?{re.escape(package.version)}\]")
+    heading = re.compile(rf"^## \[v?{re.escape(package.version)}\] - (?P<date>\d{{4}}-\d{{2}}-\d{{2}})$")
+    changelog_matches: list[tuple[int, str]] = []
+    for line_number, line in enumerate(changelog.read_text(encoding="utf-8").splitlines(), start=1):
+        if heading_prefix.match(line) is None:
+            continue
+        match = heading.fullmatch(line)
+        if match is None:
+            msg = f"{changelog}:{line_number}: release heading for {package.version} must end with YYYY-MM-DD"
+            raise TypeError(msg)
+        value = match.group("date")
+        _require_iso_date(value, path=changelog, line=line_number, field=f"release heading date for {package.version}")
+        changelog_matches.append((line_number, value))
+    if not changelog_matches:
+        return
+    if len(changelog_matches) != 1:
+        locations = ", ".join(f"{changelog}:{line}" for line, _value in changelog_matches)
+        msg = f"{locations}: duplicate release headings for {package.version}; expected exactly one"
+        raise TypeError(msg)
+    changelog_line, changelog_date = changelog_matches[0]
+    if citation_date != changelog_date:
+        msg = (
+            f"release date mismatch: {citation}:{citation_line} has {citation_date}, "
+            f"but {changelog}:{changelog_line} has {changelog_date}; both must use the generated UTC release date"
+        )
+        raise TypeError(msg)
 
 
 def _iter_markdown_files(root: Path) -> list[Path]:
@@ -368,7 +464,10 @@ def _version_references(root: Path, package: PackageInfo) -> list[VersionReferen
 def find_version_mismatches(root: Path) -> list[VersionMismatch]:
     """Return release-version references that differ from Cargo.toml."""
     package = _read_cargo_package_info(root / "Cargo.toml")
-    return [VersionMismatch(reference=reference, package=package) for reference in _version_references(root, package) if reference.version != package.version]
+    references = _version_references(root, package)
+    _validate_release_date_sync(root, package)
+    _validate_citation_doi(root / "CITATION.cff")
+    return [VersionMismatch(reference=reference, package=package) for reference in references if reference.version != package.version]
 
 
 def _parse_args(argv: Sequence[str]) -> argparse.Namespace:

--- a/scripts/check_docs_version_sync.py
+++ b/scripts/check_docs_version_sync.py
@@ -330,7 +330,8 @@ def _validate_release_date_sync(root: Path, package: PackageInfo) -> None:
         _require_iso_date(value, path=changelog, line=line_number, field=f"release heading date for {package.version}")
         changelog_matches.append((line_number, value))
     if not changelog_matches:
-        return
+        msg = f"{changelog}: missing release heading for {package.version}; expected exactly one"
+        raise TypeError(msg)
     if len(changelog_matches) != 1:
         locations = ", ".join(f"{changelog}:{line}" for line, _value in changelog_matches)
         msg = f"{locations}: duplicate release headings for {package.version}; expected exactly one"

--- a/scripts/hardware_utils.py
+++ b/scripts/hardware_utils.py
@@ -12,6 +12,7 @@ import argparse
 import contextlib
 import json
 import logging
+import os
 import platform
 import re
 import shutil
@@ -21,14 +22,14 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from subprocess_utils import ExceptionFamily, run_safe_command
+    from subprocess_utils import ExceptionFamily, ExecutableNotFoundError, run_safe_command
 else:
     try:
         # When executed as a script from scripts/
-        from subprocess_utils import ExceptionFamily, run_safe_command
+        from subprocess_utils import ExceptionFamily, ExecutableNotFoundError, run_safe_command
     except ModuleNotFoundError:
         # When imported as a module (e.g., scripts.hardware_utils)
-        from scripts.subprocess_utils import ExceptionFamily, run_safe_command
+        from scripts.subprocess_utils import ExceptionFamily, ExecutableNotFoundError, run_safe_command
 
 # Configure a module-level logger
 logger = logging.getLogger(__name__)
@@ -47,6 +48,7 @@ _LINUX_CPU_CORE_DISCOVERY_ERRORS: ExceptionFamily = (
 )
 _LINUX_MEMINFO_ERRORS: ExceptionFamily = (FileNotFoundError, PermissionError, ValueError)
 _MEMORY_VALUE_PARSE_ERRORS: ExceptionFamily = (ValueError, AttributeError)
+_GENERIC_CPU_NAMES = frozenset({"amd64", "arm", "arm64", "aarch64", "i386", "i686", "unknown", "unavailable", "x86_64"})
 
 
 class HardwareInfo:
@@ -64,14 +66,15 @@ class HardwareInfo:
         Returns:
             Tuple of (cpu_model, cpu_cores, cpu_threads)
         """
+        cpu_info = ("Unknown", "Unknown", "Unknown")
         try:
             if self.os_type == "Darwin":
-                return self._get_cpu_info_darwin()
-            if self.os_type == "Linux":
-                return self._get_cpu_info_linux()
-            if self.os_type == "Windows":
-                return self._get_cpu_info_windows()
-        except (subprocess.CalledProcessError, OSError, ValueError) as e:
+                cpu_info = self._get_cpu_info_darwin()
+            elif self.os_type == "Linux":
+                cpu_info = self._get_cpu_info_linux()
+            elif self.os_type == "Windows":
+                cpu_info = self._get_cpu_info_windows()
+        except (ExecutableNotFoundError, subprocess.CalledProcessError, OSError, ValueError) as e:
             logger.debug(
                 "Failed to get CPU info for OS %s: %s (%s)",
                 self.os_type,
@@ -79,7 +82,27 @@ class HardwareInfo:
                 type(e).__name__,
             )
 
-        return "Unknown", "Unknown", "Unknown"
+        cpu_model, cpu_cores, cpu_threads = cpu_info
+        if not self._is_concrete_cpu_model(cpu_model):
+            cpu_model = self._fallback_cpu_model()
+        return cpu_model, cpu_cores, cpu_threads
+
+    def _is_concrete_cpu_model(self, value: str) -> bool:
+        """Return whether a CPU identifier is more specific than an architecture."""
+        stripped = value.strip()
+        folded = stripped.casefold()
+        return bool(stripped) and folded not in _GENERIC_CPU_NAMES and folded != self.machine.strip().casefold()
+
+    def _fallback_cpu_model(self) -> str:
+        """Return a concrete environment/platform CPU model when available."""
+        candidates: list[str] = []
+        if self.os_type == "Windows":
+            candidates.append(os.environ.get("PROCESSOR_IDENTIFIER", ""))
+        candidates.append(platform.processor())
+        for candidate in candidates:
+            if self._is_concrete_cpu_model(candidate):
+                return candidate.strip()
+        return "Unknown"
 
     def _get_cpu_info_darwin(self) -> tuple[str, str, str]:
         """

--- a/scripts/performance_artifacts.py
+++ b/scripts/performance_artifacts.py
@@ -119,7 +119,7 @@ class TimingEstimate:
     confidence_level: float
 
     def __post_init__(self) -> None:
-        """Reject non-finite, non-positive, or inconsistent timings."""
+        """Reject non-finite, non-positive, or reversed timings."""
         for field, value in (
             ("median_ns", self.median_ns),
             ("ci_lower_ns", self.ci_lower_ns),
@@ -128,8 +128,8 @@ class TimingEstimate:
             if not math.isfinite(value) or value <= 0:
                 msg = f"{field} must be finite and positive: {value!r}"
                 raise ValueError(msg)
-        if not self.ci_lower_ns <= self.median_ns <= self.ci_upper_ns:
-            msg = f"confidence interval must contain the median: {self.ci_lower_ns} <= {self.median_ns} <= {self.ci_upper_ns}"
+        if self.ci_lower_ns > self.ci_upper_ns:
+            msg = f"confidence interval must be ordered: {self.ci_lower_ns} <= {self.ci_upper_ns}"
             raise ValueError(msg)
         if not math.isfinite(self.confidence_level) or not 0.0 < self.confidence_level < 1.0:
             msg = f"confidence_level must be finite and strictly between zero and one: {self.confidence_level!r}"

--- a/scripts/tag_release.py
+++ b/scripts/tag_release.py
@@ -17,6 +17,7 @@ import logging
 import re
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -39,6 +40,10 @@ log = logging.getLogger(__name__)
 
 _GITHUB_SCP_REMOTE_RE = re.compile(r"^git@github\.com:(?P<path>.+)$", re.IGNORECASE)
 _GITHUB_REPO_COMPONENT_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+class PackageMetadataError(ValueError):
+    """Raised when Cargo package metadata cannot define a release target."""
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +117,42 @@ def find_changelog(start: Path | None = None) -> Path:
             return candidate
     msg = "CHANGELOG.md not found in current directory or parent directory."
     raise FileNotFoundError(msg)
+
+
+def _package_version(changelog: Path) -> str:
+    """Return the authoritative Cargo package version beside the changelog."""
+    cargo_toml = changelog.parent / "Cargo.toml"
+    try:
+        manifest = cargo_toml.read_text(encoding="utf-8")
+    except OSError as exc:
+        msg = f"Could not read {cargo_toml}: {exc}"
+        raise PackageMetadataError(msg) from exc
+    try:
+        data = tomllib.loads(manifest)
+    except tomllib.TOMLDecodeError as exc:
+        msg = f"Could not parse {cargo_toml}: {exc}"
+        raise PackageMetadataError(msg) from exc
+    package = data.get("package")
+    if not isinstance(package, dict):
+        msg = f"{cargo_toml} does not define a [package] table"
+        raise PackageMetadataError(msg)
+    version = package.get("version")
+    if not isinstance(version, str) or not version.strip():
+        msg = f"{cargo_toml} does not define a non-empty package version"
+        raise PackageMetadataError(msg)
+    return version
+
+
+def _validated_release_target(tag_version: str) -> tuple[str, Path]:
+    """Validate the requested tag against Cargo before any Git tag query."""
+    validate_semver(tag_version)
+    version = parse_version(tag_version)
+    changelog = find_changelog()
+    package_version = _package_version(changelog)
+    if version != package_version:
+        msg = f"Tag version {version!r} does not match Cargo package version {package_version!r}"
+        raise ValueError(msg)
+    return version, changelog
 
 
 def _archive_path_for_version(changelog: Path, version: str) -> Path | None:
@@ -369,8 +410,7 @@ def create_tag(tag_version: str, *, force: bool = False) -> None:
         tag_version (str): The tag to create (must follow the project's SemVer format, e.g., "v1.2.3").
         force (bool): If True, replace the tag when it already exists; otherwise bail out.
     """
-    validate_semver(tag_version)
-    version = parse_version(tag_version)
+    version, changelog = _validated_release_target(tag_version)
 
     # Check for existing tag (but don't delete yet — validate first)
     tag_existed = _tag_exists(tag_version)
@@ -380,7 +420,6 @@ def create_tag(tag_version: str, *, force: bool = False) -> None:
         sys.exit(1)
 
     # Extract changelog section (before any mutation)
-    changelog = find_changelog()
     section, source = extract_changelog_section(changelog, version)
     section_bytes = len(section.encode("utf-8"))
 

--- a/scripts/tests/test_benchmark_utils.py
+++ b/scripts/tests/test_benchmark_utils.py
@@ -520,7 +520,7 @@ def test_realization_validation_stable_ids_survive_saved_baseline_comparison(tmp
     assert {comparison.benchmark_id for comparison in comparisons} == {"/".join(benchmark_id) for benchmark_id in benchmark_ids}
 
 
-def test_run_latest_for_explicit_suite_bypasses_release_signal_recipe(tmp_path: Path) -> None:
+def test_run_latest_for_explicit_suite_bypasses_release_signal_recipe(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """A named suite should run its own Cargo targets even when Just is present."""
     (tmp_path / "justfile").write_text("", encoding=UTF8)
     (tmp_path / "Cargo.toml").write_text(
@@ -541,9 +541,137 @@ def test_run_latest_for_explicit_suite_bypasses_release_signal_recipe(tmp_path: 
             "topology_guarantee_construction",
         ],
         cwd=tmp_path,
-        timeout=benchmark_utils.RELEASE_BENCH_TIMEOUT_SECONDS,
-        env=None,
+        options=benchmark_utils.ToolRunOptions(
+            timeout=benchmark_utils.RELEASE_BENCH_TIMEOUT_SECONDS,
+            env=None,
+            stream_output=True,
+        ),
     )
+    assert capsys.readouterr().err.splitlines() == [
+        "[performance] running current benchmark topology_guarantee_construction",
+        "[performance] completed current benchmark topology_guarantee_construction",
+    ]
+
+
+def test_run_saved_baseline_streams_with_progress(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """Saved-baseline benchmarks stream output with the release timeout."""
+    (tmp_path / "Cargo.toml").write_text(
+        '[[bench]]\nname = "topology_guarantee_construction"\n',
+        encoding=UTF8,
+    )
+    environment = {"CARGO_TARGET_DIR": str(tmp_path / "criterion-target")}
+
+    with patch("benchmark_utils._run_tool") as run_tool:
+        commands = benchmark_utils._run_saved_baseline_for_suite(
+            worktree=tmp_path,
+            baseline_tag="v0.7.7",
+            suite="topology",
+            env=environment,
+        )
+
+    assert commands == (
+        (
+            "cargo",
+            "bench",
+            "--profile",
+            benchmark_utils.BENCHMARK_BUILD_FLAVOR,
+            "--bench",
+            "topology_guarantee_construction",
+            "--",
+            "--save-baseline",
+            "v0.7.7",
+        ),
+    )
+    run_tool.assert_called_once_with(
+        "cargo",
+        [
+            "bench",
+            "--profile",
+            benchmark_utils.BENCHMARK_BUILD_FLAVOR,
+            "--bench",
+            "topology_guarantee_construction",
+            "--",
+            "--save-baseline",
+            "v0.7.7",
+        ],
+        cwd=tmp_path,
+        options=benchmark_utils.ToolRunOptions(
+            timeout=benchmark_utils.RELEASE_BENCH_TIMEOUT_SECONDS,
+            env=environment,
+            stream_output=True,
+        ),
+    )
+    assert capsys.readouterr().err.splitlines() == [
+        "[performance] running baseline benchmark topology_guarantee_construction for v0.7.7",
+        "[performance] completed baseline benchmark topology_guarantee_construction for v0.7.7",
+    ]
+
+
+def test_run_latest_release_signal_streams_without_false_completion(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A failed release-signal recipe streams and emits no completion marker."""
+    (tmp_path / "justfile").write_text("", encoding=UTF8)
+    environment = {"CARGO_TARGET_DIR": str(tmp_path / "criterion-target")}
+
+    with (
+        patch("benchmark_utils._run_tool", side_effect=RuntimeError("benchmark failed")) as run_tool,
+        pytest.raises(RuntimeError, match="benchmark failed"),
+    ):
+        benchmark_utils._run_latest_for_suite(worktree=tmp_path, suite="release-signal", env=environment)
+
+    run_tool.assert_called_once_with(
+        "just",
+        ["bench-latest"],
+        cwd=tmp_path,
+        options=benchmark_utils.ToolRunOptions(
+            timeout=benchmark_utils.RELEASE_BENCH_TIMEOUT_SECONDS,
+            env=environment,
+            stream_output=True,
+        ),
+    )
+    assert capsys.readouterr().err.splitlines() == ["[performance] running current release-signal benchmarks"]
+
+
+def test_run_tool_can_stream_long_running_command_output(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Streaming commands inherit stdout/stderr while keeping their long timeout."""
+    observed_kwargs: dict[str, object] = {}
+
+    def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed_kwargs.update(kwargs)
+        return completed_process()
+
+    monkeypatch.setattr(benchmark_utils, "run_safe_command", fake_run)
+
+    benchmark_utils._run_tool(
+        "cargo",
+        ["bench"],
+        cwd=tmp_path,
+        options=benchmark_utils.ToolRunOptions(
+            timeout=benchmark_utils.RELEASE_BENCH_TIMEOUT_SECONDS,
+            stream_output=True,
+        ),
+    )
+
+    assert observed_kwargs["capture_output"] is False
+    assert observed_kwargs["timeout"] == benchmark_utils.RELEASE_BENCH_TIMEOUT_SECONDS
+
+
+def test_run_tool_captures_short_command_output_by_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Short support commands retain captured output for structured diagnostics."""
+    observed_kwargs: dict[str, object] = {}
+
+    def fake_run(*_args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        observed_kwargs.update(kwargs)
+        return completed_process()
+
+    monkeypatch.setattr(benchmark_utils, "run_safe_command", fake_run)
+
+    benchmark_utils._run_tool("gh", ["release", "download"], cwd=tmp_path)
+
+    assert observed_kwargs["capture_output"] is True
+    assert observed_kwargs["timeout"] == benchmark_utils.RELEASE_COMMAND_TIMEOUT_SECONDS
 
 
 @pytest.mark.parametrize("point_estimate", [float("nan"), float("inf"), 0.0, -1.0])
@@ -684,6 +812,42 @@ def test_resolve_performance_request_current_vs_latest_uses_package_version_and_
     assert request.current_tag == "v0.8.0"
     assert request.baseline_tag == "v0.7.8"
     assert request.tags_to_fetch == ("v0.7.8",)
+
+
+def test_performance_local_rejects_identical_inferred_tags_before_external_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Same-version inference stops before fetch, worktree, or benchmark boundaries."""
+    (tmp_path / "Cargo.toml").write_text('[package]\nversion = "0.8.0"\n', encoding=UTF8)
+    monkeypatch.setattr(
+        benchmark_utils,
+        "_latest_published_release",
+        lambda _root: benchmark_utils.PublishedRelease(tag="v0.8.0", published_at="2026-08-01T00:00:00Z"),
+    )
+    preflight = Mock()
+    fetch = Mock()
+    generate = Mock()
+    worktree = Mock()
+    benchmark = Mock()
+    monkeypatch.setattr(benchmark_utils, "_preflight_performance_destinations", preflight)
+    monkeypatch.setattr(benchmark_utils, "_fetch_for_performance_request", fetch)
+    monkeypatch.setattr(benchmark_utils, "generate_performance_worktree_report", generate)
+    monkeypatch.setattr(benchmark_utils, "_run_git", worktree)
+    monkeypatch.setattr(benchmark_utils, "_run_tool", benchmark)
+    args = create_argument_parser().parse_args(["performance-local"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        benchmark_utils._cmd_performance_local(args, tmp_path)
+
+    assert exc_info.value.code == 1
+    assert "both v0.8.0" in capsys.readouterr().err
+    preflight.assert_not_called()
+    fetch.assert_not_called()
+    generate.assert_not_called()
+    worktree.assert_not_called()
+    benchmark.assert_not_called()
 
 
 def test_promote_performance_report_archives_previous_and_updates_index(tmp_path: Path) -> None:
@@ -1600,7 +1764,9 @@ class TestCriterionParser:
         [
             {"mean": {"point_estimate": float("nan"), "confidence_interval": {"lower_bound": 100000.0, "upper_bound": 120000.0}}},
             {"mean": {"point_estimate": float("inf"), "confidence_interval": {"lower_bound": 100000.0, "upper_bound": 120000.0}}},
-            {"mean": {"point_estimate": 110000.0, "confidence_interval": {"lower_bound": 120000.0, "upper_bound": 130000.0}}},
+            {"mean": {"point_estimate": 110000.0, "confidence_interval": {"lower_bound": 130000.0, "upper_bound": 120000.0}}},
+            {"mean": {"point_estimate": 110000.0, "confidence_interval": {"upper_bound": 120000.0}}},
+            {"mean": {"point_estimate": 110000.0, "confidence_interval": {"lower_bound": 100000.0}}},
         ],
     )
     def test_parse_estimates_json_rejects_invalid_estimates(self, estimates_data) -> None:
@@ -1654,8 +1820,8 @@ class TestCriterionParser:
         finally:
             estimates_path.unlink()
 
-    def test_parse_estimates_json_very_fast_benchmark_division_by_zero_protection(self) -> None:
-        """Test division by zero protection for very fast benchmarks with near-zero confidence intervals."""
+    def test_parse_estimates_json_rejects_zero_confidence_bound(self) -> None:
+        """Criterion confidence bounds must be strictly positive."""
         estimates_data = {
             "mean": {
                 "point_estimate": 1000.0,  # 1 microsecond in nanoseconds
@@ -1674,20 +1840,33 @@ class TestCriterionParser:
         try:
             result = CriterionParser.parse_estimates_json(estimates_path, 1000, "2D")
 
-            # Should not crash and should return valid data with protected throughput calculation
-            assert result is not None
-            assert result.points == 1000
-            assert result.dimension == "2D"
-            assert result.time_mean == 1.0  # 1 microsecond
-            assert result.time_low == 0.0  # Lower bound of confidence interval
-            assert result.time_high == 2.0  # Upper bound
+            assert result is None
+        finally:
+            estimates_path.unlink()
 
-            # Throughput should be calculated with epsilon protection
-            # thrpt_high = points * 1000 / max(low_us, eps) = 1000 * 1000 / max(0.0, 1e-9) = 1000 * 1000 / 1e-9
-            assert result.throughput_high is not None
-            assert result.throughput_high > 1e12  # Should be very large due to epsilon protection
-            assert result.throughput_mean is not None
-            assert result.throughput_low is not None
+    def test_parse_estimates_json_accepts_interval_that_excludes_point_estimate(self) -> None:
+        """Bootstrap point estimates need not lie inside marginal intervals."""
+        estimates_data = {
+            "mean": {
+                "point_estimate": 130000.0,
+                "confidence_interval": {
+                    "lower_bound": 100000.0,
+                    "upper_bound": 120000.0,
+                },
+            },
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            json.dump(estimates_data, f)
+            f.flush()
+            estimates_path = Path(f.name)
+
+        try:
+            result = CriterionParser.parse_estimates_json(estimates_path, 1000, "2D")
+
+            assert result is not None
+            assert result.time_mean == pytest.approx(130.0)
+            assert result.time_low == pytest.approx(100.0)
+            assert result.time_high == pytest.approx(120.0)
         finally:
             estimates_path.unlink()
 
@@ -4672,7 +4851,7 @@ class TestPerformanceSummaryGenerator:
             {"mean": []},
             {"mean": {"point_estimate": 100000.0, "confidence_interval": []}},
             {"mean": {"point_estimate": float("nan"), "confidence_interval": {"lower_bound": 90000.0, "upper_bound": 110000.0}}},
-            {"mean": {"point_estimate": 100000.0, "confidence_interval": {"lower_bound": 110000.0, "upper_bound": 120000.0}}},
+            {"mean": {"point_estimate": 100000.0, "confidence_interval": {"lower_bound": 120000.0, "upper_bound": 110000.0}}},
         ],
     )
     def test_parse_single_method_result_rejects_invalid_estimates(self, tmp_path, estimates_data) -> None:

--- a/scripts/tests/test_check_docs_version_sync.py
+++ b/scripts/tests/test_check_docs_version_sync.py
@@ -12,6 +12,7 @@ if TYPE_CHECKING:
 
 _CARGO_TOML = '[package]\nname = "delaunay"\nversion = "1.2.3"'
 _VERSION = "1.2.3"
+_ZENODO_CONCEPT_DOI = "10.5281/zenodo.16931097"
 
 
 def _write_project(
@@ -35,7 +36,7 @@ def _write_project(
         "Cargo.lock": f'version = 4\n\n[[package]]\nname = "delaunay"\nversion = "{metadata_version}"\n',
         "pyproject.toml": f'[project]\nname = "delaunay-scripts"\nversion = "{metadata_version}"\n',
         "uv.lock": f'version = 1\n\n[[package]]\nname = "delaunay-scripts"\nversion = "{metadata_version}"\nsource = {{ editable = "." }}\n',
-        "CITATION.cff": f"cff-version: 1.2.0\nversion: {metadata_version}\n",
+        "CITATION.cff": (f"cff-version: 1.2.0\nversion: {metadata_version}\ndoi: {_ZENODO_CONCEPT_DOI}\ndate-released: 2026-01-02\n"),
         "README.md": readme_text,
     }
     for filename, content in files.items():
@@ -235,13 +236,139 @@ def test_find_version_mismatches_rejects_missing_editable_uv_package(tmp_path: P
         check_docs_version_sync.find_version_mismatches(tmp_path)
 
 
-def test_find_version_mismatches_rejects_malformed_citation_version(tmp_path: Path) -> None:
+@pytest.mark.parametrize(
+    "version_line",
+    ['version: "\n', f"version: {_VERSION}#not-a-comment\n", f'version: "{_VERSION}"#not-a-comment\n'],
+)
+def test_find_version_mismatches_rejects_malformed_citation_version(tmp_path: Path, version_line: str) -> None:
     """Malformed CITATION.cff versions fail before a release can continue."""
     _write_project(tmp_path)
-    (tmp_path / "CITATION.cff").write_text('cff-version: 1.2.0\nversion: "\n', encoding="utf-8")
+    (tmp_path / "CITATION.cff").write_text(
+        f"cff-version: 1.2.0\n{version_line}doi: {_ZENODO_CONCEPT_DOI}\ndate-released: 2026-01-02\n",
+        encoding="utf-8",
+    )
 
     with pytest.raises(TypeError, match=r"CITATION\.cff:2: top-level version"):
         check_docs_version_sync.find_version_mismatches(tmp_path)
+
+
+@pytest.mark.parametrize(
+    ("date_line", "message"),
+    [
+        ("", "missing top-level date-released"),
+        ("date-released: 2026-7-28\n", "must use YYYY-MM-DD"),
+        ("date-released: 2026-02-30\n", "not a valid ISO date"),
+        ("date-released: 2026-01-02#not-a-comment\n", "must use YYYY-MM-DD"),
+        ('date-released: "2026-01-02"#not-a-comment\n', "must use YYYY-MM-DD"),
+    ],
+)
+def test_release_date_rejects_missing_or_malformed_citation_value(tmp_path: Path, date_line: str, message: str) -> None:
+    """Citation release dates are required and calendar-valid."""
+    _write_project(tmp_path)
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text(f"cff-version: 1.2.0\nversion: {_VERSION}\n{date_line}", encoding="utf-8")
+
+    with pytest.raises(TypeError, match=message) as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    assert "CITATION.cff" in str(exc_info.value)
+
+
+def test_release_date_rejects_duplicate_citation_values_with_lines(tmp_path: Path) -> None:
+    """Duplicate top-level citation dates report every conflicting line."""
+    _write_project(tmp_path)
+    citation = tmp_path / "CITATION.cff"
+    citation.write_text(
+        f"cff-version: 1.2.0\nversion: {_VERSION}\ndate-released: 2026-01-02\ndate-released: 2026-01-03\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="duplicate top-level date-released") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    message = str(exc_info.value)
+    assert "CITATION.cff:3" in message
+    assert "CITATION.cff:4" in message
+
+
+@pytest.mark.parametrize(
+    ("doi_lines", "message"),
+    [
+        ("", "missing top-level doi"),
+        ("doi: 10.5281/zenodo.99999999\n", "must remain the Zenodo concept DOI"),
+        (
+            f"doi: {_ZENODO_CONCEPT_DOI}\ndoi: {_ZENODO_CONCEPT_DOI}\n",
+            "duplicate top-level doi values",
+        ),
+    ],
+)
+def test_citation_requires_exactly_one_zenodo_concept_doi(tmp_path: Path, doi_lines: str, message: str) -> None:
+    """Release metadata keeps the stable concept DOI across versions."""
+    _write_project(tmp_path)
+    (tmp_path / "CITATION.cff").write_text(
+        f"cff-version: 1.2.0\nversion: {_VERSION}\n{doi_lines}date-released: 2026-01-02\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match=message):
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+
+def test_release_date_must_match_generated_changelog_heading(tmp_path: Path) -> None:
+    """The CFF date and current-version changelog heading use one UTC date."""
+    _write_project(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.3] - 2026-01-03\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="release date mismatch") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    message = str(exc_info.value)
+    assert "CITATION.cff:4" in message
+    assert "CHANGELOG.md:3" in message
+
+
+def test_release_date_rejects_malformed_current_changelog_heading(tmp_path: Path) -> None:
+    """A current-version heading reports its malformed date with line context."""
+    _write_project(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.3] - 2026-1-02\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="must end with YYYY-MM-DD") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    assert "CHANGELOG.md:3" in str(exc_info.value)
+
+
+def test_release_date_rejects_duplicate_current_changelog_headings(tmp_path: Path) -> None:
+    """Duplicate current-version headings report every conflicting line."""
+    _write_project(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.3] - 2026-01-02\n\n## [1.2.3] - 2026-01-02\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match="duplicate release headings") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    message = str(exc_info.value)
+    assert "CHANGELOG.md:3" in message
+    assert "CHANGELOG.md:5" in message
+
+
+def test_release_date_accepts_matching_generated_changelog_heading(tmp_path: Path) -> None:
+    """A matching generated release heading passes the date gate."""
+    _write_project(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.3] - 2026-01-02\n",
+        encoding="utf-8",
+    )
+
+    assert check_docs_version_sync.find_version_mismatches(tmp_path) == []
 
 
 def test_main_prints_mismatches(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/scripts/tests/test_check_docs_version_sync.py
+++ b/scripts/tests/test_check_docs_version_sync.py
@@ -217,7 +217,10 @@ def test_find_version_mismatches_ignores_historical_docs_and_test_fixtures(tmp_p
     fixtures = tmp_path / "tests" / "fixtures"
     fixtures.mkdir(parents=True)
     stale_snippet = 'delaunay = "0.1.0"\njust performance-release v0.1.0 v0.0.9\n'
-    (tmp_path / "CHANGELOG.md").write_text(stale_snippet, encoding="utf-8")
+    (tmp_path / "CHANGELOG.md").write_text(
+        f"# Changelog\n\n## [{_VERSION}] - 2026-01-02\n\n{stale_snippet}",
+        encoding="utf-8",
+    )
     (archive / "old.md").write_text(stale_snippet, encoding="utf-8")
     (fixtures / "example.md").write_text(stale_snippet, encoding="utf-8")
 
@@ -328,6 +331,20 @@ def test_release_date_must_match_generated_changelog_heading(tmp_path: Path) -> 
     message = str(exc_info.value)
     assert "CITATION.cff:4" in message
     assert "CHANGELOG.md:3" in message
+
+
+def test_release_date_rejects_missing_current_changelog_heading(tmp_path: Path) -> None:
+    """An existing changelog must contain exactly one current-version heading."""
+    _write_project(tmp_path)
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n## [1.2.2] - 2026-01-02\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(TypeError, match=r"missing release heading for 1\.2\.3") as exc_info:
+        check_docs_version_sync.find_version_mismatches(tmp_path)
+
+    assert "CHANGELOG.md" in str(exc_info.value)
 
 
 def test_release_date_rejects_malformed_current_changelog_heading(tmp_path: Path) -> None:

--- a/scripts/tests/test_hardware_utils.py
+++ b/scripts/tests/test_hardware_utils.py
@@ -14,6 +14,7 @@ from unittest.mock import mock_open, patch
 import pytest
 
 from hardware_utils import HardwareComparator, HardwareInfo, main
+from subprocess_utils import ExecutableNotFoundError
 
 
 @pytest.fixture
@@ -172,8 +173,9 @@ Thread(s) per core:  2"""
         assert cpu_cores == "8"
         assert cpu_threads == "16"
 
+    @patch("hardware_utils.platform.processor", return_value="")
     @patch("hardware_utils.platform.system")
-    def test_get_cpu_info_unknown_os(self, mock_system) -> None:
+    def test_get_cpu_info_unknown_os(self, mock_system, mock_processor) -> None:
         """Test CPU info detection on unknown OS."""
         mock_system.return_value = "UnknownOS"
 
@@ -183,10 +185,61 @@ Thread(s) per core:  2"""
         assert cpu_model == "Unknown"
         assert cpu_cores == "Unknown"
         assert cpu_threads == "Unknown"
+        mock_processor.assert_called_once_with()
 
+    @patch("hardware_utils.platform.processor", return_value="AMD64")
+    @patch("hardware_utils.platform.system", return_value="Windows")
+    @patch("hardware_utils.shutil.which", return_value=None)
+    def test_get_cpu_info_windows_uses_processor_identifier(
+        self,
+        mock_which,
+        mock_system,
+        mock_processor,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Windows provenance uses the concrete environment CPU identifier."""
+        monkeypatch.setenv("PROCESSOR_IDENTIFIER", "Intel64 Family 6 Model 186 Stepping 3, GenuineIntel")
+
+        cpu_model, cpu_cores, cpu_threads = HardwareInfo().get_cpu_info()
+
+        assert cpu_model == "Intel64 Family 6 Model 186 Stepping 3, GenuineIntel"
+        assert cpu_cores == "Unknown"
+        assert cpu_threads == "Unknown"
+        assert mock_which.call_count == 2
+        mock_which.assert_called_with("powershell")
+        mock_system.assert_called_once_with()
+        mock_processor.assert_called_once_with()
+
+    @patch("hardware_utils.platform.processor", return_value="Apple M4 Pro")
+    @patch("hardware_utils.platform.system", return_value="UnknownOS")
+    def test_get_cpu_info_uses_concrete_platform_fallback(self, mock_system, mock_processor) -> None:
+        """Unknown platforms retain a concrete processor model when exposed."""
+        cpu_model, cpu_cores, cpu_threads = HardwareInfo().get_cpu_info()
+
+        assert cpu_model == "Apple M4 Pro"
+        assert cpu_cores == "Unknown"
+        assert cpu_threads == "Unknown"
+        mock_system.assert_called_once_with()
+        mock_processor.assert_called_once_with()
+
+    @patch("hardware_utils.platform.processor", return_value="ppc64le")
+    @patch("hardware_utils.platform.machine", return_value="PPC64LE")
+    @patch("hardware_utils.platform.system", return_value="UnknownOS")
+    def test_get_cpu_info_rejects_processor_equal_to_machine(self, mock_system, mock_machine, mock_processor) -> None:
+        """Architecture strings are not retained as concrete processor models."""
+        cpu_model, cpu_cores, cpu_threads = HardwareInfo().get_cpu_info()
+
+        assert cpu_model == "Unknown"
+        assert cpu_cores == "Unknown"
+        assert cpu_threads == "Unknown"
+        mock_system.assert_called_once_with()
+        mock_machine.assert_called_once_with()
+        mock_processor.assert_called_once_with()
+
+    @patch("hardware_utils.platform.processor", return_value="")
     @patch("hardware_utils.platform.system")
     @patch.object(HardwareInfo, "_run_command")
-    def test_get_cpu_info_command_failure(self, mock_run_command, mock_system) -> None:
+    def test_get_cpu_info_command_failure(self, mock_run_command, mock_system, mock_processor) -> None:
         """Test CPU info detection when commands fail."""
         mock_system.return_value = "Darwin"
         mock_run_command.side_effect = subprocess.CalledProcessError(1, "cmd")
@@ -197,6 +250,21 @@ Thread(s) per core:  2"""
         assert cpu_model == "Unknown"
         assert cpu_cores == "Unknown"
         assert cpu_threads == "Unknown"
+        mock_processor.assert_called_once_with()
+
+    @patch("hardware_utils.platform.processor", return_value="Apple M4 Max")
+    @patch("hardware_utils.platform.system", return_value="Darwin")
+    @patch.object(HardwareInfo, "_run_command", side_effect=ExecutableNotFoundError("sysctl missing"))
+    def test_get_cpu_info_missing_command_uses_platform_fallback(self, mock_run_command, mock_system, mock_processor) -> None:
+        """A missing primary probe still reaches the concrete processor fallback."""
+        cpu_model, cpu_cores, cpu_threads = HardwareInfo().get_cpu_info()
+
+        assert cpu_model == "Apple M4 Max"
+        assert cpu_cores == "Unknown"
+        assert cpu_threads == "Unknown"
+        mock_run_command.assert_called_once_with(["sysctl", "-n", "machdep.cpu.brand_string"])
+        mock_system.assert_called_once_with()
+        mock_processor.assert_called_once_with()
 
     @patch("hardware_utils.platform.system")
     @patch.object(HardwareInfo, "_run_command")

--- a/scripts/tests/test_packaging.py
+++ b/scripts/tests/test_packaging.py
@@ -1,7 +1,10 @@
 """Tests for the installed Python utility package definition."""
 
 import ast
+import shutil
+import subprocess
 import tomllib
+import zipfile
 from pathlib import Path
 
 
@@ -66,3 +69,42 @@ def test_console_entry_point_import_closure_is_packaged() -> None:
         pending.extend(_local_imports(scripts_dir / f"{module}.py", local_modules) - reachable)
 
     assert reachable <= packaged_modules
+
+
+def test_support_package_uses_its_own_readme(tmp_path: Path) -> None:
+    """Built Python metadata describes the support tools, not the Rust crate."""
+    repository = Path(__file__).parents[2]
+    configuration = tomllib.loads((repository / "pyproject.toml").read_text(encoding="utf-8"))
+
+    assert configuration["project"]["readme"] == "scripts/README.md"
+
+    source = tmp_path / "source"
+    scripts = source / "scripts"
+    scripts.mkdir(parents=True)
+    for filename in ("LICENSE", "pyproject.toml", "uv.lock"):
+        shutil.copy2(repository / filename, source / filename)
+    shutil.copy2(repository / "scripts" / "README.md", scripts / "README.md")
+    for module in configuration["tool"]["setuptools"]["py-modules"]:
+        shutil.copy2(repository / "scripts" / f"{module}.py", scripts / f"{module}.py")
+
+    uv = shutil.which("uv")
+    assert uv is not None
+    wheel_output = tmp_path / "dist"
+    subprocess.run(  # noqa: S603 - executable is resolved; arguments are repository constants.
+        [uv, "build", "--wheel", "--out-dir", str(wheel_output)],
+        cwd=source,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    wheels = list(wheel_output.glob("*.whl"))
+    assert len(wheels) == 1
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        metadata_paths = [name for name in wheel.namelist() if name.endswith(".dist-info/METADATA")]
+        assert len(metadata_paths) == 1
+        metadata = wheel.read(metadata_paths[0]).decode("utf-8").replace("\r\n", "\n")
+
+    _headers, separator, description = metadata.partition("\n\n")
+    assert separator
+    assert description.startswith("# Scripts Directory\n")

--- a/scripts/tests/test_performance_artifacts.py
+++ b/scripts/tests/test_performance_artifacts.py
@@ -179,9 +179,15 @@ def test_timing_estimate_rejects_non_positive_or_non_finite_values(value: float)
         TimingEstimate(median_ns=value, ci_lower_ns=1.0, ci_upper_ns=2.0, confidence_level=0.95)
 
 
-def test_timing_estimate_rejects_interval_that_excludes_median() -> None:
-    with pytest.raises(ValueError, match="must contain the median"):
-        TimingEstimate(median_ns=3.0, ci_lower_ns=1.0, ci_upper_ns=2.0, confidence_level=0.95)
+def test_timing_estimate_accepts_ordered_interval_that_excludes_point_estimate() -> None:
+    estimate = TimingEstimate(median_ns=3.0, ci_lower_ns=1.0, ci_upper_ns=2.0, confidence_level=0.95)
+
+    assert estimate.median_ns == 3.0
+
+
+def test_timing_estimate_rejects_reversed_interval() -> None:
+    with pytest.raises(ValueError, match="confidence interval must be ordered"):
+        TimingEstimate(median_ns=2.0, ci_lower_ns=3.0, ci_upper_ns=1.0, confidence_level=0.95)
 
 
 def test_performance_row_rejects_coverage_presence_mismatch() -> None:

--- a/scripts/tests/test_tag_release.py
+++ b/scripts/tests/test_tag_release.py
@@ -2,11 +2,11 @@
 
 import subprocess
 from pathlib import PureWindowsPath
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from tag_release import _get_repo_url, create_tag, main, validate_semver
+from tag_release import _get_repo_url, _package_version, create_tag, main, validate_semver
 
 # ---------------------------------------------------------------------------
 # _get_repo_url
@@ -129,6 +129,59 @@ class TestValidateSemver:
 
 
 class TestCreateTag:
+    @pytest.fixture(autouse=True)
+    def _matching_package_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Keep existing tag tests focused on their original contracts."""
+        monkeypatch.setattr("tag_release._package_version", lambda _changelog: "1.2.3")
+
+    def test_package_version_reads_adjacent_cargo_manifest(self, tmp_path) -> None:
+        """The preflight source of truth is the package table beside the changelog."""
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n", encoding="utf-8")
+        (tmp_path / "Cargo.toml").write_text('[package]\nname = "example"\nversion = "1.2.4"\n', encoding="utf-8")
+
+        assert _package_version(changelog) == "1.2.4"
+
+    @pytest.mark.parametrize(
+        ("manifest", "error_type", "message"),
+        [
+            ("[package\n", ValueError, "Could not parse"),
+            ('[workspace]\nmembers = ["member"]\n', ValueError, r"does not define a \[package\] table"),
+            ('[package]\nname = "example"\n', ValueError, "does not define a non-empty package version"),
+            ('[package]\nversion = ""\n', ValueError, "does not define a non-empty package version"),
+            ("[package]\nversion = 123\n", ValueError, "does not define a non-empty package version"),
+        ],
+    )
+    def test_package_version_rejects_invalid_manifests(
+        self,
+        tmp_path,
+        manifest: str,
+        error_type: type[Exception],
+        message: str,
+    ) -> None:
+        """Malformed or incomplete manifests fail with path-qualified errors."""
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n", encoding="utf-8")
+        (tmp_path / "Cargo.toml").write_text(manifest, encoding="utf-8")
+
+        with pytest.raises(error_type, match=message) as exc_info:
+            _package_version(changelog)
+
+        assert "Cargo.toml" in str(exc_info.value)
+
+    def test_package_version_reports_manifest_read_failure(self, tmp_path) -> None:
+        """Filesystem failures become controlled release-preflight errors."""
+        changelog = tmp_path / "CHANGELOG.md"
+        cargo_toml = tmp_path / "Cargo.toml"
+
+        with (
+            patch.object(type(cargo_toml), "read_text", side_effect=PermissionError("denied")),
+            pytest.raises(ValueError, match="Could not read") as exc_info,
+        ):
+            _package_version(changelog)
+
+        assert str(cargo_toml) in str(exc_info.value)
+
     def test_next_step_sets_release_title(
         self,
         tmp_path,
@@ -210,6 +263,20 @@ class TestCreateTag:
         assert marker not in output.out
         assert marker not in output.err
 
+    def test_rejects_tag_that_differs_from_cargo_before_git(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A mismatched requested tag fails before querying or mutating tags."""
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n", encoding="utf-8")
+        mock_tag_exists = MagicMock()
+        monkeypatch.setattr("tag_release.find_changelog", lambda: changelog)
+        monkeypatch.setattr("tag_release._package_version", lambda _changelog: "1.2.4")
+        monkeypatch.setattr("tag_release._tag_exists", mock_tag_exists)
+
+        with pytest.raises(ValueError, match="does not match Cargo package version"):
+            create_tag("v1.2.3")
+
+        mock_tag_exists.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # main
@@ -229,3 +296,31 @@ def test_main_handles_git_timeout(capsys) -> None:
 
     assert exc_info.value.code == 1
     assert "Error: Command '['git', 'tag']' timed out after 30 seconds" in capsys.readouterr().err
+
+
+def test_main_handles_package_metadata_error_before_git(tmp_path, capsys) -> None:
+    """Manifest contract failures use the normal CLI diagnostic and avoid Git."""
+    changelog = tmp_path / "CHANGELOG.md"
+    mock_tag_exists = MagicMock()
+    with (
+        patch("sys.argv", ["tag-release", "v1.2.3"]),
+        patch("tag_release.find_changelog", return_value=changelog),
+        patch("tag_release._package_version", side_effect=ValueError("invalid package version")),
+        patch("tag_release._tag_exists", mock_tag_exists),
+        pytest.raises(SystemExit) as exc_info,
+    ):
+        main()
+
+    assert exc_info.value.code == 1
+    assert "Error: invalid package version" in capsys.readouterr().err
+    mock_tag_exists.assert_not_called()
+
+
+def test_main_does_not_hide_unexpected_type_error() -> None:
+    """Programming type errors retain their traceback instead of looking user-caused."""
+    with (
+        patch("sys.argv", ["tag-release", "v1.2.3"]),
+        patch("tag_release.create_tag", side_effect=TypeError("unexpected defect")),
+        pytest.raises(TypeError, match="unexpected defect"),
+    ):
+        main()


### PR DESCRIPTION
- reject release tags, citation dates, and DOI metadata that diverge from authoritative release metadata
- fail identical release comparisons before setup and stream progress from long benchmark phases
- preserve concrete CPU provenance and accept valid ordered Criterion confidence intervals
- package the Python support tools with their dedicated documentation

Closes #552